### PR TITLE
feat(splash): P0 boot-failure handling with full-screen retry [NIB-57]

### DIFF
--- a/lib/src/features/splash/splash_controller.dart
+++ b/lib/src/features/splash/splash_controller.dart
@@ -5,6 +5,19 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'splash_controller.g.dart';
 
+/// Discriminable boot failure surfaced as the AsyncNotifier error state so the
+/// splash screen can render a P0 (full-screen + retry) instead of leaking a raw
+/// remote exception to the UI.
+class SplashBootException implements Exception {
+  const SplashBootException(this.cause);
+
+  /// The original error (e.g. no connectivity) that broke boot.
+  final Object cause;
+
+  @override
+  String toString() => 'SplashBootException: $cause';
+}
+
 @riverpod
 class SplashController extends _$SplashController {
   @override
@@ -23,12 +36,17 @@ class SplashController extends _$SplashController {
     final isLoggedIn = ref.read(authServiceProvider);
     if (!isLoggedIn) return '/auth/login';
 
-    final baby = await ref.read(babyProfileServiceProvider).getBaby();
+    // Defensive: a failed remote read here (e.g. no connectivity) is a P0.
+    // Wrap it so the screen renders a full-screen retry rather than a raw
+    // AsyncError. Does NOT change baby_profile_service signatures.
+    final baby = await _guardBoot(
+      () => ref.read(babyProfileServiceProvider).getBaby(),
+    );
     if (baby == null) return '/onboarding/intro';
 
-    final onboardingDone = await ref
-        .read(babyProfileServiceProvider)
-        .onboardingCompleted;
+    final onboardingDone = await _guardBoot(
+      () => ref.read(babyProfileServiceProvider).onboardingCompleted,
+    );
     if (!onboardingDone) return '/onboarding/intro';
 
     // Seed local flags from Supabase so reinstalls don't re-trigger onboarding.
@@ -42,5 +60,15 @@ class SplashController extends _$SplashController {
     // }
 
     return '/home';
+  }
+
+  /// Runs a boot-critical remote read, rewrapping any throw as a
+  /// [SplashBootException] so the AsyncNotifier error state is discriminable.
+  Future<T> _guardBoot<T>(Future<T> Function() read) async {
+    try {
+      return await read();
+    } on Object catch (e) {
+      throw SplashBootException(e);
+    }
   }
 }

--- a/lib/src/features/splash/splash_controller.g.dart
+++ b/lib/src/features/splash/splash_controller.g.dart
@@ -6,7 +6,7 @@ part of 'splash_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$splashControllerHash() => r'593aac07d6a1127dfcb6257f0c442c9e2a92675f';
+String _$splashControllerHash() => r'd0eddc83e8f78378ccec338ae9b5e7617a129799';
 
 /// See also [SplashController].
 @ProviderFor(SplashController)

--- a/lib/src/features/splash/splash_screen.dart
+++ b/lib/src/features/splash/splash_screen.dart
@@ -5,6 +5,7 @@ import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/features/splash/splash_controller.dart';
 
 class SplashScreen extends ConsumerWidget {
@@ -12,6 +13,8 @@ class SplashScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // whenData fires only on the success (data) state — never on loading or
+    // error — so navigation runs once and never double-fires on a P0.
     ref.listen<AsyncValue<String>>(
       splashControllerProvider,
       (_, next) => next.whenData(context.go),
@@ -24,7 +27,7 @@ class SplashScreen extends ConsumerWidget {
       body: SafeArea(
         child: Center(
           child: state.hasError
-              ? _buildError(context, state.error)
+              ? _buildError(context, ref, isReloading: state.isLoading)
               : _buildBranding(context),
         ),
       ),
@@ -48,7 +51,17 @@ class SplashScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildError(BuildContext context, Object? error) {
+  /// P0 boot failure: full-screen maroon-accented message on cream + a primary
+  /// 'Try again' CTA that re-runs the whole boot (incl. session restore).
+  ///
+  /// While a retry is re-running the build (the previous error is carried over
+  /// during the brand-minimum delay), the CTA is disabled so rapid taps can't
+  /// keep restarting boot — guards against a tight retry loop when offline.
+  Widget _buildError(
+    BuildContext context,
+    WidgetRef ref, {
+    required bool isReloading,
+  }) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
       child: Column(
@@ -57,16 +70,24 @@ class SplashScreen extends ConsumerWidget {
           const Icon(
             Icons.error_outline_rounded,
             size: AppSizes.iconXl,
-            color: AppColors.error,
+            color: AppColors.destructive,
           ),
           const SizedBox(height: AppSizes.md),
           Text(
-            error?.toString() ??
-                'Something went wrong. Please restart the app.',
-            style: Theme.of(
-              context,
-            ).textTheme.bodyLarge?.copyWith(color: AppColors.error),
+            "We couldn't get things ready. Please check your connection "
+            'and try again.',
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: AppColors.destructive,
+            ),
             textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: AppSizes.xl),
+          AppPillButton(
+            label: 'Try again',
+            expand: false,
+            onPressed: isReloading
+                ? null
+                : () => ref.invalidate(splashControllerProvider),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- Makes a failed boot (getBaby/onboardingCompleted throws, e.g. no connectivity) a proper P0: full-screen error + working 'Try again' CTA instead of dead text.
- `SplashController.build` now wraps the two boot-critical remote reads in a defensive guard that rewraps any throw as a discriminable `SplashBootException`, so the AsyncNotifier goes to a clean error state instead of leaking a raw `AsyncError`. No `baby_profile_service` signatures changed.
- `splash_screen.dart` renders the P0 with `AppColors.destructive` (maroon) accent on `AppColors.cream` and a primary `AppPillButton` 'Try again' that re-runs the whole boot via `ref.invalidate(splashControllerProvider)`.
- The CTA is disabled while a retry is re-running (state still carries the previous error during the brand-minimum delay) so rapid taps can't restart boot in a tight loop when offline.
- Success-path redirect string, the `ref.listen(...whenData(context.go))` (fires only on data), and the 3s brand-minimum / session-settle delay are all unchanged. NIB-64 still owns the session-settle logic.

## Scope
- `lib/src/features/splash/splash_controller.dart`
- `lib/src/features/splash/splash_controller.g.dart` (regenerated)
- `lib/src/features/splash/splash_screen.dart`

## Acceptance criteria
- [x] Forcing getBaby()/onboardingCompleted to throw shows a full-screen error with 'Try again'.
- [x] Tapping 'Try again' re-runs boot (via `ref.invalidate`, re-runs the entire `build`) and proceeds on recovery.
- [x] No raw exception ever surfaces uncaught to the UI from splash (throws rewrapped as `SplashBootException` -> AsyncNotifier error state).
- [x] Success-path navigation behavior unchanged (`whenData(context.go)` fires only on the data state).

## Gate results
- `make gen`: clean, idempotent (second run produced 0 outputs; unrelated home_controller.g.dart drift reverted).
- `flutter analyze`: No issues found.
- `flutter test`: All 122 tests passed.