### PR TITLE
fix(splash): await deterministic session settle instead of blind 3s delay [NIB-64]

### DIFF
--- a/lib/src/features/splash/splash_controller.dart
+++ b/lib/src/features/splash/splash_controller.dart
@@ -20,46 +20,97 @@ class SplashBootException implements Exception {
 
 @riverpod
 class SplashController extends _$SplashController {
+  /// Minimum time the brand splash stays visible so launch never flickers,
+  /// regardless of how fast boot resolves.
+  static const _brandFloor = Duration(milliseconds: 1800);
+
+  /// Cap on how long we wait for Supabase to settle the restored session.
+  /// Past this, we proceed on whatever the current session truth is rather
+  /// than hanging the splash forever.
+  static const _sessionSettleTimeout = Duration(seconds: 4);
+
   @override
   Future<String> build() async {
-    await Future<void>.delayed(const Duration(seconds: 3));
+    // Start the brand floor at the top so it overlaps boot work; awaited in
+    // the finally below. Net effect is max(brandFloor, bootWork) on BOTH the
+    // success and the error path — keeping NIB-57's retry window intact.
+    final floorDone = Future<void>.delayed(_brandFloor);
+    try {
+      await _awaitSessionSettled();
 
-    final flags = ref.read(localFlagServiceProvider);
-    if (!flags.hasLaunched()) {
-      flags.setHasLaunched();
-      // On reinstall the session may be restored (iOS keychain persists).
-      // Fall through to the Supabase check so flags get backfilled.
+      final flags = ref.read(localFlagServiceProvider);
+      if (!flags.hasLaunched()) {
+        flags.setHasLaunched();
+        // On reinstall the session may be restored (iOS keychain persists).
+        // Fall through to the Supabase check so flags get backfilled.
+        final isLoggedIn = ref.read(authServiceProvider);
+        if (!isLoggedIn) return '/onboarding/intro';
+      }
+
       final isLoggedIn = ref.read(authServiceProvider);
-      if (!isLoggedIn) return '/onboarding/intro';
+      if (!isLoggedIn) return '/auth/login';
+
+      // Defensive: a failed remote read here (e.g. no connectivity) is a P0.
+      // Wrap it so the screen renders a full-screen retry rather than a raw
+      // AsyncError. Does NOT change baby_profile_service signatures.
+      final baby = await _guardBoot(
+        () => ref.read(babyProfileServiceProvider).getBaby(),
+      );
+      if (baby == null) return '/onboarding/intro';
+
+      final onboardingDone = await _guardBoot(
+        () => ref.read(babyProfileServiceProvider).onboardingCompleted,
+      );
+      if (!onboardingDone) return '/onboarding/intro';
+
+      // Seed local flags from Supabase so reinstalls don't re-trigger
+      // onboarding.
+      flags
+        ..setOnboardingReadinessDone()
+        ..setOnboardingBabySetupDone();
+
+      // TODO(nibbles-backend): uncomment when subscriptionServiceProvider ships
+      // if (!ref.read(subscriptionServiceProvider)) {
+      //   return '/subscription/paywall';
+      // }
+
+      return '/home';
+    } finally {
+      await floorDone;
     }
+  }
 
-    final isLoggedIn = ref.read(authServiceProvider);
-    if (!isLoggedIn) return '/auth/login';
+  /// Deterministically waits for Supabase to settle the restored session
+  /// instead of guessing with a blind delay.
+  ///
+  /// On cold start with a persisted session, [AuthService.isLoggedIn] can be
+  /// `false` at t=0 while Supabase asynchronously restores from the keychain.
+  /// Reading it too early routes a logged-in user to `/auth/login` — the race
+  /// this method kills.
+  ///
+  /// Fast path: if the session is already present, there is nothing to wait
+  /// for. Otherwise await the first auth-state emission (the `initialSession`
+  /// event = session-ready signal) with a timeout. A stalled restore resolves
+  /// via timeout — never a hang — and the caller re-reads the current truth
+  /// afterward, so a logged-out user is sent to `/auth/login` and a (rare)
+  /// late-arriving session is still honored.
+  ///
+  /// A timeout is NOT a boot failure: it is swallowed here so it never reaches
+  /// NIB-57's [_guardBoot] / P0 path. Genuine restore failures surface through
+  /// the guarded reads below.
+  Future<void> _awaitSessionSettled() async {
+    if (ref.read(authServiceProvider)) return;
 
-    // Defensive: a failed remote read here (e.g. no connectivity) is a P0.
-    // Wrap it so the screen renders a full-screen retry rather than a raw
-    // AsyncError. Does NOT change baby_profile_service signatures.
-    final baby = await _guardBoot(
-      () => ref.read(babyProfileServiceProvider).getBaby(),
-    );
-    if (baby == null) return '/onboarding/intro';
-
-    final onboardingDone = await _guardBoot(
-      () => ref.read(babyProfileServiceProvider).onboardingCompleted,
-    );
-    if (!onboardingDone) return '/onboarding/intro';
-
-    // Seed local flags from Supabase so reinstalls don't re-trigger onboarding.
-    flags
-      ..setOnboardingReadinessDone()
-      ..setOnboardingBabySetupDone();
-
-    // TODO(nibbles-backend): uncomment when subscriptionServiceProvider ships
-    // if (!ref.read(subscriptionServiceProvider)) {
-    //   return '/subscription/paywall';
-    // }
-
-    return '/home';
+    final authService = ref.read(authServiceProvider.notifier);
+    try {
+      // Any first emission is the settle signal; `initialSession(null)` lets a
+      // logged-out user proceed promptly without eating the full timeout.
+      await authService.authStateStream.first.timeout(_sessionSettleTimeout);
+    } on Object {
+      // Timeout or a stream error: stop waiting and fall through. The caller
+      // re-reads the current session truth, so this degrades to the
+      // not-logged-in fallback rather than hanging or escalating to a P0.
+    }
   }
 
   /// Runs a boot-critical remote read, rewrapping any throw as a

--- a/lib/src/features/splash/splash_controller.g.dart
+++ b/lib/src/features/splash/splash_controller.g.dart
@@ -6,7 +6,7 @@ part of 'splash_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$splashControllerHash() => r'd0eddc83e8f78378ccec338ae9b5e7617a129799';
+String _$splashControllerHash() => r'75108fb5ab484fe1c9307525240e824227cdb9b7';
 
 /// See also [SplashController].
 @ProviderFor(SplashController)

--- a/test/features/splash/splash_controller_test.dart
+++ b/test/features/splash/splash_controller_test.dart
@@ -1,0 +1,229 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/services/auth_service.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/splash/splash_controller.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+// ---------------------------------------------------------------------------
+// Mocks / fakes
+// ---------------------------------------------------------------------------
+
+class MockBabyProfileService extends Mock implements BabyProfileService {}
+
+class MockLocalFlagService extends Mock implements LocalFlagService {}
+
+/// Drives [AuthService] without touching Supabase: [build] returns a seeded
+/// logged-in value and [authStateStream] is fed by a controller the test owns,
+/// letting us emit (or withhold) the session-settle signal deterministically.
+class FakeAuthService extends AuthService {
+  FakeAuthService({
+    required bool initiallyLoggedIn,
+    required Stream<AuthState> stream,
+  }) : _initiallyLoggedIn = initiallyLoggedIn,
+       _stream = stream;
+
+  final bool _initiallyLoggedIn;
+  final Stream<AuthState> _stream;
+
+  @override
+  bool build() {
+    // Mirror the real AuthService: keep state in sync with auth events so a
+    // late session-restore signal flips isLoggedIn (the race this kills).
+    final sub = _stream.listen((s) => state = s.session != null);
+    ref.onDispose(sub.cancel);
+    return _initiallyLoggedIn;
+  }
+
+  @override
+  Stream<AuthState> get authStateStream => _stream;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+final _fakeBaby = Baby(
+  id: 'baby-001',
+  userId: 'user-001',
+  name: 'Lily',
+  dateOfBirth: DateTime(2025, 6),
+  gender: Gender.female,
+  onboardingCompleted: true,
+);
+
+AuthState _sessionEvent({required bool loggedIn}) => AuthState(
+  AuthChangeEvent.initialSession,
+  loggedIn ? _FakeSession() : null,
+);
+
+class _FakeSession extends Fake implements Session {}
+
+ProviderContainer _makeContainer({
+  required bool initiallyLoggedIn,
+  required Stream<AuthState> stream,
+  required MockBabyProfileService babyProfile,
+  required MockLocalFlagService flags,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      authServiceProvider.overrideWith(
+        () => FakeAuthService(
+          initiallyLoggedIn: initiallyLoggedIn,
+          stream: stream,
+        ),
+      ),
+      babyProfileServiceProvider.overrideWithValue(babyProfile),
+      localFlagServiceProvider.overrideWithValue(flags),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  late MockBabyProfileService babyProfile;
+  late MockLocalFlagService flags;
+
+  setUpAll(() => registerFallbackValue(_FakeSession()));
+
+  setUp(() {
+    babyProfile = MockBabyProfileService();
+    flags = MockLocalFlagService();
+    // Default: returning user who already finished onboarding.
+    when(flags.hasLaunched).thenReturn(true);
+    when(() => babyProfile.getBaby()).thenAnswer((_) async => _fakeBaby);
+    when(() => babyProfile.onboardingCompleted).thenAnswer((_) async => true);
+  });
+
+  test(
+    'persisted session at t=0 routes to /home and holds the brand floor',
+    () async {
+      // Stream never emits — proves the fast path skips the settle await, so
+      // the only thing gating resolution is the brand floor itself.
+      final container = _makeContainer(
+        initiallyLoggedIn: true,
+        stream: const Stream.empty(),
+        babyProfile: babyProfile,
+        flags: flags,
+      );
+
+      final sw = Stopwatch()..start();
+      final route = await container.read(splashControllerProvider.future);
+      sw.stop();
+
+      expect(route, '/home');
+      // Acceptance: splash shows for at least the brand-floor duration. Allow a
+      // small scheduler slack below the 1800ms floor.
+      expect(sw.elapsedMilliseconds, greaterThanOrEqualTo(1700));
+    },
+  );
+
+  test(
+    'session restores after t=0 (false then settle event) routes to /home',
+    () async {
+      // Broadcast mirrors gotrue's BehaviorSubject: both AuthService.build and
+      // the controller's `.first` can subscribe to the same stream.
+      final controller = StreamController<AuthState>.broadcast();
+      addTearDown(controller.close);
+      final container = _makeContainer(
+        initiallyLoggedIn: false,
+        stream: controller.stream,
+        babyProfile: babyProfile,
+        flags: flags,
+      );
+
+      // After the controller subscribes, the FakeAuthService updates its own
+      // state on the same event — emit a logged-in settle signal.
+      final future = container.read(splashControllerProvider.future);
+      await Future<void>.delayed(Duration.zero);
+      controller.add(_sessionEvent(loggedIn: true));
+
+      expect(await future, '/home');
+    },
+  );
+
+  test('no session: settle event with null session routes to /auth/login', () async {
+    final controller = StreamController<AuthState>.broadcast();
+    addTearDown(controller.close);
+    final container = _makeContainer(
+      initiallyLoggedIn: false,
+      stream: controller.stream,
+      babyProfile: babyProfile,
+      flags: flags,
+    );
+
+    final future = container.read(splashControllerProvider.future);
+    await Future<void>.delayed(Duration.zero);
+    controller.add(_sessionEvent(loggedIn: false));
+
+    expect(await future, '/auth/login');
+  });
+
+  test(
+    'stalled restore resolves via timeout to /auth/login, never hangs',
+    () async {
+      // A genuine stall: a broadcast stream that never emits AND never closes,
+      // so `.first` would hang forever and only `.timeout` can resolve it.
+      final controller = StreamController<AuthState>.broadcast();
+      addTearDown(controller.close);
+      final container = _makeContainer(
+        initiallyLoggedIn: false,
+        stream: controller.stream,
+        babyProfile: babyProfile,
+        flags: flags,
+      );
+
+      final route = await container.read(splashControllerProvider.future);
+
+      expect(route, '/auth/login');
+    },
+    // Resolution depends on the real ~4s settle timeout firing.
+    timeout: const Timeout(Duration(seconds: 15)),
+  );
+
+  test('first launch with no session routes to /onboarding/intro', () async {
+    when(flags.hasLaunched).thenReturn(false);
+    final controller = StreamController<AuthState>.broadcast();
+    addTearDown(controller.close);
+    final container = _makeContainer(
+      initiallyLoggedIn: false,
+      stream: controller.stream,
+      babyProfile: babyProfile,
+      flags: flags,
+    );
+
+    final future = container.read(splashControllerProvider.future);
+    await Future<void>.delayed(Duration.zero);
+    controller.add(_sessionEvent(loggedIn: false));
+
+    expect(await future, '/onboarding/intro');
+    verify(flags.setHasLaunched).called(1);
+  });
+
+  test(
+    'guarded baby read failure surfaces as SplashBootException (P0)',
+    () async {
+      when(
+        () => babyProfile.getBaby(),
+      ).thenThrow(Exception('no connectivity'));
+      final container = _makeContainer(
+        initiallyLoggedIn: true,
+        stream: const Stream.empty(),
+        babyProfile: babyProfile,
+        flags: flags,
+      );
+
+      await expectLater(
+        container.read(splashControllerProvider.future),
+        throwsA(isA<SplashBootException>()),
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the splash screen's blind 3s `Future.delayed` with a deterministic Supabase session-settle await, eliminating the cold-start race where a logged-in user with a persisted session was routed to `/auth/login` because `isLoggedIn` was read before Supabase finished restoring the keychain session.

## What changed

- Fast path: if a session is already present at t=0, skip the settle wait entirely.
- Otherwise await the first `authStateStream` emission (`initialSession` = session-ready signal) with a ~4s timeout. A timeout or stream error is swallowed and the controller re-reads the current session truth, so a real stall degrades to `/auth/login` rather than hanging or escalating to a P0.
- Brand floor (~1.8s) is started at the top of `build()` and awaited in `finally`, so the net wait is `max(brandFloor, bootWork)` on both the success and error paths.
- NIB-57's `_guardBoot` / `SplashBootException` P0 path and the reinstall flag-backfill are preserved verbatim. No changes to `auth_service.dart` (`authStateStream` was already public). Generated `home_controller.g.dart` base drift was reverted.
- Adds `test/features/splash/splash_controller_test.dart` (6 cases).

## Acceptance criteria

- [x] Cold start with a valid persisted session never routes to `/auth/login` (fast path + late-restore both route `/home`).
- [x] Splash shows for at least the brand-floor duration (Stopwatch assertion >= 1700ms).
- [x] A session-restore stall resolves via timeout (-> `/auth/login`), not a hang (broadcast stream that never emits/closes; only `.timeout` can resolve it).
- [x] No regression to NIB-57's P0 error/retry behavior (guarded baby read failure still surfaces `SplashBootException`) or the reinstall flag-backfill.

## Gate results

- `make gen`: clean; idempotent on a second run (no surprise diff).
- `flutter analyze`: No issues found.
- `flutter test`: all 128 tests pass (6 new splash controller tests included).