### PR TITLE
feat(auth): restyle signup to new DS, drop name field [NIB-112]

### DIFF
--- a/lib/src/common/components/inputs/app_text_field.dart
+++ b/lib/src/common/components/inputs/app_text_field.dart
@@ -18,6 +18,7 @@ class AppTextField extends StatefulWidget {
     this.onSubmitted,
     this.enabled = true,
     this.focusNode,
+    this.suffixIcon,
     super.key,
   });
 
@@ -34,6 +35,10 @@ class AppTextField extends StatefulWidget {
   final ValueChanged<String>? onSubmitted;
   final bool enabled;
   final FocusNode? focusNode;
+
+  /// Optional trailing widget rendered inside the field (e.g. a valid-email
+  /// checkmark or a password visibility toggle).
+  final Widget? suffixIcon;
 
   @override
   State<AppTextField> createState() => _AppTextFieldState();
@@ -111,27 +116,37 @@ class _AppTextFieldState extends State<AppTextField> {
           ),
           alignment: Alignment.center,
           padding: const EdgeInsets.symmetric(horizontal: AppSizes.md - 2),
-          child: TextField(
-            controller: widget.controller,
-            focusNode: _focusNode,
-            enabled: widget.enabled,
-            obscureText: widget.obscureText,
-            keyboardType: widget.keyboardType,
-            textInputAction: widget.textInputAction,
-            onChanged: widget.onChanged,
-            onSubmitted: widget.onSubmitted,
-            style: theme.textTheme.bodyLarge?.copyWith(
-              color: AppColors.fgStrong,
-            ),
-            cursorColor: AppColors.greenDeep,
-            decoration: InputDecoration(
-              isCollapsed: true,
-              border: InputBorder.none,
-              hintText: widget.hintText,
-              hintStyle: theme.textTheme.bodyLarge?.copyWith(
-                color: AppColors.greenSoft,
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: widget.controller,
+                  focusNode: _focusNode,
+                  enabled: widget.enabled,
+                  obscureText: widget.obscureText,
+                  keyboardType: widget.keyboardType,
+                  textInputAction: widget.textInputAction,
+                  onChanged: widget.onChanged,
+                  onSubmitted: widget.onSubmitted,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: AppColors.fgStrong,
+                  ),
+                  cursorColor: AppColors.greenDeep,
+                  decoration: InputDecoration(
+                    isCollapsed: true,
+                    border: InputBorder.none,
+                    hintText: widget.hintText,
+                    hintStyle: theme.textTheme.bodyLarge?.copyWith(
+                      color: AppColors.greenSoft,
+                    ),
+                  ),
+                ),
               ),
-            ),
+              if (widget.suffixIcon != null) ...[
+                const SizedBox(width: AppSizes.sm),
+                widget.suffixIcon!,
+              ],
+            ],
           ),
         ),
         if (hasError) ...[

--- a/lib/src/features/auth/register/register_controller.dart
+++ b/lib/src/features/auth/register/register_controller.dart
@@ -12,10 +12,6 @@ class RegisterController extends _$RegisterController {
   @override
   RegisterState build() => const RegisterState();
 
-  void updateName(String value) {
-    state = state.copyWith(name: value, errorMessage: null);
-  }
-
   void updateEmail(String value) {
     state = state.copyWith(email: EmailInput.dirty(value), errorMessage: null);
   }
@@ -25,6 +21,10 @@ class RegisterController extends _$RegisterController {
       password: PasswordInput.dirty(value),
       errorMessage: null,
     );
+  }
+
+  void toggleObscure() {
+    state = state.copyWith(obscure: !state.obscure);
   }
 
   Future<bool> submit() async {

--- a/lib/src/features/auth/register/register_controller.g.dart
+++ b/lib/src/features/auth/register/register_controller.g.dart
@@ -7,7 +7,7 @@ part of 'register_controller.dart';
 // **************************************************************************
 
 String _$registerControllerHash() =>
-    r'9076e4a1e6375e7db2bd9c51ca428dc19f3796bc';
+    r'4af0f369706202c2699ea88bdfabd210c3cb9361';
 
 /// See also [RegisterController].
 @ProviderFor(RegisterController)

--- a/lib/src/features/auth/register/register_screen.dart
+++ b/lib/src/features/auth/register/register_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/components.dart';
 import 'package:nibbles/src/features/auth/register/register_controller.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
@@ -12,7 +13,13 @@ class RegisterScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(registerControllerProvider);
+    final controller = ref.read(registerControllerProvider.notifier);
     final textTheme = Theme.of(context).textTheme;
+
+    final emailShowError =
+        state.email.isNotValid && state.email.value.isNotEmpty;
+    final passwordShowError =
+        state.password.isNotValid && state.password.value.isNotEmpty;
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -25,51 +32,54 @@ class RegisterScreen extends ConsumerWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              const SizedBox(height: AppSizes.lg),
+              const Center(child: BrandLogo(size: 72)),
               const SizedBox(height: AppSizes.xl),
-              Text('Create your account', style: textTheme.headlineLarge),
+              Text(
+                'Start Your Journey',
+                textAlign: TextAlign.center,
+                style: textTheme.displaySmall,
+              ),
               const SizedBox(height: AppSizes.sm),
               Text(
-                "Let's get you started.",
-                style: textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
+                'Create an account to begin guiding your '
+                'little one through solids.',
+                textAlign: TextAlign.center,
+                style: textTheme.bodyLarge?.copyWith(color: AppColors.fgMuted),
               ),
               const SizedBox(height: AppSizes.xl),
-              TextField(
-                key: const Key('register_name_field'),
-                onChanged: ref
-                    .read(registerControllerProvider.notifier)
-                    .updateName,
-                textCapitalization: TextCapitalization.words,
-                decoration: const InputDecoration(labelText: 'Your name'),
-              ),
-              const SizedBox(height: AppSizes.md),
-              TextField(
+              AppTextField(
                 key: const Key('register_email_field'),
-                onChanged: ref
-                    .read(registerControllerProvider.notifier)
-                    .updateEmail,
+                label: 'Email',
+                hintText: 'you@example.com',
                 keyboardType: TextInputType.emailAddress,
-                decoration: InputDecoration(
-                  labelText: 'Email',
-                  errorText:
-                      state.email.isNotValid && state.email.value.isNotEmpty
-                      ? 'Please enter a valid email.'
-                      : null,
-                ),
+                textInputAction: TextInputAction.next,
+                onChanged: controller.updateEmail,
+                errorText: emailShowError
+                    ? 'Please enter a valid email.'
+                    : null,
+                suffixIcon: state.email.isValid
+                    ? const Icon(
+                        Icons.check_circle_rounded,
+                        color: AppColors.success,
+                        size: AppSizes.iconMd,
+                      )
+                    : null,
               ),
               const SizedBox(height: AppSizes.md),
-              TextField(
+              AppTextField(
                 key: const Key('register_password_field'),
-                onChanged: ref
-                    .read(registerControllerProvider.notifier)
-                    .updatePassword,
-                obscureText: true,
-                decoration: InputDecoration(
-                  labelText: 'Password',
-                  errorText:
-                      state.password.isNotValid &&
-                          state.password.value.isNotEmpty
-                      ? 'Password must be at least 8 characters.'
-                      : null,
+                label: 'Password',
+                hintText: 'At least 8 characters',
+                obscureText: state.obscure,
+                textInputAction: TextInputAction.done,
+                onChanged: controller.updatePassword,
+                errorText: passwordShowError
+                    ? 'Password must be at least 8 characters.'
+                    : null,
+                suffixIcon: _ObscureToggle(
+                  obscure: state.obscure,
+                  onTap: controller.toggleObscure,
                 ),
               ),
               if (state.errorMessage != null) ...[
@@ -80,47 +90,149 @@ class RegisterScreen extends ConsumerWidget {
                 ),
               ],
               const SizedBox(height: AppSizes.xl),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton(
-                  key: const Key('register_submit_button'),
-                  onPressed: (!state.isValid || state.isLoading)
-                      ? null
-                      : () async {
-                          final ok = await ref
-                              .read(registerControllerProvider.notifier)
-                              .submit();
-                          if (ok && context.mounted) {
-                            context.goNamed(AppRoute.onboardingBabySetup.name);
-                          }
-                        },
-                  child: state.isLoading
-                      ? const SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: AppColors.onPrimary,
-                          ),
-                        )
-                      : const Text('Sign Up'),
-                ),
+              AppPillButton(
+                key: const Key('register_submit_button'),
+                label: state.isLoading ? 'Signing up…' : 'Sign Up',
+                onPressed: (!state.isValid || state.isLoading)
+                    ? null
+                    : () async {
+                        final ok = await controller.submit();
+                        if (ok && context.mounted) {
+                          context.goNamed(AppRoute.onboardingBabySetup.name);
+                        }
+                      },
               ),
-              const SizedBox(height: AppSizes.md),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text('Already have an account?', style: textTheme.bodySmall),
-                  TextButton(
-                    onPressed: () => context.goNamed(AppRoute.login.name),
-                    child: const Text('Log In'),
-                  ),
-                ],
+              const SizedBox(height: AppSizes.lg),
+              const _OrDivider(),
+              const SizedBox(height: AppSizes.lg),
+              _SocialButtons(
+                isLoading: state.isLoading,
+                onGoogle: () async {
+                  final ok = await controller.signInWithGoogle();
+                  if (ok && context.mounted) {
+                    context.goNamed(AppRoute.onboardingBabySetup.name);
+                  }
+                },
+                onApple: () async {
+                  final ok = await controller.signInWithApple();
+                  if (ok && context.mounted) {
+                    context.goNamed(AppRoute.onboardingBabySetup.name);
+                  }
+                },
               ),
+              const SizedBox(height: AppSizes.xl),
+              _LoginFooter(),
             ],
           ),
         ),
       ),
