### PR TITLE
chore(splash): add redirect-matrix, P0 retry, analytics tests [NIB-88]

### DIFF
--- a/test/features/splash/splash_controller_test.dart
+++ b/test/features/splash/splash_controller_test.dart
@@ -226,4 +226,121 @@ void main() {
       );
     },
   );
+
+  // ---------------------------------------------------------------------------
+  // Redirect matrix gaps (NIB-88) — branches not covered by NIB-64 above.
+  // ---------------------------------------------------------------------------
+
+  test(
+    'logged in but no baby yet routes to /onboarding/intro',
+    () async {
+      // Returning, logged-in user whose remote profile has no baby row.
+      when(() => babyProfile.getBaby()).thenAnswer((_) async => null);
+      final container = _makeContainer(
+        initiallyLoggedIn: true,
+        stream: const Stream.empty(),
+        babyProfile: babyProfile,
+        flags: flags,
+      );
+
+      expect(
+        await container.read(splashControllerProvider.future),
+        '/onboarding/intro',
+      );
+      // Never reached the flag-seeding (onboarding not complete).
+      verifyNever(flags.setOnboardingReadinessDone);
+      verifyNever(flags.setOnboardingBabySetupDone);
+    },
+  );
+
+  test(
+    'baby exists but onboarding incomplete routes to /onboarding/intro',
+    () async {
+      when(
+        () => babyProfile.onboardingCompleted,
+      ).thenAnswer((_) async => false);
+      final container = _makeContainer(
+        initiallyLoggedIn: true,
+        stream: const Stream.empty(),
+        babyProfile: babyProfile,
+        flags: flags,
+      );
+
+      expect(
+        await container.read(splashControllerProvider.future),
+        '/onboarding/intro',
+      );
+      verifyNever(flags.setOnboardingReadinessDone);
+      verifyNever(flags.setOnboardingBabySetupDone);
+    },
+  );
+
+  test(
+    'all good (logged in, baby, onboarding done) routes to /home and '
+    'seeds onboarding flags',
+    () async {
+      final container = _makeContainer(
+        initiallyLoggedIn: true,
+        stream: const Stream.empty(),
+        babyProfile: babyProfile,
+        flags: flags,
+      );
+
+      expect(
+        await container.read(splashControllerProvider.future),
+        '/home',
+      );
+      // Supabase truth seeds local flags so reinstalls skip onboarding.
+      verify(flags.setOnboardingReadinessDone).called(1);
+      verify(flags.setOnboardingBabySetupDone).called(1);
+    },
+  );
+
+  test(
+    'reinstall: first launch but session restored -> backfills flags, /home',
+    () async {
+      // app_has_launched is false (fresh install) yet the keychain restored a
+      // logged-in session: boot must NOT short-circuit to intro. It marks the
+      // launch flag, falls through the Supabase checks, and seeds onboarding
+      // flags so the reinstalled user lands on /home.
+      when(flags.hasLaunched).thenReturn(false);
+      final container = _makeContainer(
+        initiallyLoggedIn: true,
+        stream: const Stream.empty(),
+        babyProfile: babyProfile,
+        flags: flags,
+      );
+
+      expect(
+        await container.read(splashControllerProvider.future),
+        '/home',
+      );
+      verify(flags.setHasLaunched).called(1);
+      verify(flags.setOnboardingReadinessDone).called(1);
+      verify(flags.setOnboardingBabySetupDone).called(1);
+    },
+  );
+
+  test(
+    'guarded onboardingCompleted read failure surfaces as '
+    'SplashBootException (P0)',
+    () async {
+      // Second guarded read (after getBaby) throwing must also be rewrapped,
+      // not leaked as a raw error.
+      when(
+        () => babyProfile.onboardingCompleted,
+      ).thenThrow(Exception('no connectivity'));
+      final container = _makeContainer(
+        initiallyLoggedIn: true,
+        stream: const Stream.empty(),
+        babyProfile: babyProfile,
+        flags: flags,
+      );
+
+      await expectLater(
+        container.read(splashControllerProvider.future),
+        throwsA(isA<SplashBootException>()),
+      );
+    },
+  );
 }

--- a/test/features/splash/splash_screen_test.dart
+++ b/test/features/splash/splash_screen_test.dart
@@ -1,0 +1,248 @@
+// The Firebase platform-interface packages are transitive deps of
+// firebase_analytics / firebase_core; the public barrels don't re-export
+// FirebaseAnalyticsPlatform or setupFirebaseCoreMocks, so this test imports
+// them directly (test-only).
+// ignore_for_file: depend_on_referenced_packages
+
+// Widget tests for SplashScreen (NIB-88).
+//
+// Covers:
+//   - P0 boot failure renders the full-screen 'Try again' retry UI.
+//   - Tapping retry invalidates the controller and re-runs boot; navigation
+//     fires ONLY on the success state (never on loading/error) and never
+//     infinite-loops.
+//   - Analytics: a fake FirebaseAnalytics platform proves logAppOpen (boot) and
+//     logScreenView('splash') (first frame) are emitted. Analytics has no DI
+//     seam, so we record at the platform layer instead of mutating prod code.
+
+import 'package:firebase_analytics_platform_interface/firebase_analytics_platform_interface.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/services/auth_service.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/splash/splash_screen.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+// ---------------------------------------------------------------------------
+// Mocks / fakes
+// ---------------------------------------------------------------------------
+
+class MockBabyProfileService extends Mock implements BabyProfileService {}
+
+class MockLocalFlagService extends Mock implements LocalFlagService {}
+
+/// Always-logged-in [AuthService] with an empty auth stream: the controller's
+/// session-settle fast path returns immediately, so boot resolution is gated
+/// only by the (real) brand floor we pump past in the tests.
+class FakeAuthService extends AuthService {
+  @override
+  bool build() => true;
+
+  @override
+  Stream<AuthState> get authStateStream => const Stream.empty();
+}
+
+/// Records platform-level analytics calls. [FirebaseAnalyticsPlatform] is meant
+/// to be extended (default impls fill the unimplemented methods), so we only
+/// override the delegate hook + logEvent.
+class RecordingAnalyticsPlatform extends FirebaseAnalyticsPlatform {
+  RecordingAnalyticsPlatform() : super();
+
+  final loggedEvents = <Map<String, Object?>>[];
+
+  @override
+  FirebaseAnalyticsPlatform delegateFor({
+    required FirebaseApp app,
+    Map<String, dynamic>? webOptions,
+  }) => this;
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    Map<String, Object?>? parameters,
+    AnalyticsCallOptions? callOptions,
+  }) async {
+    loggedEvents.add({'name': name, 'parameters': parameters});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+final _fakeBaby = Baby(
+  id: 'baby-001',
+  userId: 'user-001',
+  name: 'Lily',
+  dateOfBirth: DateTime(2025, 6),
+  gender: Gender.female,
+  onboardingCompleted: true,
+);
+
+/// Marker widget for the success destination so we can assert navigation fired.
+class _HomeStub extends StatelessWidget {
+  const _HomeStub();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: Text('HOME_STUB')));
+}
+
+GoRouter _makeRouter() => GoRouter(
+  initialLocation: '/',
+  routes: [
+    GoRoute(path: '/', builder: (_, __) => const SplashScreen()),
+    GoRoute(path: '/home', builder: (_, __) => const _HomeStub()),
+    GoRoute(
+      path: '/auth/login',
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text('LOGIN_STUB'))),
+    ),
+    GoRoute(
+      path: '/onboarding/intro',
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text('INTRO_STUB'))),
+    ),
+  ],
+);
+
+Widget _buildSut({
+  required MockBabyProfileService babyProfile,
+  required MockLocalFlagService flags,
+  required GoRouter router,
+}) => ProviderScope(
+  overrides: [
+    authServiceProvider.overrideWith(FakeAuthService.new),
+    babyProfileServiceProvider.overrideWithValue(babyProfile),
+    localFlagServiceProvider.overrideWithValue(flags),
+  ],
+  child: MaterialApp.router(routerConfig: router),
+);
+
+void main() {
+  // Boot Firebase against the core mock so the lazily-built Analytics singleton
+  // (Analytics.instance -> FirebaseAnalytics.instance -> Firebase.app()) does
+  // not throw, and route its delegate to a recorder we can assert on.
+  //
+  // FirebaseAnalytics caches its delegate per app instance, so the platform
+  // instance is fixed on first use. Install ONE recorder before any access and
+  // clear it per test, rather than swapping instances each setUp.
+  final analytics = RecordingAnalyticsPlatform();
+
+  setUpAll(() async {
+    setupFirebaseCoreMocks();
+    await Firebase.initializeApp();
+    FirebaseAnalyticsPlatform.instance = analytics;
+  });
+
+  late MockBabyProfileService babyProfile;
+  late MockLocalFlagService flags;
+
+  setUp(() {
+    analytics.loggedEvents.clear();
+
+    babyProfile = MockBabyProfileService();
+    flags = MockLocalFlagService();
+    // Default: returning user, already onboarded -> success path -> /home.
+    when(flags.hasLaunched).thenReturn(true);
+    when(() => babyProfile.getBaby()).thenAnswer((_) async => _fakeBaby);
+    when(() => babyProfile.onboardingCompleted).thenAnswer((_) async => true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // P0 error + retry
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'P0 boot failure renders the Try again retry UI (no navigation)',
+    (tester) async {
+      when(
+        () => babyProfile.getBaby(),
+      ).thenThrow(Exception('no connectivity'));
+      final router = _makeRouter();
+
+      await tester.pumpWidget(
+        _buildSut(babyProfile: babyProfile, flags: flags, router: router),
+      );
+      // Pump past the brand floor (~1800ms) so boot resolves to the error.
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
+
+      expect(find.text('Try again'), findsOneWidget);
+      // navigation must NOT fire on the error state.
+      expect(find.text('HOME_STUB'), findsNothing);
+      expect(router.routerDelegate.currentConfiguration.uri.path, '/');
+    },
+  );
+
+  testWidgets(
+    'tapping Try again re-runs boot; navigates to /home only on success',
+    (tester) async {
+      // First boot fails, retry succeeds: getBaby throws once, then resolves.
+      var attempts = 0;
+      when(() => babyProfile.getBaby()).thenAnswer((_) async {
+        attempts++;
+        if (attempts == 1) throw Exception('no connectivity');
+        return _fakeBaby;
+      });
+      final router = _makeRouter();
+
+      await tester.pumpWidget(
+        _buildSut(babyProfile: babyProfile, flags: flags, router: router),
+      );
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pump();
+
+      // Error state surfaced, no navigation yet.
+      expect(find.text('Try again'), findsOneWidget);
+      expect(find.text('HOME_STUB'), findsNothing);
+
+      // Retry: invalidates the provider and re-runs the whole boot.
+      await tester.tap(find.text('Try again'));
+      await tester.pump(); // schedule the rebuild
+      await tester.pump(const Duration(seconds: 2)); // past brand floor again
+      await tester.pumpAndSettle();
+
+      // Navigation fired exactly on the success state.
+      expect(find.text('HOME_STUB'), findsOneWidget);
+      expect(find.text('Try again'), findsNothing);
+      // Bounded retry: boot ran twice (initial + one retry), not a loop.
+      expect(attempts, 2);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Analytics
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'emits app_open (boot) and screen_view(splash) (first frame)',
+    (tester) async {
+      final router = _makeRouter();
+
+      await tester.pumpWidget(
+        _buildSut(babyProfile: babyProfile, flags: flags, router: router),
+      );
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+
+      final names = analytics.loggedEvents.map((e) => e['name']).toList();
+      expect(names, contains('app_open'));
+      expect(names, contains('screen_view'));
+
+      final screenView = analytics.loggedEvents.firstWhere(
+        (e) => e['name'] == 'screen_view',
+      );
+      final params = screenView['parameters'] as Map<String, Object?>?;
+      expect(params?['screen_name'], 'splash');
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Extend `splash_controller_test.dart` with the redirect branches NIB-64 left uncovered: logged-in but no baby, baby present but onboarding incomplete, all-good to `/home` (asserts `setOnboardingReadinessDone` + `setOnboardingBabySetupDone` seeding), reinstall flag-backfill (first launch + restored session), and a second guarded-read (`onboardingCompleted`) throw surfacing as `SplashBootException`.
- Add `splash_screen_test.dart` widget coverage: P0 boot failure renders the full-screen 'Try again' retry UI with no navigation; tapping retry invalidates the controller and re-runs boot bounded (no infinite loop), with navigation firing only on the success state.
- Analytics asserted via a recording `FirebaseAnalyticsPlatform` (booted against the firebase_core mock, no production DI seam touched): `app_open` (boot) and `screen_view` with `screen_name=splash` (first frame).

Scope: test files under `test/features/splash/` only. No production code changed.

## Acceptance criteria
- [x] All redirect branches covered and green
- [x] P0 error -> retry path tested (widget level)
- [x] Session-restore race test passes (no false `/auth/login`) — retained from NIB-64
- [x] Analytics calls asserted (`logAppOpen` + `logScreenView('splash')`)
- [x] Retry does not infinite-loop; navigation fires only on success
- [x] Zero lint warnings; all tests pass

## Gate results
- `make gen`: succeeded, 271 outputs (unrelated base-drift `home_controller.g.dart` reverted; PR contains only the two splash test files)
- `flutter analyze`: No issues found
- `flutter test`: 136 passed (splash suite: 14 — 11 controller + 3 widget)