### PR TITLE
feat(allergen): AL-07 proceed sheet + AL-08 program complete screen [NIB-25]

### DIFF
--- a/lib/gen/assets.gen.dart
+++ b/lib/gen/assets.gen.dart
@@ -5,7 +5,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use,duplicate_definition
+// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
 
 class $AssetsIconsGen {
   const $AssetsIconsGen();
@@ -33,8 +33,11 @@ class $AssetsJsonsGen {
   /// File path: assets/jsons/.gitkeep
   String get aGitkeep => 'assets/jsons/.gitkeep';
 
+  /// File path: assets/jsons/recipe_template.json
+  String get recipeTemplate => 'assets/jsons/recipe_template.json';
+
   /// List of all assets
-  List<String> get values => [aGitkeep];
+  List<String> get values => [aGitkeep, recipeTemplate];
 }
 
 class $AssetsTranslationsGen {
@@ -50,13 +53,8 @@ class $AssetsTranslationsGen {
 class Assets {
   const Assets._();
 
-  static const String aEnv = '.env.dev';
-  static const String aEnv = '.env.prod';
   static const $AssetsIconsGen icons = $AssetsIconsGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonsGen jsons = $AssetsJsonsGen();
   static const $AssetsTranslationsGen translations = $AssetsTranslationsGen();
-
-  /// List of all assets
-  static List<String> get values => [aEnv, aEnv];
 }

--- a/lib/src/features/allergen/complete/allergen_complete_controller.dart
+++ b/lib/src/features/allergen/complete/allergen_complete_controller.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/allergen/complete/allergen_complete_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'allergen_complete_controller.g.dart';
+
+@riverpod
+class AllergenCompleteController extends _$AllergenCompleteController {
+  @override
+  Future<AllergenCompleteState> build() async {
+    final baby = await ref.read(babyProfileServiceProvider).getBaby();
+    if (baby == null) {
+      throw const UnknownException('No baby profile found.');
+    }
+
+    final result = await ref
+        .read(allergenServiceProvider)
+        .getAllergenBoardSummary(baby.id);
+    return result.fold(
+      onSuccess: (items) {
+        final allergens = items.map((i) => i.allergen).toList()
+          ..sort((a, b) => a.sequenceOrder.compareTo(b.sequenceOrder));
+
+        unawaited(Analytics.instance.logAllergenProgramCompleted());
+
+        return AllergenCompleteState(
+          babyName: baby.name,
+          babyId: baby.id,
+          allergens: allergens,
+        );
+      },
+      onFailure: (AppException error) => throw error,
+    );
+  }
+
+  /// Sets the shown-once flag so AL-08 is never re-shown for this baby.
+  void markShown() {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    ref
+        .read(localFlagServiceProvider)
+        .setProgramCompletionShown(current.babyId);
+  }
+}

--- a/lib/src/features/allergen/complete/allergen_complete_controller.g.dart
+++ b/lib/src/features/allergen/complete/allergen_complete_controller.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'allergen_complete_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$allergenCompleteControllerHash() =>
+    r'd6a59746d10498ad9ba7cab57e16d34350d21356';
+
+/// See also [AllergenCompleteController].
+@ProviderFor(AllergenCompleteController)
+final allergenCompleteControllerProvider =
+    AutoDisposeAsyncNotifierProvider<
+      AllergenCompleteController,
+      AllergenCompleteState
+    >.internal(
+      AllergenCompleteController.new,
+      name: r'allergenCompleteControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$allergenCompleteControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$AllergenCompleteController =
+    AutoDisposeAsyncNotifier<AllergenCompleteState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/allergen/complete/allergen_complete_screen.dart
+++ b/lib/src/features/allergen/complete/allergen_complete_screen.dart
@@ -1,9 +1,112 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/features/allergen/complete/allergen_complete_controller.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 class AllergenCompleteScreen extends ConsumerWidget {
   const AllergenCompleteScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Allergen Complete (AL-08)')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final stateAsync = ref.watch(allergenCompleteControllerProvider);
+
+    return PopScope(
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) {
+          ref.read(allergenCompleteControllerProvider.notifier).markShown();
+        }
+      },
+      child: Scaffold(
+        backgroundColor: AppColors.background,
+        body: stateAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => Center(child: Text(e.toString())),
+          data: (s) => SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.pagePaddingH,
+                vertical: AppSizes.pagePaddingV,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: AppSizes.xl),
+                  Center(
+                    child: const Text(
+                      '🎉',
+                      style: TextStyle(fontSize: 80),
+                    )
+                        .animate()
+                        .scale(
+                          begin: const Offset(0.5, 0.5),
+                          end: const Offset(1, 1),
+                          duration: 600.ms,
+                          curve: Curves.elasticOut,
+                        ),
+                  ),
+                  const SizedBox(height: AppSizes.lg),
+                  Text(
+                    '${s.babyName} has passed all 9 allergens! '
+                    'Well done.',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                    textAlign: TextAlign.center,
+                  ).animate().fadeIn(delay: 300.ms, duration: 400.ms),
+                  const SizedBox(height: AppSizes.sm),
+                  Text(
+                    "You've done an incredible job introducing allergens "
+                    'safely. Keep enjoying a wide variety of foods together!',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: AppColors.subtext,
+                        ),
+                    textAlign: TextAlign.center,
+                  ).animate().fadeIn(delay: 500.ms, duration: 400.ms),
+                  const SizedBox(height: AppSizes.xl),
+                  Wrap(
+                    spacing: AppSizes.sm,
+                    runSpacing: AppSizes.sm,
+                    alignment: WrapAlignment.center,
+                    children: s.allergens
+                        .map(
+                          (a) => Chip(
+                            avatar: Text(
+                              a.emoji,
+                              style: const TextStyle(fontSize: 16),
+                            ),
+                            label: Text(a.name),
+                            backgroundColor:
+                                AppColors.allergenSafe.withValues(alpha: 0.15),
+                            side: const BorderSide(
+                              color: AppColors.allergenSafe,
+                            ),
+                            labelStyle: Theme.of(context)
+                                .textTheme
+                                .labelMedium
+                                ?.copyWith(color: AppColors.allergenSafe),
+                          ),
+                        )
+                        .toList(),
+                  ).animate().fadeIn(delay: 700.ms, duration: 400.ms),
+                  const SizedBox(height: AppSizes.xxl),
+                  FilledButton(
+                    onPressed: () {
+                      ref
+                          .read(allergenCompleteControllerProvider.notifier)
+                          .markShown();
+                      context.goNamed(AppRoute.profile.name);
+                    },
+                    child: const Text('View in Profile'),
+                  ).animate().fadeIn(delay: 900.ms, duration: 400.ms),
+                  const SizedBox(height: AppSizes.md),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/src/features/allergen/complete/allergen_complete_state.dart
+++ b/lib/src/features/allergen/complete/allergen_complete_state.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+
+part 'allergen_complete_state.freezed.dart';
+
+@freezed
+class AllergenCompleteState with _$AllergenCompleteState {
+  const factory AllergenCompleteState({
+    required String babyName,
+    required String babyId,
+    required List<Allergen> allergens,
+  }) = _AllergenCompleteState;
+}

--- a/lib/src/features/allergen/complete/allergen_complete_state.freezed.dart
+++ b/lib/src/features/allergen/complete/allergen_complete_state.freezed.dart
@@ -1,0 +1,214 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'allergen_complete_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$AllergenCompleteState {
+  String get babyName => throw _privateConstructorUsedError;
+  String get babyId => throw _privateConstructorUsedError;
+  List<Allergen> get allergens => throw _privateConstructorUsedError;
+
+  /// Create a copy of AllergenCompleteState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AllergenCompleteStateCopyWith<AllergenCompleteState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AllergenCompleteStateCopyWith<$Res> {
+  factory $AllergenCompleteStateCopyWith(
+    AllergenCompleteState value,
+    $Res Function(AllergenCompleteState) then,
+  ) = _$AllergenCompleteStateCopyWithImpl<$Res, AllergenCompleteState>;
+  @useResult
+  $Res call({String babyName, String babyId, List<Allergen> allergens});
+}
+
+/// @nodoc
+class _$AllergenCompleteStateCopyWithImpl<
+  $Res,
+  $Val extends AllergenCompleteState
+>
+    implements $AllergenCompleteStateCopyWith<$Res> {
+  _$AllergenCompleteStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AllergenCompleteState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? babyName = null,
+    Object? babyId = null,
+    Object? allergens = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            babyName: null == babyName
+                ? _value.babyName
+                : babyName // ignore: cast_nullable_to_non_nullable
+                      as String,
+            babyId: null == babyId
+                ? _value.babyId
+                : babyId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            allergens: null == allergens
+                ? _value.allergens
+                : allergens // ignore: cast_nullable_to_non_nullable
+                      as List<Allergen>,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$AllergenCompleteStateImplCopyWith<$Res>
+    implements $AllergenCompleteStateCopyWith<$Res> {
+  factory _$$AllergenCompleteStateImplCopyWith(
+    _$AllergenCompleteStateImpl value,
+    $Res Function(_$AllergenCompleteStateImpl) then,
+  ) = __$$AllergenCompleteStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String babyName, String babyId, List<Allergen> allergens});
+}
+
+/// @nodoc
+class __$$AllergenCompleteStateImplCopyWithImpl<$Res>
+    extends
+        _$AllergenCompleteStateCopyWithImpl<$Res, _$AllergenCompleteStateImpl>
+    implements _$$AllergenCompleteStateImplCopyWith<$Res> {
+  __$$AllergenCompleteStateImplCopyWithImpl(
+    _$AllergenCompleteStateImpl _value,
+    $Res Function(_$AllergenCompleteStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of AllergenCompleteState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? babyName = null,
+    Object? babyId = null,
+    Object? allergens = null,
+  }) {
+    return _then(
+      _$AllergenCompleteStateImpl(
+        babyName: null == babyName
+            ? _value.babyName
+            : babyName // ignore: cast_nullable_to_non_nullable
+                  as String,
+        babyId: null == babyId
+            ? _value.babyId
+            : babyId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        allergens: null == allergens
+            ? _value._allergens
+            : allergens // ignore: cast_nullable_to_non_nullable
+                  as List<Allergen>,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$AllergenCompleteStateImpl implements _AllergenCompleteState {
+  const _$AllergenCompleteStateImpl({
+    required this.babyName,
+    required this.babyId,
+    required final List<Allergen> allergens,
+  }) : _allergens = allergens;
+
+  @override
+  final String babyName;
+  @override
+  final String babyId;
+  final List<Allergen> _allergens;
+  @override
+  List<Allergen> get allergens {
+    if (_allergens is EqualUnmodifiableListView) return _allergens;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_allergens);
+  }
+
+  @override
+  String toString() {
+    return 'AllergenCompleteState(babyName: $babyName, babyId: $babyId, allergens: $allergens)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AllergenCompleteStateImpl &&
+            (identical(other.babyName, babyName) ||
+                other.babyName == babyName) &&
+            (identical(other.babyId, babyId) || other.babyId == babyId) &&
+            const DeepCollectionEquality().equals(
+              other._allergens,
+              _allergens,
+            ));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    babyName,
+    babyId,
+    const DeepCollectionEquality().hash(_allergens),
+  );
+
+  /// Create a copy of AllergenCompleteState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AllergenCompleteStateImplCopyWith<_$AllergenCompleteStateImpl>
+  get copyWith =>
+      __$$AllergenCompleteStateImplCopyWithImpl<_$AllergenCompleteStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _AllergenCompleteState implements AllergenCompleteState {
+  const factory _AllergenCompleteState({
+    required final String babyName,
+    required final String babyId,
+    required final List<Allergen> allergens,
+  }) = _$AllergenCompleteStateImpl;
+
+  @override
+  String get babyName;
+  @override
+  String get babyId;
+  @override
+  List<Allergen> get allergens;
+
+  /// Create a copy of AllergenCompleteState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AllergenCompleteStateImplCopyWith<_$AllergenCompleteStateImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/src/features/allergen/detail/allergen_detail_controller.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_controller.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/features/allergen/detail/allergen_detail_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'allergen_detail_controller.g.dart';
+
+@riverpod
+class AllergenDetailController extends _$AllergenDetailController {
+  @override
+  Future<AllergenDetailState> build(String allergenKey) async {
+    final baby = await ref.read(babyProfileServiceProvider).getBaby();
+    if (baby == null) {
+      throw const UnknownException('No baby profile found.');
+    }
+
+    final result = await ref
+        .read(allergenServiceProvider)
+        .getAllergenBoardSummary(baby.id);
+    return result.fold(
+      onSuccess: (items) {
+        final sorted = [...items]
+          ..sort(
+            (a, b) =>
+                a.allergen.sequenceOrder.compareTo(b.allergen.sequenceOrder),
+          );
+        final currentIndex =
+            sorted.indexWhere((i) => i.allergen.key == allergenKey);
+        if (currentIndex == -1) {
+          throw NotFoundException('Allergen "$allergenKey" not found.');
+        }
+        final next = currentIndex < sorted.length - 1
+            ? sorted[currentIndex + 1].allergen
+            : null;
+        return AllergenDetailState(
+          boardItem: sorted[currentIndex],
+          babyId: baby.id,
+          nextAllergen: next,
+        );
+      },
+      onFailure: (AppException error) => throw error,
+    );
+  }
+
+  /// Advances the program to the next allergen.
+  ///
+  /// Returns the next allergen key if the program is still ongoing,
+  /// or `null` if the full program is now complete (navigate to AL-08).
+  Future<Result<String?>> advanceToNext() async {
+    final current = state.valueOrNull;
+    if (current == null) {
+      return const Result.failure(UnknownException());
+    }
+
+    final currentKey = current.boardItem.allergen.key;
+    final nextKey = current.nextAllergen?.key;
+
+    final result = await ref
+        .read(allergenServiceProvider)
+        .advanceToNextAllergen(current.babyId);
+    if (result.isFailure) return Result.failure(result.errorOrNull!);
+
+    unawaited(
+      Analytics.instance.logAllergenAdvanced(
+        fromKey: currentKey,
+        toKey: nextKey ?? 'completed',
+      ),
+    );
+    unawaited(
+      Analytics.instance.logAllergenMarkedSafe(allergenKey: currentKey),
+    );
+
+    ref.invalidateSelf();
+    return Result.success(nextKey);
+  }
+}

--- a/lib/src/features/allergen/detail/allergen_detail_controller.g.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_controller.g.dart
@@ -1,0 +1,181 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'allergen_detail_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$allergenDetailControllerHash() =>
+    r'e56120690ca6f4a9c8491f2456cd54193f79c728';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$AllergenDetailController
+    extends BuildlessAutoDisposeAsyncNotifier<AllergenDetailState> {
+  late final String allergenKey;
+
+  FutureOr<AllergenDetailState> build(String allergenKey);
+}
+
+/// See also [AllergenDetailController].
+@ProviderFor(AllergenDetailController)
+const allergenDetailControllerProvider = AllergenDetailControllerFamily();
+
+/// See also [AllergenDetailController].
+class AllergenDetailControllerFamily
+    extends Family<AsyncValue<AllergenDetailState>> {
+  /// See also [AllergenDetailController].
+  const AllergenDetailControllerFamily();
+
+  /// See also [AllergenDetailController].
+  AllergenDetailControllerProvider call(String allergenKey) {
+    return AllergenDetailControllerProvider(allergenKey);
+  }
+
+  @override
+  AllergenDetailControllerProvider getProviderOverride(
+    covariant AllergenDetailControllerProvider provider,
+  ) {
+    return call(provider.allergenKey);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'allergenDetailControllerProvider';
+}
+
+/// See also [AllergenDetailController].
+class AllergenDetailControllerProvider
+    extends
+        AutoDisposeAsyncNotifierProviderImpl<
+          AllergenDetailController,
+          AllergenDetailState
+        > {
+  /// See also [AllergenDetailController].
+  AllergenDetailControllerProvider(String allergenKey)
+    : this._internal(
+        () => AllergenDetailController()..allergenKey = allergenKey,
+        from: allergenDetailControllerProvider,
+        name: r'allergenDetailControllerProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$allergenDetailControllerHash,
+        dependencies: AllergenDetailControllerFamily._dependencies,
+        allTransitiveDependencies:
+            AllergenDetailControllerFamily._allTransitiveDependencies,
+        allergenKey: allergenKey,
+      );
+
+  AllergenDetailControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.allergenKey,
+  }) : super.internal();
+
+  final String allergenKey;
+
+  @override
+  FutureOr<AllergenDetailState> runNotifierBuild(
+    covariant AllergenDetailController notifier,
+  ) {
+    return notifier.build(allergenKey);
+  }
+
+  @override
+  Override overrideWith(AllergenDetailController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: AllergenDetailControllerProvider._internal(
+        () => create()..allergenKey = allergenKey,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        allergenKey: allergenKey,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<
+    AllergenDetailController,
+    AllergenDetailState
+  >
+  createElement() {
+    return _AllergenDetailControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AllergenDetailControllerProvider &&
+        other.allergenKey == allergenKey;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, allergenKey.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin AllergenDetailControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<AllergenDetailState> {
+  /// The parameter `allergenKey` of this provider.
+  String get allergenKey;
+}
+
+class _AllergenDetailControllerProviderElement
+    extends
+        AutoDisposeAsyncNotifierProviderElement<
+          AllergenDetailController,
+          AllergenDetailState
+        >
+    with AllergenDetailControllerRef {
+  _AllergenDetailControllerProviderElement(super.provider);
+
+  @override
+  String get allergenKey =>
+      (origin as AllergenDetailControllerProvider).allergenKey;
+}
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/allergen/detail/allergen_detail_screen.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_screen.dart
@@ -1,10 +1,97 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/features/allergen/detail/allergen_detail_controller.dart';
+import 'package:nibbles/src/features/allergen/detail/allergen_detail_state.dart';
+import 'package:nibbles/src/features/allergen/detail/widgets/proceed_confirmation_sheet.dart';
 
 class AllergenDetailScreen extends ConsumerWidget {
   const AllergenDetailScreen({required this.allergenKey, super.key});
+
   final String allergenKey;
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      Scaffold(body: Center(child: Text('Allergen Detail — $allergenKey')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final stateAsync =
+        ref.watch(allergenDetailControllerProvider(allergenKey));
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        title: stateAsync.maybeWhen(
+          data: (s) => Text(s.boardItem.allergen.name),
+          orElse: () => const SizedBox.shrink(),
+        ),
+      ),
+      body: stateAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text(e.toString())),
+        data: (s) => _DetailBody(allergenKey: allergenKey, detailState: s),
+      ),
+    );
+  }
+}
+
+class _DetailBody extends ConsumerWidget {
+  const _DetailBody({
+    required this.allergenKey,
+    required this.detailState,
+  });
+
+  final String allergenKey;
+  final AllergenDetailState detailState;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final canProceed = detailState.boardItem.status == AllergenStatus.safe ||
+        detailState.boardItem.status == AllergenStatus.flagged;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.pagePaddingV,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Placeholder — full detail UI is built in NIB-23
+          Expanded(
+            child: Center(
+              child: Text('Allergen Detail — $allergenKey'),
+            ),
+          ),
+          if (canProceed) ...[
+            FilledButton(
+              onPressed: () => _showProceedSheet(context),
+              child: Text(
+                detailState.nextAllergen != null
+                    ? 'Proceed to Next Allergen'
+                    : 'Complete Program',
+              ),
+            ),
+            const SizedBox(height: AppSizes.md),
+          ],
+        ],
+      ),
+    );
+  }
+
+  void _showProceedSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(AppSizes.radiusXl),
+        ),
+      ),
+      builder: (_) => ProceedConfirmationSheet(
+        allergenKey: allergenKey,
+        boardItem: detailState.boardItem,
+        nextAllergen: detailState.nextAllergen,
+      ),
+    );
+  }
 }

--- a/lib/src/features/allergen/detail/allergen_detail_state.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+
+part 'allergen_detail_state.freezed.dart';
+
+@freezed
+class AllergenDetailState with _$AllergenDetailState {
+  const factory AllergenDetailState({
+    required AllergenBoardItem boardItem,
+    required String babyId,
+    Allergen? nextAllergen,
+  }) = _AllergenDetailState;
+}

--- a/lib/src/features/allergen/detail/allergen_detail_state.freezed.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_state.freezed.dart
@@ -1,0 +1,237 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'allergen_detail_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$AllergenDetailState {
+  AllergenBoardItem get boardItem => throw _privateConstructorUsedError;
+  String get babyId => throw _privateConstructorUsedError;
+  Allergen? get nextAllergen => throw _privateConstructorUsedError;
+
+  /// Create a copy of AllergenDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AllergenDetailStateCopyWith<AllergenDetailState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AllergenDetailStateCopyWith<$Res> {
+  factory $AllergenDetailStateCopyWith(
+    AllergenDetailState value,
+    $Res Function(AllergenDetailState) then,
+  ) = _$AllergenDetailStateCopyWithImpl<$Res, AllergenDetailState>;
+  @useResult
+  $Res call({
+    AllergenBoardItem boardItem,
+    String babyId,
+    Allergen? nextAllergen,
+  });
+
+  $AllergenBoardItemCopyWith<$Res> get boardItem;
+  $AllergenCopyWith<$Res>? get nextAllergen;
+}
+
+/// @nodoc
+class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
+    implements $AllergenDetailStateCopyWith<$Res> {
+  _$AllergenDetailStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AllergenDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? boardItem = null,
+    Object? babyId = null,
+    Object? nextAllergen = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            boardItem: null == boardItem
+                ? _value.boardItem
+                : boardItem // ignore: cast_nullable_to_non_nullable
+                      as AllergenBoardItem,
+            babyId: null == babyId
+                ? _value.babyId
+                : babyId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            nextAllergen: freezed == nextAllergen
+                ? _value.nextAllergen
+                : nextAllergen // ignore: cast_nullable_to_non_nullable
+                      as Allergen?,
+          )
+          as $Val,
+    );
+  }
+
+  /// Create a copy of AllergenDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AllergenBoardItemCopyWith<$Res> get boardItem {
+    return $AllergenBoardItemCopyWith<$Res>(_value.boardItem, (value) {
+      return _then(_value.copyWith(boardItem: value) as $Val);
+    });
+  }
+
+  /// Create a copy of AllergenDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AllergenCopyWith<$Res>? get nextAllergen {
+    if (_value.nextAllergen == null) {
+      return null;
+    }
+
+    return $AllergenCopyWith<$Res>(_value.nextAllergen!, (value) {
+      return _then(_value.copyWith(nextAllergen: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$AllergenDetailStateImplCopyWith<$Res>
+    implements $AllergenDetailStateCopyWith<$Res> {
+  factory _$$AllergenDetailStateImplCopyWith(
+    _$AllergenDetailStateImpl value,
+    $Res Function(_$AllergenDetailStateImpl) then,
+  ) = __$$AllergenDetailStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    AllergenBoardItem boardItem,
+    String babyId,
+    Allergen? nextAllergen,
+  });
+
+  @override
+  $AllergenBoardItemCopyWith<$Res> get boardItem;
+  @override
+  $AllergenCopyWith<$Res>? get nextAllergen;
+}
+
+/// @nodoc
+class __$$AllergenDetailStateImplCopyWithImpl<$Res>
+    extends _$AllergenDetailStateCopyWithImpl<$Res, _$AllergenDetailStateImpl>
+    implements _$$AllergenDetailStateImplCopyWith<$Res> {
+  __$$AllergenDetailStateImplCopyWithImpl(
+    _$AllergenDetailStateImpl _value,
+    $Res Function(_$AllergenDetailStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of AllergenDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? boardItem = null,
+    Object? babyId = null,
+    Object? nextAllergen = freezed,
+  }) {
+    return _then(
+      _$AllergenDetailStateImpl(
+        boardItem: null == boardItem
+            ? _value.boardItem
+            : boardItem // ignore: cast_nullable_to_non_nullable
+                  as AllergenBoardItem,
+        babyId: null == babyId
+            ? _value.babyId
+            : babyId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        nextAllergen: freezed == nextAllergen
+            ? _value.nextAllergen
+            : nextAllergen // ignore: cast_nullable_to_non_nullable
+                  as Allergen?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$AllergenDetailStateImpl implements _AllergenDetailState {
+  const _$AllergenDetailStateImpl({
+    required this.boardItem,
+    required this.babyId,
+    this.nextAllergen,
+  });
+
+  @override
+  final AllergenBoardItem boardItem;
+  @override
+  final String babyId;
+  @override
+  final Allergen? nextAllergen;
+
+  @override
+  String toString() {
+    return 'AllergenDetailState(boardItem: $boardItem, babyId: $babyId, nextAllergen: $nextAllergen)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AllergenDetailStateImpl &&
+            (identical(other.boardItem, boardItem) ||
+                other.boardItem == boardItem) &&
+            (identical(other.babyId, babyId) || other.babyId == babyId) &&
+            (identical(other.nextAllergen, nextAllergen) ||
+                other.nextAllergen == nextAllergen));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, boardItem, babyId, nextAllergen);
+
+  /// Create a copy of AllergenDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AllergenDetailStateImplCopyWith<_$AllergenDetailStateImpl> get copyWith =>
+      __$$AllergenDetailStateImplCopyWithImpl<_$AllergenDetailStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _AllergenDetailState implements AllergenDetailState {
+  const factory _AllergenDetailState({
+    required final AllergenBoardItem boardItem,
+    required final String babyId,
+    final Allergen? nextAllergen,
+  }) = _$AllergenDetailStateImpl;
+
+  @override
+  AllergenBoardItem get boardItem;
+  @override
+  String get babyId;
+  @override
+  Allergen? get nextAllergen;
+
+  /// Create a copy of AllergenDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AllergenDetailStateImplCopyWith<_$AllergenDetailStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/allergen/detail/widgets/proceed_confirmation_sheet.dart
+++ b/lib/src/features/allergen/detail/widgets/proceed_confirmation_sheet.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+import 'package:nibbles/src/features/allergen/detail/allergen_detail_controller.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+class ProceedConfirmationSheet extends ConsumerStatefulWidget {
+  const ProceedConfirmationSheet({
+    required this.allergenKey,
+    required this.boardItem,
+    required this.nextAllergen,
+    super.key,
+  });
+
+  final String allergenKey;
+  final AllergenBoardItem boardItem;
+  final Allergen? nextAllergen;
+
+  @override
+  ConsumerState<ProceedConfirmationSheet> createState() =>
+      _ProceedConfirmationSheetState();
+}
+
+class _ProceedConfirmationSheetState
+    extends ConsumerState<ProceedConfirmationSheet> {
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  Future<void> _onConfirm() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    final result = await ref
+        .read(allergenDetailControllerProvider(widget.allergenKey).notifier)
+        .advanceToNext();
+
+    if (!mounted) return;
+
+    result.when(
+      success: (nextKey) {
+        Navigator.of(context).pop();
+        if (nextKey != null) {
+          context.goNamed(
+            AppRoute.allergenDetail.name,
+            pathParameters: {'allergenKey': nextKey},
+          );
+        } else {
+          context.goNamed(AppRoute.allergenComplete.name);
+        }
+      },
+      failure: (_) => setState(() {
+        _isLoading = false;
+        _errorMessage = "Couldn't save your log. Please try again.";
+      }),
+    );
+  }
+
+  String _formatDate(DateTime d) {
+    const months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    return '${months[d.month - 1]} ${d.day}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final allergen = widget.boardItem.allergen;
+    final logs = widget.boardItem.logs.take(3).toList();
+    final next = widget.nextAllergen;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSizes.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: AppColors.divider,
+                  borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSizes.lg),
+            Center(
+              child: Text(
+                allergen.emoji,
+                style: const TextStyle(fontSize: 48),
+              ),
+            ),
+            const SizedBox(height: AppSizes.sm),
+            Center(
+              child: Text(
+                '✅ ${allergen.name} passed!',
+                style: textTheme.headlineSmall,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: AppSizes.lg),
+            ...List.generate(logs.length, (i) {
+              final log = logs[i];
+              return Padding(
+                padding: const EdgeInsets.only(bottom: AppSizes.sm),
+                child: Row(
+                  children: [
+                    Icon(
+                      log.hadReaction
+                          ? Icons.warning_amber_rounded
+                          : Icons.check_circle_rounded,
+                      color: log.hadReaction
+                          ? AppColors.allergenFlagged
+                          : AppColors.allergenSafe,
+                      size: AppSizes.iconMd,
+                    ),
+                    const SizedBox(width: AppSizes.sm),
+                    Text(
+                      'Day ${i + 1} — '
+                      '${log.hadReaction ? 'Reaction' : 'No Reaction'}'
+                      ' · ${_formatDate(log.logDate)}',
+                      style: textTheme.bodyMedium,
+                    ),
+                  ],
+                ),
+              );
+            }),
+            if (_errorMessage != null) ...[
+              const SizedBox(height: AppSizes.sm),
+              Text(
+                _errorMessage!,
+                style: textTheme.bodySmall?.copyWith(color: AppColors.error),
+                textAlign: TextAlign.center,
+              ),
+            ],
+            const SizedBox(height: AppSizes.lg),
+            FilledButton(
+              onPressed: _isLoading ? null : _onConfirm,
+              child: _isLoading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: AppColors.onPrimary,
+                      ),
+                    )
+                  : Text(
+                      next != null
+                          ? 'Start ${next.name} ${next.emoji}'
+                          : 'Complete Program 🎉',
+                    ),
+            ),
+            const SizedBox(height: AppSizes.sm),
+            OutlinedButton(
+              onPressed: _isLoading ? null : () => Navigator.of(context).pop(),
+              child: Text('Stay on ${allergen.name}'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/onboarding/readiness/readiness_controller.g.dart
+++ b/lib/src/features/onboarding/readiness/readiness_controller.g.dart
@@ -7,7 +7,7 @@ part of 'readiness_controller.dart';
 // **************************************************************************
 
 String _$readinessControllerHash() =>
-    r'2ae1246e837d3abf39bf8ca242ccdc3c247c2cba';
+    r'145d2a36889c05531f008f7893b4be859c5aad38';
 
 /// See also [ReadinessController].
 @ProviderFor(ReadinessController)

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -106,6 +106,16 @@ final class Analytics {
     );
   }
 
+  Future<void> logAllergenAdvanced({
+    required String fromKey,
+    required String toKey,
+  }) async {
+    await _logEvent(
+      'allergen_advanced',
+      parameters: {'from_key': fromKey, 'to_key': toKey},
+    );
+  }
+
   Future<void> logAllergenProgramCompleted() async {
     await _logEvent('allergen_program_completed');
   }


### PR DESCRIPTION
## Summary

- **AL-07 — Proceed Confirmation Sheet**: bottom sheet triggered from allergen detail showing current allergen emoji/name, 3-log summary with reaction outcomes, and Stay/Start buttons. On confirm, calls `AllergenService.advanceToNextAllergen`, navigates to next AL-03 or AL-08 if program complete. P1 error handling inline.
- **AL-08 — Program Complete Screen**: full-screen celebration with `flutter_animate` scale/fadeIn, baby name headline, 9 allergen chips, "View in Profile" CTA. `PopScope.onPopInvokedWithResult` ensures the shown-once flag (`program_completion_shown_{babyId}`) is set on both CTA tap and back gesture.
- **AllergenDetailController** (AsyncNotifier family): loads board summary via `AllergenService`, exposes `advanceToNext() → Result<String?>` (null = completed).
- **AllergenCompleteController** (AsyncNotifier): loads baby + allergens, fires `logAllergenProgramCompleted()` on build, exposes `markShown()`.
- **Analytics**: added `logAllergenAdvanced(fromKey, toKey)` event.

## Test plan

- [ ] AL-07: sheet opens from allergen detail "Proceed to Next Allergen" button
- [ ] AL-07: shows correct allergen emoji + name + "✅ passed!" headline
- [ ] AL-07: shows up to 3 log entries with date and reaction outcome
- [ ] AL-07: "Stay on [X]" dismisses sheet, no state change
- [ ] AL-07: "Start [Next]" calls advance, navigates to next AL-03
- [ ] AL-07: on shellfish (last allergen), navigates to AL-08
- [ ] AL-07: P1 error shown inline on network failure
- [ ] AL-08: shows baby name in headline
- [ ] AL-08: all 9 allergen chips visible
- [ ] AL-08: "View in Profile" sets flag + navigates to profile
- [ ] AL-08: back gesture sets flag (shown-once enforcement)
- [ ] AL-08 not shown again on second session when flag is set
- [ ] Analytics: `allergen_advanced` and `allergen_marked_safe` fire on advance
- [ ] Analytics: `allergen_program_completed` fires when AL-08 loads