### PR TITLE
feat(auth): OB-10 sign up + OB-11–13 baby setup + AU-01 login [NIB-13]

### DIFF
--- a/lib/src/features/auth/login/login_controller.dart
+++ b/lib/src/features/auth/login/login_controller.dart
@@ -1,0 +1,45 @@
+import 'package:nibbles/src/common/domain/formz/email_input.dart';
+import 'package:nibbles/src/common/domain/formz/password_input.dart';
+import 'package:nibbles/src/common/services/auth_service.dart';
+import 'package:nibbles/src/features/auth/login/login_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'login_controller.g.dart';
+
+@riverpod
+class LoginController extends _$LoginController {
+  @override
+  LoginState build() => const LoginState();
+
+  void updateEmail(String value) {
+    state = state.copyWith(
+      email: EmailInput.dirty(value),
+      errorMessage: null,
+    );
+  }
+
+  void updatePassword(String value) {
+    state = state.copyWith(
+      password: PasswordInput.dirty(value),
+      errorMessage: null,
+    );
+  }
+
+  Future<void> submit() async {
+    state = state.copyWith(isLoading: true, errorMessage: null);
+
+    final result = await ref.read(authServiceProvider.notifier).signIn(
+          state.email.value,
+          state.password.value,
+        );
+
+    result.when(
+      success: (_) => state = state.copyWith(isLoading: false),
+      failure: (error) => state = state.copyWith(
+        isLoading: false,
+        errorMessage: error.message,
+      ),
+    );
+    // On success: GoRouter redirect picks up authServiceProvider state change
+  }
+}

