### PR TITLE
feat(allergen): AL-01 tracker overview + AL-02 board view [NIB-22]

### DIFF
--- a/lib/gen/assets.gen.dart
+++ b/lib/gen/assets.gen.dart
@@ -5,7 +5,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use,duplicate_definition
+// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
 
 class $AssetsIconsGen {
   const $AssetsIconsGen();
@@ -33,8 +33,11 @@ class $AssetsJsonsGen {
   /// File path: assets/jsons/.gitkeep
   String get aGitkeep => 'assets/jsons/.gitkeep';
 
+  /// File path: assets/jsons/recipe_template.json
+  String get recipeTemplate => 'assets/jsons/recipe_template.json';
+
   /// List of all assets
-  List<String> get values => [aGitkeep];
+  List<String> get values => [aGitkeep, recipeTemplate];
 }
 
 class $AssetsTranslationsGen {
@@ -50,13 +53,8 @@ class $AssetsTranslationsGen {
 class Assets {
   const Assets._();
 
-  static const String aEnv = '.env.dev';
-  static const String aEnv = '.env.prod';
   static const $AssetsIconsGen icons = $AssetsIconsGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonsGen jsons = $AssetsJsonsGen();
   static const $AssetsTranslationsGen translations = $AssetsTranslationsGen();
-
-  /// List of all assets
-  static List<String> get values => [aEnv, aEnv];
 }

--- a/lib/src/common/services/allergen_service.dart
+++ b/lib/src/common/services/allergen_service.dart
@@ -4,6 +4,7 @@ import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/allergen.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
 import 'package:nibbles/src/common/domain/entities/reaction_detail.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
@@ -153,6 +154,14 @@ class AllergenService {
     final next = sorted[nextIndex];
     return _repo.advanceProgramState(babyId, next.key, next.sequenceOrder);
   }
+
+  /// Returns the allergen program state for [babyId].
+  Future<Result<AllergenProgramState>> getProgramState(String babyId) =>
+      _repo.getProgramState(babyId);
+
+  /// Returns the reaction detail for a given [logId], or null if none exists.
+  Future<Result<ReactionDetail?>> getReactionDetail(String logId) =>
+      _repo.getReactionDetail(logId);
 
   /// Marks the allergen program as completed.
   Future<Result<void>> completeProgram(String babyId) =>

--- a/lib/src/common/services/baby_profile_service.dart
+++ b/lib/src/common/services/baby_profile_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nibbles/src/common/data/repositories/baby_profile_repository.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
@@ -51,3 +52,10 @@ BabyProfileService babyProfileService(BabyProfileServiceRef ref) =>
     BabyProfileService(
       ref.watch(babyProfileRepositoryProvider),
     );
+
+/// Fetches the current baby's id. Returns null if no baby exists yet.
+@riverpod
+Future<String?> currentBabyId(Ref ref) async {
+  final baby = await ref.watch(babyProfileServiceProvider).getBaby();
+  return baby?.id;
+}

--- a/lib/src/common/services/baby_profile_service.g.dart
+++ b/lib/src/common/services/baby_profile_service.g.dart
@@ -24,5 +24,24 @@ final babyProfileServiceProvider = Provider<BabyProfileService>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef BabyProfileServiceRef = ProviderRef<BabyProfileService>;
+String _$currentBabyIdHash() => r'30ac604b84e5b988e3b453a1084b51133570f9c3';
+
+/// Fetches the current baby's id. Returns null if no baby exists yet.
+///
+/// Copied from [currentBabyId].
+@ProviderFor(currentBabyId)
+final currentBabyIdProvider = AutoDisposeFutureProvider<String?>.internal(
+  currentBabyId,
+  name: r'currentBabyIdProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$currentBabyIdHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef CurrentBabyIdRef = AutoDisposeFutureProviderRef<String?>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/allergen/tracker/allergen_tracker_controller.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_controller.dart
@@ -1,0 +1,68 @@
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'allergen_tracker_controller.g.dart';
+
+@riverpod
+class AllergenTrackerController extends _$AllergenTrackerController {
+  @override
+  Future<AllergenTrackerState> build(String babyId) async {
+    final service = ref.read(allergenServiceProvider);
+
+    final (
+      Result<List<AllergenBoardItem>> boardResult,
+      Result<AllergenProgramState> programResult,
+    ) = await (
+      service.getAllergenBoardSummary(babyId),
+      service.getProgramState(babyId),
+    ).wait;
+
+    if (boardResult.isFailure) throw boardResult.errorOrNull!;
+    if (programResult.isFailure) throw programResult.errorOrNull!;
+
+    final boardItems = boardResult.dataOrNull!;
+    final programState = programResult.dataOrNull!;
+
+    // Collect all flagged logs with their allergen, sorted by date desc.
+    final flaggedEntries = boardItems
+        .expand(
+          (AllergenBoardItem b) => b.logs
+              .where((AllergenLog l) => l.hadReaction)
+              .map((AllergenLog l) => (allergen: b.allergen, log: l)),
+        )
+        .toList()
+      ..sort(
+        (
+          ({Allergen allergen, AllergenLog log}) a,
+          ({Allergen allergen, AllergenLog log}) b,
+        ) =>
+            b.log.logDate.compareTo(a.log.logDate),
+      );
+
+    final recent = flaggedEntries.take(3).toList();
+    final recentReactions = <RecentReaction>[];
+    for (final entry in recent) {
+      final detailResult = await service.getReactionDetail(entry.log.id);
+      recentReactions.add(
+        RecentReaction(
+          allergenName: entry.allergen.name,
+          allergenEmoji: entry.allergen.emoji,
+          logDate: entry.log.logDate,
+          severity: detailResult.dataOrNull?.severity,
+        ),
+      );
+    }
+
+    return AllergenTrackerState(
+      boardItems: boardItems,
+      programState: programState,
+      recentReactions: recentReactions,
+    );
+  }
+}

--- a/lib/src/features/allergen/tracker/allergen_tracker_controller.g.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_controller.g.dart
@@ -1,0 +1,179 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'allergen_tracker_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$allergenTrackerControllerHash() =>
+    r'7aa0304d59cd9aff8748b136e3cd80fa017a9900';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$AllergenTrackerController
+    extends BuildlessAutoDisposeAsyncNotifier<AllergenTrackerState> {
+  late final String babyId;
+
+  FutureOr<AllergenTrackerState> build(String babyId);
+}
+
+/// See also [AllergenTrackerController].
+@ProviderFor(AllergenTrackerController)
+const allergenTrackerControllerProvider = AllergenTrackerControllerFamily();
+
+/// See also [AllergenTrackerController].
+class AllergenTrackerControllerFamily
+    extends Family<AsyncValue<AllergenTrackerState>> {
+  /// See also [AllergenTrackerController].
+  const AllergenTrackerControllerFamily();
+
+  /// See also [AllergenTrackerController].
+  AllergenTrackerControllerProvider call(String babyId) {
+    return AllergenTrackerControllerProvider(babyId);
+  }
+
+  @override
+  AllergenTrackerControllerProvider getProviderOverride(
+    covariant AllergenTrackerControllerProvider provider,
+  ) {
+    return call(provider.babyId);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'allergenTrackerControllerProvider';
+}
+
+/// See also [AllergenTrackerController].
+class AllergenTrackerControllerProvider
+    extends
+        AutoDisposeAsyncNotifierProviderImpl<
+          AllergenTrackerController,
+          AllergenTrackerState
+        > {
+  /// See also [AllergenTrackerController].
+  AllergenTrackerControllerProvider(String babyId)
+    : this._internal(
+        () => AllergenTrackerController()..babyId = babyId,
+        from: allergenTrackerControllerProvider,
+        name: r'allergenTrackerControllerProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$allergenTrackerControllerHash,
+        dependencies: AllergenTrackerControllerFamily._dependencies,
+        allTransitiveDependencies:
+            AllergenTrackerControllerFamily._allTransitiveDependencies,
+        babyId: babyId,
+      );
+
+  AllergenTrackerControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.babyId,
+  }) : super.internal();
+
+  final String babyId;
+
+  @override
+  FutureOr<AllergenTrackerState> runNotifierBuild(
+    covariant AllergenTrackerController notifier,
+  ) {
+    return notifier.build(babyId);
+  }
+
+  @override
+  Override overrideWith(AllergenTrackerController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: AllergenTrackerControllerProvider._internal(
+        () => create()..babyId = babyId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        babyId: babyId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<
+    AllergenTrackerController,
+    AllergenTrackerState
+  >
+  createElement() {
+    return _AllergenTrackerControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AllergenTrackerControllerProvider && other.babyId == babyId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, babyId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin AllergenTrackerControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<AllergenTrackerState> {
+  /// The parameter `babyId` of this provider.
+  String get babyId;
+}
+
+class _AllergenTrackerControllerProviderElement
+    extends
+        AutoDisposeAsyncNotifierProviderElement<
+          AllergenTrackerController,
+          AllergenTrackerState
+        >
+    with AllergenTrackerControllerRef {
+  _AllergenTrackerControllerProviderElement(super.provider);
+
+  @override
+  String get babyId => (origin as AllergenTrackerControllerProvider).babyId;
+}
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/allergen/tracker/allergen_tracker_screen.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_screen.dart
@@ -1,9 +1,684 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_controller.dart';
+import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_state.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 class AllergenTrackerScreen extends ConsumerWidget {
   const AllergenTrackerScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Allergen Tracker (AL-01/02)')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final babyIdAsync = ref.watch(currentBabyIdProvider);
+
+    return babyIdAsync.when(
+      loading: () => const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (_, __) => const Scaffold(
+        body: Center(child: Text('Could not load baby profile.')),
+      ),
+      data: (babyId) {
+        if (babyId == null) {
+          return const Scaffold(
+            body: Center(child: Text('No baby profile found.')),
+          );
+        }
+        return _TrackerBody(babyId: babyId);
+      },
+    );
+  }
+}
+
+class _TrackerBody extends ConsumerWidget {
+  const _TrackerBody({required this.babyId});
+
+  final String babyId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final trackerAsync =
+        ref.watch(allergenTrackerControllerProvider(babyId));
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        backgroundColor: AppColors.background,
+        appBar: AppBar(
+          backgroundColor: AppColors.surface,
+          elevation: 0,
+          title: Text(
+            'Allergen Tracker',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          bottom: const TabBar(
+            labelColor: AppColors.primary,
+            unselectedLabelColor: AppColors.subtext,
+            indicatorColor: AppColors.primary,
+            tabs: [
+              Tab(text: 'Overview'),
+              Tab(text: 'All Allergens'),
+            ],
+          ),
+        ),
+        body: trackerAsync.when(
+          loading: () =>
+              const Center(child: CircularProgressIndicator()),
+          error: (e, _) => Center(
+            child: Padding(
+              padding: const EdgeInsets.all(AppSizes.pagePaddingH),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Could not load tracker.',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: AppSizes.sm),
+                  FilledButton(
+                    onPressed: () => ref.invalidate(
+                      allergenTrackerControllerProvider(babyId),
+                    ),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          data: (state) => TabBarView(
+            children: [
+              _OverviewTab(state: state, babyId: babyId),
+              _BoardTab(state: state, babyId: babyId),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AL-01 — Overview Tab
+// ---------------------------------------------------------------------------
+
+class _OverviewTab extends StatelessWidget {
+  const _OverviewTab({required this.state, required this.babyId});
+
+  final AllergenTrackerState state;
+  final String babyId;
+
+  int get _introducedCount => state.boardItems
+      .where(
+        (b) =>
+            b.status == AllergenStatus.safe ||
+            b.status == AllergenStatus.flagged,
+      )
+      .length;
+
+  int get _safeCount =>
+      state.boardItems.where((b) => b.status == AllergenStatus.safe).length;
+
+  int get _flaggedCount =>
+      state.boardItems.where((b) => b.status == AllergenStatus.flagged).length;
+
+  bool get _hasAnyLogs =>
+      state.boardItems.any((b) => b.logs.isNotEmpty);
+
+  bool _isTodayLogged() {
+    final currentKey = state.programState.currentAllergenKey;
+    final currentItem = state.boardItems
+        .where((b) => b.allergen.key == currentKey)
+        .firstOrNull;
+    if (currentItem == null) return false;
+    final today = DateTime.now();
+    return currentItem.logs.any(
+      (l) =>
+          l.logDate.year == today.year &&
+          l.logDate.month == today.month &&
+          l.logDate.day == today.day,
+    );
+  }
+
+  AllergenBoardItem? get _currentItem {
+    final currentKey = state.programState.currentAllergenKey;
+    return state.boardItems
+        .where((b) => b.allergen.key == currentKey)
+        .firstOrNull;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.pagePaddingV,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Progress circle
+          Center(
+            child: _ProgressCircle(
+              introduced: _introducedCount,
+              total: 9,
+            ),
+          ),
+          const SizedBox(height: AppSizes.lg),
+
+          // Stat chips
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _StatChip(
+                label: 'Safe',
+                count: _safeCount,
+                color: AppColors.allergenSafe,
+              ),
+              const SizedBox(width: AppSizes.md),
+              _StatChip(
+                label: 'Flagged',
+                count: _flaggedCount,
+                color: AppColors.allergenFlagged,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSizes.lg),
+
+          // Today's checklist card
+          if (!_hasAnyLogs)
+            _EmptyState(
+              currentItem: _currentItem,
+            )
+          else
+            _TodayCard(
+              currentItem: _currentItem,
+              isTodayLogged: _isTodayLogged(),
+            ),
+
+          // Recent reactions
+          if (state.recentReactions.isNotEmpty) ...[
+            const SizedBox(height: AppSizes.lg),
+            Text('Recent Reactions', style: textTheme.titleMedium),
+            const SizedBox(height: AppSizes.sm),
+            ...state.recentReactions.map(
+              (r) => _ReactionRow(reaction: r),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ProgressCircle extends StatelessWidget {
+  const _ProgressCircle({required this.introduced, required this.total});
+
+  final int introduced;
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = total > 0 ? introduced / total : 0.0;
+    final textTheme = Theme.of(context).textTheme;
+
+    return SizedBox(
+      width: 160,
+      height: 160,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          SizedBox.expand(
+            child: CircularProgressIndicator(
+              value: progress,
+              strokeWidth: 12,
+              backgroundColor: AppColors.divider,
+              valueColor:
+                  const AlwaysStoppedAnimation<Color>(AppColors.primary),
+            ),
+          ),
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                '$introduced/$total',
+                style: textTheme.headlineMedium?.copyWith(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              Text(
+                'introduced',
+                style: textTheme.bodySmall,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatChip extends StatelessWidget {
+  const _StatChip({
+    required this.label,
+    required this.count,
+    required this.color,
+  });
+
+  final String label;
+  final int count;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md,
+        vertical: AppSizes.sm,
+      ),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+        border: Border.all(color: color.withValues(alpha: 0.4)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+            ),
+          ),
+          const SizedBox(width: AppSizes.xs),
+          Text(
+            '$count $label',
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: color,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.currentItem});
+
+  final AllergenBoardItem? currentItem;
+
+  @override
+  Widget build(BuildContext context) {
+    final emoji = currentItem?.allergen.emoji ?? '🥜';
+    final name = currentItem?.allergen.name ?? 'Peanut';
+
+    return Container(
+      padding: const EdgeInsets.all(AppSizes.cardPadding),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceVariant,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      ),
+      child: Column(
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 40)),
+          const SizedBox(height: AppSizes.sm),
+          Text(
+            'Start your allergen journey!',
+            style: Theme.of(context).textTheme.titleSmall,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: AppSizes.xs),
+          Text(
+            'Begin with $emoji $name.',
+            style: Theme.of(context)
+                .textTheme
+                .bodyMedium
+                ?.copyWith(color: AppColors.subtext),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TodayCard extends StatelessWidget {
+  const _TodayCard({
+    required this.currentItem,
+    required this.isTodayLogged,
+  });
+
+  final AllergenBoardItem? currentItem;
+  final bool isTodayLogged;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final emoji = currentItem?.allergen.emoji ?? '';
+    final name = currentItem?.allergen.name ?? 'Current Allergen';
+
+    return Container(
+      padding: const EdgeInsets.all(AppSizes.cardPadding),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        border: Border.all(color: AppColors.divider),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Text(emoji, style: const TextStyle(fontSize: 32)),
+          const SizedBox(width: AppSizes.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text("Today's allergen", style: textTheme.bodySmall),
+                const SizedBox(height: 2),
+                Text(name, style: textTheme.titleMedium),
+              ],
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.sm,
+              vertical: AppSizes.xs,
+            ),
+            decoration: BoxDecoration(
+              color: isTodayLogged
+                  ? AppColors.allergenSafe.withValues(alpha: 0.12)
+                  : AppColors.surfaceVariant,
+              borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+            ),
+            child: Text(
+              isTodayLogged ? '✓ Logged' : 'Not yet logged',
+              style: textTheme.labelSmall?.copyWith(
+                color: isTodayLogged
+                    ? AppColors.allergenSafe
+                    : AppColors.subtext,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReactionRow extends StatelessWidget {
+  const _ReactionRow({required this.reaction});
+
+  final RecentReaction reaction;
+
+  String get _severityLabel {
+    return switch (reaction.severity) {
+      ReactionSeverity.mild => 'Mild',
+      ReactionSeverity.moderate => 'Moderate',
+      ReactionSeverity.severe => 'Severe',
+      null => 'Reaction',
+    };
+  }
+
+  Color get _severityColor {
+    return switch (reaction.severity) {
+      ReactionSeverity.mild => AppColors.warning,
+      ReactionSeverity.moderate => AppColors.secondary,
+      ReactionSeverity.severe => AppColors.allergenFlagged,
+      null => AppColors.subtext,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final date = reaction.logDate;
+    final dateStr =
+        '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}/${date.year}';
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSizes.sm),
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.cardPadding,
+          vertical: AppSizes.sm,
+        ),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          border: Border.all(color: AppColors.divider),
+        ),
+        child: Row(
+          children: [
+            Text(
+              reaction.allergenEmoji,
+              style: const TextStyle(fontSize: 20),
+            ),
+            const SizedBox(width: AppSizes.sm),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(reaction.allergenName, style: textTheme.labelLarge),
+                  Text(dateStr, style: textTheme.bodySmall),
+                ],
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.sm,
+                vertical: 3,
+              ),
+              decoration: BoxDecoration(
+                color: _severityColor.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              ),
+              child: Text(
+                _severityLabel,
+                style: textTheme.labelSmall?.copyWith(color: _severityColor),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AL-02 — Board Tab
+// ---------------------------------------------------------------------------
+
+class _BoardTab extends ConsumerWidget {
+  const _BoardTab({required this.state, required this.babyId});
+
+  final AllergenTrackerState state;
+  final String babyId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentKey = state.programState.currentAllergenKey;
+
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.pagePaddingV,
+      ),
+      itemCount: state.boardItems.length,
+      separatorBuilder: (_, __) => const SizedBox(height: AppSizes.sm),
+      itemBuilder: (context, index) {
+        final item = state.boardItems[index];
+        final isCurrent = item.allergen.key == currentKey;
+        return _AllergenBoardRow(
+          item: item,
+          isCurrent: isCurrent,
+          onTap: () => context.pushNamed(
+            AppRoute.allergenDetail.name,
+            pathParameters: {'allergenKey': item.allergen.key},
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _AllergenBoardRow extends StatelessWidget {
+  const _AllergenBoardRow({
+    required this.item,
+    required this.isCurrent,
+    required this.onTap,
+  });
+
+  final AllergenBoardItem item;
+  final bool isCurrent;
+  final VoidCallback onTap;
+
+  Color get _statusColor {
+    return switch (item.status) {
+      AllergenStatus.safe => AppColors.allergenSafe,
+      AllergenStatus.flagged => AppColors.allergenFlagged,
+      AllergenStatus.inProgress => AppColors.allergenInProgress,
+      AllergenStatus.notStarted => AppColors.allergenNotStarted,
+    };
+  }
+
+  String get _statusLabel {
+    return switch (item.status) {
+      AllergenStatus.safe => 'Safe',
+      AllergenStatus.flagged => 'Flagged',
+      AllergenStatus.inProgress => 'In Progress',
+      AllergenStatus.notStarted => 'Not Started',
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.all(AppSizes.cardPadding),
+        decoration: BoxDecoration(
+          color: isCurrent
+              ? AppColors.primary.withValues(alpha: 0.06)
+              : AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          border: Border.all(
+            color: isCurrent ? AppColors.primary : AppColors.divider,
+            width: isCurrent ? 1.5 : 1,
+          ),
+        ),
+        child: Row(
+          children: [
+            // Emoji + name
+            Text(
+              item.allergen.emoji,
+              style: const TextStyle(fontSize: 24),
+            ),
+            const SizedBox(width: AppSizes.sm),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(item.allergen.name, style: textTheme.labelLarge),
+                      if (isCurrent) ...[
+                        const SizedBox(width: AppSizes.xs),
+                        Text(
+                          '→ Current',
+                          style: textTheme.labelSmall?.copyWith(
+                            color: AppColors.primary,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: AppSizes.xs),
+                  // 3 day-slot dot indicators
+                  Row(
+                    children: List.generate(3, (i) {
+                      final log =
+                          i < item.logs.length ? item.logs[i] : null;
+                      return Padding(
+                        padding: const EdgeInsets.only(right: 6),
+                        child: _DotIndicator(log: log),
+                      );
+                    }),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: AppSizes.sm),
+            // Status badge
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.sm,
+                vertical: 4,
+              ),
+              decoration: BoxDecoration(
+                color: _statusColor.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              ),
+              child: Text(
+                _statusLabel,
+                style: textTheme.labelSmall?.copyWith(color: _statusColor),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DotIndicator extends StatelessWidget {
+  const _DotIndicator({required this.log});
+
+  final AllergenLog? log;
+
+  @override
+  Widget build(BuildContext context) {
+    if (log == null) {
+      return Container(
+        width: 12,
+        height: 12,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(color: AppColors.allergenNotStarted, width: 1.5),
+        ),
+      );
+    }
+
+    return Container(
+      width: 12,
+      height: 12,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: log!.hadReaction
+            ? AppColors.allergenFlagged
+            : AppColors.allergenSafe,
+      ),
+    );
+  }
 }

--- a/lib/src/features/allergen/tracker/allergen_tracker_state.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_state.dart
@@ -1,0 +1,25 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
+import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
+
+part 'allergen_tracker_state.freezed.dart';
+
+@freezed
+class AllergenTrackerState with _$AllergenTrackerState {
+  const factory AllergenTrackerState({
+    required List<AllergenBoardItem> boardItems,
+    required AllergenProgramState programState,
+    required List<RecentReaction> recentReactions,
+  }) = _AllergenTrackerState;
+}
+
+@freezed
+class RecentReaction with _$RecentReaction {
+  const factory RecentReaction({
+    required String allergenName,
+    required String allergenEmoji,
+    required DateTime logDate,
+    required ReactionSeverity? severity,
+  }) = _RecentReaction;
+}

--- a/lib/src/features/allergen/tracker/allergen_tracker_state.freezed.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_state.freezed.dart
@@ -1,0 +1,458 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'allergen_tracker_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$AllergenTrackerState {
+  List<AllergenBoardItem> get boardItems => throw _privateConstructorUsedError;
+  AllergenProgramState get programState => throw _privateConstructorUsedError;
+  List<RecentReaction> get recentReactions =>
+      throw _privateConstructorUsedError;
+
+  /// Create a copy of AllergenTrackerState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AllergenTrackerStateCopyWith<AllergenTrackerState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AllergenTrackerStateCopyWith<$Res> {
+  factory $AllergenTrackerStateCopyWith(
+    AllergenTrackerState value,
+    $Res Function(AllergenTrackerState) then,
+  ) = _$AllergenTrackerStateCopyWithImpl<$Res, AllergenTrackerState>;
+  @useResult
+  $Res call({
+    List<AllergenBoardItem> boardItems,
+    AllergenProgramState programState,
+    List<RecentReaction> recentReactions,
+  });
+
+  $AllergenProgramStateCopyWith<$Res> get programState;
+}
+
+/// @nodoc
+class _$AllergenTrackerStateCopyWithImpl<
+  $Res,
+  $Val extends AllergenTrackerState
+>
+    implements $AllergenTrackerStateCopyWith<$Res> {
+  _$AllergenTrackerStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AllergenTrackerState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? boardItems = null,
+    Object? programState = null,
+    Object? recentReactions = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            boardItems: null == boardItems
+                ? _value.boardItems
+                : boardItems // ignore: cast_nullable_to_non_nullable
+                      as List<AllergenBoardItem>,
+            programState: null == programState
+                ? _value.programState
+                : programState // ignore: cast_nullable_to_non_nullable
+                      as AllergenProgramState,
+            recentReactions: null == recentReactions
+                ? _value.recentReactions
+                : recentReactions // ignore: cast_nullable_to_non_nullable
+                      as List<RecentReaction>,
+          )
+          as $Val,
+    );
+  }
+
+  /// Create a copy of AllergenTrackerState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AllergenProgramStateCopyWith<$Res> get programState {
+    return $AllergenProgramStateCopyWith<$Res>(_value.programState, (value) {
+      return _then(_value.copyWith(programState: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$AllergenTrackerStateImplCopyWith<$Res>
+    implements $AllergenTrackerStateCopyWith<$Res> {
+  factory _$$AllergenTrackerStateImplCopyWith(
+    _$AllergenTrackerStateImpl value,
+    $Res Function(_$AllergenTrackerStateImpl) then,
+  ) = __$$AllergenTrackerStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    List<AllergenBoardItem> boardItems,
+    AllergenProgramState programState,
+    List<RecentReaction> recentReactions,
+  });
+
+  @override
+  $AllergenProgramStateCopyWith<$Res> get programState;
+}
+
+/// @nodoc
+class __$$AllergenTrackerStateImplCopyWithImpl<$Res>
+    extends _$AllergenTrackerStateCopyWithImpl<$Res, _$AllergenTrackerStateImpl>
+    implements _$$AllergenTrackerStateImplCopyWith<$Res> {
+  __$$AllergenTrackerStateImplCopyWithImpl(
+    _$AllergenTrackerStateImpl _value,
+    $Res Function(_$AllergenTrackerStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of AllergenTrackerState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? boardItems = null,
+    Object? programState = null,
+    Object? recentReactions = null,
+  }) {
+    return _then(
+      _$AllergenTrackerStateImpl(
+        boardItems: null == boardItems
+            ? _value._boardItems
+            : boardItems // ignore: cast_nullable_to_non_nullable
+                  as List<AllergenBoardItem>,
+        programState: null == programState
+            ? _value.programState
+            : programState // ignore: cast_nullable_to_non_nullable
+                  as AllergenProgramState,
+        recentReactions: null == recentReactions
+            ? _value._recentReactions
+            : recentReactions // ignore: cast_nullable_to_non_nullable
+                  as List<RecentReaction>,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$AllergenTrackerStateImpl implements _AllergenTrackerState {
+  const _$AllergenTrackerStateImpl({
+    required final List<AllergenBoardItem> boardItems,
+    required this.programState,
+    required final List<RecentReaction> recentReactions,
+  }) : _boardItems = boardItems,
+       _recentReactions = recentReactions;
+
+  final List<AllergenBoardItem> _boardItems;
+  @override
+  List<AllergenBoardItem> get boardItems {
+    if (_boardItems is EqualUnmodifiableListView) return _boardItems;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_boardItems);
+  }
+
+  @override
+  final AllergenProgramState programState;
+  final List<RecentReaction> _recentReactions;
+  @override
+  List<RecentReaction> get recentReactions {
+    if (_recentReactions is EqualUnmodifiableListView) return _recentReactions;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_recentReactions);
+  }
+
+  @override
+  String toString() {
+    return 'AllergenTrackerState(boardItems: $boardItems, programState: $programState, recentReactions: $recentReactions)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AllergenTrackerStateImpl &&
+            const DeepCollectionEquality().equals(
+              other._boardItems,
+              _boardItems,
+            ) &&
+            (identical(other.programState, programState) ||
+                other.programState == programState) &&
+            const DeepCollectionEquality().equals(
+              other._recentReactions,
+              _recentReactions,
+            ));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    const DeepCollectionEquality().hash(_boardItems),
+    programState,
+    const DeepCollectionEquality().hash(_recentReactions),
+  );
+
+  /// Create a copy of AllergenTrackerState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AllergenTrackerStateImplCopyWith<_$AllergenTrackerStateImpl>
+  get copyWith =>
+      __$$AllergenTrackerStateImplCopyWithImpl<_$AllergenTrackerStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _AllergenTrackerState implements AllergenTrackerState {
+  const factory _AllergenTrackerState({
+    required final List<AllergenBoardItem> boardItems,
+    required final AllergenProgramState programState,
+    required final List<RecentReaction> recentReactions,
+  }) = _$AllergenTrackerStateImpl;
+
+  @override
+  List<AllergenBoardItem> get boardItems;
+  @override
+  AllergenProgramState get programState;
+  @override
+  List<RecentReaction> get recentReactions;
+
+  /// Create a copy of AllergenTrackerState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AllergenTrackerStateImplCopyWith<_$AllergenTrackerStateImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$RecentReaction {
+  String get allergenName => throw _privateConstructorUsedError;
+  String get allergenEmoji => throw _privateConstructorUsedError;
+  DateTime get logDate => throw _privateConstructorUsedError;
+  ReactionSeverity? get severity => throw _privateConstructorUsedError;
+
+  /// Create a copy of RecentReaction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $RecentReactionCopyWith<RecentReaction> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RecentReactionCopyWith<$Res> {
+  factory $RecentReactionCopyWith(
+    RecentReaction value,
+    $Res Function(RecentReaction) then,
+  ) = _$RecentReactionCopyWithImpl<$Res, RecentReaction>;
+  @useResult
+  $Res call({
+    String allergenName,
+    String allergenEmoji,
+    DateTime logDate,
+    ReactionSeverity? severity,
+  });
+}
+
+/// @nodoc
+class _$RecentReactionCopyWithImpl<$Res, $Val extends RecentReaction>
+    implements $RecentReactionCopyWith<$Res> {
+  _$RecentReactionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of RecentReaction
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? allergenName = null,
+    Object? allergenEmoji = null,
+    Object? logDate = null,
+    Object? severity = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            allergenName: null == allergenName
+                ? _value.allergenName
+                : allergenName // ignore: cast_nullable_to_non_nullable
+                      as String,
+            allergenEmoji: null == allergenEmoji
+                ? _value.allergenEmoji
+                : allergenEmoji // ignore: cast_nullable_to_non_nullable
+                      as String,
+            logDate: null == logDate
+                ? _value.logDate
+                : logDate // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            severity: freezed == severity
+                ? _value.severity
+                : severity // ignore: cast_nullable_to_non_nullable
+                      as ReactionSeverity?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$RecentReactionImplCopyWith<$Res>
+    implements $RecentReactionCopyWith<$Res> {
+  factory _$$RecentReactionImplCopyWith(
+    _$RecentReactionImpl value,
+    $Res Function(_$RecentReactionImpl) then,
+  ) = __$$RecentReactionImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String allergenName,
+    String allergenEmoji,
+    DateTime logDate,
+    ReactionSeverity? severity,
+  });
+}
+
+/// @nodoc
+class __$$RecentReactionImplCopyWithImpl<$Res>
+    extends _$RecentReactionCopyWithImpl<$Res, _$RecentReactionImpl>
+    implements _$$RecentReactionImplCopyWith<$Res> {
+  __$$RecentReactionImplCopyWithImpl(
+    _$RecentReactionImpl _value,
+    $Res Function(_$RecentReactionImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of RecentReaction
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? allergenName = null,
+    Object? allergenEmoji = null,
+    Object? logDate = null,
+    Object? severity = freezed,
+  }) {
+    return _then(
+      _$RecentReactionImpl(
+        allergenName: null == allergenName
+            ? _value.allergenName
+            : allergenName // ignore: cast_nullable_to_non_nullable
+                  as String,
+        allergenEmoji: null == allergenEmoji
+            ? _value.allergenEmoji
+            : allergenEmoji // ignore: cast_nullable_to_non_nullable
+                  as String,
+        logDate: null == logDate
+            ? _value.logDate
+            : logDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        severity: freezed == severity
+            ? _value.severity
+            : severity // ignore: cast_nullable_to_non_nullable
+                  as ReactionSeverity?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$RecentReactionImpl implements _RecentReaction {
+  const _$RecentReactionImpl({
+    required this.allergenName,
+    required this.allergenEmoji,
+    required this.logDate,
+    required this.severity,
+  });
+
+  @override
+  final String allergenName;
+  @override
+  final String allergenEmoji;
+  @override
+  final DateTime logDate;
+  @override
+  final ReactionSeverity? severity;
+
+  @override
+  String toString() {
+    return 'RecentReaction(allergenName: $allergenName, allergenEmoji: $allergenEmoji, logDate: $logDate, severity: $severity)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RecentReactionImpl &&
+            (identical(other.allergenName, allergenName) ||
+                other.allergenName == allergenName) &&
+            (identical(other.allergenEmoji, allergenEmoji) ||
+                other.allergenEmoji == allergenEmoji) &&
+            (identical(other.logDate, logDate) || other.logDate == logDate) &&
+            (identical(other.severity, severity) ||
+                other.severity == severity));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, allergenName, allergenEmoji, logDate, severity);
+
+  /// Create a copy of RecentReaction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RecentReactionImplCopyWith<_$RecentReactionImpl> get copyWith =>
+      __$$RecentReactionImplCopyWithImpl<_$RecentReactionImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _RecentReaction implements RecentReaction {
+  const factory _RecentReaction({
+    required final String allergenName,
+    required final String allergenEmoji,
+    required final DateTime logDate,
+    required final ReactionSeverity? severity,
+  }) = _$RecentReactionImpl;
+
+  @override
+  String get allergenName;
+  @override
+  String get allergenEmoji;
+  @override
+  DateTime get logDate;
+  @override
+  ReactionSeverity? get severity;
+
+  /// Create a copy of RecentReaction
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$RecentReactionImplCopyWith<_$RecentReactionImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/onboarding/readiness/readiness_controller.g.dart
+++ b/lib/src/features/onboarding/readiness/readiness_controller.g.dart
@@ -7,7 +7,7 @@ part of 'readiness_controller.dart';
 // **************************************************************************
 
 String _$readinessControllerHash() =>
-    r'2ae1246e837d3abf39bf8ca242ccdc3c247c2cba';
+    r'145d2a36889c05531f008f7893b4be859c5aad38';
 
 /// See also [ReadinessController].
 @ProviderFor(ReadinessController)


### PR DESCRIPTION
## Summary

- **AL-01 (Overview tab):** Progress circle (X/9 introduced), Safe/Flagged stat chips, today's checklist card for the current allergen, recent reactions list (top 3, with severity chip)
- **AL-02 (Board tab):** Full 9-allergen grid with 3 day-slot dot indicators (green=logged/no reaction, red=logged/reaction, grey=empty), status badges (Not Started/In Progress/Safe/Flagged), current allergen highlighted with border + "→ Current" label, tap → AL-03 detail
- `AllergenTrackerController` — `AsyncNotifier` family by `babyId`; parallel fetch of board summary + program state; up to 3 sequential `getReactionDetail` calls for recent reactions
- `currentBabyIdProvider` added to `baby_profile_service` so the screen resolves `babyId` without a route param
- `AllergenService` now exposes `getProgramState` and `getReactionDetail` delegating to the repository

## Test plan

- [ ] Navigate to `/home/allergen/tracker` — screen loads without error
- [ ] Overview tab: progress circle shows correct X/9 count (only `safe` + `flagged` allergens count)
- [ ] Overview tab: Safe + Flagged chip counts match board items
- [ ] Overview tab: "No logs yet" empty state shown when no logs exist
- [ ] Overview tab: Today's checklist card shows current allergen with correct logged/not-yet-logged status
- [ ] Overview tab: Recent reactions section hidden when no reactions; shows up to 3 rows with severity chips when reactions exist
- [ ] Board tab: all 9 allergens listed with correct emoji and name
- [ ] Board tab: dot indicators reflect logged days (green/red/empty)
- [ ] Board tab: status badges use correct labels — `Safe` not `Completed`
- [ ] Board tab: current allergen row visually distinguished
- [ ] Board tab: tapping a row pushes AL-03 allergen detail screen
- [ ] After saving a log (via AL-05 in future), `ref.invalidate(allergenTrackerControllerProvider(babyId))` triggers board dot refresh
- [ ] Zero lint warnings (`dart analyze`)

Closes NIB-22