### PR TITLE
feat(auth): Google + Apple social sign-in repo/service/controllers [NIB-116]

### DIFF
--- a/lib/src/common/data/repositories/auth_repository.dart
+++ b/lib/src/common/data/repositories/auth_repository.dart
@@ -1,14 +1,48 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:nibbles/src/app/config/flavor_config.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 part 'auth_repository.g.dart';
 
+/// Function injected so the repo is unit-testable without a real Google SDK.
+typedef GoogleAuthenticateFn = Future<GoogleSignInAccount> Function();
+
+/// Function injected so the repo is unit-testable. Returns the access token
+/// for the granted scopes (may be null if the platform did not return one).
+typedef GoogleAuthorizeFn =
+    Future<String?> Function(GoogleSignInAccount account);
+
+/// Function injected so the repo is unit-testable without a real Apple SDK.
+typedef AppleCredentialFn =
+    Future<AuthorizationCredentialAppleID> Function(String hashedNonce);
+
+/// Function injected to make the one-shot Google initialize step swappable
+/// in tests (the real `GoogleSignIn.instance.initialize` throws on a missing
+/// platform plugin under the test runner).
+typedef GoogleInitializeFn = Future<void> Function();
+
 abstract interface class AuthRepository {
   Future<Result<void>> signUp(String email, String password);
   Future<Result<void>> signIn(String email, String password);
+
+  /// Returns `Success(true)` on a completed Google sign-in,
+  /// `Success(false)` if the user cancelled the native dialog (silent no-op),
+  /// or `Failure` for any provider/SDK/Supabase error.
+  Future<Result<bool>> signInWithGoogle();
+
+  /// Returns `Success(true)` on a completed Apple sign-in,
+  /// `Success(false)` if the user cancelled the native dialog (silent no-op),
+  /// or `Failure` for any provider/SDK/Supabase error.
+  Future<Result<bool>> signInWithApple();
+
   Future<Result<void>> signOut();
   Future<Result<void>> resetPassword(String email);
   Future<Result<void>> updatePassword(String newPassword);
@@ -17,10 +51,30 @@ abstract interface class AuthRepository {
 }
 
 class AuthRepositoryImpl implements AuthRepository {
-  AuthRepositoryImpl({SupabaseClient? supabaseClient})
-    : _supabase = supabaseClient ?? Supabase.instance.client;
+  AuthRepositoryImpl({
+    SupabaseClient? supabaseClient,
+    GoogleInitializeFn? googleInitialize,
+    GoogleAuthenticateFn? googleAuthenticate,
+    GoogleAuthorizeFn? googleAuthorize,
+    AppleCredentialFn? appleCredential,
+    String? Function()? generateRawNonce,
+  }) : _supabase = supabaseClient ?? Supabase.instance.client,
+       _googleInitialize = googleInitialize ?? _defaultGoogleInitialize,
+       _googleAuthenticate = googleAuthenticate ?? _defaultGoogleAuthenticate,
+       _googleAuthorize = googleAuthorize ?? _defaultGoogleAuthorize,
+       _appleCredential = appleCredential ?? _defaultAppleCredential,
+       _generateRawNonce = generateRawNonce;
 
   final SupabaseClient _supabase;
+  final GoogleInitializeFn _googleInitialize;
+  final GoogleAuthenticateFn _googleAuthenticate;
+  final GoogleAuthorizeFn _googleAuthorize;
+  final AppleCredentialFn _appleCredential;
+  final String? Function()? _generateRawNonce;
+
+  /// One-shot guard. `GoogleSignIn.initialize()` must run exactly once per
+  /// process — calling it twice is undefined behavior per the 7.x docs.
+  Future<void>? _googleInitFuture;
 
   @override
   bool get isLoggedIn => _supabase.auth.currentSession != null;
@@ -53,6 +107,88 @@ class AuthRepositoryImpl implements AuthRepository {
     try {
       await _supabase.auth.signInWithPassword(email: email, password: password);
       return const Result.success(null);
+    } on AuthException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<bool>> signInWithGoogle() async {
+    try {
+      await _ensureGoogleInitialized();
+
+      final GoogleSignInAccount account;
+      try {
+        account = await _googleAuthenticate();
+      } on GoogleSignInException catch (e) {
+        // User-cancel / dismissed UI is a silent no-op — not an error.
+        if (e.code == GoogleSignInExceptionCode.canceled ||
+            e.code == GoogleSignInExceptionCode.interrupted ||
+            e.code == GoogleSignInExceptionCode.uiUnavailable) {
+          return const Result.success(false);
+        }
+        return Result.failure(
+          ServerException(e.description ?? 'Google sign-in failed.'),
+        );
+      }
+
+      final idToken = account.authentication.idToken;
+      if (idToken == null) {
+        return const Result.failure(
+          ServerException('Google sign-in did not return an ID token.'),
+        );
+      }
+      final accessToken = await _googleAuthorize(account);
+
+      await _supabase.auth.signInWithIdToken(
+        provider: OAuthProvider.google,
+        idToken: idToken,
+        accessToken: accessToken,
+      );
+      return const Result.success(true);
+    } on AuthException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<bool>> signInWithApple() async {
+    try {
+      // Per the Supabase Flutter README: pass the HASHED nonce to Apple
+      // (gets embedded as the `nonce` claim in the identity JWT), then pass
+      // the RAW nonce to Supabase via `nonce:` — Supabase hashes & compares.
+      // (The ticket text inverts these; the README is canonical.)
+      final rawNonce =
+          _generateRawNonce?.call() ?? _supabase.auth.generateRawNonce();
+      final hashedNonce = sha256.convert(utf8.encode(rawNonce)).toString();
+
+      final AuthorizationCredentialAppleID credential;
+      try {
+        credential = await _appleCredential(hashedNonce);
+      } on SignInWithAppleAuthorizationException catch (e) {
+        if (e.code == AuthorizationErrorCode.canceled) {
+          return const Result.success(false);
+        }
+        return Result.failure(ServerException(e.message));
+      }
+
+      final idToken = credential.identityToken;
+      if (idToken == null) {
+        return const Result.failure(
+          ServerException('Apple sign-in did not return an ID token.'),
+        );
+      }
+
+      await _supabase.auth.signInWithIdToken(
+        provider: OAuthProvider.apple,
+        idToken: idToken,
+        nonce: rawNonce,
+      );
+      return const Result.success(true);
     } on AuthException catch (e) {
       return Result.failure(ServerException(e.message));
     } on Object {
@@ -98,6 +234,51 @@ class AuthRepositoryImpl implements AuthRepository {
       return const Result.failure(UnknownException());
     }
   }
+
+  /// `GoogleSignIn.initialize` must run exactly once per process. Calls
+  /// after the first reuse the same Future.
+  Future<void> _ensureGoogleInitialized() =>
+      _googleInitFuture ??= _googleInitialize();
+}
+
+String? _readServerClientId() {
+  if (!dotenv.isInitialized) return null;
+  final value = dotenv.maybeGet('GOOGLE_SERVER_CLIENT_ID');
+  if (value == null || value.isEmpty) return null;
+  return value;
+}
+
+/// The serverClientId is read from `.env.<flavor>` if present; otherwise the
+/// native side (iOS GIDClientID from Info.plist, Android Google Services)
+/// supplies the necessary configuration.
+Future<void> _defaultGoogleInitialize() => GoogleSignIn.instance.initialize(
+  serverClientId: _readServerClientId(),
+);
+
+Future<GoogleSignInAccount> _defaultGoogleAuthenticate() =>
+    GoogleSignIn.instance.authenticate();
+
+Future<String?> _defaultGoogleAuthorize(GoogleSignInAccount account) async {
+  // Supabase signInWithIdToken accepts a null accessToken when the ID token
+  // has no `at_hash` claim, so we use the non-prompting variant: if the user
+  // hasn't pre-authorized email/profile scopes, we skip the access token
+  // rather than block the sign-in with a second consent prompt.
+  final authz = await account.authorizationClient.authorizationForScopes(
+    const ['email', 'profile'],
+  );
+  return authz?.accessToken;
+}
+
+Future<AuthorizationCredentialAppleID> _defaultAppleCredential(
+  String hashedNonce,
+) {
+  return SignInWithApple.getAppleIDCredential(
+    scopes: const [
+      AppleIDAuthorizationScopes.email,
+      AppleIDAuthorizationScopes.fullName,
+    ],
+    nonce: hashedNonce,
+  );
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/src/common/services/auth_service.dart
+++ b/lib/src/common/services/auth_service.dart
@@ -48,6 +48,30 @@ class AuthService extends _$AuthService {
     return result;
   }
 
+  /// `Success(true)` = authenticated, `Success(false)` = user cancelled
+  /// (silent no-op, no state change), `Failure` = surfaced as P1 by the
+  /// controller.
+  Future<Result<bool>> signInWithGoogle() => _completeSocial(
+    _repo.signInWithGoogle(),
+  );
+
+  /// `Success(true)` = authenticated, `Success(false)` = user cancelled
+  /// (silent no-op, no state change), `Failure` = surfaced as P1 by the
+  /// controller.
+  Future<Result<bool>> signInWithApple() =>
+      _completeSocial(_repo.signInWithApple());
+
+  Future<Result<bool>> _completeSocial(Future<Result<bool>> future) async {
+    final result = await future;
+    // Guard on the bool data: Success(false) is a cancel — must NOT flip
+    // auth state. Only Success(true) means a real sign-in.
+    if (result.dataOrNull ?? false) {
+      await _backfillOnboardingFlagsIfNeeded();
+      state = true;
+    }
+    return result;
+  }
+
   Future<void> _backfillOnboardingFlagsIfNeeded() async {
     final flags = ref.read(localFlagServiceProvider);
     if (flags.isOnboardingBabySetupDone()) return;

--- a/lib/src/common/services/auth_service.g.dart
+++ b/lib/src/common/services/auth_service.g.dart
@@ -6,7 +6,7 @@ part of 'auth_service.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$authServiceHash() => r'a2cfc8026564fcdb1daab0c8c068731b48f0a973';
+String _$authServiceHash() => r'6e573f922d81b92e0d52978b6f159780e976fb06';
 
 /// See also [AuthService].
 @ProviderFor(AuthService)

--- a/lib/src/features/auth/login/login_controller.dart
+++ b/lib/src/features/auth/login/login_controller.dart
@@ -1,3 +1,4 @@
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/formz/email_input.dart';
 import 'package:nibbles/src/common/domain/formz/password_input.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
@@ -35,5 +36,27 @@ class LoginController extends _$LoginController {
           state = state.copyWith(isLoading: false, errorMessage: error.message),
     );
     // On success: GoRouter redirect picks up authServiceProvider state change
+  }
+
+  Future<void> signInWithGoogle() => _runSocial(
+    () => ref.read(authServiceProvider.notifier).signInWithGoogle(),
+  );
+
+  Future<void> signInWithApple() => _runSocial(
+    () => ref.read(authServiceProvider.notifier).signInWithApple(),
+  );
+
+  Future<void> _runSocial(Future<Result<bool>> Function() call) async {
+    state = state.copyWith(isLoading: true, errorMessage: null);
+
+    final result = await call();
+
+    result.when(
+      // Success(false) = user-cancel: clear loading silently, no error UI.
+      // Success(true)  = signed in: router redirect picks up the state flip.
+      success: (_) => state = state.copyWith(isLoading: false),
+      failure: (error) =>
+          state = state.copyWith(isLoading: false, errorMessage: error.message),
+    );
   }
 }

--- a/lib/src/features/auth/login/login_controller.g.dart
+++ b/lib/src/features/auth/login/login_controller.g.dart
@@ -6,7 +6,7 @@ part of 'login_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$loginControllerHash() => r'a6a266d22d99177a03d88e30d694d64167974e44';
+String _$loginControllerHash() => r'8b53cbd76a6800508851eec9f408d781c62f56fd';
 
 /// See also [LoginController].
 @ProviderFor(LoginController)

--- a/lib/src/features/auth/register/register_controller.dart
+++ b/lib/src/features/auth/register/register_controller.dart
@@ -1,3 +1,4 @@
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/formz/email_input.dart';
 import 'package:nibbles/src/common/domain/formz/password_input.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
@@ -37,6 +38,35 @@ class RegisterController extends _$RegisterController {
       success: (_) {
         state = state.copyWith(isLoading: false);
         return true;
+      },
+      failure: (error) {
+        state = state.copyWith(isLoading: false, errorMessage: error.message);
+        return false;
+      },
+    );
+  }
+
+  Future<bool> signInWithGoogle() => _runSocial(
+    () => ref.read(authServiceProvider.notifier).signInWithGoogle(),
+  );
+
+  Future<bool> signInWithApple() => _runSocial(
+    () => ref.read(authServiceProvider.notifier).signInWithApple(),
+  );
+
+  /// Returns `true` on successful sign-in, `false` for cancel or failure.
+  /// On failure the error message is stored in state so the screen can
+  /// render it as P1. On cancel the error is silent.
+  Future<bool> _runSocial(Future<Result<bool>> Function() call) async {
+    state = state.copyWith(isLoading: true, errorMessage: null);
+
+    final result = await call();
+
+    return result.when(
+      success: (signedIn) {
+        // signedIn == false ⇒ user-cancel: silent no-op, no error UI.
+        state = state.copyWith(isLoading: false);
+        return signedIn;
       },
       failure: (error) {
         state = state.copyWith(isLoading: false, errorMessage: error.message);

--- a/lib/src/features/auth/register/register_controller.g.dart
+++ b/lib/src/features/auth/register/register_controller.g.dart
@@ -7,7 +7,7 @@ part of 'register_controller.dart';
 // **************************************************************************
 
 String _$registerControllerHash() =>
-    r'2501a0ef86759484ac9ce86ce11ff8e55aea64a5';
+    r'9076e4a1e6375e7db2bd9c51ca428dc19f3796bc';
 
 /// See also [RegisterController].
 @ProviderFor(RegisterController)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -306,7 +306,7 @@ packages:
     source: hosted
     version: "0.3.5+2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   auto_size_text: ^3.0.0
   cached_network_image: ^3.2.3
   collection: ^1.19.1
+  crypto: ^3.0.0
   dio: ^5.8.0+1
   easy_localization: ^3.0.1
   firebase_analytics: ^11.4.0

--- a/test/common/data/repositories/auth_repository_test.dart
+++ b/test/common/data/repositories/auth_repository_test.dart
@@ -1,0 +1,338 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+class MockSupabaseClient extends Mock implements SupabaseClient {}
+
+class MockGoTrueClient extends Mock implements GoTrueClient {}
+
+class _FakeUserAttributes extends Fake implements UserAttributes {}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// The plugin exposes no public ctor for [GoogleSignInAccount], so we
+/// implement the interface with just the surface the repo touches:
+/// `authentication.idToken`. The repo never goes through the real
+/// authorize client — that's injected separately via `googleAuthorize`.
+class _FakeGoogleAccount implements GoogleSignInAccount {
+  _FakeGoogleAccount(this._idToken);
+
+  final String _idToken;
+
+  @override
+  GoogleSignInAuthentication get authentication =>
+      GoogleSignInAuthentication(idToken: _idToken);
+
+  @override
+  GoogleSignInAuthorizationClient get authorizationClient =>
+      throw UnimplementedError(
+        'Not used — repo injects authorize fn directly.',
+      );
+
+  @override
+  String get displayName => 'Test User';
+
+  @override
+  String get email => 'test@example.com';
+
+  @override
+  String get id => 'google-uid';
+
+  @override
+  String? get photoUrl => null;
+}
+
+AuthorizationCredentialAppleID _makeAppleCredential({String? identityToken}) {
+  return AuthorizationCredentialAppleID(
+    userIdentifier: 'apple-uid',
+    givenName: 'Test',
+    familyName: 'User',
+    authorizationCode: 'auth-code',
+    email: 'test@example.com',
+    identityToken: identityToken,
+    state: null,
+  );
+}
+
+void main() {
+  late MockSupabaseClient mockClient;
+  late MockGoTrueClient mockAuth;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeUserAttributes());
+    registerFallbackValue(OAuthProvider.google);
+  });
+
+  setUp(() {
+    mockClient = MockSupabaseClient();
+    mockAuth = MockGoTrueClient();
+    when(() => mockClient.auth).thenReturn(mockAuth);
+    // NB: `generateRawNonce` is an extension on GoTrueClient and therefore
+    // cannot be stubbed by mocktail. The repo accepts `generateRawNonce` as
+    // an injectable to bypass it in tests.
+  });
+
+  AuthRepositoryImpl buildSut({
+    GoogleAuthenticateFn? googleAuthenticate,
+    GoogleAuthorizeFn? googleAuthorize,
+    AppleCredentialFn? appleCredential,
+    String? Function()? generateRawNonce,
+  }) {
+    return AuthRepositoryImpl(
+      supabaseClient: mockClient,
+      // No-op the one-shot Google init so tests don't touch the platform.
+      googleInitialize: () async {},
+      googleAuthenticate: googleAuthenticate,
+      googleAuthorize: googleAuthorize,
+      appleCredential: appleCredential,
+      generateRawNonce: generateRawNonce,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // signInWithGoogle
+  // -------------------------------------------------------------------------
+
+  group('signInWithGoogle', () {
+    test('returns Success(true) and calls Supabase on happy path', () async {
+      final sut = buildSut(
+        googleAuthenticate: () async =>
+            _FakeGoogleAccount('id-token-x'),
+        googleAuthorize: (_) async => 'access-token-y',
+      );
+      when(
+        () => mockAuth.signInWithIdToken(
+          provider: any(named: 'provider'),
+          idToken: any(named: 'idToken'),
+          accessToken: any(named: 'accessToken'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer(
+        (_) async => AuthResponse(),
+      );
+
+      final result = await sut.signInWithGoogle();
+
+      expect(result, isA<Success<bool>>());
+      expect((result as Success<bool>).data, isTrue);
+      verify(
+        () => mockAuth.signInWithIdToken(
+          provider: OAuthProvider.google,
+          idToken: 'id-token-x',
+          accessToken: 'access-token-y',
+        ),
+      ).called(1);
+    });
+
+    test('returns Success(false) on user-cancel (no Supabase call)', () async {
+      final sut = buildSut(
+        googleAuthenticate: () async => throw const GoogleSignInException(
+          code: GoogleSignInExceptionCode.canceled,
+          description: 'user canceled',
+        ),
+        googleAuthorize: (_) async => null,
+      );
+
+      final result = await sut.signInWithGoogle();
+
+      expect(result, isA<Success<bool>>());
+      expect((result as Success<bool>).data, isFalse);
+      verifyNever(
+        () => mockAuth.signInWithIdToken(
+          provider: any(named: 'provider'),
+          idToken: any(named: 'idToken'),
+        ),
+      );
+    });
+
+    test(
+      'returns Failure(ServerException) on Google clientConfigurationError',
+      () async {
+        final sut = buildSut(
+          googleAuthenticate: () async => throw const GoogleSignInException(
+            code: GoogleSignInExceptionCode.clientConfigurationError,
+            description: 'bad client id',
+          ),
+          googleAuthorize: (_) async => null,
+        );
+
+        final result = await sut.signInWithGoogle();
+
+        expect(result, isA<Failure<bool>>());
+        expect((result as Failure<bool>).error, isA<ServerException>());
+        expect(result.error.message, contains('bad client id'));
+      },
+    );
+
+    test('returns Failure when ID token is null', () async {
+      final sut = buildSut(
+        googleAuthenticate: () async => _FakeGoogleAccountNullToken(),
+        googleAuthorize: (_) async => null,
+      );
+
+      final result = await sut.signInWithGoogle();
+
+      expect(result, isA<Failure<bool>>());
+      expect((result as Failure<bool>).error, isA<ServerException>());
+    });
+
+    test('maps Supabase AuthException to Failure(ServerException)', () async {
+      final sut = buildSut(
+        googleAuthenticate: () async =>
+            _FakeGoogleAccount('id-token-x'),
+        googleAuthorize: (_) async => 'access-token-y',
+      );
+      when(
+        () => mockAuth.signInWithIdToken(
+          provider: any(named: 'provider'),
+          idToken: any(named: 'idToken'),
+          accessToken: any(named: 'accessToken'),
+        ),
+      ).thenThrow(const AuthException('provider not enabled'));
+
+      final result = await sut.signInWithGoogle();
+
+      expect(result, isA<Failure<bool>>());
+      expect(
+        (result as Failure<bool>).error.message,
+        'provider not enabled',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // signInWithApple
+  // -------------------------------------------------------------------------
+
+  group('signInWithApple', () {
+    test(
+      'returns Success(true), passes hashed nonce to Apple and raw to Supabase',
+      () async {
+        String? receivedAppleNonce;
+        final sut = buildSut(
+          appleCredential: (hashedNonce) async {
+            receivedAppleNonce = hashedNonce;
+            return _makeAppleCredential(identityToken: 'apple-id-token');
+          },
+          generateRawNonce: () => 'raw-nonce-fixed',
+        );
+        when(
+          () => mockAuth.signInWithIdToken(
+            provider: any(named: 'provider'),
+            idToken: any(named: 'idToken'),
+            nonce: any(named: 'nonce'),
+          ),
+        ).thenAnswer((_) async => AuthResponse());
+
+        final result = await sut.signInWithApple();
+
+        expect(result, isA<Success<bool>>());
+        expect((result as Success<bool>).data, isTrue);
+
+        // Apple receives the HASHED nonce. SHA-256 of "raw-nonce-fixed".
+        expect(receivedAppleNonce, hasLength(64));
+        expect(receivedAppleNonce, isNot('raw-nonce-fixed'));
+
+        // Supabase receives the RAW nonce.
+        verify(
+          () => mockAuth.signInWithIdToken(
+            provider: OAuthProvider.apple,
+            idToken: 'apple-id-token',
+            nonce: 'raw-nonce-fixed',
+          ),
+        ).called(1);
+      },
+    );
+
+    test('returns Success(false) on user-cancel (no Supabase call)', () async {
+      final sut = buildSut(
+        appleCredential: (_) async =>
+            throw const SignInWithAppleAuthorizationException(
+              code: AuthorizationErrorCode.canceled,
+              message: 'user canceled',
+            ),
+        generateRawNonce: () => 'raw-nonce-fixed',
+      );
+
+      final result = await sut.signInWithApple();
+
+      expect(result, isA<Success<bool>>());
+      expect((result as Success<bool>).data, isFalse);
+      verifyNever(
+        () => mockAuth.signInWithIdToken(
+          provider: any(named: 'provider'),
+          idToken: any(named: 'idToken'),
+        ),
+      );
+    });
+
+    test('returns Failure on Apple authorization failure', () async {
+      final sut = buildSut(
+        appleCredential: (_) async =>
+            throw const SignInWithAppleAuthorizationException(
+              code: AuthorizationErrorCode.failed,
+              message: 'authorization failed',
+            ),
+        generateRawNonce: () => 'raw-nonce-fixed',
+      );
+
+      final result = await sut.signInWithApple();
+
+      expect(result, isA<Failure<bool>>());
+      expect((result as Failure<bool>).error, isA<ServerException>());
+      expect(result.error.message, 'authorization failed');
+    });
+
+    test('returns Failure when Apple identityToken is null', () async {
+      final sut = buildSut(
+        appleCredential: (_) async => _makeAppleCredential(),
+        generateRawNonce: () => 'raw-nonce-fixed',
+      );
+
+      final result = await sut.signInWithApple();
+
+      expect(result, isA<Failure<bool>>());
+      expect((result as Failure<bool>).error, isA<ServerException>());
+    });
+
+    test('maps Supabase AuthException to Failure(ServerException)', () async {
+      final sut = buildSut(
+        appleCredential: (_) async =>
+            _makeAppleCredential(identityToken: 'apple-id-token'),
+        generateRawNonce: () => 'raw-nonce-fixed',
+      );
+      when(
+        () => mockAuth.signInWithIdToken(
+          provider: any(named: 'provider'),
+          idToken: any(named: 'idToken'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenThrow(const AuthException('nonce mismatch'));
+
+      final result = await sut.signInWithApple();
+
+      expect(result, isA<Failure<bool>>());
+      expect((result as Failure<bool>).error.message, 'nonce mismatch');
+    });
+  });
+}
+
+/// Variant whose authentication has a null idToken.
+class _FakeGoogleAccountNullToken extends _FakeGoogleAccount {
+  _FakeGoogleAccountNullToken() : super('');
+
+  @override
+  GoogleSignInAuthentication get authentication =>
+      const GoogleSignInAuthentication(idToken: null);
+}

--- a/test/common/services/auth_service_test.dart
+++ b/test/common/services/auth_service_test.dart
@@ -148,4 +148,82 @@ void main() {
       expect(result.errorOrNull!.message, 'Password too weak.');
     });
   });
+
+  group('AuthService.signInWithGoogle', () {
+    test('isLoggedIn becomes true on Success(true)', () async {
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      final result = await sut.signInWithGoogle();
+
+      expect(result.isSuccess, isTrue);
+      expect(container.read(authServiceProvider), isTrue);
+    });
+
+    test(
+      'isLoggedIn stays false on Success(false) (cancel is silent no-op)',
+      () async {
+        when(
+          () => mockRepo.signInWithGoogle(),
+        ).thenAnswer((_) async => const Result.success(false));
+
+        final result = await sut.signInWithGoogle();
+
+        // Result still surfaces success so the controller can clear loading
+        // without showing an error — but auth state must NOT flip on cancel.
+        expect(result.isSuccess, isTrue);
+        expect(container.read(authServiceProvider), isFalse);
+      },
+    );
+
+    test('isLoggedIn stays false on Failure', () async {
+      when(() => mockRepo.signInWithGoogle()).thenAnswer(
+        (_) async => const Result.failure(ServerException('provider error')),
+      );
+
+      final result = await sut.signInWithGoogle();
+
+      expect(result.isFailure, isTrue);
+      expect(container.read(authServiceProvider), isFalse);
+    });
+  });
+
+  group('AuthService.signInWithApple', () {
+    test('isLoggedIn becomes true on Success(true)', () async {
+      when(
+        () => mockRepo.signInWithApple(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      final result = await sut.signInWithApple();
+
+      expect(result.isSuccess, isTrue);
+      expect(container.read(authServiceProvider), isTrue);
+    });
+
+    test(
+      'isLoggedIn stays false on Success(false) (cancel is silent no-op)',
+      () async {
+        when(
+          () => mockRepo.signInWithApple(),
+        ).thenAnswer((_) async => const Result.success(false));
+
+        final result = await sut.signInWithApple();
+
+        expect(result.isSuccess, isTrue);
+        expect(container.read(authServiceProvider), isFalse);
+      },
+    );
+
+    test('isLoggedIn stays false on Failure', () async {
+      when(() => mockRepo.signInWithApple()).thenAnswer(
+        (_) async => const Result.failure(ServerException('Apple error')),
+      );
+
+      final result = await sut.signInWithApple();
+
+      expect(result.isFailure, isTrue);
+      expect(container.read(authServiceProvider), isFalse);
+    });
+  });
 }

--- a/test/features/auth/login/login_controller_test.dart
+++ b/test/features/auth/login/login_controller_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/auth/login/login_controller.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockLocalFlagService extends Mock implements LocalFlagService {}
+
+void main() {
+  late MockAuthRepository mockRepo;
+  late MockLocalFlagService mockFlags;
+  late ProviderContainer container;
+
+  setUp(() {
+    mockRepo = MockAuthRepository();
+    mockFlags = MockLocalFlagService();
+    when(() => mockRepo.isLoggedIn).thenReturn(false);
+    when(
+      () => mockRepo.authStateStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(mockFlags.isOnboardingBabySetupDone).thenReturn(true);
+
+    container = ProviderContainer(
+      overrides: [
+        authRepositoryProvider.overrideWithValue(mockRepo),
+        localFlagServiceProvider.overrideWithValue(mockFlags),
+      ],
+    );
+  });
+
+  tearDown(() => container.dispose());
+
+  LoginController readController() =>
+      container.read(loginControllerProvider.notifier);
+
+  group('signInWithGoogle', () {
+    test('clears loading + no error on Success(true)', () async {
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      await readController().signInWithGoogle();
+
+      final state = container.read(loginControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('clears loading + no error on Success(false) (cancel)', () async {
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(false));
+
+      await readController().signInWithGoogle();
+
+      final state = container.read(loginControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('sets errorMessage on Failure', () async {
+      when(() => mockRepo.signInWithGoogle()).thenAnswer(
+        (_) async => const Result.failure(ServerException('Google failed')),
+      );
+
+      await readController().signInWithGoogle();
+
+      final state = container.read(loginControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, 'Google failed');
+    });
+  });
+
+  group('signInWithApple', () {
+    test('clears loading + no error on Success(true)', () async {
+      when(
+        () => mockRepo.signInWithApple(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      await readController().signInWithApple();
+
+      final state = container.read(loginControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('clears loading + no error on Success(false) (cancel)', () async {
+      when(
+        () => mockRepo.signInWithApple(),
+      ).thenAnswer((_) async => const Result.success(false));
+
+      await readController().signInWithApple();
+
+      final state = container.read(loginControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('sets errorMessage on Failure', () async {
+      when(() => mockRepo.signInWithApple()).thenAnswer(
+        (_) async => const Result.failure(ServerException('Apple failed')),
+      );
+
+      await readController().signInWithApple();
+
+      final state = container.read(loginControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, 'Apple failed');
+    });
+  });
+}

--- a/test/features/auth/register/register_controller_test.dart
+++ b/test/features/auth/register/register_controller_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/auth/register/register_controller.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockLocalFlagService extends Mock implements LocalFlagService {}
+
+void main() {
+  late MockAuthRepository mockRepo;
+  late MockLocalFlagService mockFlags;
+  late ProviderContainer container;
+
+  setUp(() {
+    mockRepo = MockAuthRepository();
+    mockFlags = MockLocalFlagService();
+    when(() => mockRepo.isLoggedIn).thenReturn(false);
+    when(
+      () => mockRepo.authStateStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(mockFlags.isOnboardingBabySetupDone).thenReturn(true);
+
+    container = ProviderContainer(
+      overrides: [
+        authRepositoryProvider.overrideWithValue(mockRepo),
+        localFlagServiceProvider.overrideWithValue(mockFlags),
+      ],
+    );
+  });
+
+  tearDown(() => container.dispose());
+
+  RegisterController readController() =>
+      container.read(registerControllerProvider.notifier);
+
+  group('signInWithGoogle', () {
+    test('returns true on Success(true), no error', () async {
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      final ok = await readController().signInWithGoogle();
+
+      expect(ok, isTrue);
+      final state = container.read(registerControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('returns false on Success(false) (cancel), no error', () async {
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(false));
+
+      final ok = await readController().signInWithGoogle();
+
+      expect(ok, isFalse);
+      final state = container.read(registerControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('returns false on Failure and sets errorMessage', () async {
+      when(() => mockRepo.signInWithGoogle()).thenAnswer(
+        (_) async => const Result.failure(ServerException('Google failed')),
+      );
+
+      final ok = await readController().signInWithGoogle();
+
+      expect(ok, isFalse);
+      final state = container.read(registerControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, 'Google failed');
+    });
+  });
+
+  group('signInWithApple', () {
+    test('returns true on Success(true), no error', () async {
+      when(
+        () => mockRepo.signInWithApple(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      final ok = await readController().signInWithApple();
+
+      expect(ok, isTrue);
+      final state = container.read(registerControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('returns false on Success(false) (cancel), no error', () async {
+      when(
+        () => mockRepo.signInWithApple(),
+      ).thenAnswer((_) async => const Result.success(false));
+
+      final ok = await readController().signInWithApple();
+
+      expect(ok, isFalse);
+      final state = container.read(registerControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('returns false on Failure and sets errorMessage', () async {
+      when(() => mockRepo.signInWithApple()).thenAnswer(
+        (_) async => const Result.failure(ServerException('Apple failed')),
+      );
+
+      final ok = await readController().signInWithApple();
+
+      expect(ok, isFalse);
+      final state = container.read(registerControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.errorMessage, 'Apple failed');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Wires Google and Apple sign-in end-to-end through the existing Repo -> Service -> Controller stack. Repo calls Supabase `signInWithIdToken` with native ID tokens from `google_sign_in` 7.x and `sign_in_with_apple` 7.x. Login/Signup controllers expose `signInWithGoogle`/`signInWithApple` methods that NIB-107 + NIB-112 reskins will wire to the social buttons. The `auth_screen` files are intentionally untouched.

## Files
- `lib/src/common/data/repositories/auth_repository.dart` — adds `signInWithGoogle()` + `signInWithApple()` to the interface and impl. All Supabase calls stay in the repo. SDK calls (`GoogleSignIn.instance.initialize`/`authenticate`/`authorizeScopes`, `SignInWithApple.getAppleIDCredential`) are injected as function typedefs so the repo is unit-testable.
- `lib/src/common/services/auth_service.dart` (+ `.g.dart`) — `signInWithGoogle` / `signInWithApple` pass-throughs that mirror the existing email/password `signIn` flow: on `Success(true)` they backfill onboarding flags and flip `state = true`. **Crucially, the state flip gates on the bool, not `isSuccess`** so `Success(false)` (cancel) does NOT flip auth.
- `lib/src/features/auth/login/login_controller.dart` (+ `.g.dart`) — `signInWithGoogle` / `signInWithApple` manage `isLoading` + `errorMessage`. Cancel clears loading silently; failure surfaces the message for the screen to render as P1.
- `lib/src/features/auth/register/register_controller.dart` (+ `.g.dart`) — same shape; returns `bool` mirroring the existing `submit()` API (`true` only on real sign-in).
- `pubspec.yaml` + `pubspec.lock` — `crypto: ^3.0.0` promoted to a direct dep so the repo can SHA-256 the Apple nonce.
- `test/common/data/repositories/auth_repository_test.dart` (new, 10 cases) — happy / cancel / config error / null token / Supabase AuthException for both providers; asserts the hashed nonce goes to Apple and the raw nonce goes to Supabase.
- `test/common/services/auth_service_test.dart` — adds 6 cases covering Success(true)/Success(false)/Failure for each provider, asserting `isLoggedIn` flips ONLY on Success(true).
- `test/features/auth/login/login_controller_test.dart` + `register/register_controller_test.dart` (new, 12 cases total) — verify cancel is silent, failure sets `errorMessage`, success returns true/clears loading.

## Apple nonce direction (worth flagging)
Followed the Supabase Flutter README — which is the canonical source the ticket references — over the literal ticket text:
- SHA-256 **hashed** nonce -> `SignInWithApple.getAppleIDCredential(nonce: ...)` (gets embedded as the `nonce` claim in the identity JWT).
- **Raw** nonce -> `supabase.auth.signInWithIdToken(nonce: ...)` (Supabase hashes and compares server-side).

The ticket spec phrases it as "pass the HASHED nonce in the `rawNonce` arg to Supabase," but there is no `rawNonce` parameter — the param is `nonce`, and per the README it expects the raw value. Code comments note this explicitly so future readers don't flag it as a bug.

## Design decisions
- **`Result<bool>`** as the social return type: `Success(true)` = signed in, `Success(false)` = user-cancel (silent no-op, no error UI), `Failure` = mapped provider/SDK/Supabase error. Cleanest discriminator and the controllers just read the bool.
- **Cancel detection** by specific error code, NOT by sentinel: `GoogleSignInExceptionCode.canceled|interrupted|uiUnavailable` -> Success(false); `SignInWithAppleAuthorizationException` with `AuthorizationErrorCode.canceled` -> Success(false). Everything else maps to `Failure(ServerException)`.
- **`GoogleSignIn.instance.initialize()` is memoized** (`_googleInitFuture ??= ...`) so it runs exactly once per process — calling it twice is documented as undefined behavior in 7.x.
- **`serverClientId`** is read from `.env.<flavor>` via `dotenv.maybeGet('GOOGLE_SERVER_CLIENT_ID')` and falls back to `null` so the iOS `GIDClientID` from `Info.plist` (NIB-117) provides it natively. No `FlavorConfig` plumbing — kept the surface small as the ticket requested.
- **Repository injection seams**: the repo accepts `googleInitialize`, `googleAuthenticate`, `googleAuthorize`, `appleCredential`, and `generateRawNonce` as constructor params, each defaulting to the real SDK call. This is what lets the repo tests run on the VM without a native plugin.

## Out of scope (intentional)
- `lib/src/features/auth/login/login_screen.dart` and `register_screen.dart` — NIB-107 and NIB-112 own the social-button rendering and will call the new controller methods.
- `ios/Runner/Info.plist` and `Runner.entitlements` — NIB-117 set the placeholders + Sign in with Apple entitlement.

## Watch-item (not a blocker)
The default Google authorize path uses `authorizationForScopes` (non-prompting) so a first-time user gets `accessToken: null` to Supabase. If the eventual ID tokens carry an `at_hash` claim, Supabase will reject a null access token. This is untestable until real OAuth config exists; revisit if the runtime path errors.

---

## USER ACTIONS REQUIRED to actually enable social sign-in
This PR ships only the code wiring. The runtime flow remains config-blocked until the following dashboards / Apple Developer / GCP items are done.

### 1. Supabase Auth — OAuth providers (dev + prod projects)
For each project (`nibbles-dev` + `nibbles-prod`), Dashboard -> Authentication -> Providers:

**Google**
- Toggle Google provider on.
- `Client ID (for OAuth)` = the GCP **Web** client ID.
- `Client Secret (for OAuth)` = the GCP Web client secret.
- `Authorized Client IDs` = comma-separated list of the iOS + Android OAuth client IDs.
- **Enable "Skip nonce check"** — required for native iOS Google sign-in (the Supabase README calls this out explicitly).
- Verify the Redirect URL Supabase displays is also registered as an authorized redirect URI on the Web client in GCP.

**Apple**
- Toggle Apple provider on.
- `Services ID` = the Apple Service ID configured below.
- `Secret Key (for OAuth)` — paste the `Team ID`, `Key ID`, downloaded `.p8` contents, and Service ID into the Supabase form.
- Add the bundle IDs (`com.aydev.nibbles` + `com.aydev.nibbles.dev`) under "Authorized Client IDs".
- Add the Supabase callback URL (`https://<project-ref>.supabase.co/auth/v1/callback`) to the Service ID's Return URLs in Apple Developer.

### 2. Apple Developer — Sign in with Apple
- Enable the **Sign in with Apple** capability on both App IDs (`com.aydev.nibbles` + `com.aydev.nibbles.dev`). Regenerate provisioning profiles after enabling. (NIB-117 added the `com.apple.developer.applesignin` entitlement.)
- Create a **Service ID** (e.g. `com.aydev.nibbles.signinwithapple`) bound to the App ID + return URLs pointing at Supabase's `/auth/v1/callback`.
- Create a **Sign in with Apple key** in Keys. Download the `.p8` and save the **Key ID** + **Team ID** for the Supabase form above.

### 3. GCP — Google OAuth client IDs
- Create OAuth 2.0 **iOS** clients for dev (`com.aydev.nibbles.dev`) and prod (`com.aydev.nibbles`).
- For each iOS client, copy the **reversed client ID** into `ios/Runner/Info.plist` — replace `REPLACE_WITH_REVERSED_GOOGLE_OAUTH_CLIENT_ID` (placeholder added in NIB-117). If dev/prod use separate GCP clients, add a second `<dict>` per flavor.
- Create OAuth 2.0 **Web** clients (the Supabase Google provider needs the Web client ID + secret).
- Optional (recommended): set `GOOGLE_SERVER_CLIENT_ID=<web-client-id>` in `.env.dev` and `.env.prod` so the repo passes it explicitly to `GoogleSignIn.initialize()`. If unset, iOS falls back to the `GIDClientID` from Info.plist.
- Android: add the debug + release **SHA-1** fingerprints to the Firebase project (dev + prod).

---

## Acceptance criteria
- [x] AuthRepository + AuthService + LoginController + RegisterController expose `signInWithGoogle` / `signInWithApple` returning `Result<T>`; no raw throws reach UI.
- [x] User-cancel is silent (no error UI state).
- [x] Provider errors map to `ServerException` / `UnknownException` via `Result.failure`.
- [x] Supabase calls remain ONLY in the repo; no DTO leaks above the repo.
- [x] `flutter analyze` zero warnings.
- [x] `flutter test` passes including new repo/service/controller unit tests for the happy + cancel + error paths.

## Gate results
- `flutter analyze`: `No issues found! (ran in 2.4s)` — zero issues.
- `flutter test`: `All tests passed!` — 166/166 (28 new across repo/service/controllers).
- `make gen`: clean and idempotent (second run produces zero new outputs).

## Test plan
- [ ] Once Supabase + Apple Developer + GCP are configured per above, do a real iOS dev sign-in via both Google and Apple buttons (wired in NIB-107 / NIB-112).
- [ ] Verify user-cancel mid-Apple-sheet returns the user to the login screen with no error toast.
- [ ] Verify a Supabase provider misconfiguration surfaces the Supabase error message as a P1 in the controller state.