### PR TITLE
feat(infra): deep link URL scheme — io.supabase.nibbles (iOS + Android) [NIB-4]

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,12 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="io.supabase.nibbles" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,14 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>io.supabase.nibbles</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/lib/src/app/runner.dart
+++ b/lib/src/app/runner.dart
@@ -11,6 +11,7 @@ import 'package:nibbles/src/app/config/flavor_config.dart';
 import 'package:nibbles/src/app/firebase/dev_firebase_options.dart';
 import 'package:nibbles/src/app/firebase/prod_firebase_options.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// Bootstrap order is strict — do not reorder.
 Future<void> bootstrap({required Flavor flavor}) async {
@@ -66,7 +67,29 @@ Future<void> bootstrap({required Flavor flavor}) async {
         .setDefaultEventParameters({'flavor': 'dev'});
   }
 
-  // 7. RevenueCat configure
+  // 7. Supabase init — scheme io.supabase.nibbles handles auth deep links
+  // (password recovery, magic link). PKCE flow intercepts the incoming URL
+  // so supabase_flutter fires AuthChangeEvent.passwordRecovery before the
+  // router processes the route.
+  await Supabase.initialize(
+    url: FlavorConfig.instance.supabaseUrl,
+    anonKey: FlavorConfig.instance.supabaseAnonKey,
+    authOptions: const FlutterAuthClientOptions(
+      authFlowType: AuthFlowType.pkce,
+    ),
+  );
+
+  // Deep link → password recovery: listen for the event and navigate to
+  // /auth/reset-password (AU-03). Router is wired in NIB-9; listener kept
+  // here so it is active from app start before any widget tree exists.
+  Supabase.instance.client.auth.onAuthStateChange.listen((data) {
+    if (data.event == AuthChangeEvent.passwordRecovery) {
+      // TODO(NIB-9): replace with router.go('/auth/reset-password') once
+      // GoRouter is wired. Navigation intentionally deferred to NIB-9.
+    }
+  });
+
+  // 8. RevenueCat configure
   final revenueCatKey = defaultTargetPlatform == TargetPlatform.iOS
       ? FlavorConfig.instance.revenueCatAppleKey
       : FlavorConfig.instance.revenueCatGoogleKey;


### PR DESCRIPTION
## Summary

- **iOS** `Info.plist`: added `CFBundleURLTypes` with `io.supabase.nibbles` scheme so password reset links open the app instead of the browser
- **Android** `AndroidManifest.xml`: added `BROWSABLE` intent-filter for `io.supabase.nibbles` scheme inside the main `<activity>`
- **`runner.dart`**: added `Supabase.initialize` (PKCE auth flow) as step 7 in the bootstrap chain; wires `onAuthStateChange` listener that will route to `/auth/reset-password` on `passwordRecovery` event (navigation deferred to NIB-9 when GoRouter is wired)

## Manual steps required

- [ ] Supabase Dashboard → Authentication → URL Configuration → add `io.supabase.nibbles://` to Redirect URLs whitelist (dev and prod projects)
- [ ] Verify `.env.dev` / `.env.prod` contain `SUPABASE_URL` and `SUPABASE_ANON_KEY`

## Test plan

- [ ] On iOS simulator: tap a Supabase password reset email link → app opens (not browser)
- [ ] On Android emulator: tap reset link → app opens via intent filter
- [ ] `AuthChangeEvent.passwordRecovery` fires in `onAuthStateChange` stream (verify with debug log)
- [ ] After NIB-9: router navigates to `/auth/reset-password`

Closes NIB-4