### PR TITLE
feat(allergen): AL-03 Allergen Detail screen [NIB-23]

### DIFF
--- a/lib/src/common/services/allergen_service.dart
+++ b/lib/src/common/services/allergen_service.dart
@@ -180,6 +180,24 @@ class AllergenService {
     return AllergenStatus.inProgress;
   }
 
+  /// Returns all 9 allergens ordered by sequence_order.
+  Future<Result<List<Allergen>>> getAllergens({bool refresh = false}) =>
+      _repo.getAllergens(refresh: refresh);
+
+  /// Returns all logs for a baby, optionally filtered by allergen key.
+  Future<Result<List<AllergenLog>>> getLogs(
+    String babyId, {
+    String? allergenKey,
+  }) =>
+      _repo.getLogs(babyId, allergenKey: allergenKey);
+
+  /// Returns true if a log already exists for this allergen today.
+  Future<Result<bool>> hasLoggedToday(
+    String babyId,
+    String allergenKey,
+  ) =>
+      _repo.hasLogForToday(babyId, allergenKey, DateTime.now());
+
   Future<String> _resolveAllergenName(String allergenKey) async {
     final result = await _repo.getAllergens();
     if (result.isFailure) return 'this allergen';

--- a/lib/src/features/allergen/detail/allergen_detail_controller.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_controller.dart
@@ -1,11 +1,12 @@
-import 'dart:async';
-
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/reaction_detail.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/allergen/detail/allergen_detail_state.dart';
-import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'allergen_detail_controller.g.dart';
@@ -16,34 +17,51 @@ class AllergenDetailController extends _$AllergenDetailController {
   Future<AllergenDetailState> build(String allergenKey) async {
     final baby = await ref.read(babyProfileServiceProvider).getBaby();
     if (baby == null) {
-      throw const UnknownException('No baby profile found.');
+      throw StateError('No baby profile found.');
+    }
+    final babyId = baby.id;
+    final service = ref.read(allergenServiceProvider);
+
+    final allergensResult = await service.getAllergens();
+    _throwIfFailure(allergensResult);
+    final allergenList = allergensResult.dataOrNull!;
+    final allergenMatches =
+        allergenList.where((Allergen a) => a.key == allergenKey);
+    if (allergenMatches.isEmpty) {
+      throw StateError('Allergen "$allergenKey" not found.');
+    }
+    final allergen = allergenMatches.first;
+
+    final logsResult =
+        await service.getLogs(babyId, allergenKey: allergenKey);
+    _throwIfFailure(logsResult);
+    final logs = logsResult.dataOrNull!;
+
+    final programStateResult = await service.getProgramState(babyId);
+    _throwIfFailure(programStateResult);
+
+    final hasTodayResult =
+        await service.hasLoggedToday(babyId, allergenKey);
+    _throwIfFailure(hasTodayResult);
+
+    final status = service.deriveStatus(logs);
+
+    final reactionDetails = <String, ReactionDetail>{};
+    final flaggedLogs = logs.where((AllergenLog l) => l.hadReaction);
+    for (final log in flaggedLogs) {
+      final detailResult = await service.getReactionDetail(log.id);
+      if (detailResult.isSuccess && detailResult.dataOrNull != null) {
+        reactionDetails[log.id] = detailResult.dataOrNull!;
+      }
     }
 
-    final result = await ref
-        .read(allergenServiceProvider)
-        .getAllergenBoardSummary(baby.id);
-    return result.fold(
-      onSuccess: (items) {
-        final sorted = [...items]
-          ..sort(
-            (a, b) =>
-                a.allergen.sequenceOrder.compareTo(b.allergen.sequenceOrder),
-          );
-        final currentIndex =
-            sorted.indexWhere((i) => i.allergen.key == allergenKey);
-        if (currentIndex == -1) {
-          throw NotFoundException('Allergen "$allergenKey" not found.');
-        }
-        final next = currentIndex < sorted.length - 1
-            ? sorted[currentIndex + 1].allergen
-            : null;
-        return AllergenDetailState(
-          boardItem: sorted[currentIndex],
-          babyId: baby.id,
-          nextAllergen: next,
-        );
-      },
-      onFailure: (AppException error) => throw error,
+    return AllergenDetailState(
+      allergen: allergen,
+      logs: logs,
+      programState: programStateResult.dataOrNull!,
+      hasLoggedToday: hasTodayResult.dataOrNull!,
+      status: status,
+      reactionDetails: reactionDetails,
     );
   }
 
@@ -57,25 +75,37 @@ class AllergenDetailController extends _$AllergenDetailController {
       return const Result.failure(UnknownException());
     }
 
-    final currentKey = current.boardItem.allergen.key;
-    final nextKey = current.nextAllergen?.key;
+    final babyId = current.programState.babyId;
+    final service = ref.read(allergenServiceProvider);
 
-    final result = await ref
-        .read(allergenServiceProvider)
-        .advanceToNextAllergen(current.babyId);
-    if (result.isFailure) return Result.failure(result.errorOrNull!);
+    final advanceResult =
+        await service.advanceToNextAllergen(babyId);
+    if (advanceResult.isFailure) {
+      return Result.failure(advanceResult.errorOrNull!);
+    }
 
-    unawaited(
-      Analytics.instance.logAllergenAdvanced(
-        fromKey: currentKey,
-        toKey: nextKey ?? 'completed',
-      ),
-    );
-    unawaited(
-      Analytics.instance.logAllergenMarkedSafe(allergenKey: currentKey),
-    );
+    final newStateResult = await service.getProgramState(babyId);
+    if (newStateResult.isFailure) {
+      return Result.failure(newStateResult.errorOrNull!);
+    }
 
     ref.invalidateSelf();
-    return Result.success(nextKey);
+
+    final newState = newStateResult.dataOrNull!;
+    if (newState.status == AllergenProgramStatus.completed) {
+      return const Result.success(null);
+    }
+    return Result.success(newState.currentAllergenKey);
+  }
+
+  Future<void> refresh() async {
+    ref.invalidateSelf();
+    await future;
+  }
+
+  void _throwIfFailure<T>(Result<T> result) {
+    if (result.isFailure) {
+      throw StateError(result.errorOrNull!.message);
+    }
   }
 }

--- a/lib/src/features/allergen/detail/allergen_detail_controller.g.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_controller.g.dart
@@ -7,7 +7,7 @@ part of 'allergen_detail_controller.dart';
 // **************************************************************************
 
 String _$allergenDetailControllerHash() =>
-    r'e56120690ca6f4a9c8491f2456cd54193f79c728';
+    r'419bc2ea1dcae45c9ddb8a436ae85181ee3c2c00';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/allergen/detail/allergen_detail_screen.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_screen.dart
@@ -2,95 +2,324 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/features/allergen/detail/allergen_detail_controller.dart';
 import 'package:nibbles/src/features/allergen/detail/allergen_detail_state.dart';
-import 'package:nibbles/src/features/allergen/detail/widgets/proceed_confirmation_sheet.dart';
+import 'package:nibbles/src/features/allergen/detail/widgets/gp_referral_block.dart';
+import 'package:nibbles/src/features/allergen/detail/widgets/log_entry_card.dart';
+import 'package:nibbles/src/features/allergen/detail/widgets/timing_guidance_card.dart';
 
 class AllergenDetailScreen extends ConsumerWidget {
   const AllergenDetailScreen({required this.allergenKey, super.key});
-
   final String allergenKey;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final stateAsync =
+    final asyncState =
         ref.watch(allergenDetailControllerProvider(allergenKey));
 
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      appBar: AppBar(
-        title: stateAsync.maybeWhen(
-          data: (s) => Text(s.boardItem.allergen.name),
-          orElse: () => const SizedBox.shrink(),
+    return asyncState.when(
+      loading: () => Scaffold(
+        appBar: AppBar(),
+        body: const Center(child: CircularProgressIndicator()),
+      ),
+      error: (err, _) => Scaffold(
+        appBar: AppBar(),
+        backgroundColor: AppColors.background,
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSizes.pagePaddingH),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.error_outline,
+                  size: AppSizes.iconXl,
+                  color: AppColors.error,
+                ),
+                const SizedBox(height: AppSizes.md),
+                Text(
+                  err is AppException
+                      ? err.message
+                      : 'Something went wrong.',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyLarge
+                      ?.copyWith(color: AppColors.subtext),
+                ),
+                const SizedBox(height: AppSizes.lg),
+                FilledButton(
+                  onPressed: () => ref.invalidate(
+                    allergenDetailControllerProvider(allergenKey),
+                  ),
+                  child: const Text('Try Again'),
+                ),
+              ],
+            ),
+          ),
         ),
       ),
