### PR TITLE
feat(auth): AU-02 forgot password + AU-03 reset password deep link [NIB-14]

### DIFF
--- a/lib/src/features/auth/forgot_password/forgot_password_controller.dart
+++ b/lib/src/features/auth/forgot_password/forgot_password_controller.dart
@@ -1,0 +1,44 @@
+import 'package:nibbles/src/common/domain/formz/email_input.dart';
+import 'package:nibbles/src/common/services/auth_service.dart';
+import 'package:nibbles/src/features/auth/forgot_password/forgot_password_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'forgot_password_controller.g.dart';
+
+@riverpod
+class ForgotPasswordController extends _$ForgotPasswordController {
+  @override
+  ForgotPasswordState build() => const ForgotPasswordState();
+
+  void updateEmail(String value) {
+    state = state.copyWith(
+      email: EmailInput.dirty(value),
+      errorMessage: null,
+    );
+  }
+
+  Future<void> submit() async {
+    final email = EmailInput.dirty(state.email.value);
+    if (email.isNotValid) {
+      state = state.copyWith(
+        email: email,
+        errorMessage: 'Please enter a valid email address.',
+      );
+      return;
+    }
+
+    state = state.copyWith(isLoading: true, errorMessage: null);
+
+    final result = await ref
+        .read(authServiceProvider.notifier)
+        .resetPassword(state.email.value);
+
+    result.when(
+      success: (_) => state = state.copyWith(isLoading: false, sent: true),
+      failure: (error) => state = state.copyWith(
+        isLoading: false,
+        errorMessage: error.message,
+      ),
+    );
+  }
+}

--- a/lib/src/features/auth/forgot_password/forgot_password_controller.g.dart
+++ b/lib/src/features/auth/forgot_password/forgot_password_controller.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'forgot_password_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$forgotPasswordControllerHash() =>
+    r'3a957daf0d3c1081d26fda78661f9abb1eaa44ed';
+
+/// See also [ForgotPasswordController].
+@ProviderFor(ForgotPasswordController)
+final forgotPasswordControllerProvider =
+    AutoDisposeNotifierProvider<
+      ForgotPasswordController,
+      ForgotPasswordState
+    >.internal(
+      ForgotPasswordController.new,
+      name: r'forgotPasswordControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$forgotPasswordControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$ForgotPasswordController = AutoDisposeNotifier<ForgotPasswordState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/auth/forgot_password/forgot_password_screen.dart
+++ b/lib/src/features/auth/forgot_password/forgot_password_screen.dart
@@ -1,9 +1,160 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/features/auth/forgot_password/forgot_password_controller.dart';
+import 'package:nibbles/src/features/auth/forgot_password/forgot_password_state.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 class ForgotPasswordScreen extends ConsumerWidget {
   const ForgotPasswordScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Forgot Password')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(forgotPasswordControllerProvider);
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_rounded),
+          onPressed: () => context.canPop()
+              ? context.pop()
+              : context.goNamed(AppRoute.login.name),
+        ),
+        title: const Text('Forgot Password'),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+          ),
+          child: state.sent
+              ? _ConfirmationView(
+                  onBackToLogin: () =>
+                      context.goNamed(AppRoute.login.name),
+                )
+              : _InputView(
+                  state: state,
+                  onEmailChanged: ref
+                      .read(forgotPasswordControllerProvider.notifier)
+                      .updateEmail,
+                  onSubmit: ref
+                      .read(forgotPasswordControllerProvider.notifier)
+                      .submit,
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InputView extends StatelessWidget {
+  const _InputView({
+    required this.state,
+    required this.onEmailChanged,
+    required this.onSubmit,
+  });
+
+  final ForgotPasswordState state;
+  final ValueChanged<String> onEmailChanged;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: AppSizes.xxl),
+        Text(
+          'Reset your password',
+          style: textTheme.headlineLarge,
+        ),
+        const SizedBox(height: AppSizes.sm),
+        Text(
+          "Enter your email and we'll send you a reset link.",
+          style: textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
+        ),
+        const SizedBox(height: AppSizes.xl),
+        TextField(
+          key: const Key('forgot_email_field'),
+          onChanged: onEmailChanged,
+          keyboardType: TextInputType.emailAddress,
+          decoration: InputDecoration(
+            labelText: 'Email',
+            errorText: state.email.isNotValid &&
+                    state.email.value.isNotEmpty
+                ? 'Please enter a valid email.'
+                : null,
+          ),
+        ),
+        if (state.errorMessage != null) ...[
+          const SizedBox(height: AppSizes.sm),
+          Text(
+            state.errorMessage!,
+            style: textTheme.bodySmall?.copyWith(color: AppColors.error),
+          ),
+        ],
+        const SizedBox(height: AppSizes.xl),
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton(
+            key: const Key('forgot_submit_button'),
+            onPressed: state.isLoading ? null : onSubmit,
+            child: state.isLoading
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: AppColors.onPrimary,
+                    ),
+                  )
+                : const Text('Send Reset Link'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ConfirmationView extends StatelessWidget {
+  const _ConfirmationView({required this.onBackToLogin});
+
+  final VoidCallback onBackToLogin;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: AppSizes.xxl),
+        const Icon(
+          Icons.mark_email_read_outlined,
+          size: AppSizes.iconXl,
+          color: AppColors.primary,
+        ),
+        const SizedBox(height: AppSizes.lg),
+        Text('Check your email', style: textTheme.headlineLarge),
+        const SizedBox(height: AppSizes.sm),
+        Text(
+          'Check your email for a reset link.',
+          style: textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
+        ),
+        const SizedBox(height: AppSizes.xl),
+        Center(
+          child: TextButton(
+            key: const Key('forgot_back_to_login'),
+            onPressed: onBackToLogin,
+            child: const Text('Back to Login'),
+          ),
+        ),
+      ],
+    );
+  }
 }

--- a/lib/src/features/auth/forgot_password/forgot_password_state.dart
+++ b/lib/src/features/auth/forgot_password/forgot_password_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/formz/email_input.dart';
+
+part 'forgot_password_state.freezed.dart';
+
+@freezed
+class ForgotPasswordState with _$ForgotPasswordState {
+  const factory ForgotPasswordState({
+    @Default(EmailInput.pure()) EmailInput email,
+    @Default(false) bool isLoading,
+    String? errorMessage,
+    @Default(false) bool sent,
+  }) = _ForgotPasswordState;
+}

--- a/lib/src/features/auth/forgot_password/forgot_password_state.freezed.dart
+++ b/lib/src/features/auth/forgot_password/forgot_password_state.freezed.dart
@@ -1,0 +1,229 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'forgot_password_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$ForgotPasswordState {
+  EmailInput get email => throw _privateConstructorUsedError;
+  bool get isLoading => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+  bool get sent => throw _privateConstructorUsedError;
+
+  /// Create a copy of ForgotPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ForgotPasswordStateCopyWith<ForgotPasswordState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ForgotPasswordStateCopyWith<$Res> {
+  factory $ForgotPasswordStateCopyWith(
+    ForgotPasswordState value,
+    $Res Function(ForgotPasswordState) then,
+  ) = _$ForgotPasswordStateCopyWithImpl<$Res, ForgotPasswordState>;
+  @useResult
+  $Res call({
+    EmailInput email,
+    bool isLoading,
+    String? errorMessage,
+    bool sent,
+  });
+}
+
+/// @nodoc
+class _$ForgotPasswordStateCopyWithImpl<$Res, $Val extends ForgotPasswordState>
+    implements $ForgotPasswordStateCopyWith<$Res> {
+  _$ForgotPasswordStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ForgotPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+    Object? sent = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            email: null == email
+                ? _value.email
+                : email // ignore: cast_nullable_to_non_nullable
+                      as EmailInput,
+            isLoading: null == isLoading
+                ? _value.isLoading
+                : isLoading // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            sent: null == sent
+                ? _value.sent
+                : sent // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ForgotPasswordStateImplCopyWith<$Res>
+    implements $ForgotPasswordStateCopyWith<$Res> {
+  factory _$$ForgotPasswordStateImplCopyWith(
+    _$ForgotPasswordStateImpl value,
+    $Res Function(_$ForgotPasswordStateImpl) then,
+  ) = __$$ForgotPasswordStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    EmailInput email,
+    bool isLoading,
+    String? errorMessage,
+    bool sent,
+  });
+}
+
+/// @nodoc
+class __$$ForgotPasswordStateImplCopyWithImpl<$Res>
+    extends _$ForgotPasswordStateCopyWithImpl<$Res, _$ForgotPasswordStateImpl>
+    implements _$$ForgotPasswordStateImplCopyWith<$Res> {
+  __$$ForgotPasswordStateImplCopyWithImpl(
+    _$ForgotPasswordStateImpl _value,
+    $Res Function(_$ForgotPasswordStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of ForgotPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+    Object? sent = null,
+  }) {
+    return _then(
+      _$ForgotPasswordStateImpl(
+        email: null == email
+            ? _value.email
+            : email // ignore: cast_nullable_to_non_nullable
+                  as EmailInput,
+        isLoading: null == isLoading
+            ? _value.isLoading
+            : isLoading // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        sent: null == sent
+            ? _value.sent
+            : sent // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ForgotPasswordStateImpl implements _ForgotPasswordState {
+  const _$ForgotPasswordStateImpl({
+    this.email = const EmailInput.pure(),
+    this.isLoading = false,
+    this.errorMessage,
+    this.sent = false,
+  });
+
+  @override
+  @JsonKey()
+  final EmailInput email;
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  final String? errorMessage;
+  @override
+  @JsonKey()
+  final bool sent;
+
+  @override
+  String toString() {
+    return 'ForgotPasswordState(email: $email, isLoading: $isLoading, errorMessage: $errorMessage, sent: $sent)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ForgotPasswordStateImpl &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage) &&
+            (identical(other.sent, sent) || other.sent == sent));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, email, isLoading, errorMessage, sent);
+
+  /// Create a copy of ForgotPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ForgotPasswordStateImplCopyWith<_$ForgotPasswordStateImpl> get copyWith =>
+      __$$ForgotPasswordStateImplCopyWithImpl<_$ForgotPasswordStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _ForgotPasswordState implements ForgotPasswordState {
+  const factory _ForgotPasswordState({
+    final EmailInput email,
+    final bool isLoading,
+    final String? errorMessage,
+    final bool sent,
+  }) = _$ForgotPasswordStateImpl;
+
+  @override
+  EmailInput get email;
+  @override
+  bool get isLoading;
+  @override
+  String? get errorMessage;
+  @override
+  bool get sent;
+
+  /// Create a copy of ForgotPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ForgotPasswordStateImplCopyWith<_$ForgotPasswordStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/auth/reset_password/reset_password_controller.dart
+++ b/lib/src/features/auth/reset_password/reset_password_controller.dart
@@ -1,0 +1,56 @@
+import 'package:nibbles/src/common/domain/formz/password_input.dart';
+import 'package:nibbles/src/common/services/auth_service.dart';
+import 'package:nibbles/src/features/auth/reset_password/reset_password_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'reset_password_controller.g.dart';
+
+@riverpod
+class ResetPasswordController extends _$ResetPasswordController {
+  @override
+  ResetPasswordState build() => const ResetPasswordState();
+
+  void updatePassword(String value) {
+    state = state.copyWith(
+      password: PasswordInput.dirty(value),
+      errorMessage: null,
+    );
+  }
+
+  void updateConfirmPassword(String value) {
+    state = state.copyWith(
+      confirmPassword: value,
+      errorMessage: null,
+    );
+  }
+
+  Future<void> submit() async {
+    final password = PasswordInput.dirty(state.password.value);
+    if (password.isNotValid) {
+      state = state.copyWith(
+        password: password,
+        errorMessage: 'Password must be at least 8 characters.',
+      );
+      return;
+    }
+    if (!state.passwordsMatch) {
+      state = state.copyWith(errorMessage: 'Passwords do not match.');
+      return;
+    }
+
+    state = state.copyWith(isLoading: true, errorMessage: null);
+
+    final result = await ref
+        .read(authServiceProvider.notifier)
+        .updatePassword(state.password.value);
+
+    result.when(
+      success: (_) =>
+          state = state.copyWith(isLoading: false, success: true),
+      failure: (error) => state = state.copyWith(
+        isLoading: false,
+        errorMessage: error.message,
+      ),
+    );
+  }
+}

--- a/lib/src/features/auth/reset_password/reset_password_controller.g.dart
+++ b/lib/src/features/auth/reset_password/reset_password_controller.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'reset_password_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$resetPasswordControllerHash() =>
+    r'272b87c7b675fe94e674309f9449a10bd1c75b8f';
+
+/// See also [ResetPasswordController].
+@ProviderFor(ResetPasswordController)
+final resetPasswordControllerProvider =
+    AutoDisposeNotifierProvider<
+      ResetPasswordController,
+      ResetPasswordState
+    >.internal(
+      ResetPasswordController.new,
+      name: r'resetPasswordControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$resetPasswordControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$ResetPasswordController = AutoDisposeNotifier<ResetPasswordState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/auth/reset_password/reset_password_screen.dart
+++ b/lib/src/features/auth/reset_password/reset_password_screen.dart
@@ -1,9 +1,121 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/features/auth/reset_password/reset_password_controller.dart';
+import 'package:nibbles/src/features/auth/reset_password/reset_password_state.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 class ResetPasswordScreen extends ConsumerWidget {
   const ResetPasswordScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Reset Password (AU-03)')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(resetPasswordControllerProvider);
+    final textTheme = Theme.of(context).textTheme;
+
+    ref.listen(
+      resetPasswordControllerProvider,
+      (_, ResetPasswordState next) {
+        if (next.success) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Password updated. Please log in.'),
+            ),
+          );
+          context.goNamed(AppRoute.login.name);
+        }
+      },
+    );
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        elevation: 0,
+        title: const Text('Set New Password'),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: AppSizes.xxl),
+              Text('Create a new password', style: textTheme.headlineLarge),
+              const SizedBox(height: AppSizes.sm),
+              Text(
+                'Your new password must be at least 8 characters.',
+                style:
+                    textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
+              ),
+              const SizedBox(height: AppSizes.xl),
+              TextField(
+                key: const Key('reset_password_new_field'),
+                onChanged: ref
+                    .read(resetPasswordControllerProvider.notifier)
+                    .updatePassword,
+                obscureText: true,
+                decoration: InputDecoration(
+                  labelText: 'New password',
+                  errorText: state.password.isNotValid &&
+                          state.password.value.isNotEmpty
+                      ? 'Password must be at least 8 characters.'
+                      : null,
+                ),
+              ),
+              const SizedBox(height: AppSizes.md),
+              TextField(
+                key: const Key('reset_password_confirm_field'),
+                onChanged: ref
+                    .read(resetPasswordControllerProvider.notifier)
+                    .updateConfirmPassword,
+                obscureText: true,
+                decoration: InputDecoration(
+                  labelText: 'Confirm password',
+                  errorText: state.confirmPassword.isNotEmpty &&
+                          !state.passwordsMatch
+                      ? 'Passwords do not match.'
+                      : null,
+                ),
+              ),
+              if (state.errorMessage != null) ...[
+                const SizedBox(height: AppSizes.sm),
+                Text(
+                  state.errorMessage!,
+                  style: textTheme.bodySmall
+                      ?.copyWith(color: AppColors.error),
+                ),
+              ],
+              const SizedBox(height: AppSizes.xl),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  key: const Key('reset_password_submit_button'),
+                  onPressed: state.isLoading ? null : () {
+                    ref
+                        .read(resetPasswordControllerProvider.notifier)
+                        .submit();
+                  },
+                  child: state.isLoading
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: AppColors.onPrimary,
+                          ),
+                        )
+                      : const Text('Confirm'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/src/features/auth/reset_password/reset_password_state.dart
+++ b/lib/src/features/auth/reset_password/reset_password_state.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/formz/password_input.dart';
+
+part 'reset_password_state.freezed.dart';
+
+@freezed
+class ResetPasswordState with _$ResetPasswordState {
+  const factory ResetPasswordState({
+    @Default(PasswordInput.pure()) PasswordInput password,
+    @Default('') String confirmPassword,
+    @Default(false) bool isLoading,
+    String? errorMessage,
+    @Default(false) bool success,
+  }) = _ResetPasswordState;
+
+  const ResetPasswordState._();
+
+  bool get passwordsMatch =>
+      password.value == confirmPassword && confirmPassword.isNotEmpty;
+}

--- a/lib/src/features/auth/reset_password/reset_password_state.freezed.dart
+++ b/lib/src/features/auth/reset_password/reset_password_state.freezed.dart
@@ -1,0 +1,259 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reset_password_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$ResetPasswordState {
+  PasswordInput get password => throw _privateConstructorUsedError;
+  String get confirmPassword => throw _privateConstructorUsedError;
+  bool get isLoading => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+  bool get success => throw _privateConstructorUsedError;
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ResetPasswordStateCopyWith<ResetPasswordState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ResetPasswordStateCopyWith<$Res> {
+  factory $ResetPasswordStateCopyWith(
+    ResetPasswordState value,
+    $Res Function(ResetPasswordState) then,
+  ) = _$ResetPasswordStateCopyWithImpl<$Res, ResetPasswordState>;
+  @useResult
+  $Res call({
+    PasswordInput password,
+    String confirmPassword,
+    bool isLoading,
+    String? errorMessage,
+    bool success,
+  });
+}
+
+/// @nodoc
+class _$ResetPasswordStateCopyWithImpl<$Res, $Val extends ResetPasswordState>
+    implements $ResetPasswordStateCopyWith<$Res> {
+  _$ResetPasswordStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? password = null,
+    Object? confirmPassword = null,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+    Object? success = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            password: null == password
+                ? _value.password
+                : password // ignore: cast_nullable_to_non_nullable
+                      as PasswordInput,
+            confirmPassword: null == confirmPassword
+                ? _value.confirmPassword
+                : confirmPassword // ignore: cast_nullable_to_non_nullable
+                      as String,
+            isLoading: null == isLoading
+                ? _value.isLoading
+                : isLoading // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            success: null == success
+                ? _value.success
+                : success // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ResetPasswordStateImplCopyWith<$Res>
+    implements $ResetPasswordStateCopyWith<$Res> {
+  factory _$$ResetPasswordStateImplCopyWith(
+    _$ResetPasswordStateImpl value,
+    $Res Function(_$ResetPasswordStateImpl) then,
+  ) = __$$ResetPasswordStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    PasswordInput password,
+    String confirmPassword,
+    bool isLoading,
+    String? errorMessage,
+    bool success,
+  });
+}
+
+/// @nodoc
+class __$$ResetPasswordStateImplCopyWithImpl<$Res>
+    extends _$ResetPasswordStateCopyWithImpl<$Res, _$ResetPasswordStateImpl>
+    implements _$$ResetPasswordStateImplCopyWith<$Res> {
+  __$$ResetPasswordStateImplCopyWithImpl(
+    _$ResetPasswordStateImpl _value,
+    $Res Function(_$ResetPasswordStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? password = null,
+    Object? confirmPassword = null,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+    Object? success = null,
+  }) {
+    return _then(
+      _$ResetPasswordStateImpl(
+        password: null == password
+            ? _value.password
+            : password // ignore: cast_nullable_to_non_nullable
+                  as PasswordInput,
+        confirmPassword: null == confirmPassword
+            ? _value.confirmPassword
+            : confirmPassword // ignore: cast_nullable_to_non_nullable
+                  as String,
+        isLoading: null == isLoading
+            ? _value.isLoading
+            : isLoading // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        success: null == success
+            ? _value.success
+            : success // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ResetPasswordStateImpl extends _ResetPasswordState {
+  const _$ResetPasswordStateImpl({
+    this.password = const PasswordInput.pure(),
+    this.confirmPassword = '',
+    this.isLoading = false,
+    this.errorMessage,
+    this.success = false,
+  }) : super._();
+
+  @override
+  @JsonKey()
+  final PasswordInput password;
+  @override
+  @JsonKey()
+  final String confirmPassword;
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  final String? errorMessage;
+  @override
+  @JsonKey()
+  final bool success;
+
+  @override
+  String toString() {
+    return 'ResetPasswordState(password: $password, confirmPassword: $confirmPassword, isLoading: $isLoading, errorMessage: $errorMessage, success: $success)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ResetPasswordStateImpl &&
+            (identical(other.password, password) ||
+                other.password == password) &&
+            (identical(other.confirmPassword, confirmPassword) ||
+                other.confirmPassword == confirmPassword) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage) &&
+            (identical(other.success, success) || other.success == success));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    password,
+    confirmPassword,
+    isLoading,
+    errorMessage,
+    success,
+  );
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ResetPasswordStateImplCopyWith<_$ResetPasswordStateImpl> get copyWith =>
+      __$$ResetPasswordStateImplCopyWithImpl<_$ResetPasswordStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _ResetPasswordState extends ResetPasswordState {
+  const factory _ResetPasswordState({
+    final PasswordInput password,
+    final String confirmPassword,
+    final bool isLoading,
+    final String? errorMessage,
+    final bool success,
+  }) = _$ResetPasswordStateImpl;
+  const _ResetPasswordState._() : super._();
+
+  @override
+  PasswordInput get password;
+  @override
+  String get confirmPassword;
+  @override
+  bool get isLoading;
+  @override
+  String? get errorMessage;
+  @override
+  bool get success;
+
+  /// Create a copy of ResetPasswordState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ResetPasswordStateImplCopyWith<_$ResetPasswordStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}


### PR DESCRIPTION
## NIB-14 — AU-02 Forgot Password + AU-03 Set New Password

### AU-02 (`/auth/forgot-password`)
- Two states via `ForgotPasswordState.sent` — input and confirmation
- Input: email field + "Send Reset Link" → `AuthService.resetPassword(email)`
- Confirmation: "Check your email for a reset link." + "Back to Login"
- P1 inline error on failure

### AU-03 (`/auth/reset-password`)
- Shown when deep link fires `AuthChangeEvent.passwordRecovery` (routing external)
- New password (PasswordInput formz, min 8 chars) + confirm password fields
- Validates match before `AuthService.updatePassword(newPassword)`
- Success: SnackBar "Password updated. Please log in." → `/auth/login` via `ref.listen`
- Inline error on failure

## Test plan
- [ ] AU-02: email + "Send Reset Link" → confirmation state shown
- [ ] AU-02: invalid email → inline error before API call
- [ ] AU-02: "Back to Login" → navigates to login
- [ ] AU-03: valid passwords match → updateUser called → toast + redirect
- [ ] AU-03: password < 8 chars → inline error
- [ ] AU-03: passwords don't match → inline error