### PR TITLE
chore(infra): align app_sizes radius, spacing, component scales to kit [NIB-47]

### DIFF
--- a/lib/src/app/themes/app_sizes.dart
+++ b/lib/src/app/themes/app_sizes.dart
@@ -1,19 +1,25 @@
+import 'package:flutter/material.dart';
+
 abstract final class AppSizes {
-  // Spacing
+  // Spacing (8pt grid)
   static const double xs = 4;
   static const double sm = 8;
+  static const double sp12 = 12;
   static const double md = 16;
+  static const double sp20 = 20;
   static const double lg = 24;
   static const double xl = 32;
+  static const double sp40 = 40;
   static const double xxl = 48;
   static const double xxxl = 64;
 
   // Border radius
   static const double radiusXs = 4;
   static const double radiusSm = 8;
-  static const double radiusMd = 12;
+  static const double radiusMd = 10;
   static const double radiusLg = 16;
-  static const double radiusXl = 24;
+  static const double radiusXl = 20;
+  static const double radius2xl = 24;
   static const double radiusFull = 999;
 
   // Icon sizes
@@ -31,12 +37,42 @@ abstract final class AppSizes {
   // Component-specific
   static const double buttonHeight = 52;
   static const double buttonHeightSm = 40;
+  static const double roundButton = 44;
+  static const double roundButtonSm = 32;
   static const double inputHeight = 52;
   static const double appBarHeight = 56;
   static const double bottomNavHeight = 64;
+  static const double bottomNavRadius = 28;
   static const double avatarSm = 32;
   static const double avatarMd = 48;
   static const double avatarLg = 80;
+  static const double avatarXl = 120;
   static const double chipHeight = 36;
+  static const double chipHeightSm = 24;
+  static const double dayChipW = 64;
+  static const double dayChipH = 86;
   static const double dividerThickness = 1;
+
+  // Shadow tokens (offsets + blur from kit colors_and_type.css)
+  static const List<BoxShadow> shadowCard = [
+    BoxShadow(
+      color: Color(0x0F272727),
+      offset: Offset(0, 2),
+      blurRadius: 8,
+    ),
+  ];
+  static const List<BoxShadow> shadowCardLifted = [
+    BoxShadow(
+      color: Color(0x1A272727),
+      offset: Offset(0, 6),
+      blurRadius: 24,
+    ),
+  ];
+  static const List<BoxShadow> shadowSwitch = [
+    BoxShadow(
+      color: Color(0x1A272727),
+      offset: Offset(0, 2),
+      blurRadius: 4,
+    ),
+  ];
 }


### PR DESCRIPTION
## Summary

Aligns radius, spacing and component-size tokens in `lib/src/app/themes/app_sizes.dart` to the Nibbles mobile kit. Legacy token names are preserved; new tokens are additive. The only intended value changes are the two redesign radii (`radiusMd` 12->10, `radiusXl` 24->20), which is the intended visual shift for the redesign.

Single-file change, no data-layer impact.

### Changes
- Radius: `radiusMd` 12->10, `radiusXl` 24->20; added `radius2xl=24`. xs/sm/lg/full unchanged.
- Spacing: added `sp12=12`, `sp20=20`, `sp40=40`. Legacy xs/sm/md/lg/xl/xxl/xxxl intact.
- Component sizes (kit.css): added `roundButton=44`, `roundButtonSm=32`, `chipHeightSm=24`, `bottomNavRadius=28`, `dayChipW=64`, `dayChipH=86`, `avatarXl=120`. `chipHeight=36`, `buttonHeight=52`, `buttonHeightSm=40` kept.
- `inputHeight` left at 52 (open question, deferred per orchestrator note).
- Shadow tokens added in-file (no new file): `shadowCard`, `shadowCardLifted`, `shadowSwitch` (offsets/blur from kit colors_and_type.css).

## Acceptance criteria
- [x] `radiusMd=10`, `radiusXl=20`, `radius2xl=24` present; other radii unchanged
- [x] `sp12`/`sp20`/`sp40` added; legacy spacing names intact
- [x] Component sizes match kit.css; no legacy AppSizes field removed
- [x] `flutter analyze` clean; no consumer file breaks

## Gate results
- make gen: clean, idempotent (2nd run = 0 outputs); unrelated base-drift generated file reverted
- flutter analyze: No issues found
- flutter test: All tests passed (118 tests)