### PR TITLE
refactor(auth): drop name from signUp pipeline [NIB-122]

### DIFF
--- a/lib/src/common/data/repositories/auth_repository.dart
+++ b/lib/src/common/data/repositories/auth_repository.dart
@@ -7,7 +7,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 part 'auth_repository.g.dart';
 
 abstract interface class AuthRepository {
-  Future<Result<void>> signUp(String name, String email, String password);
+  Future<Result<void>> signUp(String email, String password);
   Future<Result<void>> signIn(String email, String password);
   Future<Result<void>> signOut();
   Future<Result<void>> resetPassword(String email);
@@ -29,16 +29,11 @@ class AuthRepositoryImpl implements AuthRepository {
   Stream<AuthState> get authStateStream => _supabase.auth.onAuthStateChange;
 
   @override
-  Future<Result<void>> signUp(
-    String name,
-    String email,
-    String password,
-  ) async {
+  Future<Result<void>> signUp(String email, String password) async {
     try {
       final response = await _supabase.auth.signUp(
         email: email,
         password: password,
-        data: {'full_name': name},
       );
       if (response.session == null) {
         return const Result.failure(

--- a/lib/src/common/services/auth_service.dart
+++ b/lib/src/common/services/auth_service.dart
@@ -31,12 +31,8 @@ class AuthService extends _$AuthService {
 
   Stream<AuthState> get authStateStream => _repo.authStateStream;
 
-  Future<Result<void>> signUp(
-    String name,
-    String email,
-    String password,
-  ) async {
-    final result = await _repo.signUp(name, email, password);
+  Future<Result<void>> signUp(String email, String password) async {
+    final result = await _repo.signUp(email, password);
     if (result.isSuccess) state = true;
     return result;
   }

--- a/lib/src/common/services/auth_service.g.dart
+++ b/lib/src/common/services/auth_service.g.dart
@@ -6,7 +6,7 @@ part of 'auth_service.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$authServiceHash() => r'e2d913d8b719f93c6aafec93fd24fddc836443ec';
+String _$authServiceHash() => r'a2cfc8026564fcdb1daab0c8c068731b48f0a973';
 
 /// See also [AuthService].
 @ProviderFor(AuthService)

--- a/lib/src/features/auth/register/register_controller.dart
+++ b/lib/src/features/auth/register/register_controller.dart
@@ -31,7 +31,7 @@ class RegisterController extends _$RegisterController {
 
     final result = await ref
         .read(authServiceProvider.notifier)
-        .signUp(state.name, state.email.value, state.password.value);
+        .signUp(state.email.value, state.password.value);
 
     return result.when(
       success: (_) {

--- a/lib/src/features/auth/register/register_controller.g.dart
+++ b/lib/src/features/auth/register/register_controller.g.dart
@@ -7,7 +7,7 @@ part of 'register_controller.dart';
 // **************************************************************************
 
 String _$registerControllerHash() =>
-    r'6080f4e23efcbffa7a58eff6ac6737fcbd4901d3';
+    r'2501a0ef86759484ac9ce86ce11ff8e55aea64a5';
 
 /// See also [RegisterController].
 @ProviderFor(RegisterController)

--- a/lib/src/features/auth/register/register_state.dart
+++ b/lib/src/features/auth/register/register_state.dart
@@ -16,5 +16,5 @@ class RegisterState with _$RegisterState {
 
   const RegisterState._();
 
-  bool get isValid => name.isNotEmpty && email.isValid && password.isValid;
+  bool get isValid => email.isValid && password.isValid;
 }

--- a/test/common/services/auth_service_test.dart
+++ b/test/common/services/auth_service_test.dart
@@ -41,14 +41,10 @@ void main() {
   group('AuthService.signUp', () {
     test('returns Result.success on success', () async {
       when(
-        () => mockRepo.signUp(any(), any(), any()),
+        () => mockRepo.signUp(any(), any()),
       ).thenAnswer((_) async => const Result.success(null));
 
-      final result = await sut.signUp(
-        'Alice',
-        'alice@example.com',
-        'password123',
-      );
+      final result = await sut.signUp('alice@example.com', 'password123');
 
       expect(result.isSuccess, isTrue);
     });
@@ -56,16 +52,12 @@ void main() {
     test(
       'returns Result.failure with error message on duplicate email',
       () async {
-        when(() => mockRepo.signUp(any(), any(), any())).thenAnswer(
+        when(() => mockRepo.signUp(any(), any())).thenAnswer(
           (_) async =>
               const Result.failure(ServerException('Email already in use.')),
         );
 
-        final result = await sut.signUp(
-          'Alice',
-          'alice@example.com',
-          'password123',
-        );
+        final result = await sut.signUp('alice@example.com', 'password123');
 
         expect(result.isFailure, isTrue);
         expect(result.errorOrNull!.message, 'Email already in use.');


### PR DESCRIPTION
## Summary
Aligns the signUp data pipeline with the redesigned Signup screen (NIB-120 confirmed name dropped). The `name` parameter is removed from `AuthRepository.signUp` and `AuthService.signUp`, and the Supabase `raw_user_meta_data: {full_name}` write is dropped. No table/column/migration changes.

## Changes
- `auth_repository.dart`: `signUp(email, password)` — no name param, no `data: {full_name: ...}` write.
- `auth_service.dart`: `signUp(email, password)` — matches repo signature.
- `register_controller.dart`: `submit()` now calls `signUp(email, password)`.
- `register_state.dart`: `isValid = email.isValid && password.isValid` (drops `name.isNotEmpty`).
- `auth_service_test.dart`: two-arg `signUp` stubs and calls.

## Scope deviation (deliberate)
`register_state.name` and `updateName` are retained because `register_screen.dart` still wires `controller.updateName` (the Signup reskin NIB-112 owns the UI field removal). Removing them now would break compile/analyze, violating the AC. The name no longer flows into the auth pipeline — it's just a state field with no downstream effect.

## Acceptance criteria
- [x] signUp compiles + works with no name field.
- [x] No downstream null-crash from missing full_name (no readers exist in `lib/`).
- [x] Repo still returns `Result<void>`; no DTO leaks above the repo.
- [x] Tests updated and green.
- [x] `flutter analyze` zero warnings.

## Gate results
- `make gen` clean (idempotent: second run = 0 actions, no diff).
- `flutter analyze` — No issues found.
- `flutter test` — 136 passed.