### PR TITLE
feat(frontend): app theme — Nunito, AppColors, AppTypography, AppSizes, AllergenEmoji, Analytics [NIB-10]

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nibbles/src/app/themes/app_theme.dart';
 
-/// Root widget — router and theme wired in NIB-9 and NIB-10.
-class App extends StatelessWidget {
+/// Root widget — router wired in NIB-9.
+class App extends ConsumerWidget {
   const App({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const MaterialApp(
+  Widget build(BuildContext context, WidgetRef ref) {
+    return MaterialApp(
       title: 'Nibbles',
-      home: Scaffold(
+      theme: AppTheme.light(),
+      home: const Scaffold(
         body: Center(child: Text('Nibbles')),
       ),
     );

--- a/lib/src/app/constants/allergen_emoji.dart
+++ b/lib/src/app/constants/allergen_emoji.dart
@@ -1,0 +1,22 @@
+/// Static map of allergen key → emoji string.
+/// Sequence: peanut(1) → egg(2) → dairy(3) → tree_nuts(4) → sesame(5) →
+///           soy(6) → wheat(7) → fish(8) → shellfish(9)
+///
+/// Note: sesame and soy share the 🫘 emoji — visual distinction
+/// should be handled at the design layer if needed.
+abstract final class AllergenEmoji {
+  static const Map<String, String> map = {
+    'peanut': '🥜',
+    'egg': '🥚',
+    'dairy': '🥛',
+    'tree_nuts': '🌰',
+    'sesame': '🫘',
+    'soy': '🫘',
+    'wheat': '🌾',
+    'fish': '🐟',
+    'shellfish': '🦐',
+  };
+
+  /// Returns the emoji for [allergenKey], or an empty string if not found.
+  static String get(String allergenKey) => map[allergenKey] ?? '';
+}

--- a/lib/src/app/themes/app_colors.dart
+++ b/lib/src/app/themes/app_colors.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+abstract final class AppColors {
+  // Brand
+  static const Color primary = Color(0xFF4CAF82);
+  static const Color primaryLight = Color(0xFF80E0AB);
+  static const Color primaryDark = Color(0xFF2E7D5A);
+
+  // Secondary / accent
+  static const Color secondary = Color(0xFFFF8C42);
+  static const Color secondaryLight = Color(0xFFFFB47A);
+
+  // Backgrounds
+  static const Color background = Color(0xFFF9F9F9);
+  static const Color surface = Color(0xFFFFFFFF);
+  static const Color surfaceVariant = Color(0xFFF2F4F3);
+
+  // Text
+  static const Color text = Color(0xFF1A1A2E);
+  static const Color subtext = Color(0xFF6B7280);
+  static const Color hint = Color(0xFFB0B8C1);
+
+  // Semantic
+  static const Color error = Color(0xFFE53E3E);
+  static const Color success = Color(0xFF38A169);
+  static const Color warning = Color(0xFFD69E2E);
+
+  // Misc
+  static const Color divider = Color(0xFFE5E7EB);
+  static const Color onPrimary = Color(0xFFFFFFFF);
+  static const Color onSecondary = Color(0xFFFFFFFF);
+  static const Color onBackground = Color(0xFF1A1A2E);
+  static const Color onSurface = Color(0xFF1A1A2E);
+  static const Color onError = Color(0xFFFFFFFF);
+
+  // Allergen chip states
+  static const Color allergenSafe = Color(0xFF38A169);
+  static const Color allergenFlagged = Color(0xFFE53E3E);
+  static const Color allergenInProgress = Color(0xFFD69E2E);
+  static const Color allergenNotStarted = Color(0xFFB0B8C1);
+}

--- a/lib/src/app/themes/app_sizes.dart
+++ b/lib/src/app/themes/app_sizes.dart
@@ -1,0 +1,42 @@
+abstract final class AppSizes {
+  // Spacing
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 16;
+  static const double lg = 24;
+  static const double xl = 32;
+  static const double xxl = 48;
+  static const double xxxl = 64;
+
+  // Border radius
+  static const double radiusXs = 4;
+  static const double radiusSm = 8;
+  static const double radiusMd = 12;
+  static const double radiusLg = 16;
+  static const double radiusXl = 24;
+  static const double radiusFull = 999;
+
+  // Icon sizes
+  static const double iconSm = 16;
+  static const double iconMd = 24;
+  static const double iconLg = 32;
+  static const double iconXl = 48;
+
+  // Padding presets
+  static const double pagePaddingH = 20;
+  static const double pagePaddingV = 24;
+  static const double cardPadding = 16;
+  static const double listItemPaddingV = 12;
+
+  // Component-specific
+  static const double buttonHeight = 52;
+  static const double buttonHeightSm = 40;
+  static const double inputHeight = 52;
+  static const double appBarHeight = 56;
+  static const double bottomNavHeight = 64;
+  static const double avatarSm = 32;
+  static const double avatarMd = 48;
+  static const double avatarLg = 80;
+  static const double chipHeight = 36;
+  static const double dividerThickness = 1;
+}

--- a/lib/src/app/themes/app_theme.dart
+++ b/lib/src/app/themes/app_theme.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+
+export 'package:nibbles/src/app/themes/app_colors.dart';
+export 'package:nibbles/src/app/themes/app_sizes.dart';
+export 'package:nibbles/src/app/themes/app_typography.dart';
+
+abstract final class AppTheme {
+  static ThemeData light() {
+    const colorScheme = ColorScheme(
+      brightness: Brightness.light,
+      primary: AppColors.primary,
+      onPrimary: AppColors.onPrimary,
+      primaryContainer: AppColors.primaryLight,
+      onPrimaryContainer: AppColors.primaryDark,
+      secondary: AppColors.secondary,
+      onSecondary: AppColors.onSecondary,
+      secondaryContainer: AppColors.secondaryLight,
+      onSecondaryContainer: AppColors.text,
+      error: AppColors.error,
+      onError: AppColors.onError,
+      surface: AppColors.surface,
+      onSurface: AppColors.onSurface,
+      surfaceContainerHighest: AppColors.surfaceVariant,
+      onSurfaceVariant: AppColors.subtext,
+      outline: AppColors.divider,
+      outlineVariant: AppColors.hint,
+    );
+
+    const textTheme = AppTypography.textTheme;
+
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      textTheme: textTheme,
+      fontFamily: 'Nunito',
+      scaffoldBackgroundColor: AppColors.background,
+      dividerColor: AppColors.divider,
+      dividerTheme: const DividerThemeData(
+        color: AppColors.divider,
+        thickness: AppSizes.dividerThickness,
+        space: 0,
+      ),
+      appBarTheme: AppBarTheme(
+        backgroundColor: AppColors.surface,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        scrolledUnderElevation: 1,
+        shadowColor: AppColors.divider,
+        centerTitle: true,
+        titleTextStyle: textTheme.titleLarge,
+        systemOverlayStyle: SystemUiOverlayStyle.dark,
+        iconTheme: const IconThemeData(
+          color: AppColors.text,
+          size: AppSizes.iconMd,
+        ),
+      ),
+      bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+        backgroundColor: AppColors.surface,
+        selectedItemColor: AppColors.primary,
+        unselectedItemColor: AppColors.subtext,
+        selectedLabelStyle: TextStyle(
+          fontFamily: 'Nunito',
+          fontWeight: FontWeight.w700,
+          fontSize: 11,
+          color: AppColors.primary,
+        ),
+        unselectedLabelStyle: TextStyle(
+          fontFamily: 'Nunito',
+          fontWeight: FontWeight.w600,
+          fontSize: 11,
+          color: AppColors.subtext,
+        ),
+        elevation: 8,
+        type: BottomNavigationBarType.fixed,
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.primary,
+          foregroundColor: AppColors.onPrimary,
+          disabledBackgroundColor: AppColors.hint,
+          minimumSize: const Size.fromHeight(AppSizes.buttonHeight),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          ),
+          textStyle: AppTypography.button,
+          elevation: 0,
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: AppColors.primary,
+          minimumSize: const Size.fromHeight(AppSizes.buttonHeight),
+          side: const BorderSide(color: AppColors.primary, width: 1.5),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          ),
+          textStyle:
+              AppTypography.button.copyWith(color: AppColors.primary),
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: AppColors.primary,
+          textStyle: textTheme.labelLarge,
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: AppColors.surface,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.md,
+          vertical: AppSizes.md,
+        ),
+        hintStyle: textTheme.bodyMedium?.copyWith(color: AppColors.hint),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          borderSide: const BorderSide(color: AppColors.divider),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          borderSide: const BorderSide(color: AppColors.divider),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          borderSide:
+              const BorderSide(color: AppColors.primary, width: 2),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          borderSide: const BorderSide(color: AppColors.error),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          borderSide: const BorderSide(color: AppColors.error, width: 2),
+        ),
+        errorStyle:
+            textTheme.bodySmall?.copyWith(color: AppColors.error),
+      ),
+      cardTheme: const CardThemeData(
+        color: AppColors.surface,
+        elevation: 0,
+        margin: EdgeInsets.zero,
+      ),
+      chipTheme: ChipThemeData(
+        backgroundColor: AppColors.surfaceVariant,
+        selectedColor: AppColors.primaryLight,
+        labelStyle: textTheme.labelMedium,
+        side: BorderSide.none,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(
+            Radius.circular(AppSizes.radiusFull),
+          ),
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.md,
+          vertical: AppSizes.xs,
+        ),
+      ),
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: AppColors.text,
+        contentTextStyle:
+            textTheme.bodyMedium?.copyWith(color: Colors.white),
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(
+            Radius.circular(AppSizes.radiusMd),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/app/themes/app_typography.dart
+++ b/lib/src/app/themes/app_typography.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+
+abstract final class AppTypography {
+  static const TextTheme textTheme = TextTheme(
+        displayLarge: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 57,
+          fontWeight: FontWeight.w700,
+          color: AppColors.text,
+          letterSpacing: -0.25,
+        ),
+        displayMedium: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 45,
+          fontWeight: FontWeight.w700,
+          color: AppColors.text,
+        ),
+        displaySmall: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 36,
+          fontWeight: FontWeight.w700,
+          color: AppColors.text,
+        ),
+        headlineLarge: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 32,
+          fontWeight: FontWeight.w800,
+          color: AppColors.text,
+        ),
+        headlineMedium: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 28,
+          fontWeight: FontWeight.w700,
+          color: AppColors.text,
+        ),
+        headlineSmall: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 24,
+          fontWeight: FontWeight.w700,
+          color: AppColors.text,
+        ),
+        titleLarge: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 22,
+          fontWeight: FontWeight.w700,
+          color: AppColors.text,
+        ),
+        titleMedium: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          color: AppColors.text,
+          letterSpacing: 0.15,
+        ),
+        titleSmall: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+          color: AppColors.text,
+          letterSpacing: 0.1,
+        ),
+        bodyLarge: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 16,
+          fontWeight: FontWeight.w400,
+          color: AppColors.text,
+          letterSpacing: 0.5,
+        ),
+        bodyMedium: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 14,
+          fontWeight: FontWeight.w400,
+          color: AppColors.text,
+          letterSpacing: 0.25,
+        ),
+        bodySmall: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 12,
+          fontWeight: FontWeight.w400,
+          color: AppColors.subtext,
+          letterSpacing: 0.4,
+        ),
+        labelLarge: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 14,
+          fontWeight: FontWeight.w700,
+          color: AppColors.text,
+          letterSpacing: 0.1,
+        ),
+        labelMedium: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: AppColors.text,
+          letterSpacing: 0.5,
+        ),
+        labelSmall: TextStyle(
+          fontFamily: 'Nunito',
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: AppColors.subtext,
+          letterSpacing: 0.5,
+        ),
+      );
+
+  static const TextStyle sectionTitle = TextStyle(
+    fontFamily: 'Nunito',
+    fontSize: 18,
+    fontWeight: FontWeight.w800,
+    color: AppColors.text,
+  );
+
+  static const TextStyle caption = TextStyle(
+    fontFamily: 'Nunito',
+    fontSize: 12,
+    fontWeight: FontWeight.w400,
+    color: AppColors.subtext,
+    letterSpacing: 0.4,
+  );
+
+  static const TextStyle button = TextStyle(
+    fontFamily: 'Nunito',
+    fontSize: 16,
+    fontWeight: FontWeight.w700,
+    color: AppColors.onPrimary,
+    letterSpacing: 0.5,
+  );
+}

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -1,0 +1,149 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+/// Thin wrapper around [FirebaseAnalytics] that enforces no-PII policy.
+///
+/// Rules:
+/// - Never log user IDs, email addresses, names, or any PII.
+/// - Event names must be snake_case and <= 40 characters.
+/// - Parameter values must be non-PII primitives (String, num, bool).
+final class Analytics {
+  Analytics._();
+
+  static final Analytics instance = Analytics._();
+
+  final FirebaseAnalytics _analytics = FirebaseAnalytics.instance;
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  Future<void> logAppOpen() async {
+    await _analytics.logAppOpen();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Onboarding
+  // ---------------------------------------------------------------------------
+
+  Future<void> logOnboardingStarted() async {
+    await _logEvent('onboarding_started');
+  }
+
+  Future<void> logOnboardingCompleted() async {
+    await _logEvent('onboarding_completed');
+  }
+
+  Future<void> logOnboardingStepViewed({required int step}) async {
+    await _logEvent(
+      'onboarding_step_viewed',
+      parameters: {'step': step},
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Auth
+  // ---------------------------------------------------------------------------
+
+  Future<void> logSignUp() async {
+    await _analytics.logSignUp(signUpMethod: 'email');
+  }
+
+  Future<void> logLogin() async {
+    await _analytics.logLogin(loginMethod: 'email');
+  }
+
+  Future<void> logLogout() async {
+    await _logEvent('logout');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Subscription
+  // ---------------------------------------------------------------------------
+
+  Future<void> logPaywallViewed() async {
+    await _logEvent('paywall_viewed');
+  }
+
+  Future<void> logSubscriptionStarted({required String productId}) async {
+    await _logEvent(
+      'subscription_started',
+      parameters: {'product_id': productId},
+    );
+  }
+
+  Future<void> logSubscriptionRestored() async {
+    await _logEvent('subscription_restored');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Allergen tracker
+  // ---------------------------------------------------------------------------
+
+  Future<void> logAllergenLogCreated({required String allergenKey}) async {
+    await _logEvent(
+      'allergen_log_created',
+      parameters: {'allergen_key': allergenKey},
+    );
+  }
+
+  Future<void> logAllergenMarkedSafe({required String allergenKey}) async {
+    await _logEvent(
+      'allergen_marked_safe',
+      parameters: {'allergen_key': allergenKey},
+    );
+  }
+
+  Future<void> logReactionLogged({
+    required String allergenKey,
+    required String severity,
+  }) async {
+    await _logEvent(
+      'reaction_logged',
+      parameters: {
+        'allergen_key': allergenKey,
+        'severity': severity,
+      },
+    );
+  }
+
+  Future<void> logAllergenProgramCompleted() async {
+    await _logEvent('allergen_program_completed');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Recipe
+  // ---------------------------------------------------------------------------
+
+  Future<void> logRecipeViewed({required String recipeId}) async {
+    await _logEvent(
+      'recipe_viewed',
+      parameters: {'recipe_id': recipeId},
+    );
+  }
+
+  Future<void> logRecipeAddedToMealPlan({required String recipeId}) async {
+    await _logEvent(
+      'recipe_added_to_meal_plan',
+      parameters: {'recipe_id': recipeId},
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Screen tracking
+  // ---------------------------------------------------------------------------
+
+  Future<void> logScreenView({required String screenName}) async {
+    await _analytics.logScreenView(screenName: screenName);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  Future<void> _logEvent(
+    String name, {
+    Map<String, Object>? parameters,
+  }) async {
+    await _analytics.logEvent(name: name, parameters: parameters);
+  }
+}


### PR DESCRIPTION
## Summary
- `lib/src/app/themes/app_colors.dart` — full color palette (brand, semantic, allergen chip states)
- `lib/src/app/themes/app_typography.dart` — Nunito text theme (local font), all M3 slots + convenience styles
- `lib/src/app/themes/app_sizes.dart` — spacing, radius, icon, padding, component-height constants
- `lib/src/app/themes/app_theme.dart` — `AppTheme.light()` returning full `ThemeData` (M3, all component themes)
- `lib/src/app/constants/allergen_emoji.dart` — `AllergenEmoji.map` + `get()`, canonical 9-allergen sequence; sesame/soy share 🫘 per spec
- `lib/src/logging/analytics.dart` — `Analytics.instance` singleton wrapping `FirebaseAnalytics`, no PII
- `lib/src/app.dart` — wired to `AppTheme.light()`

## Test plan
- [ ] `dart analyze` passes with zero warnings ✅
- [ ] App launches and renders with Nunito font
- [ ] Primary color green (#4CAF82) visible on CTAs

Closes NIB-10