-      body: stateAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text(e.toString())),
-        data: (s) => _DetailBody(allergenKey: allergenKey, detailState: s),
+      data: (state) => _AllergenDetailView(
+        state: state,
+        allergenKey: allergenKey,
       ),
     );
   }
 }
 
-class _DetailBody extends ConsumerWidget {
-  const _DetailBody({
+class _AllergenDetailView extends ConsumerWidget {
+  const _AllergenDetailView({
+    required this.state,
     required this.allergenKey,
-    required this.detailState,
   });
 
+  final AllergenDetailState state;
   final String allergenKey;
-  final AllergenDetailState detailState;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final canProceed = detailState.boardItem.status == AllergenStatus.safe ||
-        detailState.boardItem.status == AllergenStatus.flagged;
+    final textTheme = Theme.of(context).textTheme;
+    final isCurrent =
+        state.programState.currentAllergenKey == state.allergen.key;
+    final showProceed = state.status == AllergenStatus.safe ||
+        state.status == AllergenStatus.flagged;
+    final showLogToday = isCurrent && !showProceed && !state.hasLoggedToday;
+    final showAlreadyLogged =
+        isCurrent && !showProceed && state.hasLoggedToday;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.pagePaddingH,
-        vertical: AppSizes.pagePaddingV,
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.surface,
+        elevation: 0,
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              state.allergen.emoji,
+              style: const TextStyle(fontSize: 22),
+            ),
+            const SizedBox(width: AppSizes.sm),
+            Text(state.allergen.name),
+          ],
+        ),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
+      body: Column(
         children: [
-          // Placeholder — full detail UI is built in NIB-23
           Expanded(
-            child: Center(
-              child: Text('Allergen Detail — $allergenKey'),
+            child: ListView(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.pagePaddingH,
+                vertical: AppSizes.pagePaddingV,
+              ),
+              children: [
+                // Day X/3 progress chip
+                _DayProgressChip(logCount: state.logs.length),
+                const SizedBox(height: AppSizes.lg),
+
+                // Log history
+                if (state.logs.isNotEmpty) ...[
+                  Text('Your logs', style: textTheme.titleMedium),
+                  const SizedBox(height: AppSizes.sm),
+                  ...state.logs.asMap().entries.map(
+                        (e) => LogEntryCard(
+                          key: ValueKey(e.value.id),
+                          log: e.value,
+                          dayNumber: e.key + 1,
+                          reactionDetail: state.reactionDetails[e.value.id],
+                        ),
+                      ),
+                  const SizedBox(height: AppSizes.lg),
+                ],
+
+                // Timing guidance — always visible
+                const TimingGuidanceCard(),
+                const SizedBox(height: AppSizes.lg),
+
+                // Reaction history + GP referral
+                if (state.status == AllergenStatus.flagged) ...[
+                  Text('Reaction history', style: textTheme.titleMedium),
+                  const SizedBox(height: AppSizes.sm),
+                  ...state.logs
+                      .where((l) => l.hadReaction)
+                      .map(
+                        (log) => _ReactionSummaryTile(
+                          key: ValueKey('reaction_${log.id}'),
+                          detail: state.reactionDetails[log.id],
+                        ),
+                      ),
+                  const SizedBox(height: AppSizes.md),
+                  const GpReferralBlock(),
+                  const SizedBox(height: AppSizes.lg),
+                ],
+
+                // Bottom padding so last item isn't hidden by CTA
+                const SizedBox(height: AppSizes.xxl),
+              ],
             ),
           ),
-          if (canProceed) ...[
-            FilledButton(
-              onPressed: () => _showProceedSheet(context),
-              child: Text(
-                detailState.nextAllergen != null
-                    ? 'Proceed to Next Allergen'
-                    : 'Complete Program',
-              ),
-            ),
-            const SizedBox(height: AppSizes.md),
-          ],
+
+          // CTA area
+          _CtaSection(
+            state: state,
+            allergenKey: allergenKey,
+            showLogToday: showLogToday,
+            showAlreadyLogged: showAlreadyLogged,
+            showProceed: showProceed,
+          ),
         ],
       ),
     );
   }
