### PR TITLE
chore(infra): rewrite app_theme.dart Material3 ThemeData to new tokens [NIB-48]

### DIFF
--- a/lib/src/app/themes/app_theme.dart
+++ b/lib/src/app/themes/app_theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
@@ -12,22 +13,25 @@ abstract final class AppTheme {
   static ThemeData light() {
     const colorScheme = ColorScheme(
       brightness: Brightness.light,
-      primary: AppColors.primary,
-      onPrimary: AppColors.onPrimary,
-      primaryContainer: AppColors.primaryLight,
-      onPrimaryContainer: AppColors.primaryDark,
-      secondary: AppColors.secondary,
-      onSecondary: AppColors.onSecondary,
-      secondaryContainer: AppColors.secondaryLight,
-      onSecondaryContainer: AppColors.text,
-      error: AppColors.error,
-      onError: AppColors.onError,
+      // greenDeep #3D5236 brand primary; cream foreground on it.
+      primary: AppColors.greenDeep,
+      onPrimary: AppColors.cream,
+      primaryContainer: AppColors.green,
+      onPrimaryContainer: AppColors.cream,
+      secondary: AppColors.coral,
+      onSecondary: AppColors.cream,
+      secondaryContainer: AppColors.coralSoft,
+      onSecondaryContainer: AppColors.fgStrong,
+      // Maroon #851E1E is destructive-button intent; validation borders use
+      // AppColors.error (#E53E3E) explicitly in inputDecorationTheme.
+      error: AppColors.destructive,
+      onError: AppColors.cream,
       surface: AppColors.surface,
-      onSurface: AppColors.onSurface,
+      onSurface: AppColors.fgStrong,
       surfaceContainerHighest: AppColors.surfaceVariant,
-      onSurfaceVariant: AppColors.subtext,
-      outline: AppColors.divider,
-      outlineVariant: AppColors.hint,
+      onSurfaceVariant: AppColors.fgMuted,
+      outline: AppColors.borderSoft,
+      outlineVariant: AppColors.borderMuted,
     );
 
     const textTheme = AppTypography.textTheme;
@@ -36,96 +40,101 @@ abstract final class AppTheme {
       useMaterial3: true,
       colorScheme: colorScheme,
       textTheme: textTheme,
-      fontFamily: 'Nunito',
-      scaffoldBackgroundColor: AppColors.background,
-      dividerColor: AppColors.divider,
+      fontFamily: FontFamily.parkinsans,
+      scaffoldBackgroundColor: AppColors.cream,
+      dividerColor: AppColors.borderSoft,
       dividerTheme: const DividerThemeData(
-        color: AppColors.divider,
+        color: AppColors.borderSoft,
         thickness: AppSizes.dividerThickness,
         space: 0,
       ),
+      // Most screens use the custom AppHeader (later ticket); this AppBarTheme
+      // is a sane cream/transparent-tint fallback.
       appBarTheme: AppBarTheme(
-        backgroundColor: AppColors.surface,
+        backgroundColor: AppColors.cream,
         surfaceTintColor: Colors.transparent,
         elevation: 0,
-        scrolledUnderElevation: 1,
-        shadowColor: AppColors.divider,
+        scrolledUnderElevation: 0,
+        shadowColor: AppColors.borderSoft,
         centerTitle: true,
-        titleTextStyle: textTheme.titleLarge,
+        titleTextStyle: textTheme.titleMedium,
         systemOverlayStyle: SystemUiOverlayStyle.dark,
         iconTheme: const IconThemeData(
-          color: AppColors.text,
+          color: AppColors.fgStrong,
           size: AppSizes.iconMd,
         ),
       ),
+      // Canonical nav is the custom AppBottomNav (later ticket); this block is
+      // a fallback only — retuned to the new palette.
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(
         backgroundColor: AppColors.surface,
-        selectedItemColor: AppColors.primary,
-        unselectedItemColor: AppColors.subtext,
+        selectedItemColor: AppColors.greenDeep,
+        unselectedItemColor: AppColors.fgFaint,
         selectedLabelStyle: TextStyle(
-          fontFamily: 'Nunito',
+          fontFamily: FontFamily.parkinsans,
           fontWeight: FontWeight.w700,
-          fontSize: 11,
-          color: AppColors.primary,
+          fontSize: 10,
+          color: AppColors.greenDeep,
         ),
         unselectedLabelStyle: TextStyle(
-          fontFamily: 'Nunito',
-          fontWeight: FontWeight.w600,
-          fontSize: 11,
-          color: AppColors.subtext,
+          fontFamily: FontFamily.parkinsans,
+          fontWeight: FontWeight.w700,
+          fontSize: 10,
+          color: AppColors.fgFaint,
         ),
         elevation: 8,
         type: BottomNavigationBarType.fixed,
       ),
+      // Primary CTA — greenDeep/cream pill, no per-call override needed.
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor: AppColors.primary,
-          foregroundColor: AppColors.onPrimary,
-          disabledBackgroundColor: AppColors.hint,
+          backgroundColor: AppColors.greenDeep,
+          foregroundColor: AppColors.cream,
+          disabledBackgroundColor: AppColors.borderMuted,
+          disabledForegroundColor: AppColors.cream,
           minimumSize: const Size.fromHeight(AppSizes.buttonHeight),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-          ),
+          shape: const StadiumBorder(),
           textStyle: AppTypography.button,
           elevation: 0,
         ),
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: OutlinedButton.styleFrom(
-          foregroundColor: AppColors.primary,
+          foregroundColor: AppColors.greenDeep,
           minimumSize: const Size.fromHeight(AppSizes.buttonHeight),
-          side: const BorderSide(color: AppColors.primary, width: 1.5),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-          ),
-          textStyle: AppTypography.button.copyWith(color: AppColors.primary),
+          side: const BorderSide(color: AppColors.greenDeep, width: 1.5),
+          shape: const StadiumBorder(),
+          textStyle: AppTypography.button.copyWith(color: AppColors.greenDeep),
         ),
       ),
       textButtonTheme: TextButtonThemeData(
         style: TextButton.styleFrom(
-          foregroundColor: AppColors.primary,
+          foregroundColor: AppColors.greenDeep,
           textStyle: textTheme.labelLarge,
         ),
       ),
