### PR TITLE
refactor(infra): rewrite app_typography to Parkinsans type ramp [NIB-46]

### DIFF
--- a/lib/src/app/themes/app_typography.dart
+++ b/lib/src/app/themes/app_typography.dart
@@ -1,129 +1,165 @@
 import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 
 abstract final class AppTypography {
   static const TextTheme textTheme = TextTheme(
+    // displayLarge/displayMedium — large Parkinsans bold (no feature usage).
     displayLarge: TextStyle(
-      fontFamily: 'Nunito',
+      fontFamily: FontFamily.parkinsans,
       fontSize: 57,
       fontWeight: FontWeight.w700,
+      height: 1.214,
       color: AppColors.text,
       letterSpacing: -0.25,
     ),
     displayMedium: TextStyle(
-      fontFamily: 'Nunito',
+      fontFamily: FontFamily.parkinsans,
       fontSize: 45,
       fontWeight: FontWeight.w700,
+      height: 1.214,
       color: AppColors.text,
     ),
+    // title1 — 28/700 h1.214 ls-0.01em (→ -0.28 logical px).
     displaySmall: TextStyle(
-      fontFamily: 'Nunito',
-      fontSize: 36,
-      fontWeight: FontWeight.w700,
-      color: AppColors.text,
-    ),
-    headlineLarge: TextStyle(
-      fontFamily: 'Nunito',
-      fontSize: 32,
-      fontWeight: FontWeight.w800,
-      color: AppColors.text,
-    ),
-    headlineMedium: TextStyle(
-      fontFamily: 'Nunito',
+      fontFamily: FontFamily.parkinsans,
       fontSize: 28,
       fontWeight: FontWeight.w700,
+      height: 1.214,
       color: AppColors.text,
+      letterSpacing: -0.28,
     ),
-    headlineSmall: TextStyle(
-      fontFamily: 'Nunito',
-      fontSize: 24,
+    headlineLarge: TextStyle(
+      fontFamily: FontFamily.parkinsans,
+      fontSize: 28,
       fontWeight: FontWeight.w700,
+      height: 1.214,
+      color: AppColors.text,
+      letterSpacing: -0.28,
+    ),
+    headlineMedium: TextStyle(
+      fontFamily: FontFamily.parkinsans,
+      fontSize: 28,
+      fontWeight: FontWeight.w700,
+      height: 1.214,
+      color: AppColors.text,
+      letterSpacing: -0.28,
+    ),
+    // title2 — 22/700 h1.273.
+    headlineSmall: TextStyle(
+      fontFamily: FontFamily.parkinsans,
+      fontSize: 22,
+      fontWeight: FontWeight.w700,
+      height: 1.273,
       color: AppColors.text,
     ),
     titleLarge: TextStyle(
-      fontFamily: 'Nunito',
+      fontFamily: FontFamily.parkinsans,
       fontSize: 22,
       fontWeight: FontWeight.w700,
+      height: 1.273,
       color: AppColors.text,
     ),
+    // title3 — 20/700 h1.30.
     titleMedium: TextStyle(
-      fontFamily: 'Nunito',
-      fontSize: 16,
-      fontWeight: FontWeight.w600,
-      color: AppColors.text,
-      letterSpacing: 0.15,
-    ),
-    titleSmall: TextStyle(
-      fontFamily: 'Nunito',
-      fontSize: 14,
-      fontWeight: FontWeight.w600,
-      color: AppColors.text,
-      letterSpacing: 0.1,
-    ),
-    bodyLarge: TextStyle(
-      fontFamily: 'Nunito',
-      fontSize: 16,
-      fontWeight: FontWeight.w400,
-      color: AppColors.text,
-      letterSpacing: 0.5,
-    ),
-    bodyMedium: TextStyle(
-      fontFamily: 'Nunito',
-      fontSize: 14,
-      fontWeight: FontWeight.w400,
-      color: AppColors.text,
-      letterSpacing: 0.25,
-    ),
-    bodySmall: TextStyle(
-      fontFamily: 'Nunito',
-      fontSize: 12,
-      fontWeight: FontWeight.w400,
-      color: AppColors.subtext,
-      letterSpacing: 0.4,
-    ),
-    labelLarge: TextStyle(
-      fontFamily: 'Nunito',
-      fontSize: 14,
+      fontFamily: FontFamily.parkinsans,
+      fontSize: 20,
       fontWeight: FontWeight.w700,
+      height: 1.30,
       color: AppColors.text,
-      letterSpacing: 0.1,
     ),
-    labelMedium: TextStyle(
-      fontFamily: 'Nunito',
+    // headline — 17/600 h1.294.
+    titleSmall: TextStyle(
+      fontFamily: FontFamily.parkinsans,
+      fontSize: 17,
+      fontWeight: FontWeight.w600,
+      height: 1.294,
+      color: AppColors.text,
+    ),
+    // body — 15/400 h1.467.
+    bodyLarge: TextStyle(
+      fontFamily: FontFamily.parkinsans,
+      fontSize: 15,
+      fontWeight: FontWeight.w400,
+      height: 1.467,
+      color: AppColors.text,
+    ),
+    // callout — 14/400 h1.50.
+    bodyMedium: TextStyle(
+      fontFamily: FontFamily.parkinsans,
+      fontSize: 14,
+      fontWeight: FontWeight.w400,
+      height: 1.50,
+      color: AppColors.text,
+    ),
+    // caption — 12/400 h1.333.
+    bodySmall: TextStyle(
+      fontFamily: FontFamily.parkinsans,
       fontSize: 12,
-      fontWeight: FontWeight.w600,
-      color: AppColors.text,
-      letterSpacing: 0.5,
-    ),
-    labelSmall: TextStyle(
-      fontFamily: 'Nunito',
-      fontSize: 11,
-      fontWeight: FontWeight.w600,
+      fontWeight: FontWeight.w400,
+      height: 1.333,
       color: AppColors.subtext,
-      letterSpacing: 0.5,
+    ),
+    // headline — 17/600 h1.294.
+    labelLarge: TextStyle(
+      fontFamily: FontFamily.parkinsans,
+      fontSize: 17,
+      fontWeight: FontWeight.w600,
+      height: 1.294,
+      color: AppColors.text,
+    ),
+    // subhead — 13/600 h1.538.
+    labelMedium: TextStyle(
+      fontFamily: FontFamily.parkinsans,
+      fontSize: 13,
+      fontWeight: FontWeight.w600,
+      height: 1.538,
+      color: AppColors.text,
+    ),
+    // overline — 10/700 h1.20 ls0.6 (uppercase applied at widget level).
+    labelSmall: TextStyle(
+      fontFamily: FontFamily.parkinsans,
+      fontSize: 10,
+      fontWeight: FontWeight.w700,
+      height: 1.20,
+      color: AppColors.subtext,
+      letterSpacing: 0.6,
     ),
   );
 
+  // sectionTitle — title3 (20/700 h1.30).
   static const TextStyle sectionTitle = TextStyle(
-    fontFamily: 'Nunito',
-    fontSize: 18,
-    fontWeight: FontWeight.w800,
+    fontFamily: FontFamily.parkinsans,
+    fontSize: 20,
+    fontWeight: FontWeight.w700,
+    height: 1.30,
     color: AppColors.text,
   );
 
+  // caption — 12/400 h1.333.
   static const TextStyle caption = TextStyle(
-    fontFamily: 'Nunito',
+    fontFamily: FontFamily.parkinsans,
     fontSize: 12,
     fontWeight: FontWeight.w400,
+    height: 1.333,
     color: AppColors.subtext,
-    letterSpacing: 0.4,
   );
 
+  // button ~ headline (15/700 h1.294).
   static const TextStyle button = TextStyle(
-    fontFamily: 'Nunito',
-    fontSize: 16,
+    fontFamily: FontFamily.parkinsans,
+    fontSize: 15,
     fontWeight: FontWeight.w700,
+    height: 1.294,
     color: AppColors.onPrimary,
-    letterSpacing: 0.5,
+  );
+
+  // body-bold — 15/700 h1.467 (ramp completeness; no slot mapping).
+  static const TextStyle bodyBold = TextStyle(
+    fontFamily: FontFamily.parkinsans,
+    fontSize: 15,
+    fontWeight: FontWeight.w700,
+    height: 1.467,
+    color: AppColors.text,
   );
 }


### PR DESCRIPTION
## Summary
Rewrites `lib/src/app/themes/app_typography.dart` to the Parkinsans type ramp. Every `fontFamily: 'Nunito'` is replaced with `FontFamily.parkinsans`, and the full `TextTheme` plus helper styles now follow the kit's px-derived size/weight/line-height ramp from `design/colors_and_type.css` (title1..overline).

Slots heavily consumed by features (headlineLarge x8, headlineSmall x6, labelMedium x10, etc.) are now explicitly styled so they no longer merge onto Material defaults and render off-size.

## Mapping applied
- displaySmall / headlineLarge / headlineMedium -> title1 (28/700, h1.214, ls -0.28)
- headlineSmall / titleLarge -> title2 (22/700, h1.273)
- titleMedium -> title3 (20/700, h1.30; bumped from 16/600)
- titleSmall / labelLarge -> headline (17/600, h1.294)
- bodyLarge -> body (15/400, h1.467)
- bodyMedium -> callout (14/400, h1.50)
- bodySmall -> caption (12/400, h1.333)
- labelMedium -> subhead (13/600, h1.538)
- labelSmall -> overline (10/700, h1.20, ls 0.6; uppercase applied at widget level)
- displayLarge / displayMedium kept as large Parkinsans bold
- helpers: sectionTitle -> title3, caption -> caption, button ~ headline (15/700); added bodyBold (15/700) for ramp completeness

letterSpacing notes: CSS `-0.01em` on title1 converted to logical px (-0.28 at 28px); overline `0.6` is already logical px. Stale Material letterSpacing values on all other slots were dropped (CSS ramp has no tracking on the rest).

## Acceptance criteria
- [x] No 'Nunito' string remains in app_typography.dart (`grep -c Nunito` = 0)
- [x] All ramp entries match design/colors_and_type.css sizes/weights and use correct height multipliers
- [x] Every TextTheme slot consumed by features is explicitly styled to the kit ramp (incl. headlineLarge, headlineSmall, labelMedium)
- [x] TextTheme slots populated per the mapping; helper styles restyled; flutter analyze clean; no consumer file breaks

## Gate results
- `make gen`: clean; idempotent (second run = 0 outputs, no surprise diff). Unrelated base-drift `home_controller.g.dart` reverted so the diff is theme-only.
- `flutter analyze`: No issues found.
- `flutter test`: 118 tests pass. Note: the suite requires local `.env.dev`/`.env.prod` asset files (declared in pubspec but gitignored, a pre-existing infra condition); placeholders were created locally to run the suite and are not committed.