### PR TITLE
chore(infra): add nibbles linear-start and run-milestone skills

### DIFF
--- a/.claude/skills/linear-start.md
+++ b/.claude/skills/linear-start.md
@@ -1,0 +1,210 @@
+---
+name: linear-start
+description: Nibbles-specific linear ticket workflow. Fetches ticket, runs dependency pre-flight, explores code, creates branch, routes to correct domain agent, opens PR. Overrides global linear-start for this project.
+---
+
+# /linear-start — Nibbles Ticket Workflow
+
+Ticket ID: `$ARGUMENTS`
+
+---
+
+## ⚠️ Anti-hallucination rules — read first
+
+- Never infer, recall, or fabricate ticket data. Everything must come from Linear MCP.
+- After fetching, output the raw title, status, labels, and description before doing anything else.
+- If Linear MCP is unavailable or returns an error — STOP. Report: "Linear MCP unavailable. Cannot proceed."
+
+---
+
+## Step 1 — Fetch ticket
+
+Make two MCP calls in parallel immediately:
+1. `get_issue(id: "$ARGUMENTS", includeRelations: true)` — title, description, acceptance criteria, labels, priority, milestone, relations
+2. `list_comments(issueId: "$ARGUMENTS")` — clarifications or decisions
+
+Output now:
+```
+Ticket: <ID> — <title>
+Status: <status>
+Labels: <labels>
+Description:
+<description text>
+Relations: <blocked_by entries if any>
+```
+
+Do not proceed until this is shown.
+
+---
+
+## Step 2 — Dependency pre-flight ⛔
+
+**Never skip.**
+
+### 2a. Extract blockers
+- From `relations`: entries where `type == "blocked_by"` → collect `relatedIssue.identifier`
+- From the **fetched** description text: any `NIB-\d+` patterns
+- Union both sets
+
+### 2b. Fetch all dependency statuses in parallel
+Call `get_issue` for each dep simultaneously.
+
+### 2c. Classify
+
+| Status | Classification |
+|---|---|
+| Done / Completed / Cancelled | ✅ Clear |
+| In Progress | ⚠️ Warn |
+| Backlog / Todo / Unstarted | ⛔ Blocked |
+
+### 2d. Decide
+
+**⛔ Any blocked deps → STOP:**
+```
+⛔ BLOCKED — cannot start <ID> until:
+  ⛔ <dep-id>  [<status>]  <title>
+Finish these first, then re-run.
+```
+
+**⚠️ Only in-progress deps → ask user:**
+```
+⚠️ WARNING — in progress but not done:
+  ⚠️ <dep-id>  [In Progress]  <title>
+1. Wait (recommended)
+2. Proceed anyway
+```
+Wait for response.
+
+**✅ All clear → proceed.**
+
+---
+
+## Step 3 — Clarify if needed
+
+If description is ambiguous or missing acceptance criteria — list questions and wait. Do not assume.
+
+Read any Figma links or spec docs referenced in the fetched description now.
+
+---
+
+## Step 4 — Load project context
+
+Read `.claude/CLAUDE.md`. This is mandatory.
+
+Only read `.claude/context/PROJECT_CONTEXT.md` if the ticket is large, multi-step, or touches cross-cutting concerns (routing, auth, shared services). Skip for small, well-scoped tickets.
+
+---
+
+## Step 5 — Explore relevant code
+
+Use grep, glob, and file reads to find all files this ticket will touch.
+
+- Small ticket: read only directly affected files (controller, service, repo, screen)
+- Large ticket: map all relevant files and dependencies before writing anything
+
+Start narrow, expand only if you find unexpected coupling. Show the user what you found.
+
+---
+
+## Step 6 — Assess scope
+
+| Ticket type | Path |
+|---|---|
+| Small / well-defined | Implement directly (no plan needed) |
+| Large / multi-step | Create a written plan → show user → get approval → implement |
+| Unclear | Ask user |
+
+---
+
+## Step 7 — Route to domain agent
+
+Use the ticket's **labels** field (from Step 1 MCP response — not title text):
+
+| Label | Agent to spawn |
+|---|---|
+| `Agent-Frontend` | `nibbles-frontend` |
+| `Agent-Backend` | `nibbles-backend` |
+| `Agent-Infra` | `nibbles-infra` |
+| `Agent-QA` | `nibbles-qa` |
+| `Human Touch` | STOP — output checklist, do not automate |
+
+Fallback: if no agent label, check title prefix `[Frontend]` / `[Backend]` / `[Infra]` / `[QA]`. If still unclear — ask.
+
+Tell the user which agent will be spawned and why.
+
+---
+
+## Step 8 — Create branch
+
+```
+git checkout -b <type>/<ticket-id>-<short-slug>
+```
+- Type from label: `feat`, `fix`, `chore`
+- Slug: 2–4 word kebab from ticket title
+- Must include the ticket ID
+
+---
+
+## Step 9 — Mark In Progress
+
+Set ticket status to **In Progress** via Linear MCP.
+
+---
+
+## Step 10 — Implement
+
+Spawn the domain agent identified in Step 7. Pass it:
+- The full ticket description and acceptance criteria
+- The branch name
+- The list of relevant files found in Step 5
+- Any plan approved in Step 6
+
+After the domain agent completes:
+1. Spawn `nibbles-qa` on affected files (skip if this is a QA ticket)
+2. Run `/review` on all uncommitted changes
+3. If review flags Must Fix → spawn domain agent to resolve → re-run `/review`
+
+---
+
+## Step 11 — Open PR
+
+Run `/pr-finish`.
+
+After PR is created:
+- Add PR URL as attachment on the ticket via Linear MCP: `create_attachment(issueId, url, title: "PR")`
+- Set ticket status to **In Review** via Linear MCP
+
+---
+
+## Step 12 — Report
+
+```
+✅ <ID> — <title>
+
+Branch:  <branch>
+PR:      <URL>
+Agent:   <agent used>
+
+What was built:
+- <bullet>
+
+Deviations: <any or "none">
+Manual steps: <any or "none">
+```
+
+---
+
+## Hard constraints
+
+- First action is always the Step 1 MCP fetch — no analysis before real data
+- Never skip pre-flight (Step 2)
+- Never start while ⛔ blocked tickets exist
+- Never implement Human Touch items
+- Branch name must include ticket ID
+- Keep ticket status in sync at each major step
+- If ticket has no acceptance criteria — ask before building
+- If Linear MCP is unavailable — STOP. Do not proceed.
+- Never call Supabase directly from Service, Controller, or Screen
+- Never expose DTOs above the Repository layer
+- Never use `AllergenStatus.completed` — use `AllergenStatus.safe`
+- Zero linting warnings

--- a/.claude/skills/run-milestone.md
+++ b/.claude/skills/run-milestone.md
@@ -1,0 +1,185 @@
+---
+name: run-milestone
+description: Runs a full Nibbles milestone in sequence. Fetches all tickets from Linear, resolves execution order, shows the plan, then walks through each ticket one at a time using /linear-start — pausing after each PR for you to review and merge before continuing.
+---
+
+# /run-milestone — Nibbles Milestone Runner
+
+Milestone: `$ARGUMENTS`
+
+---
+
+## ⚠️ Anti-hallucination rules — read first
+
+- All ticket data MUST come from Linear MCP calls. No exceptions.
+- Never infer, recall, or fabricate ticket IDs, titles, statuses, or dependency order from memory.
+- If any MCP call fails or returns 0 results — STOP. Report: "MCP returned no data. Cannot proceed."
+- After every MCP call, output the raw results before reasoning about them.
+
+---
+
+## Step 1 — Fetch milestone tickets
+
+Call Linear MCP:
+```
+list_issues(filter: { milestone: { name: { eq: "$ARGUMENTS" } } })
+```
+
+Output the raw results now — every ticket ID, title, status, and labels exactly as returned. Do not proceed until this list is shown.
+
+If MCP fails or returns 0 tickets — STOP. Do not guess or fill from memory.
+
+---
+
+## Step 2 — Transition Backlog → Todo
+
+For every ticket from Step 1 that is in `Backlog`, call:
+```
+save_issue(id: "<real id from Step 1>", state: "Todo")
+```
+
+Skip tickets already in `Todo`, `In Progress`, `Done`, or `Cancelled`. Never move backwards.
+
+Then filter: continue only with `Todo` and `In Progress` tickets.
+
+---
+
+## Step 3 — Fetch dependency data
+
+For every remaining ticket, call `get_issue(id, includeRelations: true)` in parallel.
+
+From each response, extract:
+- `relations` entries where `type == "blocked_by"` → `relatedIssue.identifier` values
+- Any `NIB-\d+` pattern found in the **fetched** description text (not memory)
+
+Output the dependency map — list each ticket and its blockers. Do not proceed until this is shown.
+
+---
+
+## Step 4 — Resolve execution order
+
+Build execution order **strictly from the dependency map in Step 3**. Do not use prior knowledge.
+
+Rules (in priority order):
+1. Formal `blocked_by` relations — hard constraints
+2. NIB-xx text references in fetched descriptions — soft ordering hints
+3. Domain logic: Backend tickets before Frontend tickets that consume their output
+4. When in doubt — sequential
+
+Parallel groups: only mark tickets as parallel if they have no dependency on each other AND touch completely different file trees. Never parallel if either touches `pubspec.yaml`, routing, or shared services.
+
+---
+
+## Step 5 — Present the plan and wait
+
+Output the proposed execution order using **only real ticket IDs and titles from Steps 1–3**:
+
+```
+## Milestone: <milestone name from MCP>
+
+Fetched <N> tickets. Execution order:
+
+  Step 1:  <ID>  [<label>]  <title>  → PR, then merge
+  Step 2:  <ID>  [<label>]  <title>  → PR, then merge
+  Step 3a: <ID>  [<label>]  <title>  ← parallel
+  Step 3b: <ID>  [<label>]  <title>  ← parallel
+
+Human Touch (you act, not the agent):
+  <ID>  <title>  — reason
+
+Proceed? (yes / adjust)
+```
+
+**Wait for explicit user confirmation before executing.**
+
+---
+
+## Step 6 — Execute tickets in order
+
+### For each sequential ticket:
+
+1. `git pull origin main`
+2. Run `/linear-start <ticket-id>` — this fetches, explores, implements, and opens the PR
+3. After PR is open, pause:
+   ```
+   ⏸ <ID> — <title>
+   PR: <URL>
+
+   Review and merge it, then reply "merged" to continue.
+   ```
+4. Wait for user to say "merged" (or equivalent)
+5. `git pull origin main`
+6. Move to next ticket
+
+### For parallel groups:
+
+1. `git pull origin main`
+2. Tell the user which tickets will run in parallel and ask them to confirm
+3. Run `/linear-start` for ticket A, complete it fully (including PR)
+4. Then run `/linear-start` for ticket B, complete it fully (including PR)
+   (Note: true parallelism isn't safe in one context — run sequentially but treat as logically parallel)
+5. Pause:
+   ```
+   ⏸ Parallel group done. PRs open:
+     <ID-A>: <PR URL>
+     <ID-B>: <PR URL>
+
+   Merge both, then reply "merged" to continue.
+   ```
+6. Wait for confirmation
+7. `git pull origin main`
+
+### On failure:
+
+If `/linear-start` reports ⛔ blocked or fails — STOP. Report what failed. Wait for the user to resolve before continuing.
+
+---
+
+## Step 7 — Human Touch tickets
+
+For any ticket labelled `Human Touch`:
+
+```
+## Human Touch required — your action needed
+
+### <ID> — <title>
+- [ ] <action from ticket description>
+- [ ] <action from ticket description>
+
+Reply "done" when complete to continue.
+```
+
+Wait for explicit confirmation before proceeding.
+
+---
+
+## Step 8 — Milestone complete
+
+```
+✅ <milestone name> — COMPLETE
+
+Completed:
+  ✅ <ID>  <title>  PR #N
+  ...
+
+Human Touch completed:
+  ✅ <ID>  <title>
+
+Skipped (already done):
+  <ID>  <title>
+
+Failed / blocked:
+  — none
+```
+
+---
+
+## Hard constraints
+
+- One ticket = one PR. Never combine.
+- Never start the next ticket before the previous PR is confirmed merged.
+- Never infer ticket data from memory — all IDs, titles, statuses from MCP only.
+- Never fabricate. If MCP fails — STOP.
+- Always confirm execution plan before starting.
+- Stop immediately on any ⛔ block.
+- Human Touch items require explicit user confirmation.


### PR DESCRIPTION
## Summary
- Replaces `nibbles-linear-agent` and `nibbles-milestone-runner` agents with project-level skills
- Skills run in main conversation context — all orchestration steps (ticket fetch, dependency pre-flight, code exploration, branching, status updates) are fully visible
- Only implementation is delegated to domain agents (nibbles-frontend/backend), which can be monitored with Ctrl+B
- Eliminates nested agent context degradation that caused hallucination in long runs

## Test plan
- [ ] Run `/linear-start NIB-XX` on a ticket and verify all steps are visible in main context
- [ ] Verify dependency pre-flight blocks correctly on blocked tickets
- [ ] Run `/run-milestone <name>` and verify plan is shown before execution starts
- [ ] Verify pause gates work between tickets