+      // Filled bgInput per kit (.field); focused border = greenDeep (sage
+      // focus). Validation reds use AppColors.error (#E53E3E) explicitly, NOT
+      // ColorScheme.error (maroon).
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: AppColors.surface,
+        fillColor: AppColors.bgInput,
         contentPadding: const EdgeInsets.symmetric(
           horizontal: AppSizes.md,
           vertical: AppSizes.md,
         ),
-        hintStyle: textTheme.bodyMedium?.copyWith(color: AppColors.hint),
+        hintStyle: textTheme.bodyMedium?.copyWith(color: AppColors.greenSoft),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-          borderSide: const BorderSide(color: AppColors.divider),
+          borderSide: const BorderSide(color: AppColors.borderSoft),
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-          borderSide: const BorderSide(color: AppColors.divider),
+          borderSide: const BorderSide(color: AppColors.borderSoft),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-          borderSide: const BorderSide(color: AppColors.primary, width: 2),
+          borderSide: const BorderSide(color: AppColors.greenDeep, width: 2),
         ),
         errorBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(AppSizes.radiusMd),
@@ -141,10 +150,13 @@ abstract final class AppTheme {
         color: AppColors.surface,
         elevation: 0,
         margin: EdgeInsets.zero,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(AppSizes.radiusXl)),
+        ),
       ),
       chipTheme: ChipThemeData(
         backgroundColor: AppColors.surfaceVariant,
-        selectedColor: AppColors.primaryLight,
+        selectedColor: AppColors.butter,
         labelStyle: textTheme.labelMedium,
         side: BorderSide.none,
         shape: const RoundedRectangleBorder(
@@ -155,10 +167,13 @@ abstract final class AppTheme {
           vertical: AppSizes.xs,
         ),
       ),
+      // Floating P2 toast — fgStrong surface, cream text, radiusMd.
       snackBarTheme: SnackBarThemeData(
         behavior: SnackBarBehavior.floating,
-        backgroundColor: AppColors.text,
-        contentTextStyle: textTheme.bodyMedium?.copyWith(color: Colors.white),
+        backgroundColor: AppColors.fgStrong,
+        contentTextStyle: textTheme.bodyMedium?.copyWith(
+          color: AppColors.cream,
+        ),
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(AppSizes.radiusMd)),
         ),


### PR DESCRIPTION
## Summary

Composes the new design-system tokens (AppColors NIB-45, AppTypography NIB-46, AppSizes NIB-47) into the Material3 light `ThemeData` so all themed widgets re-skin from a single source. No data-layer impact. Single file: `lib/src/app/themes/app_theme.dart` (re-export lines preserved). No consumer screens touched — they re-skin automatically.

## Changes

- fontFamily: `FontFamily.parkinsans` (all `'Nunito'` strings removed, including inline BottomNav label styles).
- ColorScheme: primary=greenDeep, onPrimary=cream, primaryContainer=green, secondary=coral, onSecondary=cream, error=destructive maroon #851E1E, surface=#FFFFFF, onSurface=fgStrong, surfaceContainerHighest=surfaceVariant, outline=borderSoft; scaffoldBackgroundColor=cream.
- Buttons: elevated greenDeep/cream pill (StadiumBorder), height 52, disabled #D9D9D9 bg + cream fg, elevation 0; outlined greenDeep 1.5px pill; text greenDeep.
- Inputs: filled bgInput #F2F2F2, radius 10, enabled borderSoft, focused greenDeep width 2 (sage focus), error #E53E3E explicit (independent of ColorScheme maroon), hint greenSoft per kit.
- AppBar: cream bg, transparent surfaceTint, Parkinsans title, dark overlay (fallback for custom AppHeader).
- BottomNav: selected greenDeep, unselected fgFaint, Parkinsans labels (fallback for custom AppBottomNav).
- Chip: bg surfaceVariant, selected butter, radiusFull, Parkinsans label. Card: white, radiusXl(20), elevation 0. SnackBar: floating, fgStrong bg, cream text, radiusMd (P2 toast).
- Re-export lines for colors/sizes/typography preserved.

## Error-surface note

ColorScheme.error = destructive maroon #851E1E (destructive-button intent). Input validation borders use AppColors.error #E53E3E explicitly in inputDecorationTheme — kept independent so validation reds do not inherit maroon.

## Acceptance criteria

- [x] ThemeData uses Parkinsans family and new ColorScheme; no `'Nunito'` string remains (grep clean).
- [x] ElevatedButton renders greenDeep/cream pill with no per-call color override.
- [x] Input fields render with bgInput fill, radius 10, sage focus border, #E53E3E error.
- [x] App boots via AppTheme.light() with zero analyzer warnings; existing screens re-skin.

## Gate results

- `make gen`: succeeded, idempotent (second run = 0 outputs). Unrelated base-drift `home_controller.g.dart` riverpod hash reverted; PR contains only `app_theme.dart`.
- `flutter analyze`: No issues found.
- `flutter test`: All 118 tests passed.