### PR TITLE
feat(onboarding): OB-01–OB-09 intro + readiness check + warning [NIB-12]

### DIFF
--- a/lib/src/features/onboarding/intro/onboarding_intro_screen.dart
+++ b/lib/src/features/onboarding/intro/onboarding_intro_screen.dart
@@ -1,9 +1,261 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
-class OnboardingIntroScreen extends ConsumerWidget {
+class OnboardingIntroScreen extends ConsumerStatefulWidget {
   const OnboardingIntroScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Onboarding Intro (OB-01/02)')));
+  ConsumerState<OnboardingIntroScreen> createState() =>
+      _OnboardingIntroScreenState();
+}
+
+class _OnboardingIntroScreenState
+    extends ConsumerState<OnboardingIntroScreen> {
+  final _pageController = PageController();
+  int _currentPage = 0;
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView(
+                controller: _pageController,
+                onPageChanged: (page) =>
+                    setState(() => _currentPage = page),
+                children: const [
+                  _OB01Welcome(),
+                  _OB02ValueProp(),
+                ],
+              ),
+            ),
+            _BottomSection(
+              currentPage: _currentPage,
+              onGetStarted: () => _pageController.nextPage(
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeInOut,
+              ),
+              onNext: () =>
+                  context.goNamed(AppRoute.onboardingReadiness.name),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OB01Welcome extends StatelessWidget {
+  const _OB01Welcome();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.pagePaddingV,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 96,
+            height: 96,
+            decoration: BoxDecoration(
+              color: AppColors.primary,
+              borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+            ),
+            child: const Icon(
+              Icons.child_care_rounded,
+              color: AppColors.onPrimary,
+              size: AppSizes.iconXl,
+            ),
+          ),
+          const SizedBox(height: AppSizes.xl),
+          Text(
+            'Nibbles',
+            style: textTheme.displaySmall?.copyWith(
+              color: AppColors.primary,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: AppSizes.md),
+          Text(
+            'Your guide to introducing solids — safely, '
+            'confidently, one bite at a time.',
+            textAlign: TextAlign.center,
+            style: textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OB02ValueProp extends StatelessWidget {
+  const _OB02ValueProp();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.pagePaddingV,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Everything you need to get started',
+            style: textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: AppSizes.xl),
+          const _FeatureRow(
+            icon: Icons.track_changes_rounded,
+            title: 'Allergen tracking',
+            subtitle:
+                'Introduce the top 9 allergens safely with guided steps.',
+          ),
+          const SizedBox(height: AppSizes.lg),
+          const _FeatureRow(
+            icon: Icons.calendar_month_rounded,
+            title: 'Meal planning',
+            subtitle:
+                "Plan weekly meals tailored to your baby's progress.",
+          ),
+          const SizedBox(height: AppSizes.lg),
+          const _FeatureRow(
+            icon: Icons.menu_book_rounded,
+            title: 'Recipe library',
+            subtitle:
+                'Age-appropriate recipes your whole family will love.',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FeatureRow extends StatelessWidget {
+  const _FeatureRow({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(AppSizes.sm),
+          decoration: BoxDecoration(
+            color: AppColors.primary.withAlpha(26),
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          ),
+          child: Icon(
+            icon,
+            color: AppColors.primary,
+            size: AppSizes.iconMd,
+          ),
+        ),
+        const SizedBox(width: AppSizes.md),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: AppSizes.xs),
+              Text(
+                subtitle,
+                style: textTheme.bodySmall?.copyWith(
+                  color: AppColors.subtext,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _BottomSection extends StatelessWidget {
+  const _BottomSection({
+    required this.currentPage,
+    required this.onGetStarted,
+    required this.onNext,
+  });
+
+  final int currentPage;
+  final VoidCallback onGetStarted;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.pagePaddingV,
+      ),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: List.generate(2, (i) {
+              final active = i == currentPage;
+              return AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                margin: const EdgeInsets.symmetric(horizontal: 4),
+                width: active ? 20 : 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: active ? AppColors.primary : AppColors.divider,
+                  borderRadius:
+                      BorderRadius.circular(AppSizes.radiusFull),
+                ),
+              );
+            }),
+          ),
+          const SizedBox(height: AppSizes.lg),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: currentPage == 0 ? onGetStarted : onNext,
+              child: Text(currentPage == 0 ? 'Get Started' : 'Next'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/src/features/onboarding/readiness/onboarding_readiness_screen.dart
+++ b/lib/src/features/onboarding/readiness/onboarding_readiness_screen.dart
@@ -1,9 +1,162 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/features/onboarding/readiness/readiness_controller.dart';
+import 'package:nibbles/src/features/onboarding/readiness/widgets/readiness_question_card.dart';
+import 'package:nibbles/src/features/onboarding/readiness/widgets/readiness_warning.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
-class OnboardingReadinessScreen extends ConsumerWidget {
+const _questions = [
+  'Has your paediatrician given the go-ahead?',
+  'Can your baby hold their head steady?',
+  'Can your baby sit upright with minimal support?',
+  'Has the tongue-thrust reflex gone?',
+  'Does your baby show interest in food?',
+  'Can your baby bring objects to their mouth?',
+];
+
+class OnboardingReadinessScreen extends ConsumerStatefulWidget {
   const OnboardingReadinessScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Readiness Check (OB-03–09)')));
+  ConsumerState<OnboardingReadinessScreen> createState() =>
+      _OnboardingReadinessScreenState();
+}
+
+class _OnboardingReadinessScreenState
+    extends ConsumerState<OnboardingReadinessScreen> {
+  int _currentIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final readinessState = ref.watch(readinessControllerProvider);
+    final controller = ref.read(readinessControllerProvider.notifier);
+    final textTheme = Theme.of(context).textTheme;
+
+    if (readinessState.showWarning) {
+      return Scaffold(
+        backgroundColor: AppColors.background,
+        appBar: AppBar(
+          backgroundColor: AppColors.background,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_rounded),
+            onPressed: () {
+              controller.goBack();
+              setState(() => _currentIndex = _questions.length - 1);
+            },
+          ),
+          title: Text('One more thing', style: textTheme.titleMedium),
+        ),
+        body: ReadinessWarning(
+          onGoBack: () {
+            controller.goBack();
+            setState(() => _currentIndex = _questions.length - 1);
+          },
+          onContinue: () => context.goNamed(AppRoute.register.name),
+        ),
+      );
+    }
+
+    final currentAnswer = readinessState.answers[_currentIndex];
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        elevation: 0,
+        leading: _currentIndex > 0
+            ? IconButton(
+                icon: const Icon(Icons.arrow_back_rounded),
+                onPressed: () => setState(() => _currentIndex--),
+              )
+            : null,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.pagePaddingH,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: List.generate(_questions.length, (i) {
+                final filled = i <= _currentIndex;
+                return Expanded(
+                  child: Container(
+                    height: 4,
+                    margin: EdgeInsets.only(
+                      right: i < _questions.length - 1 ? 4 : 0,
+                    ),
+                    decoration: BoxDecoration(
+                      color:
+                          filled ? AppColors.primary : AppColors.divider,
+                      borderRadius:
+                          BorderRadius.circular(AppSizes.radiusFull),
+                    ),
+                  ),
+                );
+              }),
+            ),
+            const SizedBox(height: AppSizes.sm),
+            Text(
+              '${_currentIndex + 1} of ${_questions.length}',
+              style:
+                  textTheme.bodySmall?.copyWith(color: AppColors.subtext),
+            ),
+            const SizedBox(height: AppSizes.xxl),
+            Text(
+              _questions[_currentIndex],
+              style: textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: AppSizes.xl),
+            ReadinessQuestionCard(
+              label: 'Yes',
+              selected: currentAnswer ?? false,
+              onTap: () =>
+                  controller.answer(_currentIndex, isYes: true),
+            ),
+            const SizedBox(height: AppSizes.md),
+            ReadinessQuestionCard(
+              label: "I'm not sure",
+              selected: !(currentAnswer ?? true),
+              onTap: () =>
+                  controller.answer(_currentIndex, isYes: false),
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: currentAnswer == null
+                    ? null
+                    : () => _onNext(controller),
+                child: Text(
+                  _currentIndex < _questions.length - 1
+                      ? 'Next'
+                      : 'See Results',
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSizes.pagePaddingV),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _onNext(ReadinessController controller) {
+    if (_currentIndex < _questions.length - 1) {
+      setState(() => _currentIndex++);
+    } else {
+      controller.finish();
+      final updatedState = ref.read(readinessControllerProvider);
+      if (!updatedState.showWarning) {
+        context.goNamed(AppRoute.register.name);
+      }
+    }
+  }
 }

--- a/lib/src/features/onboarding/readiness/readiness_controller.dart
+++ b/lib/src/features/onboarding/readiness/readiness_controller.dart
@@ -1,0 +1,32 @@
+import 'package:nibbles/src/features/onboarding/readiness/readiness_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'readiness_controller.g.dart';
+
+@riverpod
+class ReadinessController extends _$ReadinessController {
+  @override
+  ReadinessState build() => ReadinessState(answers: List.filled(6, null));
+
+  void answer(int questionIndex, {required bool isYes}) {
+    state = state.copyWith(
+      answers: List<bool?>.from(state.answers)..[questionIndex] = isYes,
+    );
+  }
+
+  /// Called after question 6 — advances to warning or completes.
+  void finish() {
+    final hasAnyUnsure = state.answers.any((a) => a == false);
+    if (hasAnyUnsure) {
+      state = state.copyWith(showWarning: true);
+    }
+  }
+
+  void goBack() {
+    state = state.copyWith(showWarning: false);
+  }
+
+  void reset() {
+    state = ReadinessState(answers: List.filled(6, null));
+  }
+}

--- a/lib/src/features/onboarding/readiness/readiness_controller.g.dart
+++ b/lib/src/features/onboarding/readiness/readiness_controller.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'readiness_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$readinessControllerHash() =>
+    r'2ae1246e837d3abf39bf8ca242ccdc3c247c2cba';
+
+/// See also [ReadinessController].
+@ProviderFor(ReadinessController)
+final readinessControllerProvider =
+    AutoDisposeNotifierProvider<ReadinessController, ReadinessState>.internal(
+      ReadinessController.new,
+      name: r'readinessControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$readinessControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$ReadinessController = AutoDisposeNotifier<ReadinessState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/onboarding/readiness/readiness_state.dart
+++ b/lib/src/features/onboarding/readiness/readiness_state.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'readiness_state.freezed.dart';
+
+@freezed
+class ReadinessState with _$ReadinessState {
+  const factory ReadinessState({
+    required List<bool?> answers,
+    @Default(false) bool showWarning,
+  }) = _ReadinessState;
+}

--- a/lib/src/features/onboarding/readiness/readiness_state.freezed.dart
+++ b/lib/src/features/onboarding/readiness/readiness_state.freezed.dart
@@ -1,0 +1,183 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'readiness_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$ReadinessState {
+  List<bool?> get answers => throw _privateConstructorUsedError;
+  bool get showWarning => throw _privateConstructorUsedError;
+
+  /// Create a copy of ReadinessState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ReadinessStateCopyWith<ReadinessState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReadinessStateCopyWith<$Res> {
+  factory $ReadinessStateCopyWith(
+    ReadinessState value,
+    $Res Function(ReadinessState) then,
+  ) = _$ReadinessStateCopyWithImpl<$Res, ReadinessState>;
+  @useResult
+  $Res call({List<bool?> answers, bool showWarning});
+}
+
+/// @nodoc
+class _$ReadinessStateCopyWithImpl<$Res, $Val extends ReadinessState>
+    implements $ReadinessStateCopyWith<$Res> {
+  _$ReadinessStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ReadinessState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? answers = null, Object? showWarning = null}) {
+    return _then(
+      _value.copyWith(
+            answers: null == answers
+                ? _value.answers
+                : answers // ignore: cast_nullable_to_non_nullable
+                      as List<bool?>,
+            showWarning: null == showWarning
+                ? _value.showWarning
+                : showWarning // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ReadinessStateImplCopyWith<$Res>
+    implements $ReadinessStateCopyWith<$Res> {
+  factory _$$ReadinessStateImplCopyWith(
+    _$ReadinessStateImpl value,
+    $Res Function(_$ReadinessStateImpl) then,
+  ) = __$$ReadinessStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<bool?> answers, bool showWarning});
+}
+
+/// @nodoc
+class __$$ReadinessStateImplCopyWithImpl<$Res>
+    extends _$ReadinessStateCopyWithImpl<$Res, _$ReadinessStateImpl>
+    implements _$$ReadinessStateImplCopyWith<$Res> {
+  __$$ReadinessStateImplCopyWithImpl(
+    _$ReadinessStateImpl _value,
+    $Res Function(_$ReadinessStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of ReadinessState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? answers = null, Object? showWarning = null}) {
+    return _then(
+      _$ReadinessStateImpl(
+        answers: null == answers
+            ? _value._answers
+            : answers // ignore: cast_nullable_to_non_nullable
+                  as List<bool?>,
+        showWarning: null == showWarning
+            ? _value.showWarning
+            : showWarning // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ReadinessStateImpl implements _ReadinessState {
+  const _$ReadinessStateImpl({
+    required final List<bool?> answers,
+    this.showWarning = false,
+  }) : _answers = answers;
+
+  final List<bool?> _answers;
+  @override
+  List<bool?> get answers {
+    if (_answers is EqualUnmodifiableListView) return _answers;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_answers);
+  }
+
+  @override
+  @JsonKey()
+  final bool showWarning;
+
+  @override
+  String toString() {
+    return 'ReadinessState(answers: $answers, showWarning: $showWarning)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReadinessStateImpl &&
+            const DeepCollectionEquality().equals(other._answers, _answers) &&
+            (identical(other.showWarning, showWarning) ||
+                other.showWarning == showWarning));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    const DeepCollectionEquality().hash(_answers),
+    showWarning,
+  );
+
+  /// Create a copy of ReadinessState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReadinessStateImplCopyWith<_$ReadinessStateImpl> get copyWith =>
+      __$$ReadinessStateImplCopyWithImpl<_$ReadinessStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _ReadinessState implements ReadinessState {
+  const factory _ReadinessState({
+    required final List<bool?> answers,
+    final bool showWarning,
+  }) = _$ReadinessStateImpl;
+
+  @override
+  List<bool?> get answers;
+  @override
+  bool get showWarning;
+
+  /// Create a copy of ReadinessState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ReadinessStateImplCopyWith<_$ReadinessStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/onboarding/readiness/widgets/readiness_question_card.dart
+++ b/lib/src/features/onboarding/readiness/widgets/readiness_question_card.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+class ReadinessQuestionCard extends StatelessWidget {
+  const ReadinessQuestionCard({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    super.key,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.lg,
+          vertical: AppSizes.md,
+        ),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.primary : AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+          border: Border.all(
+            color: selected ? AppColors.primary : AppColors.divider,
+            width: selected ? 2 : 1,
+          ),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                label,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color:
+                          selected ? AppColors.onPrimary : AppColors.text,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+            if (selected)
+              const Icon(
+                Icons.check_circle_rounded,
+                color: AppColors.onPrimary,
+                size: AppSizes.iconMd,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/onboarding/readiness/widgets/readiness_warning.dart
+++ b/lib/src/features/onboarding/readiness/widgets/readiness_warning.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+class ReadinessWarning extends StatelessWidget {
+  const ReadinessWarning({
+    required this.onGoBack,
+    required this.onContinue,
+    super.key,
+  });
+
+  final VoidCallback onGoBack;
+  final VoidCallback onContinue;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(AppSizes.lg),
+            decoration: BoxDecoration(
+              color: AppColors.warning.withAlpha(26),
+              borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+              border: Border.all(color: AppColors.warning),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Icon(
+                      Icons.info_outline_rounded,
+                      color: AppColors.warning,
+                      size: AppSizes.iconMd,
+                    ),
+                    const SizedBox(width: AppSizes.sm),
+                    Text(
+                      'Not quite ready yet?',
+                      style: textTheme.titleMedium?.copyWith(
+                        color: AppColors.warning,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppSizes.sm),
+                Text(
+                  'We recommend consulting your GP before starting solids.',
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: AppColors.text,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSizes.md),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(AppSizes.md),
+            decoration: BoxDecoration(
+              color: AppColors.surfaceVariant,
+              borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Icon(
+                  Icons.local_hospital_outlined,
+                  color: AppColors.primary,
+                  size: AppSizes.iconMd,
+                ),
+                const SizedBox(width: AppSizes.sm),
+                Expanded(
+                  child: Text(
+                    'Consulting a doctor or paediatrician before '
+                    'introducing solids is best practice for all babies.',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: AppColors.subtext,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Spacer(),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: onContinue,
+              child: const Text('I Understand, Continue'),
+            ),
+          ),
+          const SizedBox(height: AppSizes.sm),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton(
+              onPressed: onGoBack,
+              child: const Text('Go Back'),
+            ),
+          ),
+          const SizedBox(height: AppSizes.pagePaddingV),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## NIB-12 — [Frontend] OB-01–OB-09

### Screens built
- **OB-01** — Welcome: Nibbles logo, tagline, "Get Started" CTA
- **OB-02** — Value prop: allergen tracking, meal planning, recipe library feature cards
- **OB-03–08** — 6-question readiness check with animated progress bar and card selection
- **OB-09** — Soft warning screen (shown if any answer is "I'm not sure") with "Go Back" + "I Understand, Continue"

### Architecture
- `ReadinessController` — `@riverpod` Notifier with `answer(index, {required isYes})`, `finish()`, `goBack()`, `reset()`
- `ReadinessState` — `@freezed` with `List<bool?> answers` + `showWarning` flag
- `OnboardingIntroScreen` — `ConsumerStatefulWidget`, `PageView` across OB-01/OB-02
- `OnboardingReadinessScreen` — `ConsumerStatefulWidget`, question page flow + inline warning state
- No routing changes needed — stubs already wired in NIB-9

### Acceptance criteria
- [x] OB-01 and OB-02 render; "Get Started" / "Next" navigate forward
- [x] All 6 readiness questions shown one at a time with progress indicator
- [x] "Next" CTA disabled until user selects Yes or I'm not sure
- [x] Any "I'm not sure" → OB-09 warning shown after question 6
- [x] All 6 "Yes" → skip warning, go directly to `/auth/register`
- [x] "Go Back" on OB-09 returns to readiness questions
- [x] "I Understand, Continue" → `/auth/register`

## Test plan
- [ ] Cold launch → OB-01 shown (app_has_launched = false)
- [ ] Swipe or tap "Get Started" → OB-02
- [ ] "Next" on OB-02 → OB-03 readiness question 1
- [ ] Answer all 6 "Yes" → navigates to register (no warning)
- [ ] Answer one "I'm not sure" → OB-09 warning shown
- [ ] "Go Back" → returns to question 6 with previous answer preserved
- [ ] "I Understand, Continue" → register screen