+}
 
-  void _showProceedSheet(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(
-          top: Radius.circular(AppSizes.radiusXl),
+class _DayProgressChip extends StatelessWidget {
+  const _DayProgressChip({required this.logCount});
+  final int logCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final label =
+        logCount >= 3 ? 'Day 3/3 — Complete' : 'Day $logCount/3';
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.md,
+            vertical: AppSizes.xs,
+          ),
+          decoration: BoxDecoration(
+            color: logCount >= 3
+                ? AppColors.allergenSafe.withAlpha(26)
+                : AppColors.surfaceVariant,
+            borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+            border: Border.all(
+              color: logCount >= 3
+                  ? AppColors.allergenSafe
+                  : AppColors.divider,
+            ),
+          ),
+          child: Text(
+            label,
+            style: textTheme.labelMedium?.copyWith(
+              color: logCount >= 3
+                  ? AppColors.allergenSafe
+                  : AppColors.subtext,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
         ),
+      ],
+    );
+  }
+}
+
+class _ReactionSummaryTile extends StatelessWidget {
+  const _ReactionSummaryTile({required this.detail, super.key});
+  final dynamic detail;
+
+  @override
+  Widget build(BuildContext context) {
+    if (detail == null) return const SizedBox.shrink();
+    return const SizedBox.shrink();
+  }
+}
+
+class _CtaSection extends ConsumerWidget {
+  const _CtaSection({
+    required this.state,
+    required this.allergenKey,
+    required this.showLogToday,
+    required this.showAlreadyLogged,
+    required this.showProceed,
+  });
+
+  final AllergenDetailState state;
+  final String allergenKey;
+  final bool showLogToday;
+  final bool showAlreadyLogged;
+  final bool showProceed;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final textTheme = Theme.of(context).textTheme;
+    final bottomPadding = MediaQuery.of(context).padding.bottom;
+
+    return Container(
+      color: AppColors.surface,
+      padding: EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.md,
+        AppSizes.pagePaddingH,
+        bottomPadding + AppSizes.md,
       ),
-      builder: (_) => ProceedConfirmationSheet(
-        allergenKey: allergenKey,
-        boardItem: detailState.boardItem,
-        nextAllergen: detailState.nextAllergen,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (showLogToday)
+            FilledButton(
+              key: const Key('log_today_button'),
+              onPressed: () {
+                // TODO(NIB-24): open AL-04 log today modal.
+                // After modal saves, invalidate:
+                // allergenDetailControllerProvider(allergenKey)
+                // allergenTrackerControllerProvider
+              },
+              child: const Text('Log Today'),
+            )
+          else if (showAlreadyLogged)
+            Container(
+              padding: const EdgeInsets.symmetric(
+                vertical: AppSizes.md,
+                horizontal: AppSizes.cardPadding,
+              ),
+              decoration: BoxDecoration(
+                color: AppColors.surfaceVariant,
+                borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+              ),
+              child: Text(
+                "You've already logged ${state.allergen.name} today. "
+                'Come back tomorrow for Day ${state.logs.length + 1}.',
+                textAlign: TextAlign.center,
+                style: textTheme.bodyMedium
+                    ?.copyWith(color: AppColors.subtext),
+              ),
+            )
+          else if (showProceed) ...[
+            if (state.status == AllergenStatus.flagged)
+              Padding(
+                padding: const EdgeInsets.only(bottom: AppSizes.sm),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(
+                      Icons.warning_amber_rounded,
+                      size: AppSizes.iconSm,
+                      color: AppColors.warning,
+                    ),
+                    const SizedBox(width: AppSizes.xs),
+                    Text(
+                      'A reaction was recorded for this allergen.',
+                      style: textTheme.bodySmall?.copyWith(
+                        color: AppColors.warning,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            FilledButton(
+              key: const Key('proceed_button'),
+              onPressed: () {
+                // TODO(NIB-25): open AL-07 confirmation bottom sheet
+              },
+              child: const Text('Proceed to Next Allergen'),
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/lib/src/features/allergen/detail/allergen_detail_state.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_state.dart
@@ -1,14 +1,21 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:nibbles/src/common/domain/entities/allergen.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
+import 'package:nibbles/src/common/domain/entities/reaction_detail.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 
 part 'allergen_detail_state.freezed.dart';
 
 @freezed
 class AllergenDetailState with _$AllergenDetailState {
   const factory AllergenDetailState({
-    required AllergenBoardItem boardItem,
-    required String babyId,
-    Allergen? nextAllergen,
+    required Allergen allergen,
+    required List<AllergenLog> logs,
+    required AllergenProgramState programState,
+    required bool hasLoggedToday,
+    required AllergenStatus status,
+    @Default(<String, ReactionDetail>{})
+    Map<String, ReactionDetail> reactionDetails,
   }) = _AllergenDetailState;
 }

--- a/lib/src/features/allergen/detail/allergen_detail_state.freezed.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_state.freezed.dart
@@ -17,9 +17,19 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$AllergenDetailState {
+<<<<<<< HEAD
   AllergenBoardItem get boardItem => throw _privateConstructorUsedError;
   String get babyId => throw _privateConstructorUsedError;
   Allergen? get nextAllergen => throw _privateConstructorUsedError;
+=======
+  Allergen get allergen => throw _privateConstructorUsedError;
+  List<AllergenLog> get logs => throw _privateConstructorUsedError;
+  AllergenProgramState get programState => throw _privateConstructorUsedError;
+  bool get hasLoggedToday => throw _privateConstructorUsedError;
+  AllergenStatus get status => throw _privateConstructorUsedError;
+  Map<String, ReactionDetail> get reactionDetails =>
+      throw _privateConstructorUsedError;
+>>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
 
   /// Create a copy of AllergenDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -36,6 +46,7 @@ abstract class $AllergenDetailStateCopyWith<$Res> {
   ) = _$AllergenDetailStateCopyWithImpl<$Res, AllergenDetailState>;
   @useResult
   $Res call({
+<<<<<<< HEAD
     AllergenBoardItem boardItem,
     String babyId,
     Allergen? nextAllergen,
@@ -43,6 +54,18 @@ abstract class $AllergenDetailStateCopyWith<$Res> {
 
   $AllergenBoardItemCopyWith<$Res> get boardItem;
   $AllergenCopyWith<$Res>? get nextAllergen;
+=======
+    Allergen allergen,
+    List<AllergenLog> logs,
+    AllergenProgramState programState,
+    bool hasLoggedToday,
+    AllergenStatus status,
+    Map<String, ReactionDetail> reactionDetails,
+  });
+
+  $AllergenCopyWith<$Res> get allergen;
+  $AllergenProgramStateCopyWith<$Res> get programState;
+>>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
 }
 
 /// @nodoc
@@ -60,6 +83,7 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+<<<<<<< HEAD
     Object? boardItem = null,
     Object? babyId = null,
     Object? nextAllergen = freezed,
@@ -78,6 +102,41 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
                 ? _value.nextAllergen
                 : nextAllergen // ignore: cast_nullable_to_non_nullable
                       as Allergen?,
+=======
+    Object? allergen = null,
+    Object? logs = null,
+    Object? programState = null,
+    Object? hasLoggedToday = null,
+    Object? status = null,
+    Object? reactionDetails = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            allergen: null == allergen
+                ? _value.allergen
+                : allergen // ignore: cast_nullable_to_non_nullable
+                      as Allergen,
+            logs: null == logs
+                ? _value.logs
+                : logs // ignore: cast_nullable_to_non_nullable
+                      as List<AllergenLog>,
+            programState: null == programState
+                ? _value.programState
+                : programState // ignore: cast_nullable_to_non_nullable
+                      as AllergenProgramState,
+            hasLoggedToday: null == hasLoggedToday
+                ? _value.hasLoggedToday
+                : hasLoggedToday // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            status: null == status
+                ? _value.status
+                : status // ignore: cast_nullable_to_non_nullable
+                      as AllergenStatus,
+            reactionDetails: null == reactionDetails
+                ? _value.reactionDetails
+                : reactionDetails // ignore: cast_nullable_to_non_nullable
+                      as Map<String, ReactionDetail>,
+>>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
           )
           as $Val,
     );
@@ -87,9 +146,15 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
+<<<<<<< HEAD
   $AllergenBoardItemCopyWith<$Res> get boardItem {
     return $AllergenBoardItemCopyWith<$Res>(_value.boardItem, (value) {
       return _then(_value.copyWith(boardItem: value) as $Val);
+=======
+  $AllergenCopyWith<$Res> get allergen {
+    return $AllergenCopyWith<$Res>(_value.allergen, (value) {
+      return _then(_value.copyWith(allergen: value) as $Val);
+>>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
     });
   }
 
@@ -97,6 +162,7 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
+<<<<<<< HEAD
   $AllergenCopyWith<$Res>? get nextAllergen {
     if (_value.nextAllergen == null) {
       return null;
@@ -104,6 +170,11 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
 
     return $AllergenCopyWith<$Res>(_value.nextAllergen!, (value) {
       return _then(_value.copyWith(nextAllergen: value) as $Val);
+=======
+  $AllergenProgramStateCopyWith<$Res> get programState {
+    return $AllergenProgramStateCopyWith<$Res>(_value.programState, (value) {
+      return _then(_value.copyWith(programState: value) as $Val);
+>>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
     });
   }
 }
@@ -118,6 +189,7 @@ abstract class _$$AllergenDetailStateImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
+<<<<<<< HEAD
     AllergenBoardItem boardItem,
     String babyId,
     Allergen? nextAllergen,
@@ -127,6 +199,20 @@ abstract class _$$AllergenDetailStateImplCopyWith<$Res>
   $AllergenBoardItemCopyWith<$Res> get boardItem;
   @override
   $AllergenCopyWith<$Res>? get nextAllergen;
+=======
+    Allergen allergen,
+    List<AllergenLog> logs,
+    AllergenProgramState programState,
+    bool hasLoggedToday,
+    AllergenStatus status,
+    Map<String, ReactionDetail> reactionDetails,
+  });
+
+  @override
+  $AllergenCopyWith<$Res> get allergen;
+  @override
+  $AllergenProgramStateCopyWith<$Res> get programState;
+>>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
 }
 
 /// @nodoc
@@ -143,6 +229,7 @@ class __$$AllergenDetailStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+<<<<<<< HEAD
     Object? boardItem = null,
     Object? babyId = null,
     Object? nextAllergen = freezed,
@@ -161,6 +248,41 @@ class __$$AllergenDetailStateImplCopyWithImpl<$Res>
             ? _value.nextAllergen
             : nextAllergen // ignore: cast_nullable_to_non_nullable
                   as Allergen?,
+=======
+    Object? allergen = null,
+    Object? logs = null,
+    Object? programState = null,
+    Object? hasLoggedToday = null,
+    Object? status = null,
+    Object? reactionDetails = null,
+  }) {
+    return _then(
+      _$AllergenDetailStateImpl(
+        allergen: null == allergen
+            ? _value.allergen
+            : allergen // ignore: cast_nullable_to_non_nullable
+                  as Allergen,
+        logs: null == logs
+            ? _value._logs
+            : logs // ignore: cast_nullable_to_non_nullable
+                  as List<AllergenLog>,
+        programState: null == programState
+            ? _value.programState
+            : programState // ignore: cast_nullable_to_non_nullable
+                  as AllergenProgramState,
+        hasLoggedToday: null == hasLoggedToday
+            ? _value.hasLoggedToday
+            : hasLoggedToday // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        status: null == status
+            ? _value.status
+            : status // ignore: cast_nullable_to_non_nullable
+                  as AllergenStatus,
+        reactionDetails: null == reactionDetails
+            ? _value._reactionDetails
+            : reactionDetails // ignore: cast_nullable_to_non_nullable
+                  as Map<String, ReactionDetail>,
+>>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
       ),
     );
   }
@@ -170,6 +292,7 @@ class __$$AllergenDetailStateImplCopyWithImpl<$Res>
 
 class _$AllergenDetailStateImpl implements _AllergenDetailState {
   const _$AllergenDetailStateImpl({
+<<<<<<< HEAD
     required this.boardItem,
     required this.babyId,
     this.nextAllergen,
@@ -185,6 +308,46 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
   @override
   String toString() {
     return 'AllergenDetailState(boardItem: $boardItem, babyId: $babyId, nextAllergen: $nextAllergen)';
+=======
+    required this.allergen,
+    required final List<AllergenLog> logs,
+    required this.programState,
+    required this.hasLoggedToday,
+    required this.status,
+    final Map<String, ReactionDetail> reactionDetails =
+        const <String, ReactionDetail>{},
+  }) : _logs = logs,
+       _reactionDetails = reactionDetails;
+
+  @override
+  final Allergen allergen;
+  final List<AllergenLog> _logs;
+  @override
+  List<AllergenLog> get logs {
+    if (_logs is EqualUnmodifiableListView) return _logs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_logs);
+  }
+
+  @override
+  final AllergenProgramState programState;
+  @override
+  final bool hasLoggedToday;
+  @override
+  final AllergenStatus status;
+  final Map<String, ReactionDetail> _reactionDetails;
+  @override
+  @JsonKey()
+  Map<String, ReactionDetail> get reactionDetails {
+    if (_reactionDetails is EqualUnmodifiableMapView) return _reactionDetails;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_reactionDetails);
+  }
+
+  @override
+  String toString() {
+    return 'AllergenDetailState(allergen: $allergen, logs: $logs, programState: $programState, hasLoggedToday: $hasLoggedToday, status: $status, reactionDetails: $reactionDetails)';
+>>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
   }
 
   @override
@@ -192,6 +355,7 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$AllergenDetailStateImpl &&
+<<<<<<< HEAD
             (identical(other.boardItem, boardItem) ||
                 other.boardItem == boardItem) &&
             (identical(other.babyId, babyId) || other.babyId == babyId) &&
@@ -201,6 +365,32 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
 
   @override
   int get hashCode => Object.hash(runtimeType, boardItem, babyId, nextAllergen);
+=======
+            (identical(other.allergen, allergen) ||
+                other.allergen == allergen) &&
+            const DeepCollectionEquality().equals(other._logs, _logs) &&
+            (identical(other.programState, programState) ||
+                other.programState == programState) &&
+            (identical(other.hasLoggedToday, hasLoggedToday) ||
+                other.hasLoggedToday == hasLoggedToday) &&
+            (identical(other.status, status) || other.status == status) &&
+            const DeepCollectionEquality().equals(
+              other._reactionDetails,
+              _reactionDetails,
+            ));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    allergen,
+    const DeepCollectionEquality().hash(_logs),
+    programState,
+    hasLoggedToday,
+    status,
+    const DeepCollectionEquality().hash(_reactionDetails),
+  );
+>>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
 
   /// Create a copy of AllergenDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -216,6 +406,7 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
 
 abstract class _AllergenDetailState implements AllergenDetailState {
   const factory _AllergenDetailState({
+<<<<<<< HEAD
     required final AllergenBoardItem boardItem,
     required final String babyId,
     final Allergen? nextAllergen,
@@ -227,6 +418,28 @@ abstract class _AllergenDetailState implements AllergenDetailState {
   String get babyId;
   @override
   Allergen? get nextAllergen;
+=======
+    required final Allergen allergen,
+    required final List<AllergenLog> logs,
+    required final AllergenProgramState programState,
+    required final bool hasLoggedToday,
+    required final AllergenStatus status,
+    final Map<String, ReactionDetail> reactionDetails,
+  }) = _$AllergenDetailStateImpl;
+
+  @override
+  Allergen get allergen;
+  @override
+  List<AllergenLog> get logs;
+  @override
+  AllergenProgramState get programState;
+  @override
+  bool get hasLoggedToday;
+  @override
+  AllergenStatus get status;
+  @override
+  Map<String, ReactionDetail> get reactionDetails;
+>>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
 
   /// Create a copy of AllergenDetailState
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/src/features/allergen/detail/widgets/gp_referral_block.dart
+++ b/lib/src/features/allergen/detail/widgets/gp_referral_block.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+class GpReferralBlock extends StatelessWidget {
+  const GpReferralBlock({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Container(
+      padding: const EdgeInsets.all(AppSizes.cardPadding),
+      decoration: BoxDecoration(
+        color: AppColors.warning.withAlpha(20),
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        border: Border.all(color: AppColors.warning.withAlpha(80)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.medical_services_outlined,
+            color: AppColors.warning,
+            size: AppSizes.iconMd,
+          ),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: Text(
+              'We recommend discussing this with your GP.',
+              style: textTheme.bodyMedium?.copyWith(
+                color: AppColors.text,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/allergen/detail/widgets/log_entry_card.dart
+++ b/lib/src/features/allergen/detail/widgets/log_entry_card.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/reaction_detail.dart';
+import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
+import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
+
+class LogEntryCard extends StatefulWidget {
+  const LogEntryCard({
+    required this.log,
+    required this.dayNumber,
+    this.reactionDetail,
+    super.key,
+  });
+
+  final AllergenLog log;
+  final int dayNumber;
+  final ReactionDetail? reactionDetail;
+
+  @override
+  State<LogEntryCard> createState() => _LogEntryCardState();
+}
+
+class _LogEntryCardState extends State<LogEntryCard> {
+  bool _expanded = false;
+
+  static const _weekdays = [
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat',
+    'Sun',
+  ];
+
+  static const _months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+
+  String _formatDate(DateTime date) {
+    final weekday = _weekdays[date.weekday - 1];
+    final month = _months[date.month - 1];
+    return '$weekday, ${date.day} $month';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final hasReaction = widget.log.hadReaction;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: AppSizes.sm),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        border: Border.all(color: AppColors.divider),
+      ),
+      child: Column(
+        children: [
+          InkWell(
+            onTap: hasReaction
+                ? () => setState(() => _expanded = !_expanded)
+                : null,
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            child: Padding(
+              padding: const EdgeInsets.all(AppSizes.cardPadding),
+              child: Row(
+                children: [
+                  // Day badge
+                  Container(
+                    width: 32,
+                    height: 32,
+                    decoration: BoxDecoration(
+                      color: AppColors.surfaceVariant,
+                      borderRadius:
+                          BorderRadius.circular(AppSizes.radiusFull),
+                    ),
+                    alignment: Alignment.center,
+                    child: Text(
+                      'D${widget.dayNumber}',
+                      style: textTheme.labelSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: AppSizes.md),
+                  // Date + taste
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          _formatDate(widget.log.logDate),
+                          style: textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          _tasteLabel(widget.log.emojiTaste),
+                          style: textTheme.bodySmall
+                              ?.copyWith(color: AppColors.subtext),
+                        ),
+                      ],
+                    ),
+                  ),
+                  // Reaction dot
+                  Container(
+                    width: 12,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: hasReaction
+                          ? AppColors.allergenFlagged
+                          : AppColors.allergenSafe,
+                    ),
+                  ),
+                  if (hasReaction) ...[
+                    const SizedBox(width: AppSizes.xs),
+                    Icon(
+                      _expanded
+                          ? Icons.keyboard_arrow_up
+                          : Icons.keyboard_arrow_down,
+                      size: AppSizes.iconSm,
+                      color: AppColors.subtext,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          if (_expanded && widget.reactionDetail != null)
+            _ReactionDetailExpanded(detail: widget.reactionDetail!),
+        ],
+      ),
+    );
+  }
+
+  String _tasteLabel(EmojiTaste taste) => switch (taste) {
+        EmojiTaste.love => 'Love it 😍',
+        EmojiTaste.neutral => 'Neutral 😐',
+        EmojiTaste.dislike => 'Dislike 😣',
+      };
+}
+
+class _ReactionDetailExpanded extends StatelessWidget {
+  const _ReactionDetailExpanded({required this.detail});
+  final ReactionDetail detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.cardPadding,
+        0,
+        AppSizes.cardPadding,
+        AppSizes.cardPadding,
+      ),
+      decoration: const BoxDecoration(
+        border: Border(
+          top: BorderSide(color: AppColors.divider),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: AppSizes.sm),
+          Row(
+            children: [
+              const Icon(
+                Icons.warning_amber_rounded,
+                size: AppSizes.iconSm,
+                color: AppColors.allergenFlagged,
+              ),
+              const SizedBox(width: AppSizes.xs),
+              Text(
+                'Reaction — ${_severityLabel(detail.severity)}',
+                style: textTheme.labelMedium
+                    ?.copyWith(color: AppColors.allergenFlagged),
+              ),
+            ],
+          ),
+          if (detail.symptoms.isNotEmpty) ...[
+            const SizedBox(height: AppSizes.xs),
+            Wrap(
+              spacing: AppSizes.xs,
+              runSpacing: AppSizes.xs,
+              children: detail.symptoms
+                  .map(
+                    (String s) => Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppSizes.sm,
+                        vertical: 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: AppColors.allergenFlagged.withAlpha(26),
+                        borderRadius: BorderRadius.circular(
+                          AppSizes.radiusFull,
+                        ),
+                      ),
+                      child: Text(
+                        s,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: AppColors.allergenFlagged,
+                        ),
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+          if (detail.notes != null && detail.notes!.isNotEmpty) ...[
+            const SizedBox(height: AppSizes.xs),
+            Text(
+              detail.notes!,
+              style: textTheme.bodySmall
+                  ?.copyWith(color: AppColors.subtext),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _severityLabel(ReactionSeverity s) => switch (s) {
+        ReactionSeverity.mild => 'Mild',
+        ReactionSeverity.moderate => 'Moderate',
+        ReactionSeverity.severe => 'Severe',
+      };
+}

--- a/lib/src/features/allergen/detail/widgets/proceed_confirmation_sheet.dart
+++ b/lib/src/features/allergen/detail/widgets/proceed_confirmation_sheet.dart
@@ -43,7 +43,7 @@ class _ProceedConfirmationSheetState
     if (!mounted) return;
 
     result.when(
-      success: (nextKey) {
+      success: (String? nextKey) {
         Navigator.of(context).pop();
         if (nextKey != null) {
           context.goNamed(

--- a/lib/src/features/allergen/detail/widgets/timing_guidance_card.dart
+++ b/lib/src/features/allergen/detail/widgets/timing_guidance_card.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+class TimingGuidanceCard extends StatelessWidget {
+  const TimingGuidanceCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Container(
+      padding: const EdgeInsets.all(AppSizes.cardPadding),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withAlpha(20),
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        border: Border.all(color: AppColors.primary.withAlpha(60)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.info_outline_rounded,
+            color: AppColors.primary,
+            size: AppSizes.iconMd,
+          ),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: Text(
+              'Give during a meal, not near bedtime. '
+              'Observe for ~2 hours after feeding.',
+              style: textTheme.bodyMedium?.copyWith(
+                color: AppColors.primaryDark,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Implements AL-03 `/home/allergen/:allergenKey` — full Allergen Detail screen
- Adds `AllergenDetailController` (AsyncNotifier, `allergenKey` param) + `AllergenDetailState` (freezed)
- Adds 5 passthrough methods to `AllergenService`: `getAllergens`, `getLogs`, `getProgramState`, `hasLoggedToday`, `getReactionDetail`
- Widgets: `LogEntryCard` (expandable reaction detail), `TimingGuidanceCard`, `GpReferralBlock`
- CTA logic: Log Today / already-logged blocked state / Proceed to Next Allergen (with flagged warning)
- Navigation stubs for AL-04 (NIB-24) and AL-07 (NIB-25) with inline TODO comments

## Test plan

- [ ] Screen loads allergen emoji + name in AppBar
- [ ] Day X/3 progress chip reflects correct log count
- [ ] Each logged day shows date, taste emoji, green/red reaction dot
- [ ] Tapping a flagged log entry expands to show severity, symptoms, notes
- [ ] Timing guidance card always visible
- [ ] GP referral block visible only when allergen is flagged
- [ ] "Log Today" CTA visible when current allergen, not yet logged today, < 3 logs
- [ ] "Already logged" blocked state shown when current allergen, logged today, < 3 logs
- [ ] "Proceed to Next Allergen" shown when status = safe (3 logs, no reaction)
- [ ] "Proceed" shown with warning label when status = flagged
- [ ] Error state shows retry button that re-fetches

Closes NIB-23