### PR TITLE
chore(infra): build shared component library [NIB-49]

### DIFF
--- a/lib/src/app/themes/app_colors.dart
+++ b/lib/src/app/themes/app_colors.dart
@@ -74,6 +74,18 @@ abstract final class AppColors {
   static const Color bgCardTint = Color(0xFFFFFCD5);
   static const Color bgInput = Color(0xFFF2F2F2);
 
+  // ── Chip / status foreground tokens (kit components-chips) ────
+  // Deepened text colors for tinted status chips — no existing token.
+  static const Color safeFg = Color(0xFF1F6E47);
+  static const Color warnFg = Color(0xFF8A5E14);
+  static const Color flagFg = Color(0xFFB92020);
+
+  // ── Control / progress tokens ─────────────────────────────────
+  // Switch off-track grey (controls preview .switch).
+  static const Color switchTrackOff = Color(0xFFC0C0C0);
+  // Butter linear-progress fill — darkened butter (progress .bar.butter).
+  static const Color progressButterFill = Color(0xFFB7B82E);
+
   // ── Tan / wheat scale ─────────────────────────────────────────
   static const Color tanBase = Color(0xFFFFE0A9);
   static const Color tan10 = Color(0xFFFFF9EE);

--- a/lib/src/app/themes/app_sizes.dart
+++ b/lib/src/app/themes/app_sizes.dart
@@ -40,6 +40,18 @@ abstract final class AppSizes {
   static const double roundButton = 44;
   static const double roundButtonSm = 32;
   static const double inputHeight = 52;
+  // Kit .field is 48px (inputHeight=52 is a deferred decision; do not mutate).
+  static const double fieldHeight = 48;
+  // Segmented control track height (controls/segmented preview).
+  static const double segmentedHeight = 42;
+  // Switch track / thumb (controls preview: 44x24 track, 20px thumb).
+  static const double switchTrackW = 44;
+  static const double switchTrackH = 24;
+  static const double switchThumb = 20;
+  // Checkbox (.cb controls preview: 24/radius8).
+  static const double checkbox = 24;
+  // Tip-card glyph circle (cards preview: 28px).
+  static const double tipGlyph = 28;
   static const double appBarHeight = 56;
   static const double bottomNavHeight = 64;
   static const double bottomNavRadius = 28;

--- a/lib/src/common/components/boilerplate/component_gallery.dart
+++ b/lib/src/common/components/boilerplate/component_gallery.dart
@@ -1,0 +1,280 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/components.dart';
+
+/// Dev-only visual QA showcase rendering every shared component.
+///
+/// Not wired into the production GoRouter — push it manually from a dev entry
+/// point (e.g. `Navigator.push(... ComponentGallery())`) to eyeball fidelity.
+class ComponentGallery extends StatefulWidget {
+  const ComponentGallery({super.key});
+
+  @override
+  State<ComponentGallery> createState() => _ComponentGalleryState();
+}
+
+class _ComponentGalleryState extends State<ComponentGallery> {
+  int _segIndex = 0;
+  bool _switchOn = true;
+  bool _checked = true;
+  int _radioIndex = 0;
+  int _navIndex = 0;
+  int _dayIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.cream,
+      appBar: AppBar(title: const Text('Component Gallery')),
+      body: ListView(
+        padding: const EdgeInsets.all(AppSizes.sp20),
+        children: [
+          _section('Pill buttons', [
+            const AppPillButton(label: 'Primary', onPressed: _noop),
+            const SizedBox(height: AppSizes.sm),
+            const AppPillButton(
+              label: 'Secondary',
+              onPressed: _noop,
+              variant: AppPillButtonVariant.secondary,
+            ),
+            const SizedBox(height: AppSizes.sm),
+            const AppPillButton(
+              label: 'Ghost',
+              onPressed: _noop,
+              variant: AppPillButtonVariant.ghost,
+            ),
+            const SizedBox(height: AppSizes.sm),
+            const AppPillButton(
+              label: 'Destructive',
+              onPressed: _noop,
+              variant: AppPillButtonVariant.destructive,
+            ),
+            const SizedBox(height: AppSizes.sm),
+            const AppPillButton(label: 'Disabled', onPressed: null),
+            const SizedBox(height: AppSizes.sm),
+            const Row(
+              children: [
+                AppPillButton(
+                  label: 'Small',
+                  onPressed: _noop,
+                  size: AppPillButtonSize.small,
+                  expand: false,
+                ),
+              ],
+            ),
+          ]),
+          _section('Round buttons', [
+            const Row(
+              children: [
+                AppRoundButton(icon: Icon(Icons.arrow_back), onPressed: _noop),
+                SizedBox(width: AppSizes.sm),
+                AppRoundButton(
+                  icon: Icon(Icons.more_horiz),
+                  onPressed: _noop,
+                  tone: AppRoundButtonTone.ghost,
+                ),
+                SizedBox(width: AppSizes.sm),
+                AppRoundButton(
+                  icon: Icon(Icons.add),
+                  onPressed: _noop,
+                  tone: AppRoundButtonTone.green,
+                ),
+                SizedBox(width: AppSizes.sm),
+                AppRoundButton(
+                  icon: Icon(Icons.close),
+                  onPressed: _noop,
+                  size: AppRoundButtonSize.small,
+                ),
+              ],
+            ),
+          ]),
+          _section('Cards', [
+            const AppCard(child: Text('Plain white card')),
+            const SizedBox(height: AppSizes.sm),
+            const AppCard(
+              variant: AppCardVariant.soft,
+              child: Text('Soft butter card'),
+            ),
+            const SizedBox(height: AppSizes.sm),
+            const AppCard(
+              variant: AppCardVariant.dashed,
+              child: Text('Dashed card'),
+            ),
+            const SizedBox(height: AppSizes.sm),
+            const TipCard(
+              title: 'Getting Started Tips',
+              body: 'Start with single-ingredient purees and introduce one new '
+                  'food every 3-5 days.',
+            ),
+          ]),
+          _section('Chips', [
+            const Wrap(
+              spacing: AppSizes.sm,
+              runSpacing: AppSizes.sm,
+              children: [
+                AppChip(label: 'Neutral'),
+                AppChip(label: 'Safe', tone: AppChipTone.safe),
+                AppChip(label: 'Warn', tone: AppChipTone.warn),
+                AppChip(label: 'Flag', tone: AppChipTone.flag),
+                AppChip(label: 'Mute', tone: AppChipTone.mute),
+                AppChip(label: 'Butter', tone: AppChipTone.butter),
+                AppChip(label: 'Green', tone: AppChipTone.green),
+                AppChip(label: 'Fruit', emoji: '🍎'),
+              ],
+            ),
+          ]),
+          _section('Inputs', [
+            const AppTextField(label: 'First Name', hintText: 'Asther'),
+            const SizedBox(height: AppSizes.sm),
+            const AppTextField(
+              label: 'Password',
+              obscureText: true,
+              errorText: 'Must be at least 8 characters.',
+            ),
+            const SizedBox(height: AppSizes.sm),
+            const AppSearchField(hintText: 'Search recipes...'),
+          ]),
+          _section('Controls', [
+            AppSegmentedControl(
+              segments: const ['List', 'Bought'],
+              selectedIndex: _segIndex,
+              onChanged: (i) => setState(() => _segIndex = i),
+            ),
+            const SizedBox(height: AppSizes.md),
+            Row(
+              children: [
+                AppSwitch(
+                  value: _switchOn,
+                  onChanged: (v) => setState(() => _switchOn = v),
+                ),
+                const SizedBox(width: AppSizes.md),
+                AppCheckbox(
+                  value: _checked,
+                  onChanged: (v) => setState(() => _checked = v),
+                ),
+                const SizedBox(width: AppSizes.md),
+                RadioPill(
+                  label: 'Yes',
+                  selected: _radioIndex == 0,
+                  onTap: () => setState(() => _radioIndex = 0),
+                ),
+                const SizedBox(width: AppSizes.sm),
+                RadioPill(
+                  label: 'No',
+                  selected: _radioIndex == 1,
+                  onTap: () => setState(() => _radioIndex = 1),
+                ),
+              ],
+            ),
+          ]),
+          _section('Calendar', [
+            WeekStrip(
+              days: _sampleWeek(_dayIndex),
+              onDaySelected: (i) => setState(() => _dayIndex = i),
+            ),
+          ]),
+          _section('Header', [
+            const AppHeader(
+              title: 'Nibbles',
+              leading: AppRoundButton(
+                icon: Icon(Icons.arrow_back),
+                onPressed: _noop,
+              ),
+              trailing: AppRoundButton(
+                icon: Icon(Icons.person_outline),
+                onPressed: _noop,
+              ),
+              subline: 'Oliver is 6 months 12 days today!',
+            ),
+            const SizedBox(height: AppSizes.sm),
+            const AppHeader(title: 'Recipes', wash: AppHeaderWash.cream),
+          ]),
+          _section('Progress', [
+            const Row(
+              children: [
+                AppProgressRing(value: 1, max: 11),
+                SizedBox(width: AppSizes.lg),
+                Expanded(
+                  child: Column(
+                    children: [
+                      AppLinearProgress(value: 0.66),
+                      SizedBox(height: AppSizes.sm),
+                      AppLinearProgress(
+                        value: 0.42,
+                        variant: AppLinearProgressVariant.green,
+                      ),
+                      SizedBox(height: AppSizes.sm),
+                      AppLinearProgress(
+                        value: 0.8,
+                        variant: AppLinearProgressVariant.butter,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ]),
+          _section('Empty state', [
+            EmptyState(
+              title: "You don't have any list yet",
+              subtitle: 'Add an ingredient to start your shopping list.',
+              ctaLabel: '+ Add ingredient',
+              onCtaPressed: () {},
+            ),
+          ]),
+          _section('Brand', [
+            const Center(child: Quatrefoil(size: 120)),
+          ]),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSizes.md),
+          child: AppBottomNav(
+            currentIndex: _navIndex,
+            onTap: (i) => setState(() => _navIndex = i),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _section(String title, List<Widget> children) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSizes.xl),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title.toUpperCase(),
+            style: Theme.of(context).textTheme.labelSmall,
+          ),
+          const SizedBox(height: AppSizes.sm),
+          ...children,
+        ],
+      ),
+    );
+  }
+
+  static List<WeekDay> _sampleWeek(int selected) {
+    const labels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    return List.generate(labels.length, (i) {
+      final DayChipState state;
+      if (i == selected) {
+        state = DayChipState.selected;
+      } else if (i == 3 || i == 5) {
+        state = DayChipState.filled;
+      } else {
+        state = DayChipState.idle;
+      }
+      return WeekDay(
+        dayOfWeek: labels[i],
+        date: '${18 + i} Apr',
+        state: state,
+      );
+    });
+  }
+}
+
+void _noop() {}

--- a/lib/src/common/components/brand/quatrefoil.dart
+++ b/lib/src/common/components/brand/quatrefoil.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+
+/// Brand quatrefoil mark — butter petals (#EAEC8C) + sage center (#5C7852).
+/// Mirrors the Primitives.jsx `Quatrefoil` SVG, sizeable.
+class Quatrefoil extends StatelessWidget {
+  const Quatrefoil({
+    this.size = 96,
+    this.petalColor = AppColors.butter,
+    this.coreColor = AppColors.green,
+    super.key,
+  });
+
+  final double size;
+  final Color petalColor;
+  final Color coreColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final petal = _hex(petalColor);
+    final core = _hex(coreColor);
+
+    final svg = '''
+<svg width="$size" height="$size" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <path fill="$petal" d="M60 8c14 0 22 8 22 22 0 4-1 8-3 11 9 3 17 12 17 23 0 14-9 22-22 22-4 0-8-1-11-3-3 9-12 17-23 17-14 0-22-9-22-22 0-4 1-8 3-11-9-3-17-12-17-23 0-14 9-22 22-22 4 0 8 1 11 3 3-9 12-17 23-17z" transform="translate(2 2)"/>
+  <circle cx="60" cy="60" r="22" fill="$core"/>
+</svg>''';
+
+    return SvgPicture.string(svg, width: size, height: size);
+  }
+
+  String _hex(Color c) {
+    final argb = c.toARGB32();
+    final rgb = (argb & 0x00FFFFFF).toRadixString(16).padLeft(6, '0');
+    return '#$rgb';
+  }
+}

--- a/lib/src/common/components/buttons/app_pill_button.dart
+++ b/lib/src/common/components/buttons/app_pill_button.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+
+/// Visual variant for [AppPillButton] — maps to kit `.pillbtn--*`.
+enum AppPillButtonVariant { primary, secondary, ghost, destructive }
+
+/// Sizing for [AppPillButton]. `full` = h52, `small` = h40 (kit.css).
+enum AppPillButtonSize { full, small }
+
+/// Pill-shaped CTA. Mirrors kit `.pillbtn` (radiusFull, Parkinsans 700).
+///
+/// kit.css wins over the preview on pixels: full=52h, small=40h.
+class AppPillButton extends StatelessWidget {
+  const AppPillButton({
+    required this.label,
+    required this.onPressed,
+    this.variant = AppPillButtonVariant.primary,
+    this.size = AppPillButtonSize.full,
+    this.expand = true,
+    this.leading,
+    super.key,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+  final AppPillButtonVariant variant;
+  final AppPillButtonSize size;
+
+  /// Whether the button stretches to its parent's width (kit `.pillbtn--full`).
+  final bool expand;
+
+  /// Optional leading widget (e.g. a `+` icon for "Add" buttons).
+  final Widget? leading;
+
+  bool get _isSmall => size == AppPillButtonSize.small;
+
+  bool get _disabled => onPressed == null;
+
+  Color _background(AppPillButtonVariant v) {
+    if (_disabled) return AppColors.borderMuted;
+    switch (v) {
+      case AppPillButtonVariant.primary:
+        return AppColors.greenDeep;
+      case AppPillButtonVariant.secondary:
+        return Colors.transparent;
+      case AppPillButtonVariant.ghost:
+        return AppColors.butter;
+      case AppPillButtonVariant.destructive:
+        return AppColors.destructive;
+    }
+  }
+
+  Color _foreground(AppPillButtonVariant v) {
+    if (_disabled) return AppColors.cream;
+    switch (v) {
+      case AppPillButtonVariant.primary:
+      case AppPillButtonVariant.destructive:
+        return AppColors.cream;
+      case AppPillButtonVariant.secondary:
+      case AppPillButtonVariant.ghost:
+        return AppColors.greenDeep;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = _foreground(variant);
+    final height = _isSmall ? AppSizes.buttonHeightSm : AppSizes.buttonHeight;
+    final hPad = _isSmall ? AppSizes.md : AppSizes.lg;
+    final isSecondary = variant == AppPillButtonVariant.secondary;
+
+    final textStyle = AppTypography.button.copyWith(
+      color: fg,
+      fontSize: _isSmall ? 14 : 16,
+    );
+
+    final child = Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        if (leading != null) ...[
+          IconTheme.merge(
+            data: IconThemeData(color: fg, size: AppSizes.iconSm),
+            child: leading!,
+          ),
+          const SizedBox(width: AppSizes.xs),
+        ],
+        Flexible(
+          child: Text(
+            label,
+            style: textStyle,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+
+    return Material(
+      color: _background(variant),
+      shape: StadiumBorder(
+        side: isSecondary && !_disabled
+            ? const BorderSide(color: AppColors.greenDeep, width: 1.5)
+            : BorderSide.none,
+      ),
+      child: InkWell(
+        onTap: onPressed,
+        customBorder: const StadiumBorder(),
+        child: SizedBox(
+          height: height,
+          width: expand ? double.infinity : null,
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: hPad),
+            child: Center(child: child),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/buttons/app_round_button.dart
+++ b/lib/src/common/components/buttons/app_round_button.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Background tone for [AppRoundButton] — maps to kit `.rbtn--*`.
+enum AppRoundButtonTone { white, ghost, green }
+
+/// Sizing for [AppRoundButton]. `regular` = 44 circle, `small` = 32 circle.
+enum AppRoundButtonSize { regular, small }
+
+/// Circular icon button used in headers / overlays. Mirrors kit `.rbtn`.
+class AppRoundButton extends StatelessWidget {
+  const AppRoundButton({
+    required this.icon,
+    required this.onPressed,
+    this.tone = AppRoundButtonTone.white,
+    this.size = AppRoundButtonSize.regular,
+    this.semanticLabel,
+    super.key,
+  });
+
+  final Widget icon;
+  final VoidCallback? onPressed;
+  final AppRoundButtonTone tone;
+  final AppRoundButtonSize size;
+  final String? semanticLabel;
+
+  double get _diameter => size == AppRoundButtonSize.small
+      ? AppSizes.roundButtonSm
+      : AppSizes.roundButton;
+
+  Color get _background {
+    switch (tone) {
+      case AppRoundButtonTone.white:
+        return AppColors.surface;
+      case AppRoundButtonTone.ghost:
+        return Colors.transparent;
+      case AppRoundButtonTone.green:
+        return AppColors.greenDeep;
+    }
+  }
+
+  Color get _foreground => tone == AppRoundButtonTone.green
+      ? AppColors.cream
+      : AppColors.greenDeep;
+
+  @override
+  Widget build(BuildContext context) {
+    final iconSize = size == AppRoundButtonSize.small ? 18.0 : 22.0;
+
+    return Semantics(
+      button: true,
+      label: semanticLabel,
+      child: Material(
+        color: _background,
+        shape: const CircleBorder(),
+        child: InkWell(
+          onTap: onPressed,
+          customBorder: const CircleBorder(),
+          child: SizedBox(
+            width: _diameter,
+            height: _diameter,
+            child: Center(
+              child: IconTheme.merge(
+                data: IconThemeData(color: _foreground, size: iconSize),
+                child: icon,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/calendar/day_chip.dart
+++ b/lib/src/common/components/calendar/day_chip.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Visual state for [DayChip] — mirrors components-calendar preview states.
+enum DayChipState { selected, idle, filled }
+
+/// Single 64x86 day chip in a horizontal week strip. Mirrors the
+/// components-calendar preview (radiusMd). NOT table_calendar.
+///
+/// - selected: greenDeep bg, butterSoft text
+/// - idle: white bg, greenDeep text, borderSoft border
+/// - filled: butterSoft bg, green border, green check + greenDeep text
+class DayChip extends StatelessWidget {
+  const DayChip({
+    required this.dayOfWeek,
+    required this.date,
+    required this.state,
+    this.onTap,
+    super.key,
+  });
+
+  /// Short weekday label (e.g. "Mon").
+  final String dayOfWeek;
+
+  /// Short date label (e.g. "18 Apr").
+  final String date;
+  final DayChipState state;
+  final VoidCallback? onTap;
+
+  Color get _background {
+    switch (state) {
+      case DayChipState.selected:
+        return AppColors.greenDeep;
+      case DayChipState.idle:
+        return AppColors.surface;
+      case DayChipState.filled:
+        return AppColors.butterSoft;
+    }
+  }
+
+  Color get _foreground => state == DayChipState.selected
+      ? AppColors.butterSoft
+      : AppColors.greenDeep;
+
+  BoxBorder? get _border {
+    switch (state) {
+      case DayChipState.selected:
+        return null;
+      case DayChipState.idle:
+        return Border.all(color: AppColors.borderSoft);
+      case DayChipState.filled:
+        return Border.all(color: AppColors.green);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dowStyle = TextStyle(
+      fontFamily: _fontFamily(context),
+      fontSize: 13,
+      fontWeight: FontWeight.w700,
+      height: 1,
+      color: _foreground,
+    );
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        width: AppSizes.dayChipW,
+        height: AppSizes.dayChipH,
+        decoration: BoxDecoration(
+          color: _background,
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          border: _border,
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (state == DayChipState.filled)
+              const Icon(Icons.check, size: 18, color: AppColors.green),
+            Text(dayOfWeek, style: dowStyle),
+            const SizedBox(height: AppSizes.xs),
+            Text(date, style: dowStyle),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _fontFamily(BuildContext context) =>
+      Theme.of(context).textTheme.bodyLarge?.fontFamily ?? '';
+}

--- a/lib/src/common/components/calendar/week_strip.dart
+++ b/lib/src/common/components/calendar/week_strip.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/calendar/day_chip.dart';
+
+/// Immutable data for one day in a [WeekStrip].
+class WeekDay {
+  const WeekDay({
+    required this.dayOfWeek,
+    required this.date,
+    required this.state,
+  });
+
+  final String dayOfWeek;
+  final String date;
+  final DayChipState state;
+}
+
+/// Horizontally scrollable strip of [DayChip]s. The horizontal day-chip strip
+/// referenced by the spec — NOT table_calendar (month grid is themed
+/// separately for meal-plan).
+class WeekStrip extends StatelessWidget {
+  const WeekStrip({
+    required this.days,
+    this.onDaySelected,
+    super.key,
+  });
+
+  final List<WeekDay> days;
+  final ValueChanged<int>? onDaySelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: AppSizes.dayChipH,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: AppSizes.sp20),
+        itemCount: days.length,
+        separatorBuilder: (_, __) => const SizedBox(width: AppSizes.sm + 2),
+        itemBuilder: (context, i) {
+          final day = days[i];
+          return DayChip(
+            dayOfWeek: day.dayOfWeek,
+            date: day.date,
+            state: day.state,
+            onTap: onDaySelected == null ? null : () => onDaySelected!(i),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/cards/app_card.dart
+++ b/lib/src/common/components/cards/app_card.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Surface variant for [AppCard] — maps to kit `.card`, `.card--soft`,
+/// `.card--dashed`.
+enum AppCardVariant { plain, soft, dashed }
+
+/// Base container surface. radiusXl (20), kit padding 14x16 snapped to grid.
+class AppCard extends StatelessWidget {
+  const AppCard({
+    required this.child,
+    this.variant = AppCardVariant.plain,
+    this.padding = const EdgeInsets.symmetric(
+      horizontal: AppSizes.md,
+      vertical: AppSizes.sp12,
+    ),
+    this.onTap,
+    super.key,
+  });
+
+  final Widget child;
+  final AppCardVariant variant;
+  final EdgeInsetsGeometry padding;
+  final VoidCallback? onTap;
+
+  Color get _background {
+    switch (variant) {
+      case AppCardVariant.plain:
+        return AppColors.surface;
+      case AppCardVariant.soft:
+        return AppColors.butterSoft;
+      case AppCardVariant.dashed:
+        return Colors.transparent;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final radius = BorderRadius.circular(AppSizes.radiusXl);
+
+    Widget content = Container(
+      decoration: BoxDecoration(color: _background, borderRadius: radius),
+      padding: padding,
+      child: child,
+    );
+
+    if (variant == AppCardVariant.dashed) {
+      content = CustomPaint(
+        painter: const _DashedBorderPainter(
+          color: AppColors.borderMuted,
+          radius: AppSizes.radiusXl,
+        ),
+        child: content,
+      );
+    }
+
+    if (onTap != null) {
+      return Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: radius,
+          child: content,
+        ),
+      );
+    }
+    return content;
+  }
+}
+
+/// Paints a 1.5px dashed rounded-rect border (kit `.card--dashed`).
+class _DashedBorderPainter extends CustomPainter {
+  const _DashedBorderPainter({required this.color, required this.radius});
+
+  final Color color;
+  final double radius;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5;
+
+    final rrect = RRect.fromRectAndRadius(
+      Offset.zero & size,
+      Radius.circular(radius),
+    );
+    final path = Path()..addRRect(rrect);
+
+    const dash = 6.0;
+    const gap = 4.0;
+    for (final metric in path.computeMetrics()) {
+      var distance = 0.0;
+      while (distance < metric.length) {
+        canvas.drawPath(
+          metric.extractPath(distance, distance + dash),
+          paint,
+        );
+        distance += dash + gap;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_DashedBorderPainter oldDelegate) =>
+      oldDelegate.color != color || oldDelegate.radius != radius;
+}

--- a/lib/src/common/components/cards/tip_card.dart
+++ b/lib/src/common/components/cards/tip_card.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Hint / tip card. Mirrors kit `.tip`: butterSoft fill, radiusXl,
+/// 28px greenDeep glyph circle with butter glyph, 14/700 title + callout body.
+class TipCard extends StatelessWidget {
+  const TipCard({
+    required this.title,
+    required this.body,
+    this.glyph = 'i',
+    super.key,
+  });
+
+  final String title;
+  final String body;
+
+  /// Glyph rendered inside the greenDeep circle (kit default "i").
+  final String glyph;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.butterSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md,
+        vertical: AppSizes.sp12,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: AppSizes.tipGlyph,
+            height: AppSizes.tipGlyph,
+            decoration: const BoxDecoration(
+              color: AppColors.greenDeep,
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              glyph,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: AppColors.butter,
+                fontWeight: FontWeight.w700,
+                height: 1,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.fgStrong,
+                    height: 1.2,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.xs / 2),
+                Text(
+                  body,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: AppColors.fgDefault,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/chips/app_chip.dart
+++ b/lib/src/common/components/chips/app_chip.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Tone for [AppChip]. kit.css `.chip--*` is authoritative on colours/sizing;
+/// warn/flag come from the components-chips preview (no kit.css entry).
+enum AppChipTone { neutral, safe, warn, flag, mute, butter, green }
+
+/// Small tag chip. h24, radiusFull, Parkinsans 700/11. Mirrors kit `.chip`.
+class AppChip extends StatelessWidget {
+  const AppChip({
+    required this.label,
+    this.tone = AppChipTone.neutral,
+    this.icon,
+    this.emoji,
+    super.key,
+  });
+
+  final String label;
+  final AppChipTone tone;
+
+  /// Optional leading icon widget (rendered before the label).
+  final Widget? icon;
+
+  /// Optional leading emoji string (alternative to [icon]).
+  final String? emoji;
+
+  Color get _background {
+    switch (tone) {
+      case AppChipTone.neutral:
+        return AppColors.coralSoft;
+      case AppChipTone.safe:
+        return AppColors.success.withValues(alpha: 0.12);
+      case AppChipTone.warn:
+        return AppColors.warning.withValues(alpha: 0.15);
+      case AppChipTone.flag:
+        return AppColors.error.withValues(alpha: 0.12);
+      case AppChipTone.mute:
+        return AppColors.surfaceVariant;
+      case AppChipTone.butter:
+        return AppColors.butter;
+      case AppChipTone.green:
+        return AppColors.greenDeep;
+    }
+  }
+
+  Color get _foreground {
+    switch (tone) {
+      case AppChipTone.neutral:
+        return AppColors.coralDeep;
+      case AppChipTone.safe:
+        return AppColors.safeFg;
+      case AppChipTone.warn:
+        return AppColors.warnFg;
+      case AppChipTone.flag:
+        return AppColors.flagFg;
+      case AppChipTone.mute:
+        return AppColors.fgMuted;
+      case AppChipTone.butter:
+        return AppColors.greenDeep;
+      case AppChipTone.green:
+        return AppColors.cream;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = _foreground;
+    final leading = icon ??
+        (emoji != null
+            ? Text(emoji!, style: const TextStyle(fontSize: 11, height: 1))
+            : null);
+
+    return Container(
+      height: AppSizes.chipHeightSm,
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.sm + 2),
+      decoration: BoxDecoration(
+        color: _background,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      alignment: Alignment.center,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (leading != null) ...[
+            IconTheme.merge(
+              data: IconThemeData(color: fg, size: 12),
+              child: leading,
+            ),
+            const SizedBox(width: AppSizes.xs),
+          ],
+          Text(
+            label,
+            style: TextStyle(
+              fontFamily: FontFamily.parkinsans,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              height: 1,
+              color: fg,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/components.dart
+++ b/lib/src/common/components/components.dart
@@ -1,0 +1,23 @@
+/// Shared component library — theme-driven, reusable widgets consumed by
+/// every redesigned feature. See NIB-49.
+library;
+
+export 'brand/quatrefoil.dart';
+export 'buttons/app_pill_button.dart';
+export 'buttons/app_round_button.dart';
+export 'calendar/day_chip.dart';
+export 'calendar/week_strip.dart';
+export 'cards/app_card.dart';
+export 'cards/tip_card.dart';
+export 'chips/app_chip.dart';
+export 'controls/app_checkbox.dart';
+export 'controls/app_segmented_control.dart';
+export 'controls/app_switch.dart';
+export 'controls/radio_pill.dart';
+export 'feedback/empty_state.dart';
+export 'inputs/app_search_field.dart';
+export 'inputs/app_text_field.dart';
+export 'navigation/app_bottom_nav.dart';
+export 'navigation/app_header.dart';
+export 'progress/app_linear_progress.dart';
+export 'progress/app_progress_ring.dart';

--- a/lib/src/common/components/controls/app_checkbox.dart
+++ b/lib/src/common/components/controls/app_checkbox.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Square checkbox. Mirrors kit components-controls `.cb`: 24px, radius8,
+/// greenDeep fill + cream check when on. (NOT the shopping-list `.shop-row__cb`
+/// which is 22/radius6 — that is a separate widget.)
+class AppCheckbox extends StatelessWidget {
+  const AppCheckbox({
+    required this.value,
+    required this.onChanged,
+    super.key,
+  });
+
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      checked: value,
+      child: GestureDetector(
+        onTap: onChanged == null ? null : () => onChanged!(!value),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          width: AppSizes.checkbox,
+          height: AppSizes.checkbox,
+          decoration: BoxDecoration(
+            color: value ? AppColors.greenDeep : AppColors.surface,
+            borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+            border: Border.all(color: AppColors.greenDeep, width: 1.5),
+          ),
+          child: value
+              ? const Icon(
+                  Icons.check_rounded,
+                  size: AppSizes.iconSm,
+                  color: AppColors.cream,
+                )
+              : null,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/controls/app_segmented_control.dart
+++ b/lib/src/common/components/controls/app_segmented_control.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// 2-up segmented control. Mirrors kit components-segmented preview:
+/// track #EAEAEA (borderSoft), radiusMd, active segment greenDeep/cream.
+class AppSegmentedControl extends StatelessWidget {
+  const AppSegmentedControl({
+    required this.segments,
+    required this.selectedIndex,
+    required this.onChanged,
+    super.key,
+  }) : assert(segments.length == 2, 'AppSegmentedControl is 2-up only');
+
+  final List<String> segments;
+  final int selectedIndex;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      height: AppSizes.segmentedHeight,
+      padding: const EdgeInsets.all(1),
+      decoration: BoxDecoration(
+        color: AppColors.borderSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      ),
+      child: Row(
+        children: List.generate(segments.length, (i) {
+          final active = i == selectedIndex;
+          return Expanded(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => onChanged(i),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 120),
+                decoration: BoxDecoration(
+                  color: active ? AppColors.greenDeep : Colors.transparent,
+                  borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  segments[i],
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: active ? AppColors.cream : AppColors.greenDeep,
+                  ),
+                ),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/controls/app_switch.dart
+++ b/lib/src/common/components/controls/app_switch.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// On/off switch. Mirrors kit components-controls `.switch`: 44x24 track,
+/// butter-on / grey-off, greenDeep 20px thumb with shadowSwitch.
+class AppSwitch extends StatelessWidget {
+  const AppSwitch({
+    required this.value,
+    required this.onChanged,
+    super.key,
+  });
+
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    const inset = (AppSizes.switchTrackH - AppSizes.switchThumb) / 2;
+
+    return Semantics(
+      toggled: value,
+      child: GestureDetector(
+        onTap: onChanged == null ? null : () => onChanged!(!value),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          width: AppSizes.switchTrackW,
+          height: AppSizes.switchTrackH,
+          decoration: BoxDecoration(
+            color: value ? AppColors.butter : AppColors.switchTrackOff,
+            borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+          ),
+          child: Stack(
+            children: [
+              AnimatedAlign(
+                duration: const Duration(milliseconds: 150),
+                alignment:
+                    value ? Alignment.centerRight : Alignment.centerLeft,
+                child: Container(
+                  margin: const EdgeInsets.symmetric(horizontal: inset),
+                  width: AppSizes.switchThumb,
+                  height: AppSizes.switchThumb,
+                  decoration: const BoxDecoration(
+                    color: AppColors.greenDeep,
+                    shape: BoxShape.circle,
+                    boxShadow: AppSizes.shadowSwitch,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/controls/radio_pill.dart
+++ b/lib/src/common/components/controls/radio_pill.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Selectable pill used for radio-style choices (e.g. Yes / No).
+/// Mirrors kit components-controls radio pills: h36, radiusFull,
+/// selected greenDeep/cream, idle outline greenDeep.
+class RadioPill extends StatelessWidget {
+  const RadioPill({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    super.key,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final fg = selected ? AppColors.cream : AppColors.greenDeep;
+
+    return Semantics(
+      selected: selected,
+      button: true,
+      child: Material(
+        color: selected ? AppColors.greenDeep : Colors.transparent,
+        shape: StadiumBorder(
+          side: selected
+              ? BorderSide.none
+              : const BorderSide(color: AppColors.greenDeep, width: 1.5),
+        ),
+        child: InkWell(
+          onTap: onTap,
+          customBorder: const StadiumBorder(),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.md - 2,
+              vertical: AppSizes.sm,
+            ),
+            child: Text(
+              label,
+              style: theme.textTheme.labelMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: fg,
+                height: 1,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/feedback/empty_state.dart
+++ b/lib/src/common/components/feedback/empty_state.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+
+/// Empty / zero-data state. Mirrors components-empty-state preview:
+/// Quatrefoil mark + 16/700 title + caption sub + optional CTA pill.
+class EmptyState extends StatelessWidget {
+  const EmptyState({
+    required this.title,
+    required this.subtitle,
+    this.ctaLabel,
+    this.onCtaPressed,
+    this.markSize = 96,
+    super.key,
+  });
+
+  final String title;
+  final String subtitle;
+
+  /// Optional CTA pill label. When set with [onCtaPressed], a small pill button
+  /// is rendered below the subtitle.
+  final String? ctaLabel;
+  final VoidCallback? onCtaPressed;
+  final double markSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Quatrefoil(size: markSize),
+        const SizedBox(height: AppSizes.sm + 2),
+        Text(
+          title,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            color: AppColors.fgStrong,
+            height: 1.2,
+          ),
+        ),
+        const SizedBox(height: AppSizes.xs),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 220),
+          child: Text(
+            subtitle,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: AppColors.fgFaint,
+            ),
+          ),
+        ),
+        if (ctaLabel != null) ...[
+          const SizedBox(height: AppSizes.sp12),
+          AppPillButton(
+            label: ctaLabel!,
+            onPressed: onCtaPressed,
+            size: AppPillButtonSize.small,
+            expand: false,
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/src/common/components/inputs/app_search_field.dart
+++ b/lib/src/common/components/inputs/app_search_field.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Pill search field. Mirrors kit `.search` (radiusFull, bgInput fill,
+/// leading greenDeep search icon).
+class AppSearchField extends StatelessWidget {
+  const AppSearchField({
+    this.controller,
+    this.hintText = 'Search',
+    this.onChanged,
+    this.onSubmitted,
+    this.focusNode,
+    super.key,
+  });
+
+  final TextEditingController? controller;
+  final String hintText;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final FocusNode? focusNode;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      height: AppSizes.fieldHeight,
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.md - 2),
+      decoration: BoxDecoration(
+        color: AppColors.bgInput,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.search,
+            size: AppSizes.iconSm + 2,
+            color: AppColors.greenDeep,
+          ),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: TextField(
+              controller: controller,
+              focusNode: focusNode,
+              onChanged: onChanged,
+              onSubmitted: onSubmitted,
+              textInputAction: TextInputAction.search,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: AppColors.fgStrong,
+              ),
+              cursorColor: AppColors.greenDeep,
+              decoration: InputDecoration(
+                isCollapsed: true,
+                border: InputBorder.none,
+                hintText: hintText,
+                hintStyle: theme.textTheme.bodyLarge?.copyWith(
+                  color: AppColors.greenSoft,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/inputs/app_text_field.dart
+++ b/lib/src/common/components/inputs/app_text_field.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Labelled text field. Mirrors kit `.field` (h48, radiusMd, bgInput fill,
+/// sage focus shadow) + `label.field-label` (14/700) and the error state
+/// (#E53E3E border + caption error text).
+class AppTextField extends StatefulWidget {
+  const AppTextField({
+    this.label,
+    this.controller,
+    this.hintText,
+    this.errorText,
+    this.obscureText = false,
+    this.keyboardType,
+    this.textInputAction,
+    this.onChanged,
+    this.onSubmitted,
+    this.enabled = true,
+    this.focusNode,
+    super.key,
+  });
+
+  final String? label;
+  final TextEditingController? controller;
+  final String? hintText;
+
+  /// When non-null the field renders its error state (red border + caption).
+  final String? errorText;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+  final TextInputAction? textInputAction;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final bool enabled;
+  final FocusNode? focusNode;
+
+  @override
+  State<AppTextField> createState() => _AppTextFieldState();
+}
+
+class _AppTextFieldState extends State<AppTextField> {
+  late final FocusNode _focusNode;
+  bool _ownsNode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.focusNode != null) {
+      _focusNode = widget.focusNode!;
+    } else {
+      _focusNode = FocusNode();
+      _ownsNode = true;
+    }
+    _focusNode.addListener(_onFocusChanged);
+  }
+
+  void _onFocusChanged() => setState(() {});
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChanged);
+    if (_ownsNode) _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasError = widget.errorText != null;
+    final focused = _focusNode.hasFocus;
+
+    final borderColor = hasError
+        ? AppColors.error
+        : focused
+            ? AppColors.greenDeep
+            : AppColors.borderSoft;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (widget.label != null) ...[
+          Text(
+            widget.label!,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: AppColors.fgStrong,
+            ),
+          ),
+          const SizedBox(height: AppSizes.sm),
+        ],
+        AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          height: AppSizes.fieldHeight,
+          decoration: BoxDecoration(
+            color: focused ? AppColors.surface : AppColors.bgInput,
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            border: Border.all(
+              color: borderColor,
+              width: focused || hasError ? 2 : 1,
+            ),
+            boxShadow: focused && !hasError
+                ? [
+                    BoxShadow(
+                      color: AppColors.green.withValues(alpha: 0.18),
+                      spreadRadius: 3,
+                    ),
+                  ]
+                : null,
+          ),
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(horizontal: AppSizes.md - 2),
+          child: TextField(
+            controller: widget.controller,
+            focusNode: _focusNode,
+            enabled: widget.enabled,
+            obscureText: widget.obscureText,
+            keyboardType: widget.keyboardType,
+            textInputAction: widget.textInputAction,
+            onChanged: widget.onChanged,
+            onSubmitted: widget.onSubmitted,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+            cursorColor: AppColors.greenDeep,
+            decoration: InputDecoration(
+              isCollapsed: true,
+              border: InputBorder.none,
+              hintText: widget.hintText,
+              hintStyle: theme.textTheme.bodyLarge?.copyWith(
+                color: AppColors.greenSoft,
+              ),
+            ),
+          ),
+        ),
+        if (hasError) ...[
+          const SizedBox(height: AppSizes.xs),
+          Text(
+            widget.errorText!,
+            style: theme.textTheme.bodySmall?.copyWith(color: AppColors.error),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/src/common/components/navigation/app_bottom_nav.dart
+++ b/lib/src/common/components/navigation/app_bottom_nav.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// One destination in [AppBottomNav].
+class AppBottomNavItem {
+  const AppBottomNavItem({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+}
+
+/// Canonical bottom nav — the floating rounded-28 card + shadowCard variant
+/// (components-bottom-nav preview), NOT the full-width `.tabbar`.
+/// 4 tabs, active = butter pill with greenDeep content, 10/700 labels.
+class AppBottomNav extends StatelessWidget {
+  const AppBottomNav({
+    required this.currentIndex,
+    required this.onTap,
+    this.items = defaultItems,
+    super.key,
+  });
+
+  final int currentIndex;
+  final ValueChanged<int> onTap;
+  final List<AppBottomNavItem> items;
+
+  static const List<AppBottomNavItem> defaultItems = [
+    AppBottomNavItem(icon: Icons.home_outlined, label: 'Home'),
+    AppBottomNavItem(icon: Icons.restaurant_outlined, label: 'Meals'),
+    AppBottomNavItem(icon: Icons.shopping_cart_outlined, label: 'Grocery'),
+    AppBottomNavItem(icon: Icons.menu_book_outlined, label: 'Recipes'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.bottomNavRadius),
+        boxShadow: AppSizes.shadowCard,
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md + 2,
+        vertical: AppSizes.sp12,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: List.generate(items.length, (i) {
+          return _Tab(
+            item: items[i],
+            active: i == currentIndex,
+            onTap: () => onTap(i),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _Tab extends StatelessWidget {
+  const _Tab({required this.item, required this.active, required this.onTap});
+
+  final AppBottomNavItem item;
+  final bool active;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = active ? AppColors.greenDeep : AppColors.fgFaint;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.md - 2,
+          vertical: AppSizes.sm,
+        ),
+        decoration: BoxDecoration(
+          color: active ? AppColors.butter : Colors.transparent,
+          borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(item.icon, size: 22, color: fg),
+            const SizedBox(height: 3),
+            Text(
+              item.label,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0,
+                    height: 1,
+                    color: fg,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/navigation/app_header.dart
+++ b/lib/src/common/components/navigation/app_header.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Background wash for [AppHeader] — maps to kit `.topbar--*`.
+enum AppHeaderWash { butterGradient, butterSoft, cream }
+
+/// Top header. Mirrors kit `.topbar` + components-header preview:
+/// 44px round left/right slots, centered 17/700 title, optional title1 subline
+/// and optional trailing stat slot.
+///
+/// Wash: butterGradient (Home/Meals), butterSoft, cream (Recipes/ShoppingList).
+class AppHeader extends StatelessWidget {
+  const AppHeader({
+    required this.title,
+    this.wash = AppHeaderWash.butterGradient,
+    this.leading,
+    this.trailing,
+    this.subline,
+    this.stat,
+    super.key,
+  });
+
+  final String title;
+  final AppHeaderWash wash;
+
+  /// 44px round left slot (e.g. back button).
+  final Widget? leading;
+
+  /// 44px round right slot (e.g. avatar / action).
+  final Widget? trailing;
+
+  /// Optional title1-scale headline rendered below the top row.
+  final String? subline;
+
+  /// Optional widget rendered opposite the [subline] (e.g. a stat pill).
+  final Widget? stat;
+
+  Decoration get _decoration {
+    switch (wash) {
+      case AppHeaderWash.butterGradient:
+        return const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [AppColors.butter, AppColors.butterSoft],
+          ),
+        );
+      case AppHeaderWash.butterSoft:
+        return const BoxDecoration(color: AppColors.butterSoft);
+      case AppHeaderWash.cream:
+        return const BoxDecoration(color: AppColors.cream);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      decoration: _decoration,
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.md + 2,
+        AppSizes.md - 2,
+        AppSizes.md + 2,
+        AppSizes.lg - 2,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              SizedBox(
+                width: AppSizes.roundButton,
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: leading,
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  title,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.fgStrong,
+                    height: 1,
+                  ),
+                ),
+              ),
+              SizedBox(
+                width: AppSizes.roundButton,
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: trailing,
+                ),
+              ),
+            ],
+          ),
+          if (subline != null) ...[
+            const SizedBox(height: AppSizes.md - 2),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Expanded(
+                  child: Text(
+                    subline!,
+                    style: theme.textTheme.displaySmall?.copyWith(
+                      color: AppColors.fgStrong,
+                    ),
+                  ),
+                ),
+                if (stat != null) ...[
+                  const SizedBox(width: AppSizes.sp12),
+                  stat!,
+                ],
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/progress/app_linear_progress.dart
+++ b/lib/src/common/components/progress/app_linear_progress.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Colour variant for [AppLinearProgress] — components-progress preview.
+enum AppLinearProgressVariant { coral, green, butter }
+
+/// Thin pill progress bar. Mirrors components-progress preview `.bar`:
+/// 8px track, fill + matching track tint per variant.
+class AppLinearProgress extends StatelessWidget {
+  const AppLinearProgress({
+    required this.value,
+    this.variant = AppLinearProgressVariant.coral,
+    this.height = 8,
+    super.key,
+  }) : assert(value >= 0 && value <= 1, 'value must be 0..1');
+
+  /// Progress 0..1.
+  final double value;
+  final AppLinearProgressVariant variant;
+  final double height;
+
+  Color get _fill {
+    switch (variant) {
+      case AppLinearProgressVariant.coral:
+        return AppColors.coralDeep;
+      case AppLinearProgressVariant.green:
+        return AppColors.green;
+      case AppLinearProgressVariant.butter:
+        return AppColors.progressButterFill;
+    }
+  }
+
+  Color get _track {
+    switch (variant) {
+      case AppLinearProgressVariant.coral:
+        return AppColors.coralSoft;
+      case AppLinearProgressVariant.green:
+        return AppColors.green.withValues(alpha: 0.18);
+      case AppLinearProgressVariant.butter:
+        return AppColors.butter.withValues(alpha: 0.5);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      child: Stack(
+        children: [
+          Container(height: height, width: double.infinity, color: _track),
+          FractionallySizedBox(
+            widthFactor: value.clamp(0.0, 1.0),
+            child: Container(
+              height: height,
+              decoration: BoxDecoration(
+                color: _fill,
+                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/progress/app_progress_ring.dart
+++ b/lib/src/common/components/progress/app_progress_ring.dart
@@ -1,0 +1,118 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+
+/// Conic progress ring. Mirrors components-progress preview `.ring`:
+/// coralDeep sweep over a coralSoft track, white center hole showing value/max.
+class AppProgressRing extends StatelessWidget {
+  const AppProgressRing({
+    required this.value,
+    required this.max,
+    this.diameter = 110,
+    this.thickness = 15,
+    super.key,
+  }) : assert(max > 0, 'max must be positive');
+
+  final int value;
+  final int max;
+  final double diameter;
+  final double thickness;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = (value / max).clamp(0.0, 1.0);
+
+    return SizedBox(
+      width: diameter,
+      height: diameter,
+      child: CustomPaint(
+        painter: _RingPainter(
+          progress: progress,
+          thickness: thickness,
+          fill: AppColors.coralDeep,
+          track: AppColors.coralSoft,
+        ),
+        child: Center(
+          child: RichText(
+            textAlign: TextAlign.center,
+            text: TextSpan(
+              children: [
+                TextSpan(
+                  text: '$value',
+                  style: const TextStyle(
+                    fontFamily: FontFamily.parkinsans,
+                    fontSize: 22,
+                    fontWeight: FontWeight.w700,
+                    height: 1,
+                    color: AppColors.coralDeep,
+                  ),
+                ),
+                TextSpan(
+                  text: '/$max',
+                  style: const TextStyle(
+                    fontFamily: FontFamily.parkinsans,
+                    fontSize: 10,
+                    height: 1,
+                    color: AppColors.fgFaint,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RingPainter extends CustomPainter {
+  const _RingPainter({
+    required this.progress,
+    required this.thickness,
+    required this.fill,
+    required this.track,
+  });
+
+  final double progress;
+  final double thickness;
+  final Color fill;
+  final Color track;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = (size.shortestSide - thickness) / 2;
+    final rect = Rect.fromCircle(center: center, radius: radius);
+
+    final trackPaint = Paint()
+      ..color = track
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = thickness;
+    canvas.drawCircle(center, radius, trackPaint);
+
+    if (progress > 0) {
+      final fillPaint = Paint()
+        ..color = fill
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = thickness
+        ..strokeCap = StrokeCap.round;
+      // Start at 12 o'clock, sweep clockwise.
+      canvas.drawArc(
+        rect,
+        -math.pi / 2,
+        2 * math.pi * progress,
+        false,
+        fillPaint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(_RingPainter oldDelegate) =>
+      oldDelegate.progress != progress ||
+      oldDelegate.thickness != thickness ||
+      oldDelegate.fill != fill ||
+      oldDelegate.track != track;
+}


### PR DESCRIPTION
## Summary
Builds the reusable, theme-driven shared component library under `lib/src/common/components/`, matching the Nibbles mobile UI kit. Presentational only — no data-layer, Supabase, or DTO contact. All widgets pull colours/sizes/type from `AppColors`/`AppSizes`/`AppTypography`/`Theme` (no hardcoded hexes), with typed enums for variants.

Grouped folders delivered:
- `buttons/` — `AppPillButton` (primary/secondary/ghost/destructive/disabled, full=52h / small=40h, radiusFull) and `AppRoundButton` (44/32 circle; white/ghost/green).
- `cards/` — `AppCard` (radiusXl 20; plain/soft/dashed via CustomPainter) and `TipCard` (butterSoft, 28px greenDeep glyph circle).
- `chips/` — `AppChip` tone enum {neutral, safe, warn, flag, mute, butter, green}; h24 tag chip; optional leading icon/emoji.
- `inputs/` — `AppTextField` (h48, radiusMd, 14/700 label, bgInput fill, sage focus shadow, #E53E3E error border + caption) and `AppSearchField` (pill, leading search icon).
- `controls/` — `AppSegmentedControl` (2-up, #EAEAEA track, active greenDeep/cream), `AppSwitch` (44x24, butter-on, greenDeep 20px thumb + shadowSwitch), `AppCheckbox` (24/radius8, greenDeep fill+check), `RadioPill`.
- `calendar/` — `DayChip` (64x86, selected/idle/filled) and `WeekStrip` (horizontal scroll). No `table_calendar`.
- `navigation/` — `AppBottomNav` (canonical floating rounded-28 card + shadowCard, 4 tabs, active butter pill, 10/700 labels) and `AppHeader` (wash butterGradient|butterSoft|cream; 44px round slots; centred 17/700 title; optional subline + stat slot).
- `progress/` — `AppProgressRing` (coralDeep sweep over coralSoft track, starts at 12 o'clock) and `AppLinearProgress` (coral/green/butter).
- `feedback/` + `brand/` — `EmptyState` (Quatrefoil mark + title + caption + optional CTA pill) and `Quatrefoil` (butter petals + sage centre, sizeable, via flutter_svg).
- `boilerplate/ComponentGallery` — dev-only showcase rendering every component for visual QA (not wired into the production router).

Additive theme tokens only (existing tokens untouched): `AppSizes.fieldHeight=48`, `segmentedHeight`, switch/checkbox/tip sizes; `AppColors.safeFg/warnFg/flagFg`, `switchTrackOff`, `progressButterFill`.

## Tiebreak / decision notes
- kit.css wins over previews on pixel disagreements (buttons 52/40; chips h24; checkbox 24/radius8; field h48).
- `inputHeight` (52) left unchanged per orchestrator note; added `fieldHeight=48` for the kit `.field`.
- AppBottomNav = floating-card preview variant, not the full-width `.tabbar`. AppCheckbox = `.cb` 24/radius8, not the shopping-list `.shop-row__cb`. Calendar = horizontal day-chip strip, not `table_calendar`.
- AppHeader subline uses title1 (28) per the spec's named token. The header preview renders it at 22; kit.css is silent. Flagging the deviation — trivial to switch to title2 if pixel-matching the preview is preferred.

## Acceptance criteria
- [x] All listed widgets exist under `lib/src/common/components/` in grouped folders, theme-token driven (no hardcoded colours/sizes).
- [x] Variant enums implemented (button/chip tones, header wash, segmented/progress variants), rendering per kit specs/pixel sizes.
- [x] DayChip/WeekStrip without table_calendar; AppBottomNav matches floating-card preview; AppCheckbox is 24/radius8.
- [x] Boilerplate `ComponentGallery` renders every component.
- [x] Widgets reusable (no feature-specific coupling), ready for feature-redesign tickets.

## Gate results
- `make gen`: clean. No new generated files for this ticket (enums are plain Dart); ran twice for idempotency. Unrelated pre-existing base drift (`home_controller.g.dart`) reverted so the PR contains only ticket files.
- `flutter analyze`: No issues found.
- `dart run custom_lint` (riverpod_lint): 24 findings, all pre-existing base-branch debt in repositories/services/tests. Zero findings in `lib/src/common/components/`.
- `flutter test`: 118 passed. (`.env.dev`/`.env.prod` copied into the worktree to build the asset bundle for tests — gitignored, not committed.)