### PR TITLE
feat(recipe): RC-01 Recipe Library + RC-02 Recipe Detail [NIB-29]

### DIFF
--- a/lib/gen/assets.gen.dart
+++ b/lib/gen/assets.gen.dart
@@ -53,13 +53,8 @@ class $AssetsTranslationsGen {
 class Assets {
   const Assets._();
 
-  static const String aEnvDev = '.env.dev';
-  static const String aEnvProd = '.env.prod';
   static const $AssetsIconsGen icons = $AssetsIconsGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
   static const $AssetsJsonsGen jsons = $AssetsJsonsGen();
   static const $AssetsTranslationsGen translations = $AssetsTranslationsGen();
-
-  /// List of all assets
-  static List<String> get values => [aEnvDev, aEnvProd];
 }

--- a/lib/src/features/allergen/complete/allergen_complete_controller.g.dart
+++ b/lib/src/features/allergen/complete/allergen_complete_controller.g.dart
@@ -7,7 +7,7 @@ part of 'allergen_complete_controller.dart';
 // **************************************************************************
 
 String _$allergenCompleteControllerHash() =>
-    r'd6a59746d10498ad9ba7cab57e16d34350d21356';
+    r'4c1db5bef27e51f979b82d277c9664480684f360';
 
 /// See also [AllergenCompleteController].
 @ProviderFor(AllergenCompleteController)

--- a/lib/src/features/recipe/detail/recipe_detail_controller.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_controller.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:nibbles/src/common/services/recipe_service.dart';
+import 'package:nibbles/src/common/services/shopping_list_service.dart';
+import 'package:nibbles/src/features/recipe/detail/recipe_detail_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'recipe_detail_controller.g.dart';
+
+@riverpod
+class RecipeDetailController extends _$RecipeDetailController {
+  @override
+  Future<RecipeDetailState> build(String babyId, String recipeId) async {
+    final allergenSvc = ref.read(allergenServiceProvider);
+
+    final (recipeResult, programResult, logsResult) = await (
+      ref.read(recipeServiceProvider).getRecipeById(recipeId),
+      allergenSvc.getProgramState(babyId),
+      allergenSvc.getLogs(babyId),
+    ).wait;
+
+    if (recipeResult.isFailure) throw recipeResult.errorOrNull!;
+    if (programResult.isFailure) throw programResult.errorOrNull!;
+    if (logsResult.isFailure) throw logsResult.errorOrNull!;
+
+    final recipe = recipeResult.dataOrNull!;
+    final currentKey = programResult.dataOrNull!.currentAllergenKey;
+    final allLogs = logsResult.dataOrNull!;
+
+    // Derive status per allergen tag on this recipe.
+    final statuses = <String, AllergenStatus>{};
+    for (final tag in recipe.allergenTags) {
+      final tagLogs = allLogs
+          .where((AllergenLog l) => l.allergenKey == tag)
+          .toList();
+      statuses[tag] = allergenSvc.deriveStatus(tagLogs);
+    }
+
+    return RecipeDetailState(
+      recipe: recipe,
+      currentAllergenKey: currentKey,
+      allergenStatuses: statuses,
+    );
+  }
+
+  /// Assigns this recipe to a meal plan date, with optional meal time.
+  /// Fires analytics on success.
+  Future<Result<void>> assignToMealPlan(
+    DateTime date, {
+    TimeOfDay? time,
+  }) async {
+    final current = state.valueOrNull;
+    if (current == null) return const Result.failure(UnknownException());
+
+    state = AsyncData(current.copyWith(isAddingToMealPlan: true));
+
+    final result = await ref
+        .read(mealPlanServiceProvider)
+        .assignRecipe(babyId, recipeId, date, mealTime: time);
+
+    state = AsyncData(current.copyWith(isAddingToMealPlan: false));
+
+    if (result.isSuccess) {
+      await Analytics.instance.logRecipeAddedToMealPlan(recipeId: recipeId);
+    }
+
+    return result;
+  }
+
+  /// Adds selected ingredient names to the shopping list.
+  Future<Result<void>> addToShoppingList(List<String> selectedNames) async {
+    final current = state.valueOrNull;
+    if (current == null) return const Result.failure(UnknownException());
+
+    state = AsyncData(current.copyWith(isAddingToShoppingList: true));
+
+    final result = await ref
+        .read(shoppingListServiceProvider)
+        .addFromRecipe(babyId, recipeId, selectedNames);
+
+    state = AsyncData(current.copyWith(isAddingToShoppingList: false));
+    return result;
+  }
+}

--- a/lib/src/features/recipe/detail/recipe_detail_controller.g.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_controller.g.dart
@@ -1,0 +1,196 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recipe_detail_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$recipeDetailControllerHash() =>
+    r'a923f19625fd19a4dec3d1decc0224460d006d49';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$RecipeDetailController
+    extends BuildlessAutoDisposeAsyncNotifier<RecipeDetailState> {
+  late final String babyId;
+  late final String recipeId;
+
+  FutureOr<RecipeDetailState> build(String babyId, String recipeId);
+}
+
+/// See also [RecipeDetailController].
+@ProviderFor(RecipeDetailController)
+const recipeDetailControllerProvider = RecipeDetailControllerFamily();
+
+/// See also [RecipeDetailController].
+class RecipeDetailControllerFamily
+    extends Family<AsyncValue<RecipeDetailState>> {
+  /// See also [RecipeDetailController].
+  const RecipeDetailControllerFamily();
+
+  /// See also [RecipeDetailController].
+  RecipeDetailControllerProvider call(String babyId, String recipeId) {
+    return RecipeDetailControllerProvider(babyId, recipeId);
+  }
+
+  @override
+  RecipeDetailControllerProvider getProviderOverride(
+    covariant RecipeDetailControllerProvider provider,
+  ) {
+    return call(provider.babyId, provider.recipeId);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'recipeDetailControllerProvider';
+}
+
+/// See also [RecipeDetailController].
+class RecipeDetailControllerProvider
+    extends
+        AutoDisposeAsyncNotifierProviderImpl<
+          RecipeDetailController,
+          RecipeDetailState
+        > {
+  /// See also [RecipeDetailController].
+  RecipeDetailControllerProvider(String babyId, String recipeId)
+    : this._internal(
+        () => RecipeDetailController()
+          ..babyId = babyId
+          ..recipeId = recipeId,
+        from: recipeDetailControllerProvider,
+        name: r'recipeDetailControllerProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$recipeDetailControllerHash,
+        dependencies: RecipeDetailControllerFamily._dependencies,
+        allTransitiveDependencies:
+            RecipeDetailControllerFamily._allTransitiveDependencies,
+        babyId: babyId,
+        recipeId: recipeId,
+      );
+
+  RecipeDetailControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.babyId,
+    required this.recipeId,
+  }) : super.internal();
+
+  final String babyId;
+  final String recipeId;
+
+  @override
+  FutureOr<RecipeDetailState> runNotifierBuild(
+    covariant RecipeDetailController notifier,
+  ) {
+    return notifier.build(babyId, recipeId);
+  }
+
+  @override
+  Override overrideWith(RecipeDetailController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: RecipeDetailControllerProvider._internal(
+        () => create()
+          ..babyId = babyId
+          ..recipeId = recipeId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        babyId: babyId,
+        recipeId: recipeId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<
+    RecipeDetailController,
+    RecipeDetailState
+  >
+  createElement() {
+    return _RecipeDetailControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is RecipeDetailControllerProvider &&
+        other.babyId == babyId &&
+        other.recipeId == recipeId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, babyId.hashCode);
+    hash = _SystemHash.combine(hash, recipeId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin RecipeDetailControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<RecipeDetailState> {
+  /// The parameter `babyId` of this provider.
+  String get babyId;
+
+  /// The parameter `recipeId` of this provider.
+  String get recipeId;
+}
+
+class _RecipeDetailControllerProviderElement
+    extends
+        AutoDisposeAsyncNotifierProviderElement<
+          RecipeDetailController,
+          RecipeDetailState
+        >
+    with RecipeDetailControllerRef {
+  _RecipeDetailControllerProviderElement(super.provider);
+
+  @override
+  String get babyId => (origin as RecipeDetailControllerProvider).babyId;
+  @override
+  String get recipeId => (origin as RecipeDetailControllerProvider).recipeId;
+}
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/recipe/detail/recipe_detail_screen.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_screen.dart
@@ -1,10 +1,522 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nibbles/src/app/constants/allergen_emoji.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/ingredient.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/features/recipe/detail/recipe_detail_controller.dart';
+import 'package:nibbles/src/features/recipe/detail/recipe_detail_state.dart';
+import 'package:nibbles/src/features/recipe/detail/widgets/add_to_meal_plan_sheet.dart';
+import 'package:nibbles/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart';
 
 class RecipeDetailScreen extends ConsumerWidget {
   const RecipeDetailScreen({required this.recipeId, super.key});
+
   final String recipeId;
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      Scaffold(body: Center(child: Text('Recipe Detail — $recipeId')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final babyIdAsync = ref.watch(currentBabyIdProvider);
+
+    return babyIdAsync.when(
+      loading: () => const Scaffold(
+        backgroundColor: AppColors.background,
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (_, __) => const Scaffold(
+        backgroundColor: AppColors.background,
+        body: Center(child: Text('Could not load baby profile.')),
+      ),
+      data: (babyId) {
+        if (babyId == null) {
+          return const Scaffold(
+            backgroundColor: AppColors.background,
+            body: Center(child: Text('No baby profile found.')),
+          );
+        }
+        return _RecipeDetailBody(babyId: babyId, recipeId: recipeId);
+      },
+    );
+  }
+}
+
+class _RecipeDetailBody extends ConsumerWidget {
+  const _RecipeDetailBody({required this.babyId, required this.recipeId});
+
+  final String babyId;
+  final String recipeId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final detailAsync = ref.watch(
+      recipeDetailControllerProvider(babyId, recipeId),
+    );
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.surface,
+        elevation: 0,
+        leading: const BackButton(),
+      ),
+      body: detailAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSizes.lg),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  "Couldn't load recipe.",
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: AppSizes.sm),
+                FilledButton(
+                  onPressed: () => ref.invalidate(
+                    recipeDetailControllerProvider(babyId, recipeId),
+                  ),
+                  child: const Text('Retry'),
+                ),
+              ],
+            ),
+          ),
+        ),
+        data: (state) =>
+            _RecipeContent(babyId: babyId, recipeId: recipeId, state: state),
+      ),
+    );
+  }
+}
+
+class _RecipeContent extends ConsumerWidget {
+  const _RecipeContent({
+    required this.babyId,
+    required this.recipeId,
+    required this.state,
+  });
+
+  final String babyId;
+  final String recipeId;
+  final RecipeDetailState state;
+
+  Future<void> _handleAddToMealPlan(BuildContext context, WidgetRef ref) async {
+    final result = await showAddToMealPlanFlow(context);
+    if (result == null) return;
+    if (!context.mounted) return;
+
+    final controller = ref.read(
+      recipeDetailControllerProvider(babyId, recipeId).notifier,
+    );
+    final addResult = await controller.assignToMealPlan(
+      result.date,
+      time: result.time,
+    );
+
+    if (!context.mounted) return;
+
+    if (addResult.isSuccess) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Added to meal plan')));
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("Couldn't add to meal plan. Try again.")),
+      );
+    }
+  }
+
+  Future<void> _handleAddToShoppingList(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final selectedNames = await showAddToShoppingListSheet(
+      context,
+      state.recipe.ingredients,
+    );
+    if (selectedNames == null || selectedNames.isEmpty) return;
+    if (!context.mounted) return;
+
+    final controller = ref.read(
+      recipeDetailControllerProvider(babyId, recipeId).notifier,
+    );
+    final addResult = await controller.addToShoppingList(selectedNames);
+
+    if (!context.mounted) return;
+
+    if (addResult.isSuccess) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Added to shopping list')));
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("Couldn't add items. Try again.")),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final recipe = state.recipe;
+
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSizes.pagePaddingH),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Title
+                Text(
+                  recipe.title,
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.text,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.sm),
+
+                // Age range chip
+                _AgeRangeChip(ageRange: recipe.ageRange),
+                const SizedBox(height: AppSizes.sm),
+
+                // Allergen chips
+                if (recipe.allergenTags.isNotEmpty) ...[
+                  _AllergenChipsRow(
+                    tags: recipe.allergenTags,
+                    currentKey: state.currentAllergenKey,
+                    statuses: state.allergenStatuses,
+                  ),
+                  const SizedBox(height: AppSizes.md),
+                ],
+
+                // Ingredients
+                const _SectionHeader(title: 'Ingredients'),
+                const SizedBox(height: AppSizes.sm),
+                _IngredientsList(ingredients: recipe.ingredients),
+                const SizedBox(height: AppSizes.lg),
+
+                // Steps
+                const _SectionHeader(title: 'Steps'),
+                const SizedBox(height: AppSizes.sm),
+                _StepsList(steps: recipe.steps),
+                const SizedBox(height: AppSizes.lg),
+
+                // How to Serve
+                const _SectionHeader(title: 'How to Serve'),
+                const SizedBox(height: AppSizes.sm),
+                Text(
+                  recipe.howToServe,
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyMedium?.copyWith(color: AppColors.text),
+                ),
+
+                // Notes (optional)
+                if (recipe.notes != null && recipe.notes!.isNotEmpty) ...[
+                  const SizedBox(height: AppSizes.lg),
+                  const _SectionHeader(title: 'Notes'),
+                  const SizedBox(height: AppSizes.sm),
+                  Text(
+                    recipe.notes!,
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodyMedium?.copyWith(color: AppColors.subtext),
+                  ),
+                ],
+
+                const SizedBox(height: AppSizes.xl),
+              ],
+            ),
+          ),
+        ),
+
+        // Sticky CTA bar
+        _CtaBar(
+          isAddingToMealPlan: state.isAddingToMealPlan,
+          isAddingToShoppingList: state.isAddingToShoppingList,
+          onAddToMealPlan: () => _handleAddToMealPlan(context, ref),
+          onAddToShoppingList: () => _handleAddToShoppingList(context, ref),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section widgets
+// ---------------------------------------------------------------------------
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+        fontWeight: FontWeight.w700,
+        color: AppColors.text,
+      ),
+    );
+  }
+}
+
+class _AgeRangeChip extends StatelessWidget {
+  const _AgeRangeChip({required this.ageRange});
+
+  final String ageRange;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.sm + AppSizes.xs,
+        vertical: AppSizes.xs,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.primaryLight.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      child: Text(
+        'Fit for $ageRange',
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+          color: AppColors.primaryDark,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}
+
+class _AllergenChipsRow extends StatelessWidget {
+  const _AllergenChipsRow({
+    required this.tags,
+    required this.currentKey,
+    required this.statuses,
+  });
+
+  final List<String> tags;
+  final String currentKey;
+  final Map<String, AllergenStatus> statuses;
+
+  Color _chipColor(String tag) {
+    if (tag == currentKey) return const Color(0xFF2196F3);
+    return switch (statuses[tag] ?? AllergenStatus.notStarted) {
+      AllergenStatus.safe => AppColors.allergenSafe,
+      AllergenStatus.flagged => AppColors.allergenFlagged,
+      AllergenStatus.inProgress => AppColors.allergenInProgress,
+      AllergenStatus.notStarted => AppColors.allergenNotStarted,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: AppSizes.xs,
+      runSpacing: AppSizes.xs,
+      children: tags.map((tag) {
+        final emoji = AllergenEmoji.get(tag);
+        final name = tag
+            .split('_')
+            .map(
+              (w) => w.isEmpty ? '' : '${w[0].toUpperCase()}${w.substring(1)}',
+            )
+            .join(' ');
+        final color = _chipColor(tag);
+
+        return Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.sm,
+            vertical: AppSizes.xs,
+          ),
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+            border: Border.all(color: color.withValues(alpha: 0.4)),
+          ),
+          child: Text(
+            '$emoji $name',
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: color,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _IngredientsList extends StatelessWidget {
+  const _IngredientsList({required this.ingredients});
+
+  final List<Ingredient> ingredients;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (final ingredient in ingredients)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: AppSizes.xs),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('• ', style: TextStyle(color: AppColors.primary)),
+                Expanded(
+                  child: Text(
+                    '${ingredient.quantity}  ${ingredient.name}',
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodyMedium?.copyWith(color: AppColors.text),
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _StepsList extends StatelessWidget {
+  const _StepsList({required this.steps});
+
+  final List<String> steps;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (int i = 0; i < steps.length; i++)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: AppSizes.xs),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 24,
+                  height: 24,
+                  alignment: Alignment.center,
+                  decoration: const BoxDecoration(
+                    color: AppColors.primary,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Text(
+                    '${i + 1}',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: AppColors.onPrimary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppSizes.sm),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      steps[i],
+                      style: Theme.of(
+                        context,
+                      ).textTheme.bodyMedium?.copyWith(color: AppColors.text),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _CtaBar extends StatelessWidget {
+  const _CtaBar({
+    required this.isAddingToMealPlan,
+    required this.isAddingToShoppingList,
+    required this.onAddToMealPlan,
+    required this.onAddToShoppingList,
+  });
+
+  final bool isAddingToMealPlan;
+  final bool isAddingToShoppingList;
+  final VoidCallback onAddToMealPlan;
+  final VoidCallback onAddToShoppingList;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 12,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      padding: EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.sm,
+        AppSizes.pagePaddingH,
+        AppSizes.sm + MediaQuery.of(context).padding.bottom,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton(
+              onPressed: isAddingToShoppingList ? null : onAddToShoppingList,
+              style: OutlinedButton.styleFrom(
+                minimumSize: const Size(0, AppSizes.buttonHeight),
+                foregroundColor: AppColors.primary,
+                side: const BorderSide(color: AppColors.primary),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+                ),
+              ),
+              child: isAddingToShoppingList
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Add to Shopping List'),
+            ),
+          ),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: FilledButton(
+              onPressed: isAddingToMealPlan ? null : onAddToMealPlan,
+              style: FilledButton.styleFrom(
+                minimumSize: const Size(0, AppSizes.buttonHeight),
+                backgroundColor: AppColors.primary,
+                foregroundColor: AppColors.onPrimary,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+                ),
+              ),
+              child: isAddingToMealPlan
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: AppColors.onPrimary,
+                      ),
+                    )
+                  : const Text('Add to Meal Plan'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/src/features/recipe/detail/recipe_detail_state.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_state.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+
+part 'recipe_detail_state.freezed.dart';
+
+@freezed
+class RecipeDetailState with _$RecipeDetailState {
+  const factory RecipeDetailState({
+    required Recipe recipe,
+    required String currentAllergenKey,
+    @Default(<String, AllergenStatus>{})
+    Map<String, AllergenStatus> allergenStatuses,
+    @Default(false) bool isAddingToMealPlan,
+    @Default(false) bool isAddingToShoppingList,
+  }) = _RecipeDetailState;
+}

--- a/lib/src/features/recipe/detail/recipe_detail_state.freezed.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_state.freezed.dart
@@ -1,0 +1,282 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'recipe_detail_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$RecipeDetailState {
+  Recipe get recipe => throw _privateConstructorUsedError;
+  String get currentAllergenKey => throw _privateConstructorUsedError;
+  Map<String, AllergenStatus> get allergenStatuses =>
+      throw _privateConstructorUsedError;
+  bool get isAddingToMealPlan => throw _privateConstructorUsedError;
+  bool get isAddingToShoppingList => throw _privateConstructorUsedError;
+
+  /// Create a copy of RecipeDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $RecipeDetailStateCopyWith<RecipeDetailState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RecipeDetailStateCopyWith<$Res> {
+  factory $RecipeDetailStateCopyWith(
+    RecipeDetailState value,
+    $Res Function(RecipeDetailState) then,
+  ) = _$RecipeDetailStateCopyWithImpl<$Res, RecipeDetailState>;
+  @useResult
+  $Res call({
+    Recipe recipe,
+    String currentAllergenKey,
+    Map<String, AllergenStatus> allergenStatuses,
+    bool isAddingToMealPlan,
+    bool isAddingToShoppingList,
+  });
+
+  $RecipeCopyWith<$Res> get recipe;
+}
+
+/// @nodoc
+class _$RecipeDetailStateCopyWithImpl<$Res, $Val extends RecipeDetailState>
+    implements $RecipeDetailStateCopyWith<$Res> {
+  _$RecipeDetailStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of RecipeDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? recipe = null,
+    Object? currentAllergenKey = null,
+    Object? allergenStatuses = null,
+    Object? isAddingToMealPlan = null,
+    Object? isAddingToShoppingList = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            recipe: null == recipe
+                ? _value.recipe
+                : recipe // ignore: cast_nullable_to_non_nullable
+                      as Recipe,
+            currentAllergenKey: null == currentAllergenKey
+                ? _value.currentAllergenKey
+                : currentAllergenKey // ignore: cast_nullable_to_non_nullable
+                      as String,
+            allergenStatuses: null == allergenStatuses
+                ? _value.allergenStatuses
+                : allergenStatuses // ignore: cast_nullable_to_non_nullable
+                      as Map<String, AllergenStatus>,
+            isAddingToMealPlan: null == isAddingToMealPlan
+                ? _value.isAddingToMealPlan
+                : isAddingToMealPlan // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            isAddingToShoppingList: null == isAddingToShoppingList
+                ? _value.isAddingToShoppingList
+                : isAddingToShoppingList // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
+  }
+
+  /// Create a copy of RecipeDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $RecipeCopyWith<$Res> get recipe {
+    return $RecipeCopyWith<$Res>(_value.recipe, (value) {
+      return _then(_value.copyWith(recipe: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$RecipeDetailStateImplCopyWith<$Res>
+    implements $RecipeDetailStateCopyWith<$Res> {
+  factory _$$RecipeDetailStateImplCopyWith(
+    _$RecipeDetailStateImpl value,
+    $Res Function(_$RecipeDetailStateImpl) then,
+  ) = __$$RecipeDetailStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    Recipe recipe,
+    String currentAllergenKey,
+    Map<String, AllergenStatus> allergenStatuses,
+    bool isAddingToMealPlan,
+    bool isAddingToShoppingList,
+  });
+
+  @override
+  $RecipeCopyWith<$Res> get recipe;
+}
+
+/// @nodoc
+class __$$RecipeDetailStateImplCopyWithImpl<$Res>
+    extends _$RecipeDetailStateCopyWithImpl<$Res, _$RecipeDetailStateImpl>
+    implements _$$RecipeDetailStateImplCopyWith<$Res> {
+  __$$RecipeDetailStateImplCopyWithImpl(
+    _$RecipeDetailStateImpl _value,
+    $Res Function(_$RecipeDetailStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of RecipeDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? recipe = null,
+    Object? currentAllergenKey = null,
+    Object? allergenStatuses = null,
+    Object? isAddingToMealPlan = null,
+    Object? isAddingToShoppingList = null,
+  }) {
+    return _then(
+      _$RecipeDetailStateImpl(
+        recipe: null == recipe
+            ? _value.recipe
+            : recipe // ignore: cast_nullable_to_non_nullable
+                  as Recipe,
+        currentAllergenKey: null == currentAllergenKey
+            ? _value.currentAllergenKey
+            : currentAllergenKey // ignore: cast_nullable_to_non_nullable
+                  as String,
+        allergenStatuses: null == allergenStatuses
+            ? _value._allergenStatuses
+            : allergenStatuses // ignore: cast_nullable_to_non_nullable
+                  as Map<String, AllergenStatus>,
+        isAddingToMealPlan: null == isAddingToMealPlan
+            ? _value.isAddingToMealPlan
+            : isAddingToMealPlan // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        isAddingToShoppingList: null == isAddingToShoppingList
+            ? _value.isAddingToShoppingList
+            : isAddingToShoppingList // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$RecipeDetailStateImpl implements _RecipeDetailState {
+  const _$RecipeDetailStateImpl({
+    required this.recipe,
+    required this.currentAllergenKey,
+    final Map<String, AllergenStatus> allergenStatuses =
+        const <String, AllergenStatus>{},
+    this.isAddingToMealPlan = false,
+    this.isAddingToShoppingList = false,
+  }) : _allergenStatuses = allergenStatuses;
+
+  @override
+  final Recipe recipe;
+  @override
+  final String currentAllergenKey;
+  final Map<String, AllergenStatus> _allergenStatuses;
+  @override
+  @JsonKey()
+  Map<String, AllergenStatus> get allergenStatuses {
+    if (_allergenStatuses is EqualUnmodifiableMapView) return _allergenStatuses;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_allergenStatuses);
+  }
+
+  @override
+  @JsonKey()
+  final bool isAddingToMealPlan;
+  @override
+  @JsonKey()
+  final bool isAddingToShoppingList;
+
+  @override
+  String toString() {
+    return 'RecipeDetailState(recipe: $recipe, currentAllergenKey: $currentAllergenKey, allergenStatuses: $allergenStatuses, isAddingToMealPlan: $isAddingToMealPlan, isAddingToShoppingList: $isAddingToShoppingList)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RecipeDetailStateImpl &&
+            (identical(other.recipe, recipe) || other.recipe == recipe) &&
+            (identical(other.currentAllergenKey, currentAllergenKey) ||
+                other.currentAllergenKey == currentAllergenKey) &&
+            const DeepCollectionEquality().equals(
+              other._allergenStatuses,
+              _allergenStatuses,
+            ) &&
+            (identical(other.isAddingToMealPlan, isAddingToMealPlan) ||
+                other.isAddingToMealPlan == isAddingToMealPlan) &&
+            (identical(other.isAddingToShoppingList, isAddingToShoppingList) ||
+                other.isAddingToShoppingList == isAddingToShoppingList));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    recipe,
+    currentAllergenKey,
+    const DeepCollectionEquality().hash(_allergenStatuses),
+    isAddingToMealPlan,
+    isAddingToShoppingList,
+  );
+
+  /// Create a copy of RecipeDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RecipeDetailStateImplCopyWith<_$RecipeDetailStateImpl> get copyWith =>
+      __$$RecipeDetailStateImplCopyWithImpl<_$RecipeDetailStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _RecipeDetailState implements RecipeDetailState {
+  const factory _RecipeDetailState({
+    required final Recipe recipe,
+    required final String currentAllergenKey,
+    final Map<String, AllergenStatus> allergenStatuses,
+    final bool isAddingToMealPlan,
+    final bool isAddingToShoppingList,
+  }) = _$RecipeDetailStateImpl;
+
+  @override
+  Recipe get recipe;
+  @override
+  String get currentAllergenKey;
+  @override
+  Map<String, AllergenStatus> get allergenStatuses;
+  @override
+  bool get isAddingToMealPlan;
+  @override
+  bool get isAddingToShoppingList;
+
+  /// Create a copy of RecipeDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$RecipeDetailStateImplCopyWith<_$RecipeDetailStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/recipe/detail/widgets/add_to_meal_plan_sheet.dart
+++ b/lib/src/features/recipe/detail/widgets/add_to_meal_plan_sheet.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+/// Runs the Add to Meal Plan flow:
+/// 1. Date picker
+/// 2. Optional time picker dialog
+///
+/// Returns `({DateTime date, TimeOfDay? time})` on confirm, or null on cancel.
+Future<({DateTime date, TimeOfDay? time})?> showAddToMealPlanFlow(
+  BuildContext context,
+) async {
+  // Step 1: Date picker.
+  final now = DateTime.now();
+  final picked = await showDatePicker(
+    context: context,
+    initialDate: now,
+    firstDate: now,
+    lastDate: now.add(const Duration(days: 365)),
+    helpText: 'Select a meal plan date',
+  );
+
+  if (picked == null) return null;
+  if (!context.mounted) return null;
+
+  // Step 2: Optional time picker.
+  final wantTime = await showDialog<bool>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: const Text('Add a time?'),
+      content: const Text(
+        'Would you like to add a specific meal time? (optional)',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(false),
+          child: const Text('Skip'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(true),
+          child: const Text('Add Time'),
+        ),
+      ],
+    ),
+  );
+
+  if (!context.mounted) return null;
+
+  TimeOfDay? mealTime;
+  if (wantTime ?? false) {
+    mealTime = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+      helpText: 'Select meal time',
+    );
+  }
+
+  if (!context.mounted) return null;
+
+  return (date: picked, time: mealTime);
+}

--- a/lib/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart
+++ b/lib/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/entities/ingredient.dart';
+
+/// Shows a bottom sheet for selecting ingredients to add to the shopping list.
+/// Ingredient names only — no quantities. All pre-checked by default.
+Future<List<String>?> showAddToShoppingListSheet(
+  BuildContext context,
+  List<Ingredient> ingredients,
+) {
+  return showModalBottomSheet<List<String>>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppSizes.radiusLg),
+      ),
+    ),
+    builder: (context) => _ShoppingListSheet(ingredients: ingredients),
+  );
+}
+
+class _ShoppingListSheet extends StatefulWidget {
+  const _ShoppingListSheet({required this.ingredients});
+
+  final List<Ingredient> ingredients;
+
+  @override
+  State<_ShoppingListSheet> createState() => _ShoppingListSheetState();
+}
+
+class _ShoppingListSheetState extends State<_ShoppingListSheet> {
+  late Set<int> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = Set.from(Iterable.generate(widget.ingredients.length));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final count = _selected.length;
+
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Handle
+            const SizedBox(height: AppSizes.sm),
+            Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppColors.divider,
+                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              ),
+            ),
+            const SizedBox(height: AppSizes.md),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.pagePaddingH,
+              ),
+              child: Text(
+                'Add to Shopping List',
+                style: Theme.of(
+                  context,
+                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+              ),
+            ),
+            const SizedBox(height: AppSizes.sm),
+            const Divider(height: 1),
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.of(context).size.height * 0.45,
+              ),
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: widget.ingredients.length,
+                itemBuilder: (context, index) {
+                  final name = widget.ingredients[index].name;
+                  return CheckboxListTile(
+                    value: _selected.contains(index),
+                    onChanged: (checked) {
+                      setState(() {
+                        if (checked ?? false) {
+                          _selected.add(index);
+                        } else {
+                          _selected.remove(index);
+                        }
+                      });
+                    },
+                    title: Text(
+                      name,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    activeColor: AppColors.primary,
+                    controlAffinity: ListTileControlAffinity.leading,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: AppSizes.pagePaddingH,
+                    ),
+                  );
+                },
+              ),
+            ),
+            const Divider(height: 1),
+            Padding(
+              padding: const EdgeInsets.all(AppSizes.md),
+              child: SizedBox(
+                width: double.infinity,
+                height: AppSizes.buttonHeight,
+                child: FilledButton(
+                  onPressed: count == 0
+                      ? null
+                      : () {
+                          final names = _selected
+                              .map((i) => widget.ingredients[i].name)
+                              .toList();
+                          Navigator.of(context).pop(names);
+                        },
+                  style: FilledButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                    foregroundColor: AppColors.onPrimary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+                    ),
+                  ),
+                  child: Text(
+                    count == 0
+                        ? 'Select items'
+                        : 'Add $count ${count == 1 ? 'item' : 'items'}',
+                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                      color: AppColors.onPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/recipe/library/recipe_library_controller.dart
+++ b/lib/src/features/recipe/library/recipe_library_controller.dart
@@ -1,0 +1,95 @@
+import 'package:nibbles/src/app/constants/allergen_emoji.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/recipe_service.dart';
+import 'package:nibbles/src/features/recipe/library/recipe_library_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'recipe_library_controller.g.dart';
+
+/// Allergen key → display name map (sequence order preserved for sections).
+const _allergenNames = {
+  'peanut': 'Peanut',
+  'egg': 'Egg',
+  'dairy': 'Dairy',
+  'tree_nuts': 'Tree Nuts',
+  'sesame': 'Sesame',
+  'soy': 'Soy',
+  'wheat': 'Wheat',
+  'fish': 'Fish',
+  'shellfish': 'Shellfish',
+};
+
+const _allergenSequence = [
+  'peanut',
+  'egg',
+  'dairy',
+  'tree_nuts',
+  'sesame',
+  'soy',
+  'wheat',
+  'fish',
+  'shellfish',
+];
+
+@riverpod
+class RecipeLibraryController extends _$RecipeLibraryController {
+  @override
+  Future<RecipeLibraryState> build(String babyId) async {
+    final (recipesResult, programResult) = await (
+      ref.read(recipeServiceProvider).getFilteredRecipes(babyId),
+      ref.read(allergenServiceProvider).getProgramState(babyId),
+    ).wait;
+
+    if (recipesResult.isFailure) throw recipesResult.errorOrNull!;
+    if (programResult.isFailure) throw programResult.errorOrNull!;
+
+    final recipes = recipesResult.dataOrNull!;
+    final currentKey = programResult.dataOrNull!.currentAllergenKey;
+
+    final sections = <RecipeSection>[];
+
+    // 1. Recommendations — recipes tagged with current allergen.
+    final recommendations = recipes
+        .where((Recipe r) => r.allergenTags.contains(currentKey))
+        .toList();
+    if (recommendations.isNotEmpty) {
+      final name = _allergenNames[currentKey] ?? currentKey;
+      final emoji = AllergenEmoji.get(currentKey);
+      sections.add(
+        RecipeSection(
+          title: 'Recommendation for $name $emoji',
+          recipes: recommendations,
+        ),
+      );
+    }
+
+    // 2. One section per allergen in sequence order (skip current).
+    for (final key in _allergenSequence) {
+      if (key == currentKey) continue;
+      final tagged = recipes
+          .where((Recipe r) => r.allergenTags.contains(key))
+          .toList();
+      if (tagged.isEmpty) continue;
+      final name = _allergenNames[key] ?? key;
+      final emoji = AllergenEmoji.get(key);
+      sections.add(RecipeSection(title: '$name $emoji', recipes: tagged));
+    }
+
+    // 3. Untagged recipes — "All Recipes".
+    final untagged = recipes
+        .where((Recipe r) => r.allergenTags.isEmpty)
+        .toList();
+    if (untagged.isNotEmpty) {
+      sections.add(RecipeSection(title: 'All Recipes', recipes: untagged));
+    }
+
+    return RecipeLibraryState(sections: sections);
+  }
+
+  Future<void> refresh() async {
+    ref.invalidateSelf();
+    await future;
+  }
+}

--- a/lib/src/features/recipe/library/recipe_library_controller.g.dart
+++ b/lib/src/features/recipe/library/recipe_library_controller.g.dart
@@ -1,0 +1,179 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recipe_library_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$recipeLibraryControllerHash() =>
+    r'ebad0ec9e1eac7a4d8dc58cd5d1d2a6cd25656d4';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$RecipeLibraryController
+    extends BuildlessAutoDisposeAsyncNotifier<RecipeLibraryState> {
+  late final String babyId;
+
+  FutureOr<RecipeLibraryState> build(String babyId);
+}
+
+/// See also [RecipeLibraryController].
+@ProviderFor(RecipeLibraryController)
+const recipeLibraryControllerProvider = RecipeLibraryControllerFamily();
+
+/// See also [RecipeLibraryController].
+class RecipeLibraryControllerFamily
+    extends Family<AsyncValue<RecipeLibraryState>> {
+  /// See also [RecipeLibraryController].
+  const RecipeLibraryControllerFamily();
+
+  /// See also [RecipeLibraryController].
+  RecipeLibraryControllerProvider call(String babyId) {
+    return RecipeLibraryControllerProvider(babyId);
+  }
+
+  @override
+  RecipeLibraryControllerProvider getProviderOverride(
+    covariant RecipeLibraryControllerProvider provider,
+  ) {
+    return call(provider.babyId);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'recipeLibraryControllerProvider';
+}
+
+/// See also [RecipeLibraryController].
+class RecipeLibraryControllerProvider
+    extends
+        AutoDisposeAsyncNotifierProviderImpl<
+          RecipeLibraryController,
+          RecipeLibraryState
+        > {
+  /// See also [RecipeLibraryController].
+  RecipeLibraryControllerProvider(String babyId)
+    : this._internal(
+        () => RecipeLibraryController()..babyId = babyId,
+        from: recipeLibraryControllerProvider,
+        name: r'recipeLibraryControllerProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$recipeLibraryControllerHash,
+        dependencies: RecipeLibraryControllerFamily._dependencies,
+        allTransitiveDependencies:
+            RecipeLibraryControllerFamily._allTransitiveDependencies,
+        babyId: babyId,
+      );
+
+  RecipeLibraryControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.babyId,
+  }) : super.internal();
+
+  final String babyId;
+
+  @override
+  FutureOr<RecipeLibraryState> runNotifierBuild(
+    covariant RecipeLibraryController notifier,
+  ) {
+    return notifier.build(babyId);
+  }
+
+  @override
+  Override overrideWith(RecipeLibraryController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: RecipeLibraryControllerProvider._internal(
+        () => create()..babyId = babyId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        babyId: babyId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<
+    RecipeLibraryController,
+    RecipeLibraryState
+  >
+  createElement() {
+    return _RecipeLibraryControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is RecipeLibraryControllerProvider && other.babyId == babyId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, babyId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin RecipeLibraryControllerRef
+    on AutoDisposeAsyncNotifierProviderRef<RecipeLibraryState> {
+  /// The parameter `babyId` of this provider.
+  String get babyId;
+}
+
+class _RecipeLibraryControllerProviderElement
+    extends
+        AutoDisposeAsyncNotifierProviderElement<
+          RecipeLibraryController,
+          RecipeLibraryState
+        >
+    with RecipeLibraryControllerRef {
+  _RecipeLibraryControllerProviderElement(super.provider);
+
+  @override
+  String get babyId => (origin as RecipeLibraryControllerProvider).babyId;
+}
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/recipe/library/recipe_library_screen.dart
+++ b/lib/src/features/recipe/library/recipe_library_screen.dart
@@ -1,9 +1,160 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/features/recipe/library/recipe_library_controller.dart';
+import 'package:nibbles/src/features/recipe/library/recipe_library_state.dart';
+import 'package:nibbles/src/features/recipe/library/widgets/recipe_card.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 class RecipeLibraryScreen extends ConsumerWidget {
   const RecipeLibraryScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Recipe Library (RC-01)')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    final babyIdAsync = ref.watch(currentBabyIdProvider);
+
+    return babyIdAsync.when(
+      loading: () => const Scaffold(
+        backgroundColor: AppColors.background,
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (_, __) => const Scaffold(
+        backgroundColor: AppColors.background,
+        body: Center(child: Text('Could not load baby profile.')),
+      ),
+      data: (babyId) {
+        if (babyId == null) {
+          return const Scaffold(
+            backgroundColor: AppColors.background,
+            body: Center(child: Text('No baby profile found.')),
+          );
+        }
+        return _RecipeLibraryBody(babyId: babyId);
+      },
+    );
+  }
+}
+
+class _RecipeLibraryBody extends ConsumerWidget {
+  const _RecipeLibraryBody({required this.babyId});
+
+  final String babyId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final recipesAsync = ref.watch(recipeLibraryControllerProvider(babyId));
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.surface,
+        elevation: 0,
+        title: Text('Recipes', style: Theme.of(context).textTheme.titleLarge),
+      ),
+      body: recipesAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => RefreshIndicator(
+          onRefresh: () => ref
+              .read(recipeLibraryControllerProvider(babyId).notifier)
+              .refresh(),
+          child: ListView(
+            children: [
+              SizedBox(
+                height: MediaQuery.of(context).size.height * 0.6,
+                child: const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(AppSizes.lg),
+                    child: Text(
+                      "Couldn't load recipes. Pull down to retry.",
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        data: (state) => _RecipeContent(babyId: babyId, state: state),
+      ),
+    );
+  }
+}
+
+class _RecipeContent extends ConsumerWidget {
+  const _RecipeContent({required this.babyId, required this.state});
+
+  final String babyId;
+  final RecipeLibraryState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (state.sections.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: () => ref
+            .read(recipeLibraryControllerProvider(babyId).notifier)
+            .refresh(),
+        child: ListView(
+          children: [
+            SizedBox(
+              height: MediaQuery.of(context).size.height * 0.6,
+              child: const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(AppSizes.lg),
+                  child: Text(
+                    'No recipes available right now. '
+                    'Check back after completing more allergen steps.',
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () =>
+          ref.read(recipeLibraryControllerProvider(babyId).notifier).refresh(),
+      child: CustomScrollView(
+        slivers: [
+          for (final section in state.sections) ...[
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSizes.pagePaddingH,
+                  AppSizes.lg,
+                  AppSizes.pagePaddingH,
+                  AppSizes.sm,
+                ),
+                child: Text(
+                  section.title,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: AppColors.text,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ),
+            SliverList(
+              delegate: SliverChildBuilderDelegate((context, index) {
+                final recipe = section.recipes[index];
+                return RecipeCard(
+                  recipe: recipe,
+                  onTap: () => context.pushNamed(
+                    AppRoute.recipeDetail.name,
+                    pathParameters: {'recipeId': recipe.id},
+                  ),
+                );
+              }, childCount: section.recipes.length),
+            ),
+          ],
+          const SliverToBoxAdapter(child: SizedBox(height: AppSizes.xl)),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/src/features/recipe/library/recipe_library_state.dart
+++ b/lib/src/features/recipe/library/recipe_library_state.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+
+part 'recipe_library_state.freezed.dart';
+
+@freezed
+class RecipeLibraryState with _$RecipeLibraryState {
+  const factory RecipeLibraryState({required List<RecipeSection> sections}) =
+      _RecipeLibraryState;
+}
+
+@freezed
+class RecipeSection with _$RecipeSection {
+  const factory RecipeSection({
+    required String title,
+    required List<Recipe> recipes,
+  }) = _RecipeSection;
+}

--- a/lib/src/features/recipe/library/recipe_library_state.freezed.dart
+++ b/lib/src/features/recipe/library/recipe_library_state.freezed.dart
@@ -1,0 +1,321 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'recipe_library_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$RecipeLibraryState {
+  List<RecipeSection> get sections => throw _privateConstructorUsedError;
+
+  /// Create a copy of RecipeLibraryState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $RecipeLibraryStateCopyWith<RecipeLibraryState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RecipeLibraryStateCopyWith<$Res> {
+  factory $RecipeLibraryStateCopyWith(
+    RecipeLibraryState value,
+    $Res Function(RecipeLibraryState) then,
+  ) = _$RecipeLibraryStateCopyWithImpl<$Res, RecipeLibraryState>;
+  @useResult
+  $Res call({List<RecipeSection> sections});
+}
+
+/// @nodoc
+class _$RecipeLibraryStateCopyWithImpl<$Res, $Val extends RecipeLibraryState>
+    implements $RecipeLibraryStateCopyWith<$Res> {
+  _$RecipeLibraryStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of RecipeLibraryState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? sections = null}) {
+    return _then(
+      _value.copyWith(
+            sections: null == sections
+                ? _value.sections
+                : sections // ignore: cast_nullable_to_non_nullable
+                      as List<RecipeSection>,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$RecipeLibraryStateImplCopyWith<$Res>
+    implements $RecipeLibraryStateCopyWith<$Res> {
+  factory _$$RecipeLibraryStateImplCopyWith(
+    _$RecipeLibraryStateImpl value,
+    $Res Function(_$RecipeLibraryStateImpl) then,
+  ) = __$$RecipeLibraryStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<RecipeSection> sections});
+}
+
+/// @nodoc
+class __$$RecipeLibraryStateImplCopyWithImpl<$Res>
+    extends _$RecipeLibraryStateCopyWithImpl<$Res, _$RecipeLibraryStateImpl>
+    implements _$$RecipeLibraryStateImplCopyWith<$Res> {
+  __$$RecipeLibraryStateImplCopyWithImpl(
+    _$RecipeLibraryStateImpl _value,
+    $Res Function(_$RecipeLibraryStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of RecipeLibraryState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? sections = null}) {
+    return _then(
+      _$RecipeLibraryStateImpl(
+        sections: null == sections
+            ? _value._sections
+            : sections // ignore: cast_nullable_to_non_nullable
+                  as List<RecipeSection>,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$RecipeLibraryStateImpl implements _RecipeLibraryState {
+  const _$RecipeLibraryStateImpl({required final List<RecipeSection> sections})
+    : _sections = sections;
+
+  final List<RecipeSection> _sections;
+  @override
+  List<RecipeSection> get sections {
+    if (_sections is EqualUnmodifiableListView) return _sections;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_sections);
+  }
+
+  @override
+  String toString() {
+    return 'RecipeLibraryState(sections: $sections)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RecipeLibraryStateImpl &&
+            const DeepCollectionEquality().equals(other._sections, _sections));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_sections));
+
+  /// Create a copy of RecipeLibraryState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RecipeLibraryStateImplCopyWith<_$RecipeLibraryStateImpl> get copyWith =>
+      __$$RecipeLibraryStateImplCopyWithImpl<_$RecipeLibraryStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _RecipeLibraryState implements RecipeLibraryState {
+  const factory _RecipeLibraryState({
+    required final List<RecipeSection> sections,
+  }) = _$RecipeLibraryStateImpl;
+
+  @override
+  List<RecipeSection> get sections;
+
+  /// Create a copy of RecipeLibraryState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$RecipeLibraryStateImplCopyWith<_$RecipeLibraryStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$RecipeSection {
+  String get title => throw _privateConstructorUsedError;
+  List<Recipe> get recipes => throw _privateConstructorUsedError;
+
+  /// Create a copy of RecipeSection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $RecipeSectionCopyWith<RecipeSection> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RecipeSectionCopyWith<$Res> {
+  factory $RecipeSectionCopyWith(
+    RecipeSection value,
+    $Res Function(RecipeSection) then,
+  ) = _$RecipeSectionCopyWithImpl<$Res, RecipeSection>;
+  @useResult
+  $Res call({String title, List<Recipe> recipes});
+}
+
+/// @nodoc
+class _$RecipeSectionCopyWithImpl<$Res, $Val extends RecipeSection>
+    implements $RecipeSectionCopyWith<$Res> {
+  _$RecipeSectionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of RecipeSection
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? title = null, Object? recipes = null}) {
+    return _then(
+      _value.copyWith(
+            title: null == title
+                ? _value.title
+                : title // ignore: cast_nullable_to_non_nullable
+                      as String,
+            recipes: null == recipes
+                ? _value.recipes
+                : recipes // ignore: cast_nullable_to_non_nullable
+                      as List<Recipe>,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$RecipeSectionImplCopyWith<$Res>
+    implements $RecipeSectionCopyWith<$Res> {
+  factory _$$RecipeSectionImplCopyWith(
+    _$RecipeSectionImpl value,
+    $Res Function(_$RecipeSectionImpl) then,
+  ) = __$$RecipeSectionImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String title, List<Recipe> recipes});
+}
+
+/// @nodoc
+class __$$RecipeSectionImplCopyWithImpl<$Res>
+    extends _$RecipeSectionCopyWithImpl<$Res, _$RecipeSectionImpl>
+    implements _$$RecipeSectionImplCopyWith<$Res> {
+  __$$RecipeSectionImplCopyWithImpl(
+    _$RecipeSectionImpl _value,
+    $Res Function(_$RecipeSectionImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of RecipeSection
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? title = null, Object? recipes = null}) {
+    return _then(
+      _$RecipeSectionImpl(
+        title: null == title
+            ? _value.title
+            : title // ignore: cast_nullable_to_non_nullable
+                  as String,
+        recipes: null == recipes
+            ? _value._recipes
+            : recipes // ignore: cast_nullable_to_non_nullable
+                  as List<Recipe>,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$RecipeSectionImpl implements _RecipeSection {
+  const _$RecipeSectionImpl({
+    required this.title,
+    required final List<Recipe> recipes,
+  }) : _recipes = recipes;
+
+  @override
+  final String title;
+  final List<Recipe> _recipes;
+  @override
+  List<Recipe> get recipes {
+    if (_recipes is EqualUnmodifiableListView) return _recipes;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_recipes);
+  }
+
+  @override
+  String toString() {
+    return 'RecipeSection(title: $title, recipes: $recipes)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RecipeSectionImpl &&
+            (identical(other.title, title) || other.title == title) &&
+            const DeepCollectionEquality().equals(other._recipes, _recipes));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    title,
+    const DeepCollectionEquality().hash(_recipes),
+  );
+
+  /// Create a copy of RecipeSection
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RecipeSectionImplCopyWith<_$RecipeSectionImpl> get copyWith =>
+      __$$RecipeSectionImplCopyWithImpl<_$RecipeSectionImpl>(this, _$identity);
+}
+
+abstract class _RecipeSection implements RecipeSection {
+  const factory _RecipeSection({
+    required final String title,
+    required final List<Recipe> recipes,
+  }) = _$RecipeSectionImpl;
+
+  @override
+  String get title;
+  @override
+  List<Recipe> get recipes;
+
+  /// Create a copy of RecipeSection
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$RecipeSectionImplCopyWith<_$RecipeSectionImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/recipe/library/widgets/recipe_card.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_card.dart
@@ -1,0 +1,177 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/constants/allergen_emoji.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+
+class RecipeCard extends StatelessWidget {
+  const RecipeCard({required this.recipe, required this.onTap, super.key});
+
+  final Recipe recipe;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.symmetric(
+          horizontal: AppSizes.pagePaddingH,
+          vertical: AppSizes.xs,
+        ),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.06),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            _Thumbnail(url: recipe.thumbnailUrl),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.md,
+                  vertical: AppSizes.sm + AppSizes.xs,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      recipe.title,
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        color: AppColors.text,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: AppSizes.xs),
+                    _AgeTag(ageRange: recipe.ageRange),
+                    if (recipe.allergenTags.isNotEmpty) ...[
+                      const SizedBox(height: AppSizes.xs),
+                      _AllergenChips(tags: recipe.allergenTags),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            const Icon(
+              Icons.chevron_right,
+              color: AppColors.hint,
+              size: AppSizes.iconMd,
+            ),
+            const SizedBox(width: AppSizes.sm),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Thumbnail extends StatelessWidget {
+  const _Thumbnail({required this.url});
+
+  final String? url;
+
+  @override
+  Widget build(BuildContext context) {
+    const size = 72.0;
+    const radius = BorderRadius.only(
+      topLeft: Radius.circular(AppSizes.radiusMd),
+      bottomLeft: Radius.circular(AppSizes.radiusMd),
+    );
+
+    if (url == null || url!.isEmpty) {
+      return Container(
+        width: size,
+        height: size,
+        decoration: const BoxDecoration(
+          color: AppColors.surfaceVariant,
+          borderRadius: radius,
+        ),
+        child: const Icon(
+          Icons.restaurant_outlined,
+          color: AppColors.hint,
+          size: AppSizes.iconLg,
+        ),
+      );
+    }
+
+    return ClipRRect(
+      borderRadius: radius,
+      child: CachedNetworkImage(
+        imageUrl: url!,
+        width: size,
+        height: size,
+        fit: BoxFit.cover,
+        placeholder: (_, __) => Container(
+          width: size,
+          height: size,
+          color: AppColors.surfaceVariant,
+        ),
+        errorWidget: (_, __, ___) => Container(
+          width: size,
+          height: size,
+          color: AppColors.surfaceVariant,
+          child: const Icon(
+            Icons.restaurant_outlined,
+            color: AppColors.hint,
+            size: AppSizes.iconLg,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AgeTag extends StatelessWidget {
+  const _AgeTag({required this.ageRange});
+
+  final String ageRange;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.sm, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColors.primaryLight.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      child: Text(
+        ageRange,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: AppColors.primaryDark,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}
+
+class _AllergenChips extends StatelessWidget {
+  const _AllergenChips({required this.tags});
+
+  final List<String> tags;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: AppSizes.xs,
+      children: tags
+          .map(
+            (tag) => Text(
+              AllergenEmoji.get(tag),
+              style: const TextStyle(fontSize: 14),
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/src/features/splash/splash_controller.g.dart
+++ b/lib/src/features/splash/splash_controller.g.dart
@@ -6,7 +6,7 @@ part of 'splash_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$splashControllerHash() => r'daad027e9c7327d3eb5a3522b37eb3ae0d55cfc7';
+String _$splashControllerHash() => r'e69c69bc1e7b337dcb3e8863051c9a72d2e24331';
 
 /// See also [SplashController].
 @ProviderFor(SplashController)


### PR DESCRIPTION
## Summary

- **RC-01 Recipe Library** (`/home/recipe`): grouped sections (Recommendations for current allergen → per-allergen in sequence order → All Recipes), allergen filtering via `RecipeService.getFilteredRecipes`, pull-to-refresh, empty + error states
- **RC-02 Recipe Detail** (`/home/recipes/:recipeId`): scrollable layout with title, age range chip, allergen chips (colour-coded by status), ingredients with quantities, numbered steps, How to Serve, Notes; no bottom nav
- **Add to Meal Plan flow**: `showDatePicker` → optional `showTimePicker` → `MealPlanService.assignRecipe` + `recipeAddedToMealPlan` analytics event
- **Add to Shopping List modal**: ingredient names only (no quantities), all pre-checked, selective add → `ShoppingListService.addFromRecipe`

## Test plan

- [ ] Recipe Library loads and groups recipes by allergen sections (recommendations first)
- [ ] Recipes tagged with flagged allergens do not appear
- [ ] Pull-to-refresh reloads from Supabase
- [ ] Empty state shown when all recipes are filtered out
- [ ] Error state shown on load failure with pull-to-refresh
- [ ] Tapping a recipe card navigates to Recipe Detail (no bottom nav)
- [ ] Recipe Detail shows ingredients WITH quantities
- [ ] Allergen chips colour-coded: green=safe, blue=current, orange=in-progress, grey=not-started
- [ ] "Add to Shopping List" modal shows names only (no quantities), all pre-checked
- [ ] Deselecting ingredients works; only selected names added
- [ ] "Add to Meal Plan" opens date picker → optional time picker → confirms upsert
- [ ] Toast "Added to meal plan" / "Added to shopping list" shown on success
- [ ] `recipeAddedToMealPlan` analytics event fires on successful meal plan add
- [ ] `flutter analyze` passes with zero issues

Closes NIB-29