### PR TITLE
chore(infra): social-login deps, iOS OAuth scaffolding, BrandLogo widget [NIB-117]

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		510E5F47C112C1D852325BF1 /* Pods-Runner.debug-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-prod.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-prod.xcconfig"; sourceTree = "<group>"; };
 		5BEF8388A933BF3F6D148688 /* Pods-RunnerTests.release-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release-prod.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release-prod.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
+		74858FB01ED2DC5600515811 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		8FF7D970532DAC0231227F52 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -157,6 +158,7 @@
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+				74858FB01ED2DC5600515811 /* Runner.entitlements */,
 			);
 			path = Runner;
 			sourceTree = "<group>";
@@ -541,6 +543,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 32T8HNVYGX;
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -724,6 +727,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 32T8HNVYGX;
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -747,6 +751,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 32T8HNVYGX;
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -769,6 +774,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 32T8HNVYGX;
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -792,6 +798,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 32T8HNVYGX;
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -814,6 +821,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 32T8HNVYGX;
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -836,6 +844,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 32T8HNVYGX;
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -859,6 +868,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 32T8HNVYGX;
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -881,6 +891,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = 32T8HNVYGX;
 				ENABLE_BITCODE = NO;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -52,6 +52,19 @@
 				<string>com.aydev.nibbles.dev</string>
 			</array>
 		</dict>
+		<!-- Google OAuth callback (NIB-117). The scheme is the REVERSED Google OAuth
+		     iOS client ID from GCP, e.g. com.googleusercontent.apps.123456789-abcdef.
+		     TODO: replace REPLACE_WITH_REVERSED_GOOGLE_OAUTH_CLIENT_ID with the real
+		     reversed client ID from the GCP OAuth 2.0 iOS client (dev + prod share
+		     one entry; if dev and prod use separate GCP clients, add a second dict). -->
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>REPLACE_WITH_REVERSED_GOOGLE_OAUTH_CLIENT_ID</string>
+			</array>
+		</dict>
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>Nibbles uses your camera to take photos of allergen exposures.</string>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- NIB-117: Sign in with Apple capability.
+	     The Apple Developer account associated with this app's bundle ids
+	     (com.aydev.nibbles + com.aydev.nibbles.dev) MUST have the
+	     "Sign in with Apple" capability enabled on its App ID for this
+	     entitlement to be honored at signing time. -->
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/lib/src/common/components/brand/brand_logo.dart
+++ b/lib/src/common/components/brand/brand_logo.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+
+/// Horizontal lockup of the [Quatrefoil] mark + `nibbles` Parkinsans wordmark.
+///
+/// Mirrors `design/preview/brand-logo.html`: 96 mark + 44/1 800 Parkinsans
+/// wordmark in greenDeep, separated by ~33% of the mark width. `size` scales
+/// the entire lockup proportionally (mark + wordmark + gap) so the visual
+/// rhythm of the kit is preserved at any size.
+class BrandLogo extends StatelessWidget {
+  const BrandLogo({this.size = 120, super.key});
+
+  /// Width/height of the quatrefoil mark in logical pixels. Wordmark and gap
+  /// scale proportionally relative to the kit's 96 reference.
+  final double size;
+
+  // Kit reference dimensions (design/preview/brand-logo.html).
+  static const double _refMark = 96;
+  static const double _refWordFontSize = 44;
+  static const double _refGap = 32;
+
+  @override
+  Widget build(BuildContext context) {
+    final scale = size / _refMark;
+    final wordSize = _refWordFontSize * scale;
+    final gap = _refGap * scale;
+
+    final wordmark = AppTypography.brandWordmark.copyWith(
+      fontSize: wordSize,
+      // brandWordmark letterSpacing is logical px tuned to 42; rescale to the
+      // -0.02em ratio used in the kit at the new font size.
+      letterSpacing: wordSize * -0.02,
+      color: AppColors.greenDeep,
+    );
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Quatrefoil(size: size),
+        SizedBox(width: gap),
+        Text('nibbles', style: wordmark),
+      ],
+    );
+  }
+}

--- a/lib/src/common/components/components.dart
+++ b/lib/src/common/components/components.dart
@@ -2,6 +2,7 @@
 /// every redesigned feature. See NIB-49.
 library;
 
+export 'brand/brand_logo.dart';
 export 'brand/quatrefoil.dart';
 export 'buttons/app_pill_button.dart';
 export 'buttons/app_round_button.dart';

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,10 +11,12 @@ import firebase_analytics
 import firebase_core
 import firebase_crashlytics
 import flutter_local_notifications
+import google_sign_in_ios
 import package_info_plus
 import purchases_flutter
 import share_plus
 import shared_preferences_foundation
+import sign_in_with_apple
 import sqflite_darwin
 import url_launcher_macos
 
@@ -25,10 +27,12 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PurchasesFlutterPlugin.register(with: registry.registrar(forPlugin: "PurchasesFlutterPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -775,6 +775,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.3.3"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
+  google_sign_in:
+    dependency: "direct main"
+    description:
+      name: google_sign_in
+      sha256: "521031b65853b4409b8213c0387d57edaad7e2a949ce6dea0d8b2afc9cb29763"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
+  google_sign_in_android:
+    dependency: transitive
+    description:
+      name: google_sign_in_android
+      sha256: df5c15533814ed20b7d9e1c5a40a73f174e5d5017bd2669b1c72fb6596fde812
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.11"
+  google_sign_in_ios:
+    dependency: transitive
+    description:
+      name: google_sign_in_ios
+      sha256: ac1e4c1205267cb7999d1d81333fccffdfda29e853f434bbaf71525498bb6950
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  google_sign_in_platform_interface:
+    dependency: transitive
+    description:
+      name: google_sign_in_platform_interface
+      sha256: "7f59208c42b415a3cca203571128d6f84f885fead2d5b53eb65a9e27f2965bb5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  google_sign_in_web:
+    dependency: transitive
+    description:
+      name: google_sign_in_web
+      sha256: d473003eeca892f96a01a64fc803378be765071cb0c265ee872c7f8683245d14
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   gotrue:
     dependency: transitive
     description:
@@ -1553,6 +1601,30 @@ packages:
     description:
       name: shelf_web_socket
       sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  sign_in_with_apple:
+    dependency: "direct main"
+    description:
+      name: sign_in_with_apple
+      sha256: "8bd875c8e8748272749eb6d25b896f768e7e9d60988446d543fe85a37a2392b8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
+  sign_in_with_apple_platform_interface:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple_platform_interface
+      sha256: "981bca52cf3bb9c3ad7ef44aace2d543e5c468bb713fd8dda4275ff76dfa6659"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  sign_in_with_apple_web:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple_web
+      sha256: f316400827f52cafcf50d00e1a2e8a0abc534ca1264e856a81c5f06bd5b10fed
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   freezed_annotation: ^2.4.0
   go_router: ^14.6.3
   google_fonts: ^6.2.1
+  google_sign_in: ^7.2.0
   hive_flutter: ^1.1.0
   image_picker: ^1.1.2
   json_annotation: ^4.9.0
@@ -36,6 +37,7 @@ dependencies:
   purchases_flutter: ^7.0.0
   retrofit: ^4.4.2
   riverpod_annotation: ^2.6.0
+  sign_in_with_apple: ^7.0.1
   supabase_flutter: ^2.0.0
   table_calendar: ^3.1.3
 

--- a/test/common/components/brand/brand_logo_test.dart
+++ b/test/common/components/brand/brand_logo_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/components/brand/brand_logo.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+
+void main() {
+  group('BrandLogo (NIB-117)', () {
+    testWidgets('renders default lockup: Quatrefoil + nibbles wordmark',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: BrandLogo()),
+        ),
+      );
+
+      expect(find.byType(BrandLogo), findsOneWidget);
+      expect(find.byType(Quatrefoil), findsOneWidget);
+      expect(find.text('nibbles'), findsOneWidget);
+    });
+
+    testWidgets('honors size param on the mark', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: BrandLogo(size: 48)),
+        ),
+      );
+
+      final quatrefoil = tester.widget<Quatrefoil>(find.byType(Quatrefoil));
+      expect(quatrefoil.size, 48);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
NIB-117 code parts: add `google_sign_in` + `sign_in_with_apple` to pubspec, scaffold the iOS Info.plist + entitlements for the eventual social login flow, and ship a reusable `BrandLogo` widget (Quatrefoil mark + Parkinsans wordmark). NIB-116 will import the SDKs in `auth_repository`; nothing imports them in Dart yet, so no lint regressions.

## Files
- `pubspec.yaml` + `pubspec.lock` — `google_sign_in: ^7.2.0`, `sign_in_with_apple: ^7.0.1`.
- `ios/Runner/Info.plist` — placeholder `CFBundleURLTypes` entry `REPLACE_WITH_REVERSED_GOOGLE_OAUTH_CLIENT_ID` with a TODO comment.
- `ios/Runner/Runner.entitlements` (new) — `com.apple.developer.applesignin = [Default]` with a comment noting the App ID must have the capability enabled.
- `ios/Runner.xcodeproj/project.pbxproj` — added entitlements file reference + group entry + `CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements` on all 9 Runner build configurations.
- `lib/src/common/components/brand/brand_logo.dart` (new) — horizontal `Quatrefoil` + `AppTypography.brandWordmark` lockup, sizable; default size 120, proportions match `design/preview/brand-logo.html`.
- `lib/src/common/components/components.dart` — exports `brand_logo.dart`.
- `test/common/components/brand/brand_logo_test.dart` (new) — renders at default size, honors custom size.
- `macos/Flutter/GeneratedPluginRegistrant.swift` — auto-registered by Flutter after `pub get`.

## Parkinsans verification
`Parkinsans` is registered in `pubspec.yaml` (font family with 6 weights from `assets/fonts/`), exposed via `lib/gen/fonts.gen.dart` (`FontFamily.parkinsans`), and consumed by `AppTypography.brandWordmark` already added by NIB-50. No change needed.

## Acceptance criteria
- [x] `flutter pub get` succeeds with the two new deps.
- [x] `flutter analyze` — `No issues found! (ran in 2.0s)`.
- [x] `flutter test` — `All tests passed!` (138 tests, includes 2 new `BrandLogo` widget tests).
- [x] `make gen` clean; re-running `make gen` produces no extra diff (idempotent).
- [x] iOS Info.plist + entitlements carry the placeholder/entitlement entries with clear TODO comments.
- [x] BrandLogo widget exists, exported, render-tested.

## USER ACTIONS REQUIRED to actually enable social sign-in
The PR ships only the code scaffold. The following are CONFIG-BLOCKED on dashboards / Apple Developer / GCP and were intentionally not attempted.

### 1. GCP — Google OAuth client IDs
- Create OAuth 2.0 iOS clients for **dev** (`com.aydev.nibbles.dev`) and **prod** (`com.aydev.nibbles`) bundle ids.
- For each iOS client, copy the **reversed client ID** (e.g. `com.googleusercontent.apps.123456789-abcdef`) into `ios/Runner/Info.plist` — replace `REPLACE_WITH_REVERSED_GOOGLE_OAUTH_CLIENT_ID`. If dev and prod use different GCP clients, add a second `<dict>` entry per flavor.
- Create OAuth 2.0 Web clients (Supabase needs the web client ID + secret for its Google provider).
- For Android: add the debug + release **SHA-1** fingerprints to the Firebase project (dev + prod). google-services.json already in the repo.

### 2. Apple Developer — Sign in with Apple
- Enable the **Sign in with Apple** capability on both App IDs (`com.aydev.nibbles` + `com.aydev.nibbles.dev`). Regenerate provisioning profiles after enabling.
- Create a **Service ID** (e.g. `com.aydev.nibbles.signinwithapple`) and bind it to a primary App ID + return URLs that point to your Supabase project's `/auth/v1/callback`.
- Create a **Sign in with Apple key** in the Keys section. Download the `.p8` private key and save the **Key ID** + **Team ID**.

### 3. Supabase Auth — OAuth providers (dev + prod projects)
For each project (`nibbles-dev` + `nibbles-prod`), Dashboard -> Authentication -> Providers:

**Google**
- Toggle Google provider on.
- `Client ID (for OAuth)` = the GCP Web client ID.
- `Client Secret (for OAuth)` = the GCP Web client secret.
- `Authorized Client IDs` = comma-separated list of the iOS + Android OAuth client IDs.
- Verify the Redirect URL Supabase displays is also registered as an authorized redirect URI on the Web client in GCP.

**Apple**
- Toggle Apple provider on.
- `Services ID` = the Apple Service ID created above.
- `Secret Key (for OAuth)` — Supabase generates from `Team ID`, `Key ID`, the downloaded `.p8` contents, and Service ID. Paste all four into the Supabase form.
- Add the Supabase callback URL (`https://<project-ref>.supabase.co/auth/v1/callback`) to the Service ID's Return URLs in Apple Developer.

### 4. Deep-link wiring (handled in NIB-116, just FYI)
- The Supabase OAuth callback returns to the app via deep link; the iOS URL types entry above is the iOS side. Android deep links are picked up via the existing app-link config in `android/app/src/main/AndroidManifest.xml` once SHA-1s are uploaded.

## Gate results
- `flutter analyze`: clean
- `flutter test`: 138/138 pass
- `make gen`: clean + idempotent

## Test plan
- [ ] Once GCP + Apple + Supabase are configured, NIB-116 wires the SDK imports and the social buttons.
- [ ] Manual smoke: iOS dev build signs successfully with the new entitlement (requires App ID capability enabled).
- [ ] Manual smoke: BrandLogo renders pixel-correct against `design/preview/brand-logo.html` at default size 120.