+    );
+  }
+}
+
+class _ObscureToggle extends StatelessWidget {
+  const _ObscureToggle({required this.obscure, required this.onTap});
+
+  final bool obscure;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkResponse(
+      onTap: onTap,
+      radius: AppSizes.iconMd,
+      child: Icon(
+        obscure
+            ? Icons.visibility_off_outlined
+            : Icons.visibility_outlined,
+        color: AppColors.fgMuted,
+        size: AppSizes.iconMd,
+      ),
+    );
+  }
+}
+
+class _OrDivider extends StatelessWidget {
+  const _OrDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Row(
+      children: [
+        const Expanded(child: Divider(color: AppColors.borderSoft)),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSizes.md),
+          child: Text(
+            'Or sign up with',
+            style: textTheme.bodySmall?.copyWith(color: AppColors.fgMuted),
+          ),
+        ),
+        const Expanded(child: Divider(color: AppColors.borderSoft)),
+      ],
+    );
+  }
+}
+
+class _SocialButtons extends StatelessWidget {
+  const _SocialButtons({
+    required this.isLoading,
+    required this.onGoogle,
+    required this.onApple,
+  });
+
+  final bool isLoading;
+  final VoidCallback onGoogle;
+  final VoidCallback onApple;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: AppPillButton(
+            key: const Key('register_google_button'),
+            label: 'Google',
+            variant: AppPillButtonVariant.secondary,
+            onPressed: isLoading ? null : onGoogle,
+            // TODO(infra): swap Material icon for brand Google glyph when
+            // design/assets/google.svg ships.
+            leading: const Icon(Icons.g_mobiledata_rounded),
+          ),
+        ),
+        const SizedBox(width: AppSizes.md),
+        Expanded(
+          child: AppPillButton(
+            key: const Key('register_apple_button'),
+            label: 'Apple',
+            variant: AppPillButtonVariant.secondary,
+            onPressed: isLoading ? null : onApple,
+            // TODO(infra): swap Material icon for brand Apple glyph when
+            // design/assets/apple.svg ships.
+            leading: const Icon(Icons.apple_rounded),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _LoginFooter extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          'Already have an account?',
+          style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
+        ),
+        TextButton(
+          onPressed: () => context.goNamed(AppRoute.login.name),
+          child: const Text('Login'),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/features/auth/register/register_state.dart
+++ b/lib/src/features/auth/register/register_state.dart
@@ -7,9 +7,9 @@ part 'register_state.freezed.dart';
 @freezed
 class RegisterState with _$RegisterState {
   const factory RegisterState({
-    @Default('') String name,
     @Default(EmailInput.pure()) EmailInput email,
     @Default(PasswordInput.pure()) PasswordInput password,
+    @Default(true) bool obscure,
     @Default(false) bool isLoading,
     String? errorMessage,
   }) = _RegisterState;

--- a/lib/src/features/auth/register/register_state.freezed.dart
+++ b/lib/src/features/auth/register/register_state.freezed.dart
@@ -17,9 +17,9 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$RegisterState {
-  String get name => throw _privateConstructorUsedError;
   EmailInput get email => throw _privateConstructorUsedError;
   PasswordInput get password => throw _privateConstructorUsedError;
+  bool get obscure => throw _privateConstructorUsedError;
   bool get isLoading => throw _privateConstructorUsedError;
   String? get errorMessage => throw _privateConstructorUsedError;
 
@@ -38,9 +38,9 @@ abstract class $RegisterStateCopyWith<$Res> {
   ) = _$RegisterStateCopyWithImpl<$Res, RegisterState>;
   @useResult
   $Res call({
-    String name,
     EmailInput email,
     PasswordInput password,
+    bool obscure,
     bool isLoading,
     String? errorMessage,
   });
@@ -61,18 +61,14 @@ class _$RegisterStateCopyWithImpl<$Res, $Val extends RegisterState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = null,
     Object? email = null,
     Object? password = null,
+    Object? obscure = null,
     Object? isLoading = null,
     Object? errorMessage = freezed,
   }) {
     return _then(
       _value.copyWith(
-            name: null == name
-                ? _value.name
-                : name // ignore: cast_nullable_to_non_nullable
-                      as String,
             email: null == email
                 ? _value.email
                 : email // ignore: cast_nullable_to_non_nullable
@@ -81,6 +77,10 @@ class _$RegisterStateCopyWithImpl<$Res, $Val extends RegisterState>
                 ? _value.password
                 : password // ignore: cast_nullable_to_non_nullable
                       as PasswordInput,
+            obscure: null == obscure
+                ? _value.obscure
+                : obscure // ignore: cast_nullable_to_non_nullable
+                      as bool,
             isLoading: null == isLoading
                 ? _value.isLoading
                 : isLoading // ignore: cast_nullable_to_non_nullable
@@ -105,9 +105,9 @@ abstract class _$$RegisterStateImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    String name,
     EmailInput email,
     PasswordInput password,
+    bool obscure,
     bool isLoading,
     String? errorMessage,
   });
@@ -127,18 +127,14 @@ class __$$RegisterStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = null,
     Object? email = null,
     Object? password = null,
+    Object? obscure = null,
     Object? isLoading = null,
     Object? errorMessage = freezed,
   }) {
     return _then(
       _$RegisterStateImpl(
-        name: null == name
-            ? _value.name
-            : name // ignore: cast_nullable_to_non_nullable
-                  as String,
         email: null == email
             ? _value.email
             : email // ignore: cast_nullable_to_non_nullable
@@ -147,6 +143,10 @@ class __$$RegisterStateImplCopyWithImpl<$Res>
             ? _value.password
             : password // ignore: cast_nullable_to_non_nullable
                   as PasswordInput,
+        obscure: null == obscure
+            ? _value.obscure
+            : obscure // ignore: cast_nullable_to_non_nullable
+                  as bool,
         isLoading: null == isLoading
             ? _value.isLoading
             : isLoading // ignore: cast_nullable_to_non_nullable
@@ -164,16 +164,13 @@ class __$$RegisterStateImplCopyWithImpl<$Res>
 
 class _$RegisterStateImpl extends _RegisterState {
   const _$RegisterStateImpl({
-    this.name = '',
     this.email = const EmailInput.pure(),
     this.password = const PasswordInput.pure(),
+    this.obscure = true,
     this.isLoading = false,
     this.errorMessage,
   }) : super._();
 
-  @override
-  @JsonKey()
-  final String name;
   @override
   @JsonKey()
   final EmailInput email;
@@ -182,13 +179,16 @@ class _$RegisterStateImpl extends _RegisterState {
   final PasswordInput password;
   @override
   @JsonKey()
+  final bool obscure;
+  @override
+  @JsonKey()
   final bool isLoading;
   @override
   final String? errorMessage;
 
   @override
   String toString() {
-    return 'RegisterState(name: $name, email: $email, password: $password, isLoading: $isLoading, errorMessage: $errorMessage)';
+    return 'RegisterState(email: $email, password: $password, obscure: $obscure, isLoading: $isLoading, errorMessage: $errorMessage)';
   }
 
   @override
@@ -196,10 +196,10 @@ class _$RegisterStateImpl extends _RegisterState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RegisterStateImpl &&
-            (identical(other.name, name) || other.name == name) &&
             (identical(other.email, email) || other.email == email) &&
             (identical(other.password, password) ||
                 other.password == password) &&
+            (identical(other.obscure, obscure) || other.obscure == obscure) &&
             (identical(other.isLoading, isLoading) ||
                 other.isLoading == isLoading) &&
             (identical(other.errorMessage, errorMessage) ||
@@ -207,8 +207,14 @@ class _$RegisterStateImpl extends _RegisterState {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, name, email, password, isLoading, errorMessage);
+  int get hashCode => Object.hash(
+    runtimeType,
+    email,
+    password,
+    obscure,
+    isLoading,
+    errorMessage,
+  );
 
   /// Create a copy of RegisterState
   /// with the given fields replaced by the non-null parameter values.
@@ -221,20 +227,20 @@ class _$RegisterStateImpl extends _RegisterState {
 
 abstract class _RegisterState extends RegisterState {
   const factory _RegisterState({
-    final String name,
     final EmailInput email,
     final PasswordInput password,
+    final bool obscure,
     final bool isLoading,
     final String? errorMessage,
   }) = _$RegisterStateImpl;
   const _RegisterState._() : super._();
 
   @override
-  String get name;
-  @override
   EmailInput get email;
   @override
   PasswordInput get password;
+  @override
+  bool get obscure;
   @override
   bool get isLoading;
   @override


### PR DESCRIPTION
## Summary
Migrates SignupScreen to the new design system per Figma 1023:6996 / 1023:7060: BrandLogo, two fields (email with valid-check, password with visibility toggle), Or-divider + Google/Apple social buttons, AppPillButton CTA. Removes the name field from the screen and cleans up the dead `name` / `updateName` compile-compat stubs that NIB-122 left in `RegisterState` / `RegisterController`.

## Changes
- `register_screen.dart` rebuilt to use BrandLogo, two `AppTextField`s, inline social row, `AppPillButton`, login footer.
- `register_state.dart`: drop `name`; add `bool obscure = true` for password toggle.
- `register_controller.dart`: drop `updateName`; add `toggleObscure()`.
- `app_text_field.dart`: additive optional `suffixIcon` param (default null) for valid-email checkmark and password visibility toggle. Existing callers (reset_password, forgot_password, gallery) unaffected.
- Widget keys preserved: `register_email_field`, `register_password_field`, `register_submit_button`. New: `register_google_button`, `register_apple_button`.
- Social brand glyphs not yet in `design/assets/` — Material icon fallbacks with `TODO(infra)` per spec.
- `register_controller_test.dart` already did not reference `name` / `updateName`; no test changes required.

## Acceptance criteria
- [x] Screen matches Figma 1023:6996 (two fields, no name, BrandLogo, social buttons).
- [x] `EmailInput.isValid` -> trailing green checkmark; otherwise none. No availability check (enumeration-safe).
- [x] Password toggle works (state-driven via `obscure`).
- [x] `RegisterState` no longer references `name`; `isValid = email.isValid && password.isValid`; `controller.updateName` removed.
- [x] All tests green; flutter analyze zero warnings.

## Gate results
- `make gen`: clean (276 outputs; second run = 0 actions, stable).
- `flutter analyze`: No issues found.
- `flutter test`: All 166 tests passed.