### PR TITLE
feat(allergen): AllergenRepository + AllergenService — full data layer [NIB-21]

### DIFF
--- a/lib/src/common/data/repositories/allergen_repository.dart
+++ b/lib/src/common/data/repositories/allergen_repository.dart
@@ -1,0 +1,346 @@
+// freezed copies @JsonKey field annotations into generated parts, triggering a
+// false-positive from very_good_analysis on the generated getter declarations.
+// ignore_for_file: invalid_annotation_target
+import 'dart:convert';
+
+import 'package:nibbles/src/common/data/sources/local/hive_service.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
+import 'package:nibbles/src/common/domain/entities/reaction_detail.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
+import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
+import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'allergen_repository.g.dart';
+
+abstract interface class AllergenRepository {
+  /// ALLRG-01: Fetch all 9 allergens ordered by sequence_order.
+  /// Serves from Hive cache if available; fetches from Supabase on cache miss
+  /// or when [refresh] is true.
+  Future<Result<List<Allergen>>> getAllergens({bool refresh = false});
+
+  /// ALLRG-02: Fetch allergen_program_state for the given baby.
+  Future<Result<AllergenProgramState>> getProgramState(String babyId);
+
+  /// ALLRG-03: Fetch all allergen_logs for baby, optionally filtered.
+  Future<Result<List<AllergenLog>>> getLogs(
+    String babyId, {
+    String? allergenKey,
+  });
+
+  /// ALLRG-04: Check if a log exists for (baby_id, allergen_key, log_date)
+  /// by calendar day — not timestamp.
+  Future<Result<bool>> hasLogForToday(
+    String babyId,
+    String allergenKey,
+    DateTime date,
+  );
+
+  /// ALLRG-05: Insert allergen_log row.
+  Future<Result<AllergenLog>> saveLog(AllergenLog log);
+
+  /// ALLRG-06: Insert reaction_details row.
+  Future<Result<ReactionDetail>> saveReactionDetail(ReactionDetail detail);
+
+  /// ALLRG-07: Advance program state to next allergen.
+  Future<Result<void>> advanceProgramState(
+    String babyId,
+    String nextAllergenKey,
+    int nextSequenceOrder,
+  );
+
+  /// ALLRG-08: Mark program as completed.
+  Future<Result<void>> completeProgramState(String babyId);
+
+  /// ALLRG-09: Fetch reaction_details for a given log.
+  Future<Result<ReactionDetail?>> getReactionDetail(String logId);
+}
+
+class AllergenRepositoryImpl implements AllergenRepository {
+  AllergenRepositoryImpl({
+    SupabaseClient? supabaseClient,
+    HiveService? hiveService,
+  })  : _supabase = supabaseClient ?? Supabase.instance.client,
+        _hive = hiveService ?? HiveService();
+
+  final SupabaseClient _supabase;
+  final HiveService _hive;
+
+  static const _cacheKey = 'allergens_list';
+
+  @override
+  Future<Result<List<Allergen>>> getAllergens({bool refresh = false}) async {
+    if (!refresh) {
+      final cached = _hive.allergensBox.get(_cacheKey);
+      if (cached != null) {
+        try {
+          final list = (jsonDecode(cached) as List<dynamic>)
+              .cast<Map<String, dynamic>>()
+              .map(Allergen.fromJson)
+              .toList();
+          return Result.success(list);
+        } on Object {
+          // Cache corrupt — fall through to remote fetch.
+        }
+      }
+    }
+
+    try {
+      final data = await _supabase
+          .from('allergens')
+          .select()
+          .order('sequence_order');
+
+      final allergens = (data as List<dynamic>)
+          .cast<Map<String, dynamic>>()
+          .map(_allergenFromRow)
+          .toList();
+
+      await _hive.allergensBox.put(
+        _cacheKey,
+        jsonEncode(allergens.map((a) => a.toJson()).toList()),
+      );
+
+      return Result.success(allergens);
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<AllergenProgramState>> getProgramState(String babyId) async {
+    try {
+      final data = await _supabase
+          .from('allergen_program_state')
+          .select()
+          .eq('baby_id', babyId)
+          .single();
+
+      return Result.success(_programStateFromRow(data));
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<List<AllergenLog>>> getLogs(
+    String babyId, {
+    String? allergenKey,
+  }) async {
+    try {
+      var query = _supabase
+          .from('allergen_logs')
+          .select()
+          .eq('baby_id', babyId);
+
+      if (allergenKey != null) {
+        query = query.eq('allergen_key', allergenKey);
+      }
+
+      final data = await query.order('created_at');
+      return Result.success(
+        (data as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .map(_logFromRow)
+            .toList(),
+      );
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<bool>> hasLogForToday(
+    String babyId,
+    String allergenKey,
+    DateTime date,
+  ) async {
+    try {
+      final dateStr = _formatDate(date);
+      final data = await _supabase
+          .from('allergen_logs')
+          .select('id')
+          .eq('baby_id', babyId)
+          .eq('allergen_key', allergenKey)
+          .eq('log_date', dateStr)
+          .limit(1);
+
+      return Result.success((data as List<dynamic>).isNotEmpty);
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<AllergenLog>> saveLog(AllergenLog log) async {
+    try {
+      final data = await _supabase
+          .from('allergen_logs')
+          .insert({
+            'baby_id': log.babyId,
+            'allergen_key': log.allergenKey,
+            'emoji_taste': log.emojiTaste.toJson(),
+            'had_reaction': log.hadReaction,
+            'log_date': _formatDate(log.logDate),
+          })
+          .select()
+          .single();
+
+      return Result.success(_logFromRow(data));
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<ReactionDetail>> saveReactionDetail(
+    ReactionDetail detail,
+  ) async {
+    try {
+      final data = await _supabase
+          .from('reaction_details')
+          .insert({
+            'log_id': detail.logId,
+            'severity': detail.severity.toJson(),
+            'symptoms': detail.symptoms,
+            if (detail.notes != null) 'notes': detail.notes,
+          })
+          .select()
+          .single();
+
+      return Result.success(_reactionDetailFromRow(data));
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<void>> advanceProgramState(
+    String babyId,
+    String nextAllergenKey,
+    int nextSequenceOrder,
+  ) async {
+    try {
+      await _supabase
+          .from('allergen_program_state')
+          .update({
+            'current_allergen_key': nextAllergenKey,
+            'current_sequence_order': nextSequenceOrder,
+          })
+          .eq('baby_id', babyId);
+
+      return const Result.success(null);
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<void>> completeProgramState(String babyId) async {
+    try {
+      await _supabase
+          .from('allergen_program_state')
+          .update({
+            'status': AllergenProgramStatus.completed.toJson(),
+          })
+          .eq('baby_id', babyId);
+
+      return const Result.success(null);
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<ReactionDetail?>> getReactionDetail(String logId) async {
+    try {
+      final data = await _supabase
+          .from('reaction_details')
+          .select()
+          .eq('log_id', logId)
+          .limit(1)
+          .maybeSingle();
+
+      if (data == null) return const Result.success(null);
+      return Result.success(_reactionDetailFromRow(data));
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  // --- Row mappers ---
+
+  Allergen _allergenFromRow(Map<String, dynamic> row) => Allergen(
+        key: row['key'] as String,
+        name: row['name'] as String,
+        sequenceOrder: row['sequence_order'] as int,
+        emoji: row['emoji'] as String,
+      );
+
+  AllergenLog _logFromRow(Map<String, dynamic> row) => AllergenLog(
+        id: row['id'] as String,
+        babyId: row['baby_id'] as String,
+        allergenKey: row['allergen_key'] as String,
+        emojiTaste: EmojiTasteX.fromJson(row['emoji_taste'] as String),
+        hadReaction: row['had_reaction'] as bool,
+        logDate: DateTime.parse(row['log_date'] as String),
+        createdAt: DateTime.parse(row['created_at'] as String),
+      );
+
+  AllergenProgramState _programStateFromRow(Map<String, dynamic> row) =>
+      AllergenProgramState(
+        id: row['id'] as String,
+        babyId: row['baby_id'] as String,
+        currentAllergenKey: row['current_allergen_key'] as String,
+        currentSequenceOrder: row['current_sequence_order'] as int,
+        status: AllergenProgramStatusX.fromJson(row['status'] as String),
+        createdAt: DateTime.parse(row['created_at'] as String),
+        updatedAt: DateTime.parse(row['updated_at'] as String),
+      );
+
+  ReactionDetail _reactionDetailFromRow(Map<String, dynamic> row) =>
+      ReactionDetail(
+        id: row['id'] as String,
+        logId: row['log_id'] as String,
+        severity: ReactionSeverityX.fromJson(row['severity'] as String),
+        symptoms: (row['symptoms'] as List<dynamic>).cast<String>(),
+        notes: row['notes'] as String?,
+        createdAt: DateTime.parse(row['created_at'] as String),
+      );
+
+  static String _formatDate(DateTime date) =>
+      '${date.year.toString().padLeft(4, '0')}-'
+      '${date.month.toString().padLeft(2, '0')}-'
+      '${date.day.toString().padLeft(2, '0')}';
+}
+
+@Riverpod(keepAlive: true)
+AllergenRepository allergenRepository(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  AllergenRepositoryRef ref,
+) =>
+    AllergenRepositoryImpl();

--- a/lib/src/common/data/repositories/allergen_repository.g.dart
+++ b/lib/src/common/data/repositories/allergen_repository.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'allergen_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$allergenRepositoryHash() =>
+    r'c01dac41ff626eb66e01a596ca126e2b2ed40424';
+
+/// See also [allergenRepository].
+@ProviderFor(allergenRepository)
+final allergenRepositoryProvider = Provider<AllergenRepository>.internal(
+  allergenRepository,
+  name: r'allergenRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$allergenRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AllergenRepositoryRef = ProviderRef<AllergenRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/common/data/sources/remote/config/app_exception.dart
+++ b/lib/src/common/data/sources/remote/config/app_exception.dart
@@ -35,3 +35,12 @@ final class NotFoundException extends AppException {
 final class UnknownException extends AppException {
   const UnknownException([super.message = 'An unexpected error occurred.']);
 }
+
+/// Returned when a user attempts to log the same allergen twice in one day.
+final class DuplicateLogException extends AppException {
+  DuplicateLogException(String allergenName)
+      : super(
+          "You've already logged $allergenName today. "
+          'Come back tomorrow for the next day.',
+        );
+}

--- a/lib/src/common/domain/entities/allergen.dart
+++ b/lib/src/common/domain/entities/allergen.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'allergen.freezed.dart';
+part 'allergen.g.dart';
+
+@freezed
+class Allergen with _$Allergen {
+  const factory Allergen({
+    required String key,
+    required String name,
+    required int sequenceOrder,
+    required String emoji,
+  }) = _Allergen;
+
+  factory Allergen.fromJson(Map<String, dynamic> json) =>
+      _$AllergenFromJson(json);
+}

--- a/lib/src/common/domain/entities/allergen.freezed.dart
+++ b/lib/src/common/domain/entities/allergen.freezed.dart
@@ -1,0 +1,228 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'allergen.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+Allergen _$AllergenFromJson(Map<String, dynamic> json) {
+  return _Allergen.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Allergen {
+  String get key => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  int get sequenceOrder => throw _privateConstructorUsedError;
+  String get emoji => throw _privateConstructorUsedError;
+
+  /// Serializes this Allergen to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Allergen
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AllergenCopyWith<Allergen> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AllergenCopyWith<$Res> {
+  factory $AllergenCopyWith(Allergen value, $Res Function(Allergen) then) =
+      _$AllergenCopyWithImpl<$Res, Allergen>;
+  @useResult
+  $Res call({String key, String name, int sequenceOrder, String emoji});
+}
+
+/// @nodoc
+class _$AllergenCopyWithImpl<$Res, $Val extends Allergen>
+    implements $AllergenCopyWith<$Res> {
+  _$AllergenCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Allergen
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = null,
+    Object? name = null,
+    Object? sequenceOrder = null,
+    Object? emoji = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            key: null == key
+                ? _value.key
+                : key // ignore: cast_nullable_to_non_nullable
+                      as String,
+            name: null == name
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                      as String,
+            sequenceOrder: null == sequenceOrder
+                ? _value.sequenceOrder
+                : sequenceOrder // ignore: cast_nullable_to_non_nullable
+                      as int,
+            emoji: null == emoji
+                ? _value.emoji
+                : emoji // ignore: cast_nullable_to_non_nullable
+                      as String,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$AllergenImplCopyWith<$Res>
+    implements $AllergenCopyWith<$Res> {
+  factory _$$AllergenImplCopyWith(
+    _$AllergenImpl value,
+    $Res Function(_$AllergenImpl) then,
+  ) = __$$AllergenImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String key, String name, int sequenceOrder, String emoji});
+}
+
+/// @nodoc
+class __$$AllergenImplCopyWithImpl<$Res>
+    extends _$AllergenCopyWithImpl<$Res, _$AllergenImpl>
+    implements _$$AllergenImplCopyWith<$Res> {
+  __$$AllergenImplCopyWithImpl(
+    _$AllergenImpl _value,
+    $Res Function(_$AllergenImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of Allergen
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = null,
+    Object? name = null,
+    Object? sequenceOrder = null,
+    Object? emoji = null,
+  }) {
+    return _then(
+      _$AllergenImpl(
+        key: null == key
+            ? _value.key
+            : key // ignore: cast_nullable_to_non_nullable
+                  as String,
+        name: null == name
+            ? _value.name
+            : name // ignore: cast_nullable_to_non_nullable
+                  as String,
+        sequenceOrder: null == sequenceOrder
+            ? _value.sequenceOrder
+            : sequenceOrder // ignore: cast_nullable_to_non_nullable
+                  as int,
+        emoji: null == emoji
+            ? _value.emoji
+            : emoji // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$AllergenImpl implements _Allergen {
+  const _$AllergenImpl({
+    required this.key,
+    required this.name,
+    required this.sequenceOrder,
+    required this.emoji,
+  });
+
+  factory _$AllergenImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AllergenImplFromJson(json);
+
+  @override
+  final String key;
+  @override
+  final String name;
+  @override
+  final int sequenceOrder;
+  @override
+  final String emoji;
+
+  @override
+  String toString() {
+    return 'Allergen(key: $key, name: $name, sequenceOrder: $sequenceOrder, emoji: $emoji)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AllergenImpl &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.sequenceOrder, sequenceOrder) ||
+                other.sequenceOrder == sequenceOrder) &&
+            (identical(other.emoji, emoji) || other.emoji == emoji));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, name, sequenceOrder, emoji);
+
+  /// Create a copy of Allergen
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AllergenImplCopyWith<_$AllergenImpl> get copyWith =>
+      __$$AllergenImplCopyWithImpl<_$AllergenImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$AllergenImplToJson(this);
+  }
+}
+
+abstract class _Allergen implements Allergen {
+  const factory _Allergen({
+    required final String key,
+    required final String name,
+    required final int sequenceOrder,
+    required final String emoji,
+  }) = _$AllergenImpl;
+
+  factory _Allergen.fromJson(Map<String, dynamic> json) =
+      _$AllergenImpl.fromJson;
+
+  @override
+  String get key;
+  @override
+  String get name;
+  @override
+  int get sequenceOrder;
+  @override
+  String get emoji;
+
+  /// Create a copy of Allergen
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AllergenImplCopyWith<_$AllergenImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/common/domain/entities/allergen.g.dart
+++ b/lib/src/common/domain/entities/allergen.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'allergen.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$AllergenImpl _$$AllergenImplFromJson(Map<String, dynamic> json) =>
+    _$AllergenImpl(
+      key: json['key'] as String,
+      name: json['name'] as String,
+      sequenceOrder: (json['sequenceOrder'] as num).toInt(),
+      emoji: json['emoji'] as String,
+    );
+
+Map<String, dynamic> _$$AllergenImplToJson(_$AllergenImpl instance) =>
+    <String, dynamic>{
+      'key': instance.key,
+      'name': instance.name,
+      'sequenceOrder': instance.sequenceOrder,
+      'emoji': instance.emoji,
+    };

--- a/lib/src/common/domain/entities/allergen_board_item.dart
+++ b/lib/src/common/domain/entities/allergen_board_item.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+
+part 'allergen_board_item.freezed.dart';
+
+@freezed
+class AllergenBoardItem with _$AllergenBoardItem {
+  const factory AllergenBoardItem({
+    required Allergen allergen,
+    required List<AllergenLog> logs,
+    required AllergenStatus status,
+  }) = _AllergenBoardItem;
+}

--- a/lib/src/common/domain/entities/allergen_board_item.freezed.dart
+++ b/lib/src/common/domain/entities/allergen_board_item.freezed.dart
@@ -1,0 +1,222 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'allergen_board_item.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$AllergenBoardItem {
+  Allergen get allergen => throw _privateConstructorUsedError;
+  List<AllergenLog> get logs => throw _privateConstructorUsedError;
+  AllergenStatus get status => throw _privateConstructorUsedError;
+
+  /// Create a copy of AllergenBoardItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AllergenBoardItemCopyWith<AllergenBoardItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AllergenBoardItemCopyWith<$Res> {
+  factory $AllergenBoardItemCopyWith(
+    AllergenBoardItem value,
+    $Res Function(AllergenBoardItem) then,
+  ) = _$AllergenBoardItemCopyWithImpl<$Res, AllergenBoardItem>;
+  @useResult
+  $Res call({Allergen allergen, List<AllergenLog> logs, AllergenStatus status});
+
+  $AllergenCopyWith<$Res> get allergen;
+}
+
+/// @nodoc
+class _$AllergenBoardItemCopyWithImpl<$Res, $Val extends AllergenBoardItem>
+    implements $AllergenBoardItemCopyWith<$Res> {
+  _$AllergenBoardItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AllergenBoardItem
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? allergen = null,
+    Object? logs = null,
+    Object? status = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            allergen: null == allergen
+                ? _value.allergen
+                : allergen // ignore: cast_nullable_to_non_nullable
+                      as Allergen,
+            logs: null == logs
+                ? _value.logs
+                : logs // ignore: cast_nullable_to_non_nullable
+                      as List<AllergenLog>,
+            status: null == status
+                ? _value.status
+                : status // ignore: cast_nullable_to_non_nullable
+                      as AllergenStatus,
+          )
+          as $Val,
+    );
+  }
+
+  /// Create a copy of AllergenBoardItem
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AllergenCopyWith<$Res> get allergen {
+    return $AllergenCopyWith<$Res>(_value.allergen, (value) {
+      return _then(_value.copyWith(allergen: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$AllergenBoardItemImplCopyWith<$Res>
+    implements $AllergenBoardItemCopyWith<$Res> {
+  factory _$$AllergenBoardItemImplCopyWith(
+    _$AllergenBoardItemImpl value,
+    $Res Function(_$AllergenBoardItemImpl) then,
+  ) = __$$AllergenBoardItemImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Allergen allergen, List<AllergenLog> logs, AllergenStatus status});
+
+  @override
+  $AllergenCopyWith<$Res> get allergen;
+}
+
+/// @nodoc
+class __$$AllergenBoardItemImplCopyWithImpl<$Res>
+    extends _$AllergenBoardItemCopyWithImpl<$Res, _$AllergenBoardItemImpl>
+    implements _$$AllergenBoardItemImplCopyWith<$Res> {
+  __$$AllergenBoardItemImplCopyWithImpl(
+    _$AllergenBoardItemImpl _value,
+    $Res Function(_$AllergenBoardItemImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of AllergenBoardItem
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? allergen = null,
+    Object? logs = null,
+    Object? status = null,
+  }) {
+    return _then(
+      _$AllergenBoardItemImpl(
+        allergen: null == allergen
+            ? _value.allergen
+            : allergen // ignore: cast_nullable_to_non_nullable
+                  as Allergen,
+        logs: null == logs
+            ? _value._logs
+            : logs // ignore: cast_nullable_to_non_nullable
+                  as List<AllergenLog>,
+        status: null == status
+            ? _value.status
+            : status // ignore: cast_nullable_to_non_nullable
+                  as AllergenStatus,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$AllergenBoardItemImpl implements _AllergenBoardItem {
+  const _$AllergenBoardItemImpl({
+    required this.allergen,
+    required final List<AllergenLog> logs,
+    required this.status,
+  }) : _logs = logs;
+
+  @override
+  final Allergen allergen;
+  final List<AllergenLog> _logs;
+  @override
+  List<AllergenLog> get logs {
+    if (_logs is EqualUnmodifiableListView) return _logs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_logs);
+  }
+
+  @override
+  final AllergenStatus status;
+
+  @override
+  String toString() {
+    return 'AllergenBoardItem(allergen: $allergen, logs: $logs, status: $status)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AllergenBoardItemImpl &&
+            (identical(other.allergen, allergen) ||
+                other.allergen == allergen) &&
+            const DeepCollectionEquality().equals(other._logs, _logs) &&
+            (identical(other.status, status) || other.status == status));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    allergen,
+    const DeepCollectionEquality().hash(_logs),
+    status,
+  );
+
+  /// Create a copy of AllergenBoardItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AllergenBoardItemImplCopyWith<_$AllergenBoardItemImpl> get copyWith =>
+      __$$AllergenBoardItemImplCopyWithImpl<_$AllergenBoardItemImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _AllergenBoardItem implements AllergenBoardItem {
+  const factory _AllergenBoardItem({
+    required final Allergen allergen,
+    required final List<AllergenLog> logs,
+    required final AllergenStatus status,
+  }) = _$AllergenBoardItemImpl;
+
+  @override
+  Allergen get allergen;
+  @override
+  List<AllergenLog> get logs;
+  @override
+  AllergenStatus get status;
+
+  /// Create a copy of AllergenBoardItem
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AllergenBoardItemImplCopyWith<_$AllergenBoardItemImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/common/domain/entities/allergen_log.dart
+++ b/lib/src/common/domain/entities/allergen_log.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
+
+part 'allergen_log.freezed.dart';
+
+@freezed
+class AllergenLog with _$AllergenLog {
+  const factory AllergenLog({
+    required String id,
+    required String babyId,
+    required String allergenKey,
+    required EmojiTaste emojiTaste,
+    required bool hadReaction,
+    required DateTime logDate,
+    required DateTime createdAt,
+  }) = _AllergenLog;
+}

--- a/lib/src/common/domain/entities/allergen_log.freezed.dart
+++ b/lib/src/common/domain/entities/allergen_log.freezed.dart
@@ -1,0 +1,293 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'allergen_log.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$AllergenLog {
+  String get id => throw _privateConstructorUsedError;
+  String get babyId => throw _privateConstructorUsedError;
+  String get allergenKey => throw _privateConstructorUsedError;
+  EmojiTaste get emojiTaste => throw _privateConstructorUsedError;
+  bool get hadReaction => throw _privateConstructorUsedError;
+  DateTime get logDate => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+
+  /// Create a copy of AllergenLog
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AllergenLogCopyWith<AllergenLog> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AllergenLogCopyWith<$Res> {
+  factory $AllergenLogCopyWith(
+    AllergenLog value,
+    $Res Function(AllergenLog) then,
+  ) = _$AllergenLogCopyWithImpl<$Res, AllergenLog>;
+  @useResult
+  $Res call({
+    String id,
+    String babyId,
+    String allergenKey,
+    EmojiTaste emojiTaste,
+    bool hadReaction,
+    DateTime logDate,
+    DateTime createdAt,
+  });
+}
+
+/// @nodoc
+class _$AllergenLogCopyWithImpl<$Res, $Val extends AllergenLog>
+    implements $AllergenLogCopyWith<$Res> {
+  _$AllergenLogCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AllergenLog
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? babyId = null,
+    Object? allergenKey = null,
+    Object? emojiTaste = null,
+    Object? hadReaction = null,
+    Object? logDate = null,
+    Object? createdAt = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            babyId: null == babyId
+                ? _value.babyId
+                : babyId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            allergenKey: null == allergenKey
+                ? _value.allergenKey
+                : allergenKey // ignore: cast_nullable_to_non_nullable
+                      as String,
+            emojiTaste: null == emojiTaste
+                ? _value.emojiTaste
+                : emojiTaste // ignore: cast_nullable_to_non_nullable
+                      as EmojiTaste,
+            hadReaction: null == hadReaction
+                ? _value.hadReaction
+                : hadReaction // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            logDate: null == logDate
+                ? _value.logDate
+                : logDate // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            createdAt: null == createdAt
+                ? _value.createdAt
+                : createdAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$AllergenLogImplCopyWith<$Res>
+    implements $AllergenLogCopyWith<$Res> {
+  factory _$$AllergenLogImplCopyWith(
+    _$AllergenLogImpl value,
+    $Res Function(_$AllergenLogImpl) then,
+  ) = __$$AllergenLogImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String babyId,
+    String allergenKey,
+    EmojiTaste emojiTaste,
+    bool hadReaction,
+    DateTime logDate,
+    DateTime createdAt,
+  });
+}
+
+/// @nodoc
+class __$$AllergenLogImplCopyWithImpl<$Res>
+    extends _$AllergenLogCopyWithImpl<$Res, _$AllergenLogImpl>
+    implements _$$AllergenLogImplCopyWith<$Res> {
+  __$$AllergenLogImplCopyWithImpl(
+    _$AllergenLogImpl _value,
+    $Res Function(_$AllergenLogImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of AllergenLog
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? babyId = null,
+    Object? allergenKey = null,
+    Object? emojiTaste = null,
+    Object? hadReaction = null,
+    Object? logDate = null,
+    Object? createdAt = null,
+  }) {
+    return _then(
+      _$AllergenLogImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        babyId: null == babyId
+            ? _value.babyId
+            : babyId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        allergenKey: null == allergenKey
+            ? _value.allergenKey
+            : allergenKey // ignore: cast_nullable_to_non_nullable
+                  as String,
+        emojiTaste: null == emojiTaste
+            ? _value.emojiTaste
+            : emojiTaste // ignore: cast_nullable_to_non_nullable
+                  as EmojiTaste,
+        hadReaction: null == hadReaction
+            ? _value.hadReaction
+            : hadReaction // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        logDate: null == logDate
+            ? _value.logDate
+            : logDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        createdAt: null == createdAt
+            ? _value.createdAt
+            : createdAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$AllergenLogImpl implements _AllergenLog {
+  const _$AllergenLogImpl({
+    required this.id,
+    required this.babyId,
+    required this.allergenKey,
+    required this.emojiTaste,
+    required this.hadReaction,
+    required this.logDate,
+    required this.createdAt,
+  });
+
+  @override
+  final String id;
+  @override
+  final String babyId;
+  @override
+  final String allergenKey;
+  @override
+  final EmojiTaste emojiTaste;
+  @override
+  final bool hadReaction;
+  @override
+  final DateTime logDate;
+  @override
+  final DateTime createdAt;
+
+  @override
+  String toString() {
+    return 'AllergenLog(id: $id, babyId: $babyId, allergenKey: $allergenKey, emojiTaste: $emojiTaste, hadReaction: $hadReaction, logDate: $logDate, createdAt: $createdAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AllergenLogImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.babyId, babyId) || other.babyId == babyId) &&
+            (identical(other.allergenKey, allergenKey) ||
+                other.allergenKey == allergenKey) &&
+            (identical(other.emojiTaste, emojiTaste) ||
+                other.emojiTaste == emojiTaste) &&
+            (identical(other.hadReaction, hadReaction) ||
+                other.hadReaction == hadReaction) &&
+            (identical(other.logDate, logDate) || other.logDate == logDate) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    babyId,
+    allergenKey,
+    emojiTaste,
+    hadReaction,
+    logDate,
+    createdAt,
+  );
+
+  /// Create a copy of AllergenLog
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AllergenLogImplCopyWith<_$AllergenLogImpl> get copyWith =>
+      __$$AllergenLogImplCopyWithImpl<_$AllergenLogImpl>(this, _$identity);
+}
+
+abstract class _AllergenLog implements AllergenLog {
+  const factory _AllergenLog({
+    required final String id,
+    required final String babyId,
+    required final String allergenKey,
+    required final EmojiTaste emojiTaste,
+    required final bool hadReaction,
+    required final DateTime logDate,
+    required final DateTime createdAt,
+  }) = _$AllergenLogImpl;
+
+  @override
+  String get id;
+  @override
+  String get babyId;
+  @override
+  String get allergenKey;
+  @override
+  EmojiTaste get emojiTaste;
+  @override
+  bool get hadReaction;
+  @override
+  DateTime get logDate;
+  @override
+  DateTime get createdAt;
+
+  /// Create a copy of AllergenLog
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AllergenLogImplCopyWith<_$AllergenLogImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/common/domain/entities/allergen_program_state.dart
+++ b/lib/src/common/domain/entities/allergen_program_state.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
+
+part 'allergen_program_state.freezed.dart';
+
+@freezed
+class AllergenProgramState with _$AllergenProgramState {
+  const factory AllergenProgramState({
+    required String id,
+    required String babyId,
+    required String currentAllergenKey,
+    required int currentSequenceOrder,
+    required AllergenProgramStatus status,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) = _AllergenProgramState;
+}

--- a/lib/src/common/domain/entities/allergen_program_state.freezed.dart
+++ b/lib/src/common/domain/entities/allergen_program_state.freezed.dart
@@ -1,0 +1,300 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'allergen_program_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$AllergenProgramState {
+  String get id => throw _privateConstructorUsedError;
+  String get babyId => throw _privateConstructorUsedError;
+  String get currentAllergenKey => throw _privateConstructorUsedError;
+  int get currentSequenceOrder => throw _privateConstructorUsedError;
+  AllergenProgramStatus get status => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  DateTime get updatedAt => throw _privateConstructorUsedError;
+
+  /// Create a copy of AllergenProgramState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AllergenProgramStateCopyWith<AllergenProgramState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AllergenProgramStateCopyWith<$Res> {
+  factory $AllergenProgramStateCopyWith(
+    AllergenProgramState value,
+    $Res Function(AllergenProgramState) then,
+  ) = _$AllergenProgramStateCopyWithImpl<$Res, AllergenProgramState>;
+  @useResult
+  $Res call({
+    String id,
+    String babyId,
+    String currentAllergenKey,
+    int currentSequenceOrder,
+    AllergenProgramStatus status,
+    DateTime createdAt,
+    DateTime updatedAt,
+  });
+}
+
+/// @nodoc
+class _$AllergenProgramStateCopyWithImpl<
+  $Res,
+  $Val extends AllergenProgramState
+>
+    implements $AllergenProgramStateCopyWith<$Res> {
+  _$AllergenProgramStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AllergenProgramState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? babyId = null,
+    Object? currentAllergenKey = null,
+    Object? currentSequenceOrder = null,
+    Object? status = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            babyId: null == babyId
+                ? _value.babyId
+                : babyId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            currentAllergenKey: null == currentAllergenKey
+                ? _value.currentAllergenKey
+                : currentAllergenKey // ignore: cast_nullable_to_non_nullable
+                      as String,
+            currentSequenceOrder: null == currentSequenceOrder
+                ? _value.currentSequenceOrder
+                : currentSequenceOrder // ignore: cast_nullable_to_non_nullable
+                      as int,
+            status: null == status
+                ? _value.status
+                : status // ignore: cast_nullable_to_non_nullable
+                      as AllergenProgramStatus,
+            createdAt: null == createdAt
+                ? _value.createdAt
+                : createdAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            updatedAt: null == updatedAt
+                ? _value.updatedAt
+                : updatedAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$AllergenProgramStateImplCopyWith<$Res>
+    implements $AllergenProgramStateCopyWith<$Res> {
+  factory _$$AllergenProgramStateImplCopyWith(
+    _$AllergenProgramStateImpl value,
+    $Res Function(_$AllergenProgramStateImpl) then,
+  ) = __$$AllergenProgramStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String babyId,
+    String currentAllergenKey,
+    int currentSequenceOrder,
+    AllergenProgramStatus status,
+    DateTime createdAt,
+    DateTime updatedAt,
+  });
+}
+
+/// @nodoc
+class __$$AllergenProgramStateImplCopyWithImpl<$Res>
+    extends _$AllergenProgramStateCopyWithImpl<$Res, _$AllergenProgramStateImpl>
+    implements _$$AllergenProgramStateImplCopyWith<$Res> {
+  __$$AllergenProgramStateImplCopyWithImpl(
+    _$AllergenProgramStateImpl _value,
+    $Res Function(_$AllergenProgramStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of AllergenProgramState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? babyId = null,
+    Object? currentAllergenKey = null,
+    Object? currentSequenceOrder = null,
+    Object? status = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(
+      _$AllergenProgramStateImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        babyId: null == babyId
+            ? _value.babyId
+            : babyId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        currentAllergenKey: null == currentAllergenKey
+            ? _value.currentAllergenKey
+            : currentAllergenKey // ignore: cast_nullable_to_non_nullable
+                  as String,
+        currentSequenceOrder: null == currentSequenceOrder
+            ? _value.currentSequenceOrder
+            : currentSequenceOrder // ignore: cast_nullable_to_non_nullable
+                  as int,
+        status: null == status
+            ? _value.status
+            : status // ignore: cast_nullable_to_non_nullable
+                  as AllergenProgramStatus,
+        createdAt: null == createdAt
+            ? _value.createdAt
+            : createdAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        updatedAt: null == updatedAt
+            ? _value.updatedAt
+            : updatedAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$AllergenProgramStateImpl implements _AllergenProgramState {
+  const _$AllergenProgramStateImpl({
+    required this.id,
+    required this.babyId,
+    required this.currentAllergenKey,
+    required this.currentSequenceOrder,
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  @override
+  final String id;
+  @override
+  final String babyId;
+  @override
+  final String currentAllergenKey;
+  @override
+  final int currentSequenceOrder;
+  @override
+  final AllergenProgramStatus status;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime updatedAt;
+
+  @override
+  String toString() {
+    return 'AllergenProgramState(id: $id, babyId: $babyId, currentAllergenKey: $currentAllergenKey, currentSequenceOrder: $currentSequenceOrder, status: $status, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AllergenProgramStateImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.babyId, babyId) || other.babyId == babyId) &&
+            (identical(other.currentAllergenKey, currentAllergenKey) ||
+                other.currentAllergenKey == currentAllergenKey) &&
+            (identical(other.currentSequenceOrder, currentSequenceOrder) ||
+                other.currentSequenceOrder == currentSequenceOrder) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    babyId,
+    currentAllergenKey,
+    currentSequenceOrder,
+    status,
+    createdAt,
+    updatedAt,
+  );
+
+  /// Create a copy of AllergenProgramState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AllergenProgramStateImplCopyWith<_$AllergenProgramStateImpl>
+  get copyWith =>
+      __$$AllergenProgramStateImplCopyWithImpl<_$AllergenProgramStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _AllergenProgramState implements AllergenProgramState {
+  const factory _AllergenProgramState({
+    required final String id,
+    required final String babyId,
+    required final String currentAllergenKey,
+    required final int currentSequenceOrder,
+    required final AllergenProgramStatus status,
+    required final DateTime createdAt,
+    required final DateTime updatedAt,
+  }) = _$AllergenProgramStateImpl;
+
+  @override
+  String get id;
+  @override
+  String get babyId;
+  @override
+  String get currentAllergenKey;
+  @override
+  int get currentSequenceOrder;
+  @override
+  AllergenProgramStatus get status;
+  @override
+  DateTime get createdAt;
+  @override
+  DateTime get updatedAt;
+
+  /// Create a copy of AllergenProgramState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AllergenProgramStateImplCopyWith<_$AllergenProgramStateImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/src/common/domain/entities/reaction_detail.dart
+++ b/lib/src/common/domain/entities/reaction_detail.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
+
+part 'reaction_detail.freezed.dart';
+
+@freezed
+class ReactionDetail with _$ReactionDetail {
+  const factory ReactionDetail({
+    required String id,
+    required String logId,
+    required ReactionSeverity severity,
+    required List<String> symptoms,
+    required DateTime createdAt,
+    String? notes,
+  }) = _ReactionDetail;
+}

--- a/lib/src/common/domain/entities/reaction_detail.freezed.dart
+++ b/lib/src/common/domain/entities/reaction_detail.freezed.dart
@@ -1,0 +1,279 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reaction_detail.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$ReactionDetail {
+  String get id => throw _privateConstructorUsedError;
+  String get logId => throw _privateConstructorUsedError;
+  ReactionSeverity get severity => throw _privateConstructorUsedError;
+  List<String> get symptoms => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  String? get notes => throw _privateConstructorUsedError;
+
+  /// Create a copy of ReactionDetail
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ReactionDetailCopyWith<ReactionDetail> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReactionDetailCopyWith<$Res> {
+  factory $ReactionDetailCopyWith(
+    ReactionDetail value,
+    $Res Function(ReactionDetail) then,
+  ) = _$ReactionDetailCopyWithImpl<$Res, ReactionDetail>;
+  @useResult
+  $Res call({
+    String id,
+    String logId,
+    ReactionSeverity severity,
+    List<String> symptoms,
+    DateTime createdAt,
+    String? notes,
+  });
+}
+
+/// @nodoc
+class _$ReactionDetailCopyWithImpl<$Res, $Val extends ReactionDetail>
+    implements $ReactionDetailCopyWith<$Res> {
+  _$ReactionDetailCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ReactionDetail
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? logId = null,
+    Object? severity = null,
+    Object? symptoms = null,
+    Object? createdAt = null,
+    Object? notes = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            logId: null == logId
+                ? _value.logId
+                : logId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            severity: null == severity
+                ? _value.severity
+                : severity // ignore: cast_nullable_to_non_nullable
+                      as ReactionSeverity,
+            symptoms: null == symptoms
+                ? _value.symptoms
+                : symptoms // ignore: cast_nullable_to_non_nullable
+                      as List<String>,
+            createdAt: null == createdAt
+                ? _value.createdAt
+                : createdAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            notes: freezed == notes
+                ? _value.notes
+                : notes // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ReactionDetailImplCopyWith<$Res>
+    implements $ReactionDetailCopyWith<$Res> {
+  factory _$$ReactionDetailImplCopyWith(
+    _$ReactionDetailImpl value,
+    $Res Function(_$ReactionDetailImpl) then,
+  ) = __$$ReactionDetailImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String logId,
+    ReactionSeverity severity,
+    List<String> symptoms,
+    DateTime createdAt,
+    String? notes,
+  });
+}
+
+/// @nodoc
+class __$$ReactionDetailImplCopyWithImpl<$Res>
+    extends _$ReactionDetailCopyWithImpl<$Res, _$ReactionDetailImpl>
+    implements _$$ReactionDetailImplCopyWith<$Res> {
+  __$$ReactionDetailImplCopyWithImpl(
+    _$ReactionDetailImpl _value,
+    $Res Function(_$ReactionDetailImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of ReactionDetail
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? logId = null,
+    Object? severity = null,
+    Object? symptoms = null,
+    Object? createdAt = null,
+    Object? notes = freezed,
+  }) {
+    return _then(
+      _$ReactionDetailImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        logId: null == logId
+            ? _value.logId
+            : logId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        severity: null == severity
+            ? _value.severity
+            : severity // ignore: cast_nullable_to_non_nullable
+                  as ReactionSeverity,
+        symptoms: null == symptoms
+            ? _value._symptoms
+            : symptoms // ignore: cast_nullable_to_non_nullable
+                  as List<String>,
+        createdAt: null == createdAt
+            ? _value.createdAt
+            : createdAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        notes: freezed == notes
+            ? _value.notes
+            : notes // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ReactionDetailImpl implements _ReactionDetail {
+  const _$ReactionDetailImpl({
+    required this.id,
+    required this.logId,
+    required this.severity,
+    required final List<String> symptoms,
+    required this.createdAt,
+    this.notes,
+  }) : _symptoms = symptoms;
+
+  @override
+  final String id;
+  @override
+  final String logId;
+  @override
+  final ReactionSeverity severity;
+  final List<String> _symptoms;
+  @override
+  List<String> get symptoms {
+    if (_symptoms is EqualUnmodifiableListView) return _symptoms;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_symptoms);
+  }
+
+  @override
+  final DateTime createdAt;
+  @override
+  final String? notes;
+
+  @override
+  String toString() {
+    return 'ReactionDetail(id: $id, logId: $logId, severity: $severity, symptoms: $symptoms, createdAt: $createdAt, notes: $notes)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReactionDetailImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.logId, logId) || other.logId == logId) &&
+            (identical(other.severity, severity) ||
+                other.severity == severity) &&
+            const DeepCollectionEquality().equals(other._symptoms, _symptoms) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.notes, notes) || other.notes == notes));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    logId,
+    severity,
+    const DeepCollectionEquality().hash(_symptoms),
+    createdAt,
+    notes,
+  );
+
+  /// Create a copy of ReactionDetail
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReactionDetailImplCopyWith<_$ReactionDetailImpl> get copyWith =>
+      __$$ReactionDetailImplCopyWithImpl<_$ReactionDetailImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _ReactionDetail implements ReactionDetail {
+  const factory _ReactionDetail({
+    required final String id,
+    required final String logId,
+    required final ReactionSeverity severity,
+    required final List<String> symptoms,
+    required final DateTime createdAt,
+    final String? notes,
+  }) = _$ReactionDetailImpl;
+
+  @override
+  String get id;
+  @override
+  String get logId;
+  @override
+  ReactionSeverity get severity;
+  @override
+  List<String> get symptoms;
+  @override
+  DateTime get createdAt;
+  @override
+  String? get notes;
+
+  /// Create a copy of ReactionDetail
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ReactionDetailImplCopyWith<_$ReactionDetailImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/common/domain/enums/allergen_program_status.dart
+++ b/lib/src/common/domain/enums/allergen_program_status.dart
@@ -1,0 +1,16 @@
+enum AllergenProgramStatus { inProgress, completed, flagged }
+
+extension AllergenProgramStatusX on AllergenProgramStatus {
+  String toJson() => switch (this) {
+        AllergenProgramStatus.inProgress => 'in_progress',
+        AllergenProgramStatus.completed => 'completed',
+        AllergenProgramStatus.flagged => 'flagged',
+      };
+
+  static AllergenProgramStatus fromJson(String value) => switch (value) {
+        'in_progress' => AllergenProgramStatus.inProgress,
+        'completed' => AllergenProgramStatus.completed,
+        'flagged' => AllergenProgramStatus.flagged,
+        _ => AllergenProgramStatus.inProgress,
+      };
+}

--- a/lib/src/common/domain/enums/allergen_status.dart
+++ b/lib/src/common/domain/enums/allergen_status.dart
@@ -1,0 +1,1 @@
+enum AllergenStatus { notStarted, inProgress, safe, flagged }

--- a/lib/src/common/domain/enums/emoji_taste.dart
+++ b/lib/src/common/domain/enums/emoji_taste.dart
@@ -1,0 +1,16 @@
+enum EmojiTaste { love, neutral, dislike }
+
+extension EmojiTasteX on EmojiTaste {
+  String toJson() => switch (this) {
+        EmojiTaste.love => 'love',
+        EmojiTaste.neutral => 'neutral',
+        EmojiTaste.dislike => 'dislike',
+      };
+
+  static EmojiTaste fromJson(String value) => switch (value) {
+        'love' => EmojiTaste.love,
+        'neutral' => EmojiTaste.neutral,
+        'dislike' => EmojiTaste.dislike,
+        _ => EmojiTaste.neutral,
+      };
+}

--- a/lib/src/common/domain/enums/reaction_severity.dart
+++ b/lib/src/common/domain/enums/reaction_severity.dart
@@ -1,0 +1,16 @@
+enum ReactionSeverity { mild, moderate, severe }
+
+extension ReactionSeverityX on ReactionSeverity {
+  String toJson() => switch (this) {
+        ReactionSeverity.mild => 'mild',
+        ReactionSeverity.moderate => 'moderate',
+        ReactionSeverity.severe => 'severe',
+      };
+
+  static ReactionSeverity fromJson(String value) => switch (value) {
+        'mild' => ReactionSeverity.mild,
+        'moderate' => ReactionSeverity.moderate,
+        'severe' => ReactionSeverity.severe,
+        _ => ReactionSeverity.mild,
+      };
+}

--- a/lib/src/common/services/allergen_service.dart
+++ b/lib/src/common/services/allergen_service.dart
@@ -1,0 +1,197 @@
+import 'package:nibbles/src/common/data/repositories/allergen_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/reaction_detail.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'allergen_service.g.dart';
+
+class AllergenService {
+  const AllergenService(this._repo);
+
+  final AllergenRepository _repo;
+
+  /// Returns the allergen the baby is currently working through.
+  Future<Result<Allergen>> getCurrentAllergen(String babyId) async {
+    final stateResult = await _repo.getProgramState(babyId);
+    if (stateResult.isFailure) {
+      return Result.failure(stateResult.errorOrNull!);
+    }
+
+    final allergensResult = await _repo.getAllergens();
+    if (allergensResult.isFailure) {
+      return Result.failure(allergensResult.errorOrNull!);
+    }
+
+    final state = stateResult.dataOrNull!;
+    final allergens = allergensResult.dataOrNull!;
+
+    final current = allergens.firstWhere(
+      (a) => a.key == state.currentAllergenKey,
+      orElse: () => allergens.first,
+    );
+
+    return Result.success(current);
+  }
+
+  /// Assembles all 9 allergens with their logs and derived [AllergenStatus].
+  Future<Result<List<AllergenBoardItem>>> getAllergenBoardSummary(
+    String babyId,
+  ) async {
+    final allergensResult = await _repo.getAllergens();
+    if (allergensResult.isFailure) {
+      return Result.failure(allergensResult.errorOrNull!);
+    }
+
+    final logsResult = await _repo.getLogs(babyId);
+    if (logsResult.isFailure) {
+      return Result.failure(logsResult.errorOrNull!);
+    }
+
+    final allergens = allergensResult.dataOrNull!;
+    final allLogs = logsResult.dataOrNull!;
+
+    final items = allergens
+        .map(
+          (allergen) {
+            final logs = allLogs
+                .where((l) => l.allergenKey == allergen.key)
+                .toList();
+            return AllergenBoardItem(
+              allergen: allergen,
+              logs: logs,
+              status: deriveStatus(logs),
+            );
+          },
+        )
+        .toList();
+
+    return Result.success(items);
+  }
+
+  /// Saves a daily allergen log.
+  ///
+  /// Returns [DuplicateLogException] if a log already exists for the same
+  /// allergen on the same calendar day — never inserts a duplicate.
+  Future<Result<AllergenLog>> saveAllergenLog({
+    required String babyId,
+    required String allergenKey,
+    required EmojiTaste emojiTaste,
+    required bool hadReaction,
+    ReactionDetail? reactionDetail,
+  }) async {
+    final today = DateTime.now();
+
+    final duplicateCheck =
+        await _repo.hasLogForToday(babyId, allergenKey, today);
+    if (duplicateCheck.isFailure) {
+      return Result.failure(duplicateCheck.errorOrNull!);
+    }
+
+    if (duplicateCheck.dataOrNull!) {
+      final name = await _resolveAllergenName(allergenKey);
+      return Result.failure(DuplicateLogException(name));
+    }
+
+    final logResult = await _repo.saveLog(
+      AllergenLog(
+        id: '',
+        babyId: babyId,
+        allergenKey: allergenKey,
+        emojiTaste: emojiTaste,
+        hadReaction: hadReaction,
+        logDate: today,
+        createdAt: today,
+      ),
+    );
+    if (logResult.isFailure) return Result.failure(logResult.errorOrNull!);
+
+    final savedLog = logResult.dataOrNull!;
+
+    if (hadReaction && reactionDetail != null) {
+      final detailResult = await _repo.saveReactionDetail(
+        reactionDetail.copyWith(id: '', logId: savedLog.id),
+      );
+      if (detailResult.isFailure) {
+        return Result.failure(detailResult.errorOrNull!);
+      }
+    }
+
+    return Result.success(savedLog);
+  }
+
+  /// Advances the program to the next allergen in sequence.
+  /// Completes the program automatically if the current allergen is last.
+  Future<Result<void>> advanceToNextAllergen(String babyId) async {
+    final stateResult = await _repo.getProgramState(babyId);
+    if (stateResult.isFailure) {
+      return Result.failure(stateResult.errorOrNull!);
+    }
+
+    final allergensResult = await _repo.getAllergens();
+    if (allergensResult.isFailure) {
+      return Result.failure(allergensResult.errorOrNull!);
+    }
+
+    final state = stateResult.dataOrNull!;
+    final sorted = List<Allergen>.from(allergensResult.dataOrNull!)
+      ..sort((a, b) => a.sequenceOrder.compareTo(b.sequenceOrder));
+
+    final nextIndex = sorted.indexWhere(
+      (a) => a.sequenceOrder > state.currentSequenceOrder,
+    );
+
+    if (nextIndex == -1) {
+      return _repo.completeProgramState(babyId);
+    }
+
+    final next = sorted[nextIndex];
+    return _repo.advanceProgramState(babyId, next.key, next.sequenceOrder);
+  }
+
+  /// Marks the allergen program as completed.
+  Future<Result<void>> completeProgram(String babyId) =>
+      _repo.completeProgramState(babyId);
+
+  /// Derives [AllergenStatus] from a list of logs for a single allergen.
+  ///
+  /// - 0 logs          → [AllergenStatus.notStarted]
+  /// - any hadReaction  → [AllergenStatus.flagged]
+  /// - 3+ no reaction   → [AllergenStatus.safe]  (NEVER `completed`)
+  /// - 1–2 no reaction  → [AllergenStatus.inProgress]
+  AllergenStatus deriveStatus(List<AllergenLog> logs) {
+    if (logs.isEmpty) return AllergenStatus.notStarted;
+    if (logs.any((l) => l.hadReaction)) return AllergenStatus.flagged;
+    if (logs.length >= 3) return AllergenStatus.safe;
+    return AllergenStatus.inProgress;
+  }
+
+  Future<String> _resolveAllergenName(String allergenKey) async {
+    final result = await _repo.getAllergens();
+    if (result.isFailure) return 'this allergen';
+    return result.dataOrNull!
+        .firstWhere(
+          (a) => a.key == allergenKey,
+          orElse: () => const Allergen(
+            key: '',
+            name: 'this allergen',
+            sequenceOrder: 0,
+            emoji: '',
+          ),
+        )
+        .name;
+  }
+}
+
+@Riverpod(keepAlive: true)
+AllergenService allergenService(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  AllergenServiceRef ref,
+) =>
+    AllergenService(ref.watch(allergenRepositoryProvider));

--- a/lib/src/common/services/allergen_service.g.dart
+++ b/lib/src/common/services/allergen_service.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'allergen_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$allergenServiceHash() => r'12c206067f050a06765e4d29f290b908305c1b90';
+
+/// See also [allergenService].
+@ProviderFor(allergenService)
+final allergenServiceProvider = Provider<AllergenService>.internal(
+  allergenService,
+  name: r'allergenServiceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$allergenServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AllergenServiceRef = ProviderRef<AllergenService>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package


### PR DESCRIPTION
## NIB-21 — AllergenRepository + AllergenService

### What was built

**Enums**
- `AllergenStatus` — `notStarted / inProgress / safe / flagged` (no `completed`)
- `AllergenProgramStatus` — `inProgress / completed / flagged` with `toJson`/`fromJson`
- `EmojiTaste` — `love / neutral / dislike` with `toJson`/`fromJson`
- `ReactionSeverity` — `mild / moderate / severe` with `toJson`/`fromJson`

**Domain entities (freezed)**
- `Allergen` — with `fromJson`/`toJson` for Hive caching
- `AllergenLog`, `AllergenProgramState`, `ReactionDetail` — pure freezed
- `AllergenBoardItem` — assembled in service, no JSON

**AppException**
- `DuplicateLogException` added to `app_exception.dart` (sealed class requires same-file definition)

**AllergenRepository (ALLRG-01..09)**
- `getAllergens({refresh})` — Hive read-through cache (`allergens` box, key `allergens_list`)
- `getProgramState(babyId)` — single row from `allergen_program_state`
- `getLogs(babyId, {allergenKey})` — all logs, optional allergen filter
- `hasLogForToday(babyId, allergenKey, date)` — calendar-day comparison via `log_date` string
- `saveLog(log)` — inserts without `id` (Postgres auto-generates)
- `saveReactionDetail(detail)` — inserts without `id`
- `advanceProgramState(babyId, nextKey, nextOrder)` — UPDATE program state
- `completeProgramState(babyId)` — sets `status = 'completed'`
- `getReactionDetail(logId)` — nullable fetch

**AllergenService**
- `getCurrentAllergen(babyId)` — resolves from program state
- `getAllergenBoardSummary(babyId)` — all 9 allergens with logs + derived status
- `saveAllergenLog(...)` — duplicate guard → save log → optionally save reaction detail
- `advanceToNextAllergen(babyId)` — advances or auto-completes on last allergen
- `completeProgram(babyId)` — delegates to repository
- `deriveStatus(logs)` — pure function, canonical `AllergenStatus` derivation

### Acceptance criteria
- [x] `hasLogForToday` compares by calendar date, not timestamp
- [x] `saveAllergenLog` returns `DuplicateLogException` for same-day duplicate
- [x] `deriveStatus` returns `.safe` (never `.completed`) for 3 logs with no reactions
- [x] `getAllergenBoardSummary` assembles all 9 allergens with logs and status
- [x] `advanceToNextAllergen` updates DB; completes program if last allergen
- [x] `completeProgram` sets `status = 'completed'`
- [x] All methods return `Result<T>`, never throw
- [x] Hive read-through cache for allergens list with `refresh` flag for foreground updates