### PR TITLE
refactor(auth): restyle reset-password screen to new DS [NIB-115]

### DIFF
--- a/lib/src/features/auth/reset_password/reset_password_screen.dart
+++ b/lib/src/features/auth/reset_password/reset_password_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/inputs/app_text_field.dart';
 import 'package:nibbles/src/features/auth/reset_password/reset_password_controller.dart';
 import 'package:nibbles/src/features/auth/reset_password/reset_password_state.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
@@ -24,12 +26,17 @@ class ResetPasswordScreen extends ConsumerWidget {
       }
     });
 
+    final controller = ref.read(resetPasswordControllerProvider.notifier);
+
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
         backgroundColor: AppColors.background,
         elevation: 0,
-        title: const Text('Set New Password'),
+        title: Text(
+          'Set New Password',
+          style: textTheme.titleMedium?.copyWith(color: AppColors.fgStrong),
+        ),
       ),
       body: SafeArea(
         child: Padding(
@@ -40,42 +47,41 @@ class ResetPasswordScreen extends ConsumerWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const SizedBox(height: AppSizes.xxl),
-              Text('Create a new password', style: textTheme.headlineLarge),
+              Text(
+                'Create a new password',
+                style: textTheme.headlineLarge?.copyWith(
+                  color: AppColors.fgStrong,
+                ),
+              ),
               const SizedBox(height: AppSizes.sm),
               Text(
                 'Your new password must be at least 8 characters.',
-                style: textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
+                style: textTheme.bodyLarge?.copyWith(color: AppColors.fgMuted),
               ),
               const SizedBox(height: AppSizes.xl),
-              TextField(
+              AppTextField(
                 key: const Key('reset_password_new_field'),
-                onChanged: ref
-                    .read(resetPasswordControllerProvider.notifier)
-                    .updatePassword,
+                label: 'New password',
+                hintText: 'Enter new password',
                 obscureText: true,
-                decoration: InputDecoration(
-                  labelText: 'New password',
-                  errorText:
-                      state.password.isNotValid &&
-                          state.password.value.isNotEmpty
-                      ? 'Password must be at least 8 characters.'
-                      : null,
-                ),
+                onChanged: controller.updatePassword,
+                errorText:
+                    state.password.isNotValid &&
+                        state.password.value.isNotEmpty
+                    ? 'Password must be at least 8 characters.'
+                    : null,
               ),
               const SizedBox(height: AppSizes.md),
-              TextField(
+              AppTextField(
                 key: const Key('reset_password_confirm_field'),
-                onChanged: ref
-                    .read(resetPasswordControllerProvider.notifier)
-                    .updateConfirmPassword,
+                label: 'Confirm password',
+                hintText: 'Re-enter new password',
                 obscureText: true,
-                decoration: InputDecoration(
-                  labelText: 'Confirm password',
-                  errorText:
-                      state.confirmPassword.isNotEmpty && !state.passwordsMatch
-                      ? 'Passwords do not match.'
-                      : null,
-                ),
+                onChanged: controller.updateConfirmPassword,
+                errorText:
+                    state.confirmPassword.isNotEmpty && !state.passwordsMatch
+                    ? 'Passwords do not match.'
+                    : null,
               ),
               if (state.errorMessage != null) ...[
                 const SizedBox(height: AppSizes.sm),
@@ -85,28 +91,20 @@ class ResetPasswordScreen extends ConsumerWidget {
                 ),
               ],
               const SizedBox(height: AppSizes.xl),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton(
-                  key: const Key('reset_password_submit_button'),
-                  onPressed: state.isLoading
-                      ? null
-                      : () {
-                          ref
-                              .read(resetPasswordControllerProvider.notifier)
-                              .submit();
-                        },
-                  child: state.isLoading
-                      ? const SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: AppColors.onPrimary,
-                          ),
-                        )
-                      : const Text('Confirm'),
-                ),
+              AppPillButton(
+                key: const Key('reset_password_submit_button'),
+                label: 'Confirm',
+                onPressed: state.isLoading ? null : controller.submit,
+                leading: state.isLoading
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: AppColors.cream,
+                        ),
+                      )
+                    : null,
               ),
             ],
           ),


### PR DESCRIPTION
## Summary

Restyles AU-03 reset-password screen to the new design system. No behavioral changes.

- Swaps theme references to the new sage/butter/coral DS tokens (`fgStrong`, `fgMuted`, `cream`).
- Replaces both password `TextField`s with `AppTextField` (filled inputs, sage focus shadow, inline error state).
- Replaces the `FilledButton` with `AppPillButton` (primary/sage). `isLoading` still disables the button (greys to `borderMuted`) and now renders the spinner via `leading` to preserve the loading affordance.
- Keeps the `updatePassword` flow, success snackbar, and login redirect untouched.
- Keeps inline P1 error and confirm-mismatch error.
- Widget keys preserved: `reset_password_new_field`, `reset_password_confirm_field`, `reset_password_submit_button`.

## Notes

- `AppTextField` does not currently expose a visibility-toggle affordance. Adding one would require modifying the shared component (out of scope per orchestrator note: "Scope: lib/src/features/auth/reset_password/reset_password_screen.dart only"). Both fields remain `obscureText: true`; a visibility-toggle slot on `AppTextField` should be a separate DS ticket.

## Acceptance criteria

- [x] Visually consistent with the new DS (sage tokens, AppTextField, AppPillButton primary).
- [x] No behavioral change to the AU-03 flow (controller, snackbar, redirect, keys, error states unchanged).
- [x] Zero analyzer warnings.

## Gate results

- `make gen` — clean, idempotent (0 outputs on second run).
- `flutter analyze` — No issues found.
- `flutter test` — All tests passed.