### PR TITLE
feat(splash): wire app-open + screen-view analytics, Crashlytics on boot failure [NIB-72]

### DIFF
--- a/lib/src/app/runner.dart
+++ b/lib/src/app/runner.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -53,6 +54,15 @@ Future<void> bootstrap({required Flavor flavor}) async {
 
   // 4. Firebase init (firebase options wired in NIB-3)
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+
+  // Route uncaught Flutter framework + platform errors to Crashlytics. Wired
+  // immediately after Firebase init so any subsequent boot crash is captured.
+  // No PII is recorded — only the framework error/stack.
+  FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
+  WidgetsBinding.instance.platformDispatcher.onError = (error, stack) {
+    FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+    return true;
+  };
 
   // 5. Supabase init
   await Supabase.initialize(

--- a/lib/src/features/splash/splash_controller.dart
+++ b/lib/src/features/splash/splash_controller.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'splash_controller.g.dart';
@@ -31,6 +35,10 @@ class SplashController extends _$SplashController {
 
   @override
   Future<String> build() async {
+    // Fire-and-forget app-open event. Guarded so an uninitialised Firebase or
+    // analytics hiccup never throws into — or blocks — boot/navigation.
+    unawaited(_logAppOpen());
+
     // Start the brand floor at the top so it overlaps boot work; awaited in
     // the finally below. Net effect is max(brandFloor, bootWork) on BOTH the
     // success and the error path — keeping NIB-57's retry window intact.
@@ -115,11 +123,48 @@ class SplashController extends _$SplashController {
 
   /// Runs a boot-critical remote read, rewrapping any throw as a
   /// [SplashBootException] so the AsyncNotifier error state is discriminable.
+  ///
+  /// The original error is recorded to Crashlytics (non-fatal, no PII) so the
+  /// P0 retry UI is backed by a background diagnostic record. The record is
+  /// fire-and-forget — it never blocks or alters the error path.
   Future<T> _guardBoot<T>(Future<T> Function() read) async {
     try {
       return await read();
-    } on Object catch (e) {
+    } on Object catch (e, st) {
+      unawaited(_recordBootFailure(e, st));
       throw SplashBootException(e);
+    }
+  }
+
+  /// Logs `app_open` via the existing [Analytics] wrapper. That wrapper (and
+  /// the `FirebaseAnalytics.instance` access inside it) can throw synchronously
+  /// when Firebase is uninitialised, so the whole body is guarded: the returned
+  /// future always completes normally and the `unawaited` caller never
+  /// escalates a stray analytics failure to the root error zone.
+  Future<void> _logAppOpen() async {
+    try {
+      await Analytics.instance.logAppOpen();
+    } on Object catch (_) {
+      // Analytics is best-effort; swallow so boot/navigation is never blocked.
+    }
+  }
+
+  /// Records a boot failure to Crashlytics as a non-fatal diagnostic. No PII is
+  /// passed: only the raw error/stack and a static reason string. Guarded so a
+  /// Crashlytics failure (e.g. uninitialised Firebase in tests) never escapes.
+  Future<void> _recordBootFailure(Object error, StackTrace stack) async {
+    try {
+      await FirebaseCrashlytics.instance.recordError(
+        error,
+        stack,
+        reason: 'splash_boot_failed',
+        // Explicit: this is a non-fatal diagnostic backing the P0 retry UI,
+        // distinct from the global fatal handler in runner.dart.
+        // ignore: avoid_redundant_argument_values
+        fatal: false,
+      );
+    } on Object catch (_) {
+      // Best-effort background record; never block or alter the P0 path.
     }
   }
 }

--- a/lib/src/features/splash/splash_controller.g.dart
+++ b/lib/src/features/splash/splash_controller.g.dart
@@ -6,7 +6,7 @@ part of 'splash_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$splashControllerHash() => r'75108fb5ab484fe1c9307525240e824227cdb9b7';
+String _$splashControllerHash() => r'959074011de7d5a0f7ac3145b47f4cc602ec0362';
 
 /// See also [SplashController].
 @ProviderFor(SplashController)

--- a/lib/src/features/splash/splash_screen.dart
+++ b/lib/src/features/splash/splash_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -7,12 +9,37 @@ import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/features/splash/splash_controller.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 
-class SplashScreen extends ConsumerWidget {
+class SplashScreen extends ConsumerStatefulWidget {
   const SplashScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends ConsumerState<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Emit screen_view('splash') once on the first frame. Guarded + unawaited
+    // so an uninitialised Firebase / analytics hiccup never throws into the
+    // frame callback or blocks the splash.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_logScreenView());
+    });
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await Analytics.instance.logScreenView(screenName: 'splash');
+    } on Object catch (_) {
+      // Analytics is best-effort; never surface to the UI.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     // whenData fires only on the success (data) state — never on loading or
     // error — so navigation runs once and never double-fires on a P0.
     ref.listen<AsyncValue<String>>(
@@ -27,7 +54,7 @@ class SplashScreen extends ConsumerWidget {
       body: SafeArea(
         child: Center(
           child: state.hasError
-              ? _buildError(context, ref, isReloading: state.isLoading)
+              ? _buildError(context, isReloading: state.isLoading)
               : _buildBranding(context),
         ),
       ),
@@ -58,8 +85,7 @@ class SplashScreen extends ConsumerWidget {
   /// during the brand-minimum delay), the CTA is disabled so rapid taps can't
   /// keep restarting boot — guards against a tight retry loop when offline.
   Widget _buildError(
-    BuildContext context,
-    WidgetRef ref, {
+    BuildContext context, {
     required bool isReloading,
   }) {
     return Padding(


### PR DESCRIPTION
## Summary

Instruments the splash boot with analytics + Crashlytics, reusing existing `Analytics` methods (no new event names) and the `FirebaseCrashlytics.recordError` precedent. All instrumentation is fire-and-forget (guarded + `unawaited`) so it never blocks navigation or throws. Preserves the NIB-57 `_guardBoot`/`SplashBootException` P0 path and the NIB-64 session-settle logic unchanged.

### Changes
- `splash_controller.dart`: `logAppOpen()` at the top of `build()`; `recordError(reason: 'splash_boot_failed', fatal: false)` in the `_guardBoot` catch before throwing `SplashBootException`. Both wrapped so a sync throw from `FirebaseAnalytics/Crashlytics.instance` (e.g. uninitialised Firebase) completes the future normally.
- `splash_screen.dart`: converted to `ConsumerStatefulWidget`; emits `logScreenView('splash')` once on first frame via `addPostFrameCallback`.
- `runner.dart`: added a global `FlutterError.onError` + `PlatformDispatcher.onError` -> Crashlytics handler immediately after `Firebase.initializeApp`, before Supabase init (strict bootstrap order preserved).

## Acceptance criteria
- [x] `app_open` + `screen_view('splash')` emitted on launch
- [x] Boot failure produces a Crashlytics record with reason `splash_boot_failed` and no PII
- [x] Analytics/Crashlytics failures never crash or block splash (guarded + unawaited)
- [x] No user id/email/baby name passed to analytics or Crashlytics from splash

## Gate results
- `make gen`: clean, idempotent (no unrelated generated drift; reverted base `home_controller.g.dart` drift)
- `flutter analyze`: No issues found
- `flutter test`: All 128 tests passed (incl. the P0 `SplashBootException` test exercising the new `recordError` path with Firebase uninitialised)