### PR TITLE
feat(recipe): RecipeService + RecipeRepository + domain entities [NIB-27]

### DIFF
--- a/lib/src/common/data/repositories/recipe_repository.dart
+++ b/lib/src/common/data/repositories/recipe_repository.dart
@@ -1,0 +1,186 @@
+// freezed copies @JsonKey field annotations into generated parts, triggering a
+// false-positive from very_good_analysis on the generated getter declarations.
+// ignore_for_file: invalid_annotation_target
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:nibbles/src/common/data/sources/local/hive_service.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/ingredient.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'recipe_repository.g.dart';
+
+abstract interface class RecipeRepository {
+  /// RECIPE-01: Fetch all recipes from Supabase, ordered by title.
+  /// Serves from Hive cache if available; refreshes in background.
+  Future<Result<List<Recipe>>> getAllRecipes();
+
+  /// RECIPE-02: Fetch recipes where allergen_tags contains [allergenKey].
+  Future<Result<List<Recipe>>> getRecipesByAllergen(String allergenKey);
+
+  /// RECIPE-03: Fetch single recipe by ID.
+  Future<Result<Recipe>> getRecipeById(String recipeId);
+}
+
+class RecipeRepositoryImpl implements RecipeRepository {
+  RecipeRepositoryImpl({
+    SupabaseClient? supabaseClient,
+    HiveService? hiveService,
+  })  : _supabase = supabaseClient ?? Supabase.instance.client,
+        _hive = hiveService ?? HiveService();
+
+  final SupabaseClient _supabase;
+  final HiveService _hive;
+
+  static const _cacheKey = 'recipes_all';
+
+  @override
+  Future<Result<List<Recipe>>> getAllRecipes() async {
+    final cached = _hive.recipesBox.get(_cacheKey);
+    if (cached != null) {
+      try {
+        final list = (jsonDecode(cached) as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .map(Recipe.fromJson)
+            .toList();
+        // Background refresh — do not await.
+        unawaited(_refreshCache());
+        return Result.success(list);
+      } on Object catch (e, st) {
+        // Cache corrupt — log and fall through to remote fetch.
+        unawaited(
+          FirebaseCrashlytics.instance.recordError(
+            e,
+            st,
+            reason: 'Recipe Hive cache corruption',
+          ),
+        );
+      }
+    }
+
+    return _fetchFromSupabaseAndCache();
+  }
+
+  @override
+  Future<Result<List<Recipe>>> getRecipesByAllergen(String allergenKey) async {
+    // Use cached all-recipes and filter client-side to avoid extra RPC.
+    final allResult = await getAllRecipes();
+    if (allResult.isFailure) {
+      return Result.failure(allResult.errorOrNull!);
+    }
+    final filtered = allResult
+        .dataOrNull!
+        .where((r) => r.allergenTags.contains(allergenKey))
+        .toList();
+    return Result.success(filtered);
+  }
+
+  @override
+  Future<Result<Recipe>> getRecipeById(String recipeId) async {
+    // Check cache first.
+    final cached = _hive.recipesBox.get(_cacheKey);
+    if (cached != null) {
+      try {
+        final list = (jsonDecode(cached) as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .map(Recipe.fromJson)
+            .toList();
+        final match = list.where((r) => r.id == recipeId).firstOrNull;
+        if (match != null) return Result.success(match);
+      } on Object {
+        // Cache unusable — fall through to remote.
+      }
+    }
+
+    try {
+      final data = await _supabase
+          .from('recipes')
+          .select()
+          .eq('id', recipeId)
+          .single();
+
+      return Result.success(_recipeFromRow(data));
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  // --- Private helpers ---
+
+  Future<Result<List<Recipe>>> _fetchFromSupabaseAndCache() async {
+    try {
+      final data = await _supabase
+          .from('recipes')
+          .select()
+          .order('title');
+
+      final recipes = (data as List<dynamic>)
+          .cast<Map<String, dynamic>>()
+          .map(_recipeFromRow)
+          .toList();
+
+      await _hive.recipesBox.put(
+        _cacheKey,
+        jsonEncode(recipes.map((r) => r.toJson()).toList()),
+      );
+
+      return Result.success(recipes);
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  Future<void> _refreshCache() async {
+    try {
+      final data = await _supabase
+          .from('recipes')
+          .select()
+          .order('title');
+
+      final recipes = (data as List<dynamic>)
+          .cast<Map<String, dynamic>>()
+          .map(_recipeFromRow)
+          .toList();
+
+      await _hive.recipesBox.put(
+        _cacheKey,
+        jsonEncode(recipes.map((r) => r.toJson()).toList()),
+      );
+    } on Object {
+      // Silent background refresh — errors are not surfaced to UI.
+    }
+  }
+
+  Recipe _recipeFromRow(Map<String, dynamic> row) {
+    final rawIngredients =
+        (row['ingredients'] as List<dynamic>).cast<Map<String, dynamic>>();
+    return Recipe(
+      id: row['id'] as String,
+      title: row['title'] as String,
+      ageRange: row['age_range'] as String,
+      allergenTags: (row['allergen_tags'] as List<dynamic>).cast<String>(),
+      ingredients: rawIngredients.map(Ingredient.fromJson).toList(),
+      steps: (row['steps'] as List<dynamic>).cast<String>(),
+      howToServe: row['how_to_serve'] as String,
+      notes: row['notes'] as String?,
+      thumbnailUrl: row['thumbnail_url'] as String?,
+    );
+  }
+}
+
+@Riverpod(keepAlive: true)
+RecipeRepository recipeRepository(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  RecipeRepositoryRef ref,
+) =>
+    RecipeRepositoryImpl();

--- a/lib/src/common/data/repositories/recipe_repository.g.dart
+++ b/lib/src/common/data/repositories/recipe_repository.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recipe_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$recipeRepositoryHash() => r'b333507501c624197fb37dc2a5a9f49b1fd05f9d';
+
+/// See also [recipeRepository].
+@ProviderFor(recipeRepository)
+final recipeRepositoryProvider = Provider<RecipeRepository>.internal(
+  recipeRepository,
+  name: r'recipeRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$recipeRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef RecipeRepositoryRef = ProviderRef<RecipeRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/common/domain/entities/ingredient.dart
+++ b/lib/src/common/domain/entities/ingredient.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'ingredient.freezed.dart';
+part 'ingredient.g.dart';
+
+@freezed
+class Ingredient with _$Ingredient {
+  const factory Ingredient({
+    required String name,
+    required String quantity,
+  }) = _Ingredient;
+
+  factory Ingredient.fromJson(Map<String, dynamic> json) =>
+      _$IngredientFromJson(json);
+}

--- a/lib/src/common/domain/entities/ingredient.freezed.dart
+++ b/lib/src/common/domain/entities/ingredient.freezed.dart
@@ -1,0 +1,185 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'ingredient.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+Ingredient _$IngredientFromJson(Map<String, dynamic> json) {
+  return _Ingredient.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Ingredient {
+  String get name => throw _privateConstructorUsedError;
+  String get quantity => throw _privateConstructorUsedError;
+
+  /// Serializes this Ingredient to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Ingredient
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $IngredientCopyWith<Ingredient> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $IngredientCopyWith<$Res> {
+  factory $IngredientCopyWith(
+    Ingredient value,
+    $Res Function(Ingredient) then,
+  ) = _$IngredientCopyWithImpl<$Res, Ingredient>;
+  @useResult
+  $Res call({String name, String quantity});
+}
+
+/// @nodoc
+class _$IngredientCopyWithImpl<$Res, $Val extends Ingredient>
+    implements $IngredientCopyWith<$Res> {
+  _$IngredientCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Ingredient
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? name = null, Object? quantity = null}) {
+    return _then(
+      _value.copyWith(
+            name: null == name
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                      as String,
+            quantity: null == quantity
+                ? _value.quantity
+                : quantity // ignore: cast_nullable_to_non_nullable
+                      as String,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$IngredientImplCopyWith<$Res>
+    implements $IngredientCopyWith<$Res> {
+  factory _$$IngredientImplCopyWith(
+    _$IngredientImpl value,
+    $Res Function(_$IngredientImpl) then,
+  ) = __$$IngredientImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String name, String quantity});
+}
+
+/// @nodoc
+class __$$IngredientImplCopyWithImpl<$Res>
+    extends _$IngredientCopyWithImpl<$Res, _$IngredientImpl>
+    implements _$$IngredientImplCopyWith<$Res> {
+  __$$IngredientImplCopyWithImpl(
+    _$IngredientImpl _value,
+    $Res Function(_$IngredientImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of Ingredient
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? name = null, Object? quantity = null}) {
+    return _then(
+      _$IngredientImpl(
+        name: null == name
+            ? _value.name
+            : name // ignore: cast_nullable_to_non_nullable
+                  as String,
+        quantity: null == quantity
+            ? _value.quantity
+            : quantity // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$IngredientImpl implements _Ingredient {
+  const _$IngredientImpl({required this.name, required this.quantity});
+
+  factory _$IngredientImpl.fromJson(Map<String, dynamic> json) =>
+      _$$IngredientImplFromJson(json);
+
+  @override
+  final String name;
+  @override
+  final String quantity;
+
+  @override
+  String toString() {
+    return 'Ingredient(name: $name, quantity: $quantity)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$IngredientImpl &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.quantity, quantity) ||
+                other.quantity == quantity));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, name, quantity);
+
+  /// Create a copy of Ingredient
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$IngredientImplCopyWith<_$IngredientImpl> get copyWith =>
+      __$$IngredientImplCopyWithImpl<_$IngredientImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$IngredientImplToJson(this);
+  }
+}
+
+abstract class _Ingredient implements Ingredient {
+  const factory _Ingredient({
+    required final String name,
+    required final String quantity,
+  }) = _$IngredientImpl;
+
+  factory _Ingredient.fromJson(Map<String, dynamic> json) =
+      _$IngredientImpl.fromJson;
+
+  @override
+  String get name;
+  @override
+  String get quantity;
+
+  /// Create a copy of Ingredient
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$IngredientImplCopyWith<_$IngredientImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/common/domain/entities/ingredient.g.dart
+++ b/lib/src/common/domain/entities/ingredient.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ingredient.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$IngredientImpl _$$IngredientImplFromJson(Map<String, dynamic> json) =>
+    _$IngredientImpl(
+      name: json['name'] as String,
+      quantity: json['quantity'] as String,
+    );
+
+Map<String, dynamic> _$$IngredientImplToJson(_$IngredientImpl instance) =>
+    <String, dynamic>{'name': instance.name, 'quantity': instance.quantity};

--- a/lib/src/common/domain/entities/recipe.dart
+++ b/lib/src/common/domain/entities/recipe.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/entities/ingredient.dart';
+
+part 'recipe.freezed.dart';
+part 'recipe.g.dart';
+
+@freezed
+class Recipe with _$Recipe {
+  const factory Recipe({
+    required String id,
+    required String title,
+    required String ageRange,
+    required List<String> allergenTags,
+    required List<Ingredient> ingredients,
+    required List<String> steps,
+    required String howToServe,
+    String? notes,
+    String? thumbnailUrl,
+  }) = _Recipe;
+
+  factory Recipe.fromJson(Map<String, dynamic> json) => _$RecipeFromJson(json);
+}

--- a/lib/src/common/domain/entities/recipe.freezed.dart
+++ b/lib/src/common/domain/entities/recipe.freezed.dart
@@ -1,0 +1,374 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'recipe.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+Recipe _$RecipeFromJson(Map<String, dynamic> json) {
+  return _Recipe.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Recipe {
+  String get id => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String get ageRange => throw _privateConstructorUsedError;
+  List<String> get allergenTags => throw _privateConstructorUsedError;
+  List<Ingredient> get ingredients => throw _privateConstructorUsedError;
+  List<String> get steps => throw _privateConstructorUsedError;
+  String get howToServe => throw _privateConstructorUsedError;
+  String? get notes => throw _privateConstructorUsedError;
+  String? get thumbnailUrl => throw _privateConstructorUsedError;
+
+  /// Serializes this Recipe to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Recipe
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $RecipeCopyWith<Recipe> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RecipeCopyWith<$Res> {
+  factory $RecipeCopyWith(Recipe value, $Res Function(Recipe) then) =
+      _$RecipeCopyWithImpl<$Res, Recipe>;
+  @useResult
+  $Res call({
+    String id,
+    String title,
+    String ageRange,
+    List<String> allergenTags,
+    List<Ingredient> ingredients,
+    List<String> steps,
+    String howToServe,
+    String? notes,
+    String? thumbnailUrl,
+  });
+}
+
+/// @nodoc
+class _$RecipeCopyWithImpl<$Res, $Val extends Recipe>
+    implements $RecipeCopyWith<$Res> {
+  _$RecipeCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Recipe
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? ageRange = null,
+    Object? allergenTags = null,
+    Object? ingredients = null,
+    Object? steps = null,
+    Object? howToServe = null,
+    Object? notes = freezed,
+    Object? thumbnailUrl = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            title: null == title
+                ? _value.title
+                : title // ignore: cast_nullable_to_non_nullable
+                      as String,
+            ageRange: null == ageRange
+                ? _value.ageRange
+                : ageRange // ignore: cast_nullable_to_non_nullable
+                      as String,
+            allergenTags: null == allergenTags
+                ? _value.allergenTags
+                : allergenTags // ignore: cast_nullable_to_non_nullable
+                      as List<String>,
+            ingredients: null == ingredients
+                ? _value.ingredients
+                : ingredients // ignore: cast_nullable_to_non_nullable
+                      as List<Ingredient>,
+            steps: null == steps
+                ? _value.steps
+                : steps // ignore: cast_nullable_to_non_nullable
+                      as List<String>,
+            howToServe: null == howToServe
+                ? _value.howToServe
+                : howToServe // ignore: cast_nullable_to_non_nullable
+                      as String,
+            notes: freezed == notes
+                ? _value.notes
+                : notes // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            thumbnailUrl: freezed == thumbnailUrl
+                ? _value.thumbnailUrl
+                : thumbnailUrl // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$RecipeImplCopyWith<$Res> implements $RecipeCopyWith<$Res> {
+  factory _$$RecipeImplCopyWith(
+    _$RecipeImpl value,
+    $Res Function(_$RecipeImpl) then,
+  ) = __$$RecipeImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String title,
+    String ageRange,
+    List<String> allergenTags,
+    List<Ingredient> ingredients,
+    List<String> steps,
+    String howToServe,
+    String? notes,
+    String? thumbnailUrl,
+  });
+}
+
+/// @nodoc
+class __$$RecipeImplCopyWithImpl<$Res>
+    extends _$RecipeCopyWithImpl<$Res, _$RecipeImpl>
+    implements _$$RecipeImplCopyWith<$Res> {
+  __$$RecipeImplCopyWithImpl(
+    _$RecipeImpl _value,
+    $Res Function(_$RecipeImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of Recipe
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? ageRange = null,
+    Object? allergenTags = null,
+    Object? ingredients = null,
+    Object? steps = null,
+    Object? howToServe = null,
+    Object? notes = freezed,
+    Object? thumbnailUrl = freezed,
+  }) {
+    return _then(
+      _$RecipeImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        title: null == title
+            ? _value.title
+            : title // ignore: cast_nullable_to_non_nullable
+                  as String,
+        ageRange: null == ageRange
+            ? _value.ageRange
+            : ageRange // ignore: cast_nullable_to_non_nullable
+                  as String,
+        allergenTags: null == allergenTags
+            ? _value._allergenTags
+            : allergenTags // ignore: cast_nullable_to_non_nullable
+                  as List<String>,
+        ingredients: null == ingredients
+            ? _value._ingredients
+            : ingredients // ignore: cast_nullable_to_non_nullable
+                  as List<Ingredient>,
+        steps: null == steps
+            ? _value._steps
+            : steps // ignore: cast_nullable_to_non_nullable
+                  as List<String>,
+        howToServe: null == howToServe
+            ? _value.howToServe
+            : howToServe // ignore: cast_nullable_to_non_nullable
+                  as String,
+        notes: freezed == notes
+            ? _value.notes
+            : notes // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        thumbnailUrl: freezed == thumbnailUrl
+            ? _value.thumbnailUrl
+            : thumbnailUrl // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$RecipeImpl implements _Recipe {
+  const _$RecipeImpl({
+    required this.id,
+    required this.title,
+    required this.ageRange,
+    required final List<String> allergenTags,
+    required final List<Ingredient> ingredients,
+    required final List<String> steps,
+    required this.howToServe,
+    this.notes,
+    this.thumbnailUrl,
+  }) : _allergenTags = allergenTags,
+       _ingredients = ingredients,
+       _steps = steps;
+
+  factory _$RecipeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RecipeImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String title;
+  @override
+  final String ageRange;
+  final List<String> _allergenTags;
+  @override
+  List<String> get allergenTags {
+    if (_allergenTags is EqualUnmodifiableListView) return _allergenTags;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_allergenTags);
+  }
+
+  final List<Ingredient> _ingredients;
+  @override
+  List<Ingredient> get ingredients {
+    if (_ingredients is EqualUnmodifiableListView) return _ingredients;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_ingredients);
+  }
+
+  final List<String> _steps;
+  @override
+  List<String> get steps {
+    if (_steps is EqualUnmodifiableListView) return _steps;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_steps);
+  }
+
+  @override
+  final String howToServe;
+  @override
+  final String? notes;
+  @override
+  final String? thumbnailUrl;
+
+  @override
+  String toString() {
+    return 'Recipe(id: $id, title: $title, ageRange: $ageRange, allergenTags: $allergenTags, ingredients: $ingredients, steps: $steps, howToServe: $howToServe, notes: $notes, thumbnailUrl: $thumbnailUrl)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RecipeImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.ageRange, ageRange) ||
+                other.ageRange == ageRange) &&
+            const DeepCollectionEquality().equals(
+              other._allergenTags,
+              _allergenTags,
+            ) &&
+            const DeepCollectionEquality().equals(
+              other._ingredients,
+              _ingredients,
+            ) &&
+            const DeepCollectionEquality().equals(other._steps, _steps) &&
+            (identical(other.howToServe, howToServe) ||
+                other.howToServe == howToServe) &&
+            (identical(other.notes, notes) || other.notes == notes) &&
+            (identical(other.thumbnailUrl, thumbnailUrl) ||
+                other.thumbnailUrl == thumbnailUrl));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    title,
+    ageRange,
+    const DeepCollectionEquality().hash(_allergenTags),
+    const DeepCollectionEquality().hash(_ingredients),
+    const DeepCollectionEquality().hash(_steps),
+    howToServe,
+    notes,
+    thumbnailUrl,
+  );
+
+  /// Create a copy of Recipe
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RecipeImplCopyWith<_$RecipeImpl> get copyWith =>
+      __$$RecipeImplCopyWithImpl<_$RecipeImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$RecipeImplToJson(this);
+  }
+}
+
+abstract class _Recipe implements Recipe {
+  const factory _Recipe({
+    required final String id,
+    required final String title,
+    required final String ageRange,
+    required final List<String> allergenTags,
+    required final List<Ingredient> ingredients,
+    required final List<String> steps,
+    required final String howToServe,
+    final String? notes,
+    final String? thumbnailUrl,
+  }) = _$RecipeImpl;
+
+  factory _Recipe.fromJson(Map<String, dynamic> json) = _$RecipeImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get title;
+  @override
+  String get ageRange;
+  @override
+  List<String> get allergenTags;
+  @override
+  List<Ingredient> get ingredients;
+  @override
+  List<String> get steps;
+  @override
+  String get howToServe;
+  @override
+  String? get notes;
+  @override
+  String? get thumbnailUrl;
+
+  /// Create a copy of Recipe
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$RecipeImplCopyWith<_$RecipeImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/common/domain/entities/recipe.g.dart
+++ b/lib/src/common/domain/entities/recipe.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recipe.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$RecipeImpl _$$RecipeImplFromJson(Map<String, dynamic> json) => _$RecipeImpl(
+  id: json['id'] as String,
+  title: json['title'] as String,
+  ageRange: json['ageRange'] as String,
+  allergenTags: (json['allergenTags'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  ingredients: (json['ingredients'] as List<dynamic>)
+      .map((e) => Ingredient.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  steps: (json['steps'] as List<dynamic>).map((e) => e as String).toList(),
+  howToServe: json['howToServe'] as String,
+  notes: json['notes'] as String?,
+  thumbnailUrl: json['thumbnailUrl'] as String?,
+);
+
+Map<String, dynamic> _$$RecipeImplToJson(_$RecipeImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'ageRange': instance.ageRange,
+      'allergenTags': instance.allergenTags,
+      'ingredients': instance.ingredients,
+      'steps': instance.steps,
+      'howToServe': instance.howToServe,
+      'notes': instance.notes,
+      'thumbnailUrl': instance.thumbnailUrl,
+    };

--- a/lib/src/common/services/recipe_service.dart
+++ b/lib/src/common/services/recipe_service.dart
@@ -1,0 +1,103 @@
+import 'package:nibbles/src/common/data/repositories/allergen_repository.dart';
+import 'package:nibbles/src/common/data/repositories/recipe_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'recipe_service.g.dart';
+
+class RecipeService {
+  const RecipeService(this._recipeRepo, this._allergenRepo);
+
+  final RecipeRepository _recipeRepo;
+  final AllergenRepository _allergenRepo;
+
+  /// Fetches all recipes, filtering out any tagged with the baby's flagged
+  /// allergens (i.e. allergens where a reaction was recorded).
+  Future<Result<List<Recipe>>> getFilteredRecipes(String babyId) async {
+    final flaggedResult = await _getFlaggedAllergenKeys(babyId);
+    if (flaggedResult.isFailure) {
+      return Result.failure(flaggedResult.errorOrNull!);
+    }
+
+    final recipesResult = await _recipeRepo.getAllRecipes();
+    if (recipesResult.isFailure) {
+      return Result.failure(recipesResult.errorOrNull!);
+    }
+
+    final flagged = flaggedResult.dataOrNull!;
+    final recipes = recipesResult.dataOrNull!;
+
+    if (flagged.isEmpty) return Result.success(recipes);
+
+    return Result.success(
+      recipes
+          .where((r) => !r.allergenTags.any(flagged.contains))
+          .toList(),
+    );
+  }
+
+  /// Returns recipes tagged with [allergenKey] that are not flagged for
+  /// [babyId]. Used for the Home recommendations strip.
+  Future<Result<List<Recipe>>> getRecommendationsForAllergen(
+    String allergenKey,
+    String babyId,
+  ) async {
+    final flaggedResult = await _getFlaggedAllergenKeys(babyId);
+    if (flaggedResult.isFailure) {
+      return Result.failure(flaggedResult.errorOrNull!);
+    }
+
+    final flagged = flaggedResult.dataOrNull!;
+
+    // If the target allergen itself is flagged, no recommendations.
+    if (flagged.contains(allergenKey)) return const Result.success([]);
+
+    final recipesResult = await _recipeRepo.getRecipesByAllergen(allergenKey);
+    if (recipesResult.isFailure) {
+      return Result.failure(recipesResult.errorOrNull!);
+    }
+
+    final recipes = recipesResult.dataOrNull!;
+
+    // Also exclude recipes that have other flagged allergen tags.
+    return Result.success(
+      recipes
+          .where((r) => !r.allergenTags.any(flagged.contains))
+          .toList(),
+    );
+  }
+
+  /// Fetches a single recipe by ID.
+  Future<Result<Recipe>> getRecipeById(String recipeId) =>
+      _recipeRepo.getRecipeById(recipeId);
+
+  // --- Private helpers ---
+
+  /// Returns the set of allergen keys for which [babyId] has had a reaction.
+  Future<Result<Set<String>>> _getFlaggedAllergenKeys(String babyId) async {
+    final logsResult = await _allergenRepo.getLogs(babyId);
+    if (logsResult.isFailure) {
+      return Result.failure(logsResult.errorOrNull!);
+    }
+
+    final flaggedKeys = logsResult
+        .dataOrNull!
+        .where((l) => l.hadReaction)
+        .map((l) => l.allergenKey)
+        .toSet();
+
+    return Result.success(flaggedKeys);
+  }
+}
+
+@Riverpod(keepAlive: true)
+RecipeService recipeService(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  RecipeServiceRef ref,
+) =>
+    RecipeService(
+      ref.watch(recipeRepositoryProvider),
+      ref.watch(allergenRepositoryProvider),
+    );

--- a/lib/src/common/services/recipe_service.g.dart
+++ b/lib/src/common/services/recipe_service.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recipe_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$recipeServiceHash() => r'da9420d0f6bb91cd698acf16fcbdaf56ab92a9cc';
+
+/// See also [recipeService].
+@ProviderFor(recipeService)
+final recipeServiceProvider = Provider<RecipeService>.internal(
+  recipeService,
+  name: r'recipeServiceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$recipeServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef RecipeServiceRef = ProviderRef<RecipeService>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/allergen/detail/allergen_detail_state.freezed.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_state.freezed.dart
@@ -17,11 +17,6 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$AllergenDetailState {
-<<<<<<< HEAD
-  AllergenBoardItem get boardItem => throw _privateConstructorUsedError;
-  String get babyId => throw _privateConstructorUsedError;
-  Allergen? get nextAllergen => throw _privateConstructorUsedError;
-=======
   Allergen get allergen => throw _privateConstructorUsedError;
   List<AllergenLog> get logs => throw _privateConstructorUsedError;
   AllergenProgramState get programState => throw _privateConstructorUsedError;
@@ -29,7 +24,6 @@ mixin _$AllergenDetailState {
   AllergenStatus get status => throw _privateConstructorUsedError;
   Map<String, ReactionDetail> get reactionDetails =>
       throw _privateConstructorUsedError;
->>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
 
   /// Create a copy of AllergenDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -46,15 +40,6 @@ abstract class $AllergenDetailStateCopyWith<$Res> {
   ) = _$AllergenDetailStateCopyWithImpl<$Res, AllergenDetailState>;
   @useResult
   $Res call({
-<<<<<<< HEAD
-    AllergenBoardItem boardItem,
-    String babyId,
-    Allergen? nextAllergen,
-  });
-
-  $AllergenBoardItemCopyWith<$Res> get boardItem;
-  $AllergenCopyWith<$Res>? get nextAllergen;
-=======
     Allergen allergen,
     List<AllergenLog> logs,
     AllergenProgramState programState,
@@ -65,7 +50,6 @@ abstract class $AllergenDetailStateCopyWith<$Res> {
 
   $AllergenCopyWith<$Res> get allergen;
   $AllergenProgramStateCopyWith<$Res> get programState;
->>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
 }
 
 /// @nodoc
@@ -83,26 +67,6 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-<<<<<<< HEAD
-    Object? boardItem = null,
-    Object? babyId = null,
-    Object? nextAllergen = freezed,
-  }) {
-    return _then(
-      _value.copyWith(
-            boardItem: null == boardItem
-                ? _value.boardItem
-                : boardItem // ignore: cast_nullable_to_non_nullable
-                      as AllergenBoardItem,
-            babyId: null == babyId
-                ? _value.babyId
-                : babyId // ignore: cast_nullable_to_non_nullable
-                      as String,
-            nextAllergen: freezed == nextAllergen
-                ? _value.nextAllergen
-                : nextAllergen // ignore: cast_nullable_to_non_nullable
-                      as Allergen?,
-=======
     Object? allergen = null,
     Object? logs = null,
     Object? programState = null,
@@ -136,7 +100,6 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
                 ? _value.reactionDetails
                 : reactionDetails // ignore: cast_nullable_to_non_nullable
                       as Map<String, ReactionDetail>,
->>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
           )
           as $Val,
     );
@@ -146,15 +109,9 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-<<<<<<< HEAD
-  $AllergenBoardItemCopyWith<$Res> get boardItem {
-    return $AllergenBoardItemCopyWith<$Res>(_value.boardItem, (value) {
-      return _then(_value.copyWith(boardItem: value) as $Val);
-=======
   $AllergenCopyWith<$Res> get allergen {
     return $AllergenCopyWith<$Res>(_value.allergen, (value) {
       return _then(_value.copyWith(allergen: value) as $Val);
->>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
     });
   }
 
@@ -162,19 +119,9 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-<<<<<<< HEAD
-  $AllergenCopyWith<$Res>? get nextAllergen {
-    if (_value.nextAllergen == null) {
-      return null;
-    }
-
-    return $AllergenCopyWith<$Res>(_value.nextAllergen!, (value) {
-      return _then(_value.copyWith(nextAllergen: value) as $Val);
-=======
   $AllergenProgramStateCopyWith<$Res> get programState {
     return $AllergenProgramStateCopyWith<$Res>(_value.programState, (value) {
       return _then(_value.copyWith(programState: value) as $Val);
->>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
     });
   }
 }
@@ -189,17 +136,6 @@ abstract class _$$AllergenDetailStateImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-<<<<<<< HEAD
-    AllergenBoardItem boardItem,
-    String babyId,
-    Allergen? nextAllergen,
-  });
-
-  @override
-  $AllergenBoardItemCopyWith<$Res> get boardItem;
-  @override
-  $AllergenCopyWith<$Res>? get nextAllergen;
-=======
     Allergen allergen,
     List<AllergenLog> logs,
     AllergenProgramState programState,
@@ -212,7 +148,6 @@ abstract class _$$AllergenDetailStateImplCopyWith<$Res>
   $AllergenCopyWith<$Res> get allergen;
   @override
   $AllergenProgramStateCopyWith<$Res> get programState;
->>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
 }
 
 /// @nodoc
@@ -229,26 +164,6 @@ class __$$AllergenDetailStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-<<<<<<< HEAD
-    Object? boardItem = null,
-    Object? babyId = null,
-    Object? nextAllergen = freezed,
-  }) {
-    return _then(
-      _$AllergenDetailStateImpl(
-        boardItem: null == boardItem
-            ? _value.boardItem
-            : boardItem // ignore: cast_nullable_to_non_nullable
-                  as AllergenBoardItem,
-        babyId: null == babyId
-            ? _value.babyId
-            : babyId // ignore: cast_nullable_to_non_nullable
-                  as String,
-        nextAllergen: freezed == nextAllergen
-            ? _value.nextAllergen
-            : nextAllergen // ignore: cast_nullable_to_non_nullable
-                  as Allergen?,
-=======
     Object? allergen = null,
     Object? logs = null,
     Object? programState = null,
@@ -282,7 +197,6 @@ class __$$AllergenDetailStateImplCopyWithImpl<$Res>
             ? _value._reactionDetails
             : reactionDetails // ignore: cast_nullable_to_non_nullable
                   as Map<String, ReactionDetail>,
->>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
       ),
     );
   }
@@ -292,23 +206,6 @@ class __$$AllergenDetailStateImplCopyWithImpl<$Res>
 
 class _$AllergenDetailStateImpl implements _AllergenDetailState {
   const _$AllergenDetailStateImpl({
-<<<<<<< HEAD
-    required this.boardItem,
-    required this.babyId,
-    this.nextAllergen,
-  });
-
-  @override
-  final AllergenBoardItem boardItem;
-  @override
-  final String babyId;
-  @override
-  final Allergen? nextAllergen;
-
-  @override
-  String toString() {
-    return 'AllergenDetailState(boardItem: $boardItem, babyId: $babyId, nextAllergen: $nextAllergen)';
-=======
     required this.allergen,
     required final List<AllergenLog> logs,
     required this.programState,
@@ -347,7 +244,6 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
   @override
   String toString() {
     return 'AllergenDetailState(allergen: $allergen, logs: $logs, programState: $programState, hasLoggedToday: $hasLoggedToday, status: $status, reactionDetails: $reactionDetails)';
->>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
   }
 
   @override
@@ -355,17 +251,6 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$AllergenDetailStateImpl &&
-<<<<<<< HEAD
-            (identical(other.boardItem, boardItem) ||
-                other.boardItem == boardItem) &&
-            (identical(other.babyId, babyId) || other.babyId == babyId) &&
-            (identical(other.nextAllergen, nextAllergen) ||
-                other.nextAllergen == nextAllergen));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, boardItem, babyId, nextAllergen);
-=======
             (identical(other.allergen, allergen) ||
                 other.allergen == allergen) &&
             const DeepCollectionEquality().equals(other._logs, _logs) &&
@@ -390,7 +275,6 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
     status,
     const DeepCollectionEquality().hash(_reactionDetails),
   );
->>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
 
   /// Create a copy of AllergenDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -406,19 +290,6 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
 
 abstract class _AllergenDetailState implements AllergenDetailState {
   const factory _AllergenDetailState({
-<<<<<<< HEAD
-    required final AllergenBoardItem boardItem,
-    required final String babyId,
-    final Allergen? nextAllergen,
-  }) = _$AllergenDetailStateImpl;
-
-  @override
-  AllergenBoardItem get boardItem;
-  @override
-  String get babyId;
-  @override
-  Allergen? get nextAllergen;
-=======
     required final Allergen allergen,
     required final List<AllergenLog> logs,
     required final AllergenProgramState programState,
@@ -439,7 +310,6 @@ abstract class _AllergenDetailState implements AllergenDetailState {
   AllergenStatus get status;
   @override
   Map<String, ReactionDetail> get reactionDetails;
->>>>>>> 9739361 (feat(allergen): AL-03 Allergen Detail screen — log history, timing guidance, CTAs [NIB-23])
 
   /// Create a copy of AllergenDetailState
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/src/features/allergen/log/allergen_log_controller.g.dart
+++ b/lib/src/features/allergen/log/allergen_log_controller.g.dart
@@ -7,7 +7,7 @@ part of 'allergen_log_controller.dart';
 // **************************************************************************
 
 String _$allergenLogControllerHash() =>
-    r'963ce03daa7b0d01e6ff5aefb1d98e837fae164c';
+    r'b58d0edbf6439f50814ef6f8d57ef7c1f514463e';
 
 /// See also [AllergenLogController].
 @ProviderFor(AllergenLogController)


### PR DESCRIPTION
## Summary

- New `Ingredient` and `Recipe` freezed domain entities (with `json_serializable`)
- `RecipeRepositoryImpl`: Hive read-through cache (`recipes_all` key), silent background refresh via `unawaited`, Crashlytics on cache corruption; covers RECIPE-01/02/03
- `RecipeService`: `getFilteredRecipes` (excludes recipes tagged with baby's flagged allergens), `getRecommendationsForAllergen` (current allergen, non-flagged), `getRecipeById`
- Both providers `keepAlive`; zero lint warnings

## Test plan

- [ ] `getFilteredRecipes` — verify recipes with flagged allergen tags are excluded
- [ ] `getFilteredRecipes` — verify recipes with no allergen tags are always visible
- [ ] `getRecommendationsForAllergen` — verify only recipes tagged with given key returned, excluding flagged
- [ ] `getRecommendationsForAllergen` — verify empty list when allergen itself is flagged
- [ ] `getRecipeById` — verify cache hit path and Supabase fallback
- [ ] Cold start: no Hive cache → fetches from Supabase and populates cache
- [ ] Warm start: Hive cache hit → returns immediately + background refresh fires

## Notes

⚠️ Recipe seeding (50+ recipes from client JSON) is pending client delivery per NIB-7. This PR delivers the data layer; seeding is a separate Human Touch step.

Closes NIB-27