--- a/lib/src/features/auth/login/login_controller.g.dart
+++ b/lib/src/features/auth/login/login_controller.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'login_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$loginControllerHash() => r'a6a266d22d99177a03d88e30d694d64167974e44';
+
+/// See also [LoginController].
+@ProviderFor(LoginController)
+final loginControllerProvider =
+    AutoDisposeNotifierProvider<LoginController, LoginState>.internal(
+      LoginController.new,
+      name: r'loginControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$loginControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$LoginController = AutoDisposeNotifier<LoginState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/auth/login/login_screen.dart
+++ b/lib/src/features/auth/login/login_screen.dart
@@ -1,9 +1,119 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/features/auth/login/login_controller.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 class LoginScreen extends ConsumerWidget {
   const LoginScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Login')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(loginControllerProvider);
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+            vertical: AppSizes.pagePaddingV,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: AppSizes.xl),
+              Text('Welcome back', style: textTheme.headlineLarge),
+              const SizedBox(height: AppSizes.sm),
+              Text(
+                'Log in to continue.',
+                style:
+                    textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
+              ),
+              const SizedBox(height: AppSizes.xl),
+              TextField(
+                key: const Key('login_email_field'),
+                onChanged: ref
+                    .read(loginControllerProvider.notifier)
+                    .updateEmail,
+                keyboardType: TextInputType.emailAddress,
+                decoration: InputDecoration(
+                  labelText: 'Email',
+                  errorText:
+                      state.email.isNotValid && state.email.value.isNotEmpty
+                          ? 'Please enter a valid email.'
+                          : null,
+                ),
+              ),
+              const SizedBox(height: AppSizes.md),
+              TextField(
+                key: const Key('login_password_field'),
+                onChanged: ref
+                    .read(loginControllerProvider.notifier)
+                    .updatePassword,
+                obscureText: true,
+                decoration: const InputDecoration(labelText: 'Password'),
+              ),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  onPressed: () =>
+                      context.goNamed(AppRoute.forgotPassword.name),
+                  child: const Text('Forgot your password?'),
+                ),
+              ),
+              if (state.errorMessage != null) ...[
+                const SizedBox(height: AppSizes.xs),
+                Text(
+                  state.errorMessage!,
+                  style:
+                      textTheme.bodySmall?.copyWith(color: AppColors.error),
+                ),
+              ],
+              const SizedBox(height: AppSizes.lg),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  key: const Key('login_submit_button'),
+                  onPressed: state.isLoading
+                      ? null
+                      : ref
+                          .read(loginControllerProvider.notifier)
+                          .submit,
+                  child: state.isLoading
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: AppColors.onPrimary,
+                          ),
+                        )
+                      : const Text('Log In'),
+                ),
+              ),
+              const SizedBox(height: AppSizes.md),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    "Don't have an account?",
+                    style: textTheme.bodySmall,
+                  ),
+                  TextButton(
+                    onPressed: () =>
+                        context.goNamed(AppRoute.register.name),
+                    child: const Text('Sign Up'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/src/features/auth/login/login_state.dart
+++ b/lib/src/features/auth/login/login_state.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/formz/email_input.dart';
+import 'package:nibbles/src/common/domain/formz/password_input.dart';
+
+part 'login_state.freezed.dart';
+
+@freezed
+class LoginState with _$LoginState {
+  const factory LoginState({
+    @Default(EmailInput.pure()) EmailInput email,
+    @Default(PasswordInput.pure()) PasswordInput password,
+    @Default(false) bool isLoading,
+    String? errorMessage,
+  }) = _LoginState;
+}

--- a/lib/src/features/auth/login/login_state.freezed.dart
+++ b/lib/src/features/auth/login/login_state.freezed.dart
@@ -1,0 +1,227 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'login_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$LoginState {
+  EmailInput get email => throw _privateConstructorUsedError;
+  PasswordInput get password => throw _privateConstructorUsedError;
+  bool get isLoading => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+
+  /// Create a copy of LoginState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $LoginStateCopyWith<LoginState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LoginStateCopyWith<$Res> {
+  factory $LoginStateCopyWith(
+    LoginState value,
+    $Res Function(LoginState) then,
+  ) = _$LoginStateCopyWithImpl<$Res, LoginState>;
+  @useResult
+  $Res call({
+    EmailInput email,
+    PasswordInput password,
+    bool isLoading,
+    String? errorMessage,
+  });
+}
+
+/// @nodoc
+class _$LoginStateCopyWithImpl<$Res, $Val extends LoginState>
+    implements $LoginStateCopyWith<$Res> {
+  _$LoginStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of LoginState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+    Object? password = null,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            email: null == email
+                ? _value.email
+                : email // ignore: cast_nullable_to_non_nullable
+                      as EmailInput,
+            password: null == password
+                ? _value.password
+                : password // ignore: cast_nullable_to_non_nullable
+                      as PasswordInput,
+            isLoading: null == isLoading
+                ? _value.isLoading
+                : isLoading // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$LoginStateImplCopyWith<$Res>
+    implements $LoginStateCopyWith<$Res> {
+  factory _$$LoginStateImplCopyWith(
+    _$LoginStateImpl value,
+    $Res Function(_$LoginStateImpl) then,
+  ) = __$$LoginStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    EmailInput email,
+    PasswordInput password,
+    bool isLoading,
+    String? errorMessage,
+  });
+}
+
+/// @nodoc
+class __$$LoginStateImplCopyWithImpl<$Res>
+    extends _$LoginStateCopyWithImpl<$Res, _$LoginStateImpl>
+    implements _$$LoginStateImplCopyWith<$Res> {
+  __$$LoginStateImplCopyWithImpl(
+    _$LoginStateImpl _value,
+    $Res Function(_$LoginStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of LoginState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? email = null,
+    Object? password = null,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _$LoginStateImpl(
+        email: null == email
+            ? _value.email
+            : email // ignore: cast_nullable_to_non_nullable
+                  as EmailInput,
+        password: null == password
+            ? _value.password
+            : password // ignore: cast_nullable_to_non_nullable
+                  as PasswordInput,
+        isLoading: null == isLoading
+            ? _value.isLoading
+            : isLoading // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$LoginStateImpl implements _LoginState {
+  const _$LoginStateImpl({
+    this.email = const EmailInput.pure(),
+    this.password = const PasswordInput.pure(),
+    this.isLoading = false,
+    this.errorMessage,
+  });
+
+  @override
+  @JsonKey()
+  final EmailInput email;
+  @override
+  @JsonKey()
+  final PasswordInput password;
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  final String? errorMessage;
+
+  @override
+  String toString() {
+    return 'LoginState(email: $email, password: $password, isLoading: $isLoading, errorMessage: $errorMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LoginStateImpl &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.password, password) ||
+                other.password == password) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, email, password, isLoading, errorMessage);
+
+  /// Create a copy of LoginState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LoginStateImplCopyWith<_$LoginStateImpl> get copyWith =>
+      __$$LoginStateImplCopyWithImpl<_$LoginStateImpl>(this, _$identity);
+}
+
+abstract class _LoginState implements LoginState {
+  const factory _LoginState({
+    final EmailInput email,
+    final PasswordInput password,
+    final bool isLoading,
+    final String? errorMessage,
+  }) = _$LoginStateImpl;
+
+  @override
+  EmailInput get email;
+  @override
+  PasswordInput get password;
+  @override
+  bool get isLoading;
+  @override
+  String? get errorMessage;
+
+  /// Create a copy of LoginState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$LoginStateImplCopyWith<_$LoginStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/auth/register/register_controller.dart
+++ b/lib/src/features/auth/register/register_controller.dart
@@ -1,0 +1,55 @@
+import 'package:nibbles/src/common/domain/formz/email_input.dart';
+import 'package:nibbles/src/common/domain/formz/password_input.dart';
+import 'package:nibbles/src/common/services/auth_service.dart';
+import 'package:nibbles/src/features/auth/register/register_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'register_controller.g.dart';
+
+@riverpod
+class RegisterController extends _$RegisterController {
+  @override
+  RegisterState build() => const RegisterState();
+
+  void updateName(String value) {
+    state = state.copyWith(name: value, errorMessage: null);
+  }
+
+  void updateEmail(String value) {
+    state = state.copyWith(
+      email: EmailInput.dirty(value),
+      errorMessage: null,
+    );
+  }
+
+  void updatePassword(String value) {
+    state = state.copyWith(
+      password: PasswordInput.dirty(value),
+      errorMessage: null,
+    );
+  }
+
+  Future<bool> submit() async {
+    state = state.copyWith(isLoading: true, errorMessage: null);
+
+    final result = await ref.read(authServiceProvider.notifier).signUp(
+          state.name,
+          state.email.value,
+          state.password.value,
+        );
+
+    return result.when(
+      success: (_) {
+        state = state.copyWith(isLoading: false);
+        return true;
+      },
+      failure: (error) {
+        state = state.copyWith(
+          isLoading: false,
+          errorMessage: error.message,
+        );
+        return false;
+      },
+    );
+  }
+}

--- a/lib/src/features/auth/register/register_controller.g.dart
+++ b/lib/src/features/auth/register/register_controller.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'register_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$registerControllerHash() =>
+    r'6080f4e23efcbffa7a58eff6ac6737fcbd4901d3';
+
+/// See also [RegisterController].
+@ProviderFor(RegisterController)
+final registerControllerProvider =
+    AutoDisposeNotifierProvider<RegisterController, RegisterState>.internal(
+      RegisterController.new,
+      name: r'registerControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$registerControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$RegisterController = AutoDisposeNotifier<RegisterState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/auth/register/register_screen.dart
+++ b/lib/src/features/auth/register/register_screen.dart
@@ -1,9 +1,133 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/features/auth/register/register_controller.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 class RegisterScreen extends ConsumerWidget {
   const RegisterScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Register')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(registerControllerProvider);
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+            vertical: AppSizes.pagePaddingV,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: AppSizes.xl),
+              Text('Create your account', style: textTheme.headlineLarge),
+              const SizedBox(height: AppSizes.sm),
+              Text(
+                "Let's get you started.",
+                style:
+                    textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
+              ),
+              const SizedBox(height: AppSizes.xl),
+              TextField(
+                key: const Key('register_name_field'),
+                onChanged: ref
+                    .read(registerControllerProvider.notifier)
+                    .updateName,
+                textCapitalization: TextCapitalization.words,
+                decoration: const InputDecoration(labelText: 'Your name'),
+              ),
+              const SizedBox(height: AppSizes.md),
+              TextField(
+                key: const Key('register_email_field'),
+                onChanged: ref
+                    .read(registerControllerProvider.notifier)
+                    .updateEmail,
+                keyboardType: TextInputType.emailAddress,
+                decoration: InputDecoration(
+                  labelText: 'Email',
+                  errorText:
+                      state.email.isNotValid && state.email.value.isNotEmpty
+                          ? 'Please enter a valid email.'
+                          : null,
+                ),
+              ),
+              const SizedBox(height: AppSizes.md),
+              TextField(
+                key: const Key('register_password_field'),
+                onChanged: ref
+                    .read(registerControllerProvider.notifier)
+                    .updatePassword,
+                obscureText: true,
+                decoration: InputDecoration(
+                  labelText: 'Password',
+                  errorText: state.password.isNotValid &&
+                          state.password.value.isNotEmpty
+                      ? 'Password must be at least 8 characters.'
+                      : null,
+                ),
+              ),
+              if (state.errorMessage != null) ...[
+                const SizedBox(height: AppSizes.sm),
+                Text(
+                  state.errorMessage!,
+                  style:
+                      textTheme.bodySmall?.copyWith(color: AppColors.error),
+                ),
+              ],
+              const SizedBox(height: AppSizes.xl),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  key: const Key('register_submit_button'),
+                  onPressed: (!state.isValid || state.isLoading)
+                      ? null
+                      : () async {
+                          final ok = await ref
+                              .read(registerControllerProvider.notifier)
+                              .submit();
+                          if (ok && context.mounted) {
+                            context.goNamed(
+                              AppRoute.onboardingBabySetup.name,
+                            );
+                          }
+                        },
+                  child: state.isLoading
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: AppColors.onPrimary,
+                          ),
+                        )
+                      : const Text('Sign Up'),
+                ),
+              ),
+              const SizedBox(height: AppSizes.md),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'Already have an account?',
+                    style: textTheme.bodySmall,
+                  ),
+                  TextButton(
+                    onPressed: () =>
+                        context.goNamed(AppRoute.login.name),
+                    child: const Text('Log In'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/src/features/auth/register/register_state.dart
+++ b/lib/src/features/auth/register/register_state.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/formz/email_input.dart';
+import 'package:nibbles/src/common/domain/formz/password_input.dart';
+
+part 'register_state.freezed.dart';
+
+@freezed
+class RegisterState with _$RegisterState {
+  const factory RegisterState({
+    @Default('') String name,
+    @Default(EmailInput.pure()) EmailInput email,
+    @Default(PasswordInput.pure()) PasswordInput password,
+    @Default(false) bool isLoading,
+    String? errorMessage,
+  }) = _RegisterState;
+
+  const RegisterState._();
+
+  bool get isValid =>
+      name.isNotEmpty && email.isValid && password.isValid;
+}

--- a/lib/src/features/auth/register/register_state.freezed.dart
+++ b/lib/src/features/auth/register/register_state.freezed.dart
@@ -1,0 +1,249 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'register_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$RegisterState {
+  String get name => throw _privateConstructorUsedError;
+  EmailInput get email => throw _privateConstructorUsedError;
+  PasswordInput get password => throw _privateConstructorUsedError;
+  bool get isLoading => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+
+  /// Create a copy of RegisterState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $RegisterStateCopyWith<RegisterState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RegisterStateCopyWith<$Res> {
+  factory $RegisterStateCopyWith(
+    RegisterState value,
+    $Res Function(RegisterState) then,
+  ) = _$RegisterStateCopyWithImpl<$Res, RegisterState>;
+  @useResult
+  $Res call({
+    String name,
+    EmailInput email,
+    PasswordInput password,
+    bool isLoading,
+    String? errorMessage,
+  });
+}
+
+/// @nodoc
+class _$RegisterStateCopyWithImpl<$Res, $Val extends RegisterState>
+    implements $RegisterStateCopyWith<$Res> {
+  _$RegisterStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of RegisterState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? email = null,
+    Object? password = null,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            name: null == name
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                      as String,
+            email: null == email
+                ? _value.email
+                : email // ignore: cast_nullable_to_non_nullable
+                      as EmailInput,
+            password: null == password
+                ? _value.password
+                : password // ignore: cast_nullable_to_non_nullable
+                      as PasswordInput,
+            isLoading: null == isLoading
+                ? _value.isLoading
+                : isLoading // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$RegisterStateImplCopyWith<$Res>
+    implements $RegisterStateCopyWith<$Res> {
+  factory _$$RegisterStateImplCopyWith(
+    _$RegisterStateImpl value,
+    $Res Function(_$RegisterStateImpl) then,
+  ) = __$$RegisterStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String name,
+    EmailInput email,
+    PasswordInput password,
+    bool isLoading,
+    String? errorMessage,
+  });
+}
+
+/// @nodoc
+class __$$RegisterStateImplCopyWithImpl<$Res>
+    extends _$RegisterStateCopyWithImpl<$Res, _$RegisterStateImpl>
+    implements _$$RegisterStateImplCopyWith<$Res> {
+  __$$RegisterStateImplCopyWithImpl(
+    _$RegisterStateImpl _value,
+    $Res Function(_$RegisterStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of RegisterState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? email = null,
+    Object? password = null,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _$RegisterStateImpl(
+        name: null == name
+            ? _value.name
+            : name // ignore: cast_nullable_to_non_nullable
+                  as String,
+        email: null == email
+            ? _value.email
+            : email // ignore: cast_nullable_to_non_nullable
+                  as EmailInput,
+        password: null == password
+            ? _value.password
+            : password // ignore: cast_nullable_to_non_nullable
+                  as PasswordInput,
+        isLoading: null == isLoading
+            ? _value.isLoading
+            : isLoading // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$RegisterStateImpl extends _RegisterState {
+  const _$RegisterStateImpl({
+    this.name = '',
+    this.email = const EmailInput.pure(),
+    this.password = const PasswordInput.pure(),
+    this.isLoading = false,
+    this.errorMessage,
+  }) : super._();
+
+  @override
+  @JsonKey()
+  final String name;
+  @override
+  @JsonKey()
+  final EmailInput email;
+  @override
+  @JsonKey()
+  final PasswordInput password;
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  final String? errorMessage;
+
+  @override
+  String toString() {
+    return 'RegisterState(name: $name, email: $email, password: $password, isLoading: $isLoading, errorMessage: $errorMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RegisterStateImpl &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.email, email) || other.email == email) &&
+            (identical(other.password, password) ||
+                other.password == password) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, name, email, password, isLoading, errorMessage);
+
+  /// Create a copy of RegisterState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RegisterStateImplCopyWith<_$RegisterStateImpl> get copyWith =>
+      __$$RegisterStateImplCopyWithImpl<_$RegisterStateImpl>(this, _$identity);
+}
+
+abstract class _RegisterState extends RegisterState {
+  const factory _RegisterState({
+    final String name,
+    final EmailInput email,
+    final PasswordInput password,
+    final bool isLoading,
+    final String? errorMessage,
+  }) = _$RegisterStateImpl;
+  const _RegisterState._() : super._();
+
+  @override
+  String get name;
+  @override
+  EmailInput get email;
+  @override
+  PasswordInput get password;
+  @override
+  bool get isLoading;
+  @override
+  String? get errorMessage;
+
+  /// Create a copy of RegisterState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$RegisterStateImplCopyWith<_$RegisterStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/onboarding/baby_setup/baby_setup_controller.dart
+++ b/lib/src/features/onboarding/baby_setup/baby_setup_controller.dart
@@ -1,0 +1,64 @@
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/domain/formz/baby_name_input.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/features/onboarding/baby_setup/baby_setup_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'baby_setup_controller.g.dart';
+
+@riverpod
+class BabySetupController extends _$BabySetupController {
+  @override
+  BabySetupState build() => const BabySetupState();
+
+  void updateName(String value) {
+    state = state.copyWith(
+      babyName: BabyNameInput.dirty(value),
+      errorMessage: null,
+    );
+  }
+
+  void updateDob(DateTime value) {
+    state = state.copyWith(dob: value, errorMessage: null);
+  }
+
+  void updateGender(Gender value) {
+    state = state.copyWith(gender: value, errorMessage: null);
+  }
+
+  void nextStep() {
+    state = state.copyWith(step: state.step + 1);
+  }
+
+  void previousStep() {
+    if (state.step > 0) {
+      state = state.copyWith(step: state.step - 1);
+    }
+  }
+
+  Future<bool> submit() async {
+    if (state.dob == null || state.gender == null) return false;
+
+    state = state.copyWith(isLoading: true, errorMessage: null);
+
+    final result = await ref.read(babyProfileServiceProvider).createBaby(
+          state.babyName.value,
+          state.dob!,
+          state.gender!,
+        );
+
+    return result.when(
+      success: (_) {
+        state = state.copyWith(isLoading: false);
+        return true;
+      },
+      failure: (error) {
+        state = state.copyWith(
+          isLoading: false,
+          errorMessage: error.message,
+        );
+        return false;
+      },
+    );
+  }
+}

--- a/lib/src/features/onboarding/baby_setup/baby_setup_controller.g.dart
+++ b/lib/src/features/onboarding/baby_setup/baby_setup_controller.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'baby_setup_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$babySetupControllerHash() =>
+    r'1cdcbfb30e3f6284988f16f59eac37801e6f5c39';
+
+/// See also [BabySetupController].
+@ProviderFor(BabySetupController)
+final babySetupControllerProvider =
+    AutoDisposeNotifierProvider<BabySetupController, BabySetupState>.internal(
+      BabySetupController.new,
+      name: r'babySetupControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$babySetupControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$BabySetupController = AutoDisposeNotifier<BabySetupState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/onboarding/baby_setup/baby_setup_state.dart
+++ b/lib/src/features/onboarding/baby_setup/baby_setup_state.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/domain/formz/baby_name_input.dart';
+
+part 'baby_setup_state.freezed.dart';
+
+@freezed
+class BabySetupState with _$BabySetupState {
+  const factory BabySetupState({
+    @Default(0) int step,
+    @Default(BabyNameInput.pure()) BabyNameInput babyName,
+    DateTime? dob,
+    Gender? gender,
+    @Default(false) bool isLoading,
+    String? errorMessage,
+  }) = _BabySetupState;
+}

--- a/lib/src/features/onboarding/baby_setup/baby_setup_state.freezed.dart
+++ b/lib/src/features/onboarding/baby_setup/baby_setup_state.freezed.dart
@@ -1,0 +1,277 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'baby_setup_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$BabySetupState {
+  int get step => throw _privateConstructorUsedError;
+  BabyNameInput get babyName => throw _privateConstructorUsedError;
+  DateTime? get dob => throw _privateConstructorUsedError;
+  Gender? get gender => throw _privateConstructorUsedError;
+  bool get isLoading => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+
+  /// Create a copy of BabySetupState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $BabySetupStateCopyWith<BabySetupState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BabySetupStateCopyWith<$Res> {
+  factory $BabySetupStateCopyWith(
+    BabySetupState value,
+    $Res Function(BabySetupState) then,
+  ) = _$BabySetupStateCopyWithImpl<$Res, BabySetupState>;
+  @useResult
+  $Res call({
+    int step,
+    BabyNameInput babyName,
+    DateTime? dob,
+    Gender? gender,
+    bool isLoading,
+    String? errorMessage,
+  });
+}
+
+/// @nodoc
+class _$BabySetupStateCopyWithImpl<$Res, $Val extends BabySetupState>
+    implements $BabySetupStateCopyWith<$Res> {
+  _$BabySetupStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of BabySetupState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? step = null,
+    Object? babyName = null,
+    Object? dob = freezed,
+    Object? gender = freezed,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            step: null == step
+                ? _value.step
+                : step // ignore: cast_nullable_to_non_nullable
+                      as int,
+            babyName: null == babyName
+                ? _value.babyName
+                : babyName // ignore: cast_nullable_to_non_nullable
+                      as BabyNameInput,
+            dob: freezed == dob
+                ? _value.dob
+                : dob // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            gender: freezed == gender
+                ? _value.gender
+                : gender // ignore: cast_nullable_to_non_nullable
+                      as Gender?,
+            isLoading: null == isLoading
+                ? _value.isLoading
+                : isLoading // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$BabySetupStateImplCopyWith<$Res>
+    implements $BabySetupStateCopyWith<$Res> {
+  factory _$$BabySetupStateImplCopyWith(
+    _$BabySetupStateImpl value,
+    $Res Function(_$BabySetupStateImpl) then,
+  ) = __$$BabySetupStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    int step,
+    BabyNameInput babyName,
+    DateTime? dob,
+    Gender? gender,
+    bool isLoading,
+    String? errorMessage,
+  });
+}
+
+/// @nodoc
+class __$$BabySetupStateImplCopyWithImpl<$Res>
+    extends _$BabySetupStateCopyWithImpl<$Res, _$BabySetupStateImpl>
+    implements _$$BabySetupStateImplCopyWith<$Res> {
+  __$$BabySetupStateImplCopyWithImpl(
+    _$BabySetupStateImpl _value,
+    $Res Function(_$BabySetupStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of BabySetupState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? step = null,
+    Object? babyName = null,
+    Object? dob = freezed,
+    Object? gender = freezed,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _$BabySetupStateImpl(
+        step: null == step
+            ? _value.step
+            : step // ignore: cast_nullable_to_non_nullable
+                  as int,
+        babyName: null == babyName
+            ? _value.babyName
+            : babyName // ignore: cast_nullable_to_non_nullable
+                  as BabyNameInput,
+        dob: freezed == dob
+            ? _value.dob
+            : dob // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        gender: freezed == gender
+            ? _value.gender
+            : gender // ignore: cast_nullable_to_non_nullable
+                  as Gender?,
+        isLoading: null == isLoading
+            ? _value.isLoading
+            : isLoading // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$BabySetupStateImpl implements _BabySetupState {
+  const _$BabySetupStateImpl({
+    this.step = 0,
+    this.babyName = const BabyNameInput.pure(),
+    this.dob,
+    this.gender,
+    this.isLoading = false,
+    this.errorMessage,
+  });
+
+  @override
+  @JsonKey()
+  final int step;
+  @override
+  @JsonKey()
+  final BabyNameInput babyName;
+  @override
+  final DateTime? dob;
+  @override
+  final Gender? gender;
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  final String? errorMessage;
+
+  @override
+  String toString() {
+    return 'BabySetupState(step: $step, babyName: $babyName, dob: $dob, gender: $gender, isLoading: $isLoading, errorMessage: $errorMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BabySetupStateImpl &&
+            (identical(other.step, step) || other.step == step) &&
+            (identical(other.babyName, babyName) ||
+                other.babyName == babyName) &&
+            (identical(other.dob, dob) || other.dob == dob) &&
+            (identical(other.gender, gender) || other.gender == gender) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    step,
+    babyName,
+    dob,
+    gender,
+    isLoading,
+    errorMessage,
+  );
+
+  /// Create a copy of BabySetupState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BabySetupStateImplCopyWith<_$BabySetupStateImpl> get copyWith =>
+      __$$BabySetupStateImplCopyWithImpl<_$BabySetupStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _BabySetupState implements BabySetupState {
+  const factory _BabySetupState({
+    final int step,
+    final BabyNameInput babyName,
+    final DateTime? dob,
+    final Gender? gender,
+    final bool isLoading,
+    final String? errorMessage,
+  }) = _$BabySetupStateImpl;
+
+  @override
+  int get step;
+  @override
+  BabyNameInput get babyName;
+  @override
+  DateTime? get dob;
+  @override
+  Gender? get gender;
+  @override
+  bool get isLoading;
+  @override
+  String? get errorMessage;
+
+  /// Create a copy of BabySetupState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$BabySetupStateImplCopyWith<_$BabySetupStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/onboarding/baby_setup/onboarding_baby_setup_screen.dart
+++ b/lib/src/features/onboarding/baby_setup/onboarding_baby_setup_screen.dart
@@ -1,9 +1,254 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/features/onboarding/baby_setup/baby_setup_controller.dart';
+import 'package:nibbles/src/features/onboarding/baby_setup/baby_setup_state.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 class OnboardingBabySetupScreen extends ConsumerWidget {
   const OnboardingBabySetupScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Baby Setup (OB-11–13)')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(babySetupControllerProvider);
+    final controller = ref.read(babySetupControllerProvider.notifier);
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        elevation: 0,
+        leading: state.step > 0
+            ? IconButton(
+                icon: const Icon(Icons.arrow_back_rounded),
+                onPressed: controller.previousStep,
+              )
+            : null,
+        title: Text(
+          'Step ${state.step + 1} of 3',
+          style: textTheme.bodySmall?.copyWith(color: AppColors.subtext),
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+            vertical: AppSizes.pagePaddingV,
+          ),
+          child: switch (state.step) {
+            0 => _NameStep(state: state, controller: controller),
+            1 => _DobStep(state: state, controller: controller),
+            _ => _GenderStep(
+                state: state,
+                controller: controller,
+                onSuccess: () =>
+                    context.goNamed(AppRoute.paywall.name),
+              ),
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _NameStep extends StatelessWidget {
+  const _NameStep({required this.state, required this.controller});
+
+  final BabySetupState state;
+  final BabySetupController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: AppSizes.lg),
+        Text("What's your baby's name?", style: textTheme.headlineLarge),
+        const SizedBox(height: AppSizes.xl),
+        TextField(
+          key: const Key('baby_name_field'),
+          onChanged: controller.updateName,
+          textCapitalization: TextCapitalization.words,
+          decoration: InputDecoration(
+            labelText: "Baby's name",
+            errorText: state.babyName.isNotValid &&
+                    state.babyName.value.isNotEmpty
+                ? 'Please enter a valid name.'
+                : null,
+          ),
+        ),
+        const Spacer(),
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton(
+            key: const Key('baby_name_next'),
+            onPressed: state.babyName.isValid ? controller.nextStep : null,
+            child: const Text('Next'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DobStep extends StatelessWidget {
+  const _DobStep({required this.state, required this.controller});
+
+  final BabySetupState state;
+  final BabySetupController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final now = DateTime.now();
+    final initialDate = state.dob ?? now.subtract(const Duration(days: 180));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: AppSizes.lg),
+        Text('When was your baby born?', style: textTheme.headlineLarge),
+        const SizedBox(height: AppSizes.xl),
+        SizedBox(
+          height: 200,
+          child: CupertinoDatePicker(
+            key: const Key('baby_dob_picker'),
+            mode: CupertinoDatePickerMode.date,
+            initialDateTime: initialDate,
+            maximumDate: now,
+            minimumDate: now.subtract(const Duration(days: 365 * 3)),
+            onDateTimeChanged: controller.updateDob,
+          ),
+        ),
+        const Spacer(),
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton(
+            key: const Key('baby_dob_next'),
+            onPressed: state.dob != null ? controller.nextStep : null,
+            child: const Text('Next'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _GenderStep extends StatelessWidget {
+  const _GenderStep({
+    required this.state,
+    required this.controller,
+    required this.onSuccess,
+  });
+
+  final BabySetupState state;
+  final BabySetupController controller;
+  final VoidCallback onSuccess;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: AppSizes.lg),
+        Text("What's your baby's gender?", style: textTheme.headlineLarge),
+        const SizedBox(height: AppSizes.xl),
+        ...Gender.values.map(
+          (g) => Padding(
+            padding: const EdgeInsets.only(bottom: AppSizes.md),
+            child: _GenderCard(
+              label: _genderLabel(g),
+              selected: state.gender == g,
+              onTap: () => controller.updateGender(g),
+            ),
+          ),
+        ),
+        if (state.errorMessage != null) ...[
+          const SizedBox(height: AppSizes.sm),
+          Text(
+            state.errorMessage!,
+            style: textTheme.bodySmall?.copyWith(color: AppColors.error),
+          ),
+        ],
+        const Spacer(),
+        SizedBox(
+          width: double.infinity,
+          child: FilledButton(
+            key: const Key('baby_setup_submit'),
+            onPressed: (state.gender == null || state.isLoading)
+                ? null
+                : () async {
+                    final ok = await controller.submit();
+                    if (ok && context.mounted) onSuccess();
+                  },
+            child: state.isLoading
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: AppColors.onPrimary,
+                    ),
+                  )
+                : const Text("Let's go!"),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _genderLabel(Gender g) => switch (g) {
+        Gender.male => 'Male',
+        Gender.female => 'Female',
+        Gender.preferNotToSay => 'Prefer not to say',
+      };
+}
+
+class _GenderCard extends StatelessWidget {
+  const _GenderCard({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.lg,
+          vertical: AppSizes.md,
+        ),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.primary : AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+          border: Border.all(
+            color: selected ? AppColors.primary : AppColors.divider,
+            width: selected ? 2 : 1,
+          ),
+        ),
+        child: Text(
+          label,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: selected ? AppColors.onPrimary : AppColors.text,
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
## NIB-13 — OB-10 Sign Up + OB-11–13 Baby Setup + AU-01 Login

### OB-10 Register (`/auth/register`)
- Name, email (EmailInput formz), password (PasswordInput formz) fields
- "Sign Up" CTA → `AuthService.signUp(name, email, password)` → navigates to `/onboarding/baby-setup`
- "Already have an account? Log In" link
- P1 inline error

### AU-01 Login (`/auth/login`)
- Email + password fields with formz validation
- "Log In" → `AuthService.signIn(email, password)` → GoRouter redirect handles destination
- "Forgot your password?" + "Sign Up" links
- P1 inline error

### OB-11–13 Baby Setup (`/onboarding/baby-setup`)
- Step 1: Baby name (BabyNameInput formz)
- Step 2: DOB (CupertinoDatePicker, max today, min 3 years ago)
- Step 3: Gender selection (Male / Female / Prefer not to say) + "Let's go!" → `BabyProfileService.createBaby(name, dob, gender)` → `/subscription/paywall`
- Back navigation between steps
- P1 inline error on submit failure

## Test plan
- [ ] Register with valid fields → account created → baby setup screen
- [ ] Register with invalid email → inline error before API
- [ ] Register with existing email → Supabase error inline
- [ ] Login with valid creds → GoRouter redirects correctly
- [ ] Login with wrong password → Supabase error inline
- [ ] Baby setup: all 3 steps → baby created → paywall
- [ ] Baby setup: back button works between steps