### PR TITLE
chore(auth): analytics events + crashlytics non-fatals for auth [NIB-118]

### DIFF
--- a/lib/src/common/data/repositories/auth_repository.dart
+++ b/lib/src/common/data/repositories/auth_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:nibbles/src/app/config/flavor_config.dart';
@@ -28,6 +29,11 @@ typedef AppleCredentialFn =
 /// in tests (the real `GoogleSignIn.instance.initialize` throws on a missing
 /// platform plugin under the test runner).
 typedef GoogleInitializeFn = Future<void> Function();
+
+/// Function injected so unit tests don't touch real Crashlytics. Records a
+/// non-fatal diagnostic for an unrecognised auth exception path.
+typedef AuthCrashRecorderFn =
+    Future<void> Function(Object error, StackTrace stack);
 
 abstract interface class AuthRepository {
   Future<Result<void>> signUp(String email, String password);
@@ -58,12 +64,14 @@ class AuthRepositoryImpl implements AuthRepository {
     GoogleAuthorizeFn? googleAuthorize,
     AppleCredentialFn? appleCredential,
     String? Function()? generateRawNonce,
+    AuthCrashRecorderFn? crashRecorder,
   }) : _supabase = supabaseClient ?? Supabase.instance.client,
        _googleInitialize = googleInitialize ?? _defaultGoogleInitialize,
        _googleAuthenticate = googleAuthenticate ?? _defaultGoogleAuthenticate,
        _googleAuthorize = googleAuthorize ?? _defaultGoogleAuthorize,
        _appleCredential = appleCredential ?? _defaultAppleCredential,
-       _generateRawNonce = generateRawNonce;
+       _generateRawNonce = generateRawNonce,
+       _crashRecorder = crashRecorder ?? _defaultCrashRecorder;
 
   final SupabaseClient _supabase;
   final GoogleInitializeFn _googleInitialize;
@@ -71,6 +79,7 @@ class AuthRepositoryImpl implements AuthRepository {
   final GoogleAuthorizeFn _googleAuthorize;
   final AppleCredentialFn _appleCredential;
   final String? Function()? _generateRawNonce;
+  final AuthCrashRecorderFn _crashRecorder;
 
   /// One-shot guard. `GoogleSignIn.initialize()` must run exactly once per
   /// process — calling it twice is undefined behavior per the 7.x docs.
@@ -97,7 +106,8 @@ class AuthRepositoryImpl implements AuthRepository {
       return const Result.success(null);
     } on AuthException catch (e) {
       return Result.failure(ServerException(e.message));
-    } on Object {
+    } on Object catch (e, st) {
+      await _recordAuthUnknown(e, st);
       return const Result.failure(UnknownException());
     }
   }
@@ -109,7 +119,8 @@ class AuthRepositoryImpl implements AuthRepository {
       return const Result.success(null);
     } on AuthException catch (e) {
       return Result.failure(ServerException(e.message));
-    } on Object {
+    } on Object catch (e, st) {
+      await _recordAuthUnknown(e, st);
       return const Result.failure(UnknownException());
     }
   }
@@ -150,7 +161,8 @@ class AuthRepositoryImpl implements AuthRepository {
       return const Result.success(true);
     } on AuthException catch (e) {
       return Result.failure(ServerException(e.message));
-    } on Object {
+    } on Object catch (e, st) {
+      await _recordAuthUnknown(e, st);
       return const Result.failure(UnknownException());
     }
   }
@@ -191,7 +203,8 @@ class AuthRepositoryImpl implements AuthRepository {
       return const Result.success(true);
     } on AuthException catch (e) {
       return Result.failure(ServerException(e.message));
-    } on Object {
+    } on Object catch (e, st) {
+      await _recordAuthUnknown(e, st);
       return const Result.failure(UnknownException());
     }
   }
@@ -203,7 +216,8 @@ class AuthRepositoryImpl implements AuthRepository {
       return const Result.success(null);
     } on AuthException catch (e) {
       return Result.failure(ServerException(e.message));
-    } on Object {
+    } on Object catch (e, st) {
+      await _recordAuthUnknown(e, st);
       return const Result.failure(UnknownException());
     }
   }
@@ -218,7 +232,8 @@ class AuthRepositoryImpl implements AuthRepository {
       return const Result.success(null);
     } on AuthException catch (e) {
       return Result.failure(ServerException(e.message));
-    } on Object {
+    } on Object catch (e, st) {
+      await _recordAuthUnknown(e, st);
       return const Result.failure(UnknownException());
     }
   }
@@ -230,7 +245,8 @@ class AuthRepositoryImpl implements AuthRepository {
       return const Result.success(null);
     } on AuthException catch (e) {
       return Result.failure(ServerException(e.message));
-    } on Object {
+    } on Object catch (e, st) {
+      await _recordAuthUnknown(e, st);
       return const Result.failure(UnknownException());
     }
   }
@@ -239,6 +255,18 @@ class AuthRepositoryImpl implements AuthRepository {
   /// after the first reuse the same Future.
   Future<void> _ensureGoogleInitialized() =>
       _googleInitFuture ??= _googleInitialize();
+
+  /// Records an unrecognised auth-path exception to Crashlytics as a
+  /// non-fatal. Guarded so a Crashlytics failure (e.g. uninitialised Firebase
+  /// in tests) never escalates the original failure path. No PII passed —
+  /// only the raw error/stack and a static reason string.
+  Future<void> _recordAuthUnknown(Object error, StackTrace stack) async {
+    try {
+      await _crashRecorder(error, stack);
+    } on Object {
+      // Crashlytics is best-effort; never let it escalate the auth failure.
+    }
+  }
 }
 
 String? _readServerClientId() {
@@ -280,6 +308,13 @@ Future<AuthorizationCredentialAppleID> _defaultAppleCredential(
     nonce: hashedNonce,
   );
 }
+
+Future<void> _defaultCrashRecorder(Object error, StackTrace stack) =>
+    FirebaseCrashlytics.instance.recordError(
+      error,
+      stack,
+      reason: 'auth_unknown',
+    );
 
 @Riverpod(keepAlive: true)
 // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.

--- a/lib/src/features/auth/forgot_password/forgot_password_controller.dart
+++ b/lib/src/features/auth/forgot_password/forgot_password_controller.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:nibbles/src/common/domain/formz/email_input.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/features/auth/forgot_password/forgot_password_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'forgot_password_controller.g.dart';
@@ -31,9 +34,20 @@ class ForgotPasswordController extends _$ForgotPasswordController {
         .resetPassword(state.email.value);
 
     result.when(
-      success: (_) => state = state.copyWith(isLoading: false, sent: true),
+      success: (_) {
+        state = state.copyWith(isLoading: false, sent: true);
+        _fireAndForget(
+          ref.read(analyticsProvider).logPasswordResetRequested(),
+        );
+      },
       failure: (error) =>
           state = state.copyWith(isLoading: false, errorMessage: error.message),
     );
+  }
+
+  /// Analytics is best-effort. Swallow any rejected future so it never blocks
+  /// navigation or escalates to the root zone.
+  void _fireAndForget(Future<void> future) {
+    unawaited(future.catchError((Object _) {}));
   }
 }

--- a/lib/src/features/auth/forgot_password/forgot_password_controller.g.dart
+++ b/lib/src/features/auth/forgot_password/forgot_password_controller.g.dart
@@ -7,7 +7,7 @@ part of 'forgot_password_controller.dart';
 // **************************************************************************
 
 String _$forgotPasswordControllerHash() =>
-    r'3a957daf0d3c1081d26fda78661f9abb1eaa44ed';
+    r'6eb18753f1101a6704df4ebe450f0359f85addca';
 
 /// See also [ForgotPasswordController].
 @ProviderFor(ForgotPasswordController)

--- a/lib/src/features/auth/login/login_controller.dart
+++ b/lib/src/features/auth/login/login_controller.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/formz/email_input.dart';
 import 'package:nibbles/src/common/domain/formz/password_input.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/features/auth/login/login_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'login_controller.g.dart';
@@ -28,6 +31,12 @@ class LoginController extends _$LoginController {
   }
 
   Future<void> submit() async {
+    _fireAndForget(
+      ref
+          .read(analyticsProvider)
+          .logLoginMethodSelected(method: AuthMethod.email),
+    );
+
     state = state.copyWith(isLoading: true, errorMessage: null);
 
     final result = await ref
@@ -35,22 +44,46 @@ class LoginController extends _$LoginController {
         .signIn(state.email.value, state.password.value);
 
     result.when(
-      success: (_) => state = state.copyWith(isLoading: false),
-      failure: (error) =>
-          state = state.copyWith(isLoading: false, errorMessage: error.message),
+      success: (_) {
+        state = state.copyWith(isLoading: false);
+        _fireAndForget(
+          ref.read(analyticsProvider).logLoginSuccess(method: AuthMethod.email),
+        );
+      },
+      failure: (error) {
+        state = state.copyWith(isLoading: false, errorMessage: error.message);
+        _fireAndForget(
+          ref.read(analyticsProvider).logLoginFailure(
+            method: AuthMethod.email,
+            errorCode: authErrorCode(error),
+          ),
+        );
+      },
     );
     // On success: GoRouter redirect picks up authServiceProvider state change
   }
 
   Future<void> signInWithGoogle() => _runSocial(
-    () => ref.read(authServiceProvider.notifier).signInWithGoogle(),
+    method: AuthMethod.google,
+    provider: SocialProvider.google,
+    call: () => ref.read(authServiceProvider.notifier).signInWithGoogle(),
   );
 
   Future<void> signInWithApple() => _runSocial(
-    () => ref.read(authServiceProvider.notifier).signInWithApple(),
+    method: AuthMethod.apple,
+    provider: SocialProvider.apple,
+    call: () => ref.read(authServiceProvider.notifier).signInWithApple(),
   );
 
-  Future<void> _runSocial(Future<Result<bool>> Function() call) async {
+  Future<void> _runSocial({
+    required AuthMethod method,
+    required SocialProvider provider,
+    required Future<Result<bool>> Function() call,
+  }) async {
+    _fireAndForget(
+      ref.read(analyticsProvider).logLoginMethodSelected(method: method),
+    );
+
     state = state.copyWith(isLoading: true, errorMessage: null);
 
     final result = await call();
@@ -58,9 +91,35 @@ class LoginController extends _$LoginController {
     result.when(
       // Success(false) = user-cancel: clear loading silently, no error UI.
       // Success(true)  = signed in: router redirect picks up the state flip.
-      success: (_) => state = state.copyWith(isLoading: false),
-      failure: (error) =>
-          state = state.copyWith(isLoading: false, errorMessage: error.message),
+      success: (signedIn) {
+        state = state.copyWith(isLoading: false);
+        if (signedIn) {
+          _fireAndForget(
+            ref.read(analyticsProvider).logLoginSuccess(method: method),
+          );
+        } else {
+          _fireAndForget(
+            ref
+                .read(analyticsProvider)
+                .logSocialLoginCancelled(provider: provider),
+          );
+        }
+      },
+      failure: (error) {
+        state = state.copyWith(isLoading: false, errorMessage: error.message);
+        _fireAndForget(
+          ref.read(analyticsProvider).logLoginFailure(
+            method: method,
+            errorCode: authErrorCode(error),
+          ),
+        );
+      },
     );
+  }
+
+  /// Analytics is best-effort. Swallow any rejected future so it never blocks
+  /// navigation or escalates to the root zone.
+  void _fireAndForget(Future<void> future) {
+    unawaited(future.catchError((Object _) {}));
   }
 }

--- a/lib/src/features/auth/login/login_controller.g.dart
+++ b/lib/src/features/auth/login/login_controller.g.dart
@@ -6,7 +6,7 @@ part of 'login_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$loginControllerHash() => r'1145394dd7ee3831cc321ec84a61e566f0ce6e5a';
+String _$loginControllerHash() => r'70dda1143989256b3b5b1fdad9225baa1373ecba';
 
 /// See also [LoginController].
 @ProviderFor(LoginController)

--- a/lib/src/features/auth/register/register_controller.dart
+++ b/lib/src/features/auth/register/register_controller.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/formz/email_input.dart';
 import 'package:nibbles/src/common/domain/formz/password_input.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/features/auth/register/register_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'register_controller.g.dart';
@@ -28,6 +31,12 @@ class RegisterController extends _$RegisterController {
   }
 
   Future<bool> submit() async {
+    _fireAndForget(
+      ref
+          .read(analyticsProvider)
+          .logSignUpMethodSelected(method: AuthMethod.email),
+    );
+
     state = state.copyWith(isLoading: true, errorMessage: null);
 
     final result = await ref
@@ -37,27 +46,50 @@ class RegisterController extends _$RegisterController {
     return result.when(
       success: (_) {
         state = state.copyWith(isLoading: false);
+        _fireAndForget(
+          ref
+              .read(analyticsProvider)
+              .logSignUpSuccess(method: AuthMethod.email),
+        );
         return true;
       },
       failure: (error) {
         state = state.copyWith(isLoading: false, errorMessage: error.message);
+        _fireAndForget(
+          ref.read(analyticsProvider).logSignUpFailure(
+            method: AuthMethod.email,
+            errorCode: authErrorCode(error),
+          ),
+        );
         return false;
       },
     );
   }
 
   Future<bool> signInWithGoogle() => _runSocial(
-    () => ref.read(authServiceProvider.notifier).signInWithGoogle(),
+    method: AuthMethod.google,
+    provider: SocialProvider.google,
+    call: () => ref.read(authServiceProvider.notifier).signInWithGoogle(),
   );
 
   Future<bool> signInWithApple() => _runSocial(
-    () => ref.read(authServiceProvider.notifier).signInWithApple(),
+    method: AuthMethod.apple,
+    provider: SocialProvider.apple,
+    call: () => ref.read(authServiceProvider.notifier).signInWithApple(),
   );
 
   /// Returns `true` on successful sign-in, `false` for cancel or failure.
   /// On failure the error message is stored in state so the screen can
   /// render it as P1. On cancel the error is silent.
-  Future<bool> _runSocial(Future<Result<bool>> Function() call) async {
+  Future<bool> _runSocial({
+    required AuthMethod method,
+    required SocialProvider provider,
+    required Future<Result<bool>> Function() call,
+  }) async {
+    _fireAndForget(
+      ref.read(analyticsProvider).logSignUpMethodSelected(method: method),
+    );
+
     state = state.copyWith(isLoading: true, errorMessage: null);
 
     final result = await call();
@@ -66,12 +98,35 @@ class RegisterController extends _$RegisterController {
       success: (signedIn) {
         // signedIn == false ⇒ user-cancel: silent no-op, no error UI.
         state = state.copyWith(isLoading: false);
+        if (signedIn) {
+          _fireAndForget(
+            ref.read(analyticsProvider).logSignUpSuccess(method: method),
+          );
+        } else {
+          _fireAndForget(
+            ref
+                .read(analyticsProvider)
+                .logSocialLoginCancelled(provider: provider),
+          );
+        }
         return signedIn;
       },
       failure: (error) {
         state = state.copyWith(isLoading: false, errorMessage: error.message);
+        _fireAndForget(
+          ref.read(analyticsProvider).logSignUpFailure(
+            method: method,
+            errorCode: authErrorCode(error),
+          ),
+        );
         return false;
       },
     );
+  }
+
+  /// Analytics is best-effort. Swallow any rejected future so it never blocks
+  /// navigation or escalates to the root zone.
+  void _fireAndForget(Future<void> future) {
+    unawaited(future.catchError((Object _) {}));
   }
 }

--- a/lib/src/features/auth/register/register_controller.g.dart
+++ b/lib/src/features/auth/register/register_controller.g.dart
@@ -7,7 +7,7 @@ part of 'register_controller.dart';
 // **************************************************************************
 
 String _$registerControllerHash() =>
-    r'4af0f369706202c2699ea88bdfabd210c3cb9361';
+    r'719eb5625536c94ecbd5749d299fb6189893867a';
 
 /// See also [RegisterController].
 @ProviderFor(RegisterController)

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -1,4 +1,47 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'analytics.g.dart';
+
+/// Provider for the [Analytics] wrapper. Defaults to the real singleton; tests
+/// override it with a fake recorder to assert calls without touching Firebase.
+@Riverpod(keepAlive: true)
+// Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+// ignore: deprecated_member_use_from_same_package
+Analytics analytics(AnalyticsRef ref) => Analytics.instance;
+
+/// Auth methods surfaced in analytics events. Mirrors the values listed in
+/// NIB-118: 'email', 'google', 'apple'.
+enum AuthMethod {
+  email,
+  google,
+  apple;
+
+  String get value => name;
+}
+
+/// Social providers surfaced in `social_login_cancelled`. Distinct from
+/// [AuthMethod] because email is never a "social" provider.
+enum SocialProvider {
+  google,
+  apple;
+
+  String get value => name;
+}
+
+/// Maps an [AppException] subtype to a stable, non-PII analytics error code.
+///
+/// Codes are derived from the exception TYPE only — the raw message (which can
+/// contain Supabase or provider strings) is never used. Keep the set small and
+/// stable so downstream dashboards stay consistent.
+String authErrorCode(AppException error) => switch (error) {
+  NetworkException() => 'network',
+  ServerException() => 'server_exception',
+  UnauthorizedException() => 'unauthorized',
+  NotFoundException() => 'not_found',
+  UnknownException() => 'unknown',
+};
 
 /// Thin wrapper around [FirebaseAnalytics] that enforces no-PII policy.
 ///
@@ -6,7 +49,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 /// - Never log user IDs, email addresses, names, or any PII.
 /// - Event names must be snake_case and <= 40 characters.
 /// - Parameter values must be non-PII primitives (String, num, bool).
-final class Analytics {
+class Analytics {
   Analytics._();
 
   static final Analytics instance = Analytics._();
@@ -38,15 +81,70 @@ final class Analytics {
   }
 
   // ---------------------------------------------------------------------------
-  // Auth
+  // Auth — login
   // ---------------------------------------------------------------------------
 
-  Future<void> logSignUp() async {
-    await _analytics.logSignUp(signUpMethod: 'email');
+  Future<void> logLoginMethodSelected({required AuthMethod method}) async {
+    await _logEvent(
+      'login_method_selected',
+      parameters: {'method': method.value},
+    );
   }
 
-  Future<void> logLogin() async {
-    await _analytics.logLogin(loginMethod: 'email');
+  Future<void> logLoginSuccess({required AuthMethod method}) async {
+    await _logEvent('login_success', parameters: {'method': method.value});
+  }
+
+  Future<void> logLoginFailure({
+    required AuthMethod method,
+    required String errorCode,
+  }) async {
+    await _logEvent(
+      'login_failure',
+      parameters: {'method': method.value, 'error_code': errorCode},
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Auth — sign up
+  // ---------------------------------------------------------------------------
+
+  Future<void> logSignUpMethodSelected({required AuthMethod method}) async {
+    await _logEvent(
+      'sign_up_method_selected',
+      parameters: {'method': method.value},
+    );
+  }
+
+  Future<void> logSignUpSuccess({required AuthMethod method}) async {
+    await _logEvent('sign_up_success', parameters: {'method': method.value});
+  }
+
+  Future<void> logSignUpFailure({
+    required AuthMethod method,
+    required String errorCode,
+  }) async {
+    await _logEvent(
+      'sign_up_failure',
+      parameters: {'method': method.value, 'error_code': errorCode},
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Auth — password reset + social cancel + logout
+  // ---------------------------------------------------------------------------
+
+  Future<void> logPasswordResetRequested() async {
+    await _logEvent('password_reset_requested');
+  }
+
+  Future<void> logSocialLoginCancelled({
+    required SocialProvider provider,
+  }) async {
+    await _logEvent(
+      'social_login_cancelled',
+      parameters: {'provider': provider.value},
+    );
   }
 
   Future<void> logLogout() async {

--- a/lib/src/logging/analytics.g.dart
+++ b/lib/src/logging/analytics.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'analytics.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$analyticsHash() => r'124fb5d6987b796158f6c5442f34ebc16c9613ce';
+
+/// Provider for the [Analytics] wrapper. Defaults to the real singleton; tests
+/// override it with a fake recorder to assert calls without touching Firebase.
+///
+/// Copied from [analytics].
+@ProviderFor(analytics)
+final analyticsProvider = Provider<Analytics>.internal(
+  analytics,
+  name: r'analyticsProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$analyticsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AnalyticsRef = ProviderRef<Analytics>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/test/common/data/repositories/auth_repository_test.dart
+++ b/test/common/data/repositories/auth_repository_test.dart
@@ -88,6 +88,7 @@ void main() {
     GoogleAuthorizeFn? googleAuthorize,
     AppleCredentialFn? appleCredential,
     String? Function()? generateRawNonce,
+    AuthCrashRecorderFn? crashRecorder,
   }) {
     return AuthRepositoryImpl(
       supabaseClient: mockClient,
@@ -97,6 +98,8 @@ void main() {
       googleAuthorize: googleAuthorize,
       appleCredential: appleCredential,
       generateRawNonce: generateRawNonce,
+      // Default: swallow so tests don't touch real Crashlytics.
+      crashRecorder: crashRecorder ?? (_, __) async {},
     );
   }
 
@@ -324,6 +327,52 @@ void main() {
 
       expect(result, isA<Failure<bool>>());
       expect((result as Failure<bool>).error.message, 'nonce mismatch');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Crashlytics non-fatal on UnknownException path
+  // -------------------------------------------------------------------------
+
+  group('Crashlytics non-fatal', () {
+    test('records the original error on signIn UnknownException', () async {
+      Object? recordedError;
+      final sut = buildSut(
+        crashRecorder: (error, _) async {
+          recordedError = error;
+        },
+      );
+      final boom = Exception('boom');
+      when(
+        () => mockAuth.signInWithPassword(
+          email: any(named: 'email'),
+          password: any(named: 'password'),
+        ),
+      ).thenThrow(boom);
+
+      final result = await sut.signIn('e@e.com', 'pw');
+
+      expect(result, isA<Failure<void>>());
+      expect((result as Failure<void>).error, isA<UnknownException>());
+      expect(recordedError, same(boom));
+    });
+
+    test('crash recorder throwing does NOT escalate', () async {
+      final sut = buildSut(
+        crashRecorder: (_, __) => throw Exception('crashlytics down'),
+      );
+      when(
+        () => mockAuth.signInWithPassword(
+          email: any(named: 'email'),
+          password: any(named: 'password'),
+        ),
+      ).thenThrow(Exception('boom'));
+
+      // Must complete normally with a Failure — Crashlytics must not bubble.
+      final result = await sut.signIn('e@e.com', 'pw');
+
+      expect(result, isA<Failure<void>>());
+      expect((result as Failure<void>).error, isA<UnknownException>());
     });
   });
 }

--- a/test/features/auth/forgot_password/forgot_password_controller_test.dart
+++ b/test/features/auth/forgot_password/forgot_password_controller_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/auth/forgot_password/forgot_password_controller.dart';
+import 'package:nibbles/src/features/auth/forgot_password/forgot_password_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockLocalFlagService extends Mock implements LocalFlagService {}
+
+void main() {
+  late MockAuthRepository mockRepo;
+  late MockLocalFlagService mockFlags;
+  late FakeAnalytics fakeAnalytics;
+  late ProviderContainer container;
+
+  setUp(() {
+    mockRepo = MockAuthRepository();
+    mockFlags = MockLocalFlagService();
+    fakeAnalytics = FakeAnalytics();
+    when(() => mockRepo.isLoggedIn).thenReturn(false);
+    when(
+      () => mockRepo.authStateStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(mockFlags.isOnboardingBabySetupDone).thenReturn(true);
+
+    container = ProviderContainer(
+      overrides: [
+        authRepositoryProvider.overrideWithValue(mockRepo),
+        localFlagServiceProvider.overrideWithValue(mockFlags),
+        analyticsProvider.overrideWithValue(fakeAnalytics),
+      ],
+    )
+    // Hold the controller alive across awaits so state isn't lost to
+    // auto-dispose between assertions.
+    ..listen<ForgotPasswordState>(
+      forgotPasswordControllerProvider,
+      (_, __) {},
+    );
+  });
+
+  tearDown(() => container.dispose());
+
+  ForgotPasswordController readController() =>
+      container.read(forgotPasswordControllerProvider.notifier);
+
+  test('invalid email short-circuits and does NOT fire any event', () async {
+    readController().updateEmail('not-an-email');
+
+    await readController().submit();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(fakeAnalytics.calls, isEmpty);
+    verifyNever(() => mockRepo.resetPassword(any()));
+  });
+
+  test('fires password_reset_requested on success', () async {
+    when(
+      () => mockRepo.resetPassword(any()),
+    ).thenAnswer((_) async => const Result.success(null));
+
+    readController().updateEmail('jane@example.com');
+    await readController().submit();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(forgotPasswordControllerProvider).sent, isTrue);
+    expect(fakeAnalytics.eventNames, ['password_reset_requested']);
+    expect(fakeAnalytics.calls.single.parameters, isEmpty);
+  });
+
+  test('does NOT fire on Failure', () async {
+    when(() => mockRepo.resetPassword(any())).thenAnswer(
+      (_) async => const Result.failure(ServerException('rate-limited')),
+    );
+
+    readController().updateEmail('jane@example.com');
+    await readController().submit();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(forgotPasswordControllerProvider).sent, isFalse);
+    expect(fakeAnalytics.calls, isEmpty);
+  });
+}

--- a/test/features/auth/login/login_controller_test.dart
+++ b/test/features/auth/login/login_controller_test.dart
@@ -6,6 +6,10 @@ import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/auth/login/login_controller.dart';
+import 'package:nibbles/src/features/auth/login/login_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../../support/fake_analytics.dart';
 
 class MockAuthRepository extends Mock implements AuthRepository {}
 
@@ -14,11 +18,13 @@ class MockLocalFlagService extends Mock implements LocalFlagService {}
 void main() {
   late MockAuthRepository mockRepo;
   late MockLocalFlagService mockFlags;
+  late FakeAnalytics fakeAnalytics;
   late ProviderContainer container;
 
   setUp(() {
     mockRepo = MockAuthRepository();
     mockFlags = MockLocalFlagService();
+    fakeAnalytics = FakeAnalytics();
     when(() => mockRepo.isLoggedIn).thenReturn(false);
     when(
       () => mockRepo.authStateStream,
@@ -29,14 +35,98 @@ void main() {
       overrides: [
         authRepositoryProvider.overrideWithValue(mockRepo),
         localFlagServiceProvider.overrideWithValue(mockFlags),
+        analyticsProvider.overrideWithValue(fakeAnalytics),
       ],
-    );
+    )
+    // Hold the controller alive across awaits so state isn't lost to
+    // auto-dispose between assertions.
+    ..listen<LoginState>(loginControllerProvider, (_, __) {});
   });
 
   tearDown(() => container.dispose());
 
   LoginController readController() =>
       container.read(loginControllerProvider.notifier);
+
+  // ---------------------------------------------------------------------------
+  // submit() — email login
+  // ---------------------------------------------------------------------------
+
+  group('submit (email)', () {
+    test('fires method_selected + success on Success', () async {
+      when(
+        () => mockRepo.signIn(any(), any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      await readController().submit();
+
+      // Drain pending fire-and-forget microtasks.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        fakeAnalytics.eventNames,
+        ['login_method_selected', 'login_success'],
+      );
+      expect(
+        fakeAnalytics.calls[0].parameters,
+        {'method': 'email'},
+      );
+      expect(
+        fakeAnalytics.calls[1].parameters,
+        {'method': 'email'},
+      );
+    });
+
+    test('fires method_selected + failure on Failure', () async {
+      when(() => mockRepo.signIn(any(), any())).thenAnswer(
+        (_) async => const Result.failure(ServerException('bad creds')),
+      );
+
+      await readController().submit();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        fakeAnalytics.eventNames,
+        ['login_method_selected', 'login_failure'],
+      );
+      expect(
+        fakeAnalytics.calls[1].parameters,
+        {'method': 'email', 'error_code': 'server_exception'},
+      );
+    });
+
+    test('maps NetworkException to network error_code', () async {
+      when(() => mockRepo.signIn(any(), any())).thenAnswer(
+        (_) async => const Result.failure(NetworkException()),
+      );
+
+      await readController().submit();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        fakeAnalytics.calls.last.parameters,
+        {'method': 'email', 'error_code': 'network'},
+      );
+    });
+
+    test('maps UnknownException to unknown error_code', () async {
+      when(() => mockRepo.signIn(any(), any())).thenAnswer(
+        (_) async => const Result.failure(UnknownException()),
+      );
+
+      await readController().submit();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        fakeAnalytics.calls.last.parameters,
+        {'method': 'email', 'error_code': 'unknown'},
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // signInWithGoogle
+  // ---------------------------------------------------------------------------
 
   group('signInWithGoogle', () {
     test('clears loading + no error on Success(true)', () async {
@@ -45,10 +135,19 @@ void main() {
       ).thenAnswer((_) async => const Result.success(true));
 
       await readController().signInWithGoogle();
+      await Future<void>.delayed(Duration.zero);
 
       final state = container.read(loginControllerProvider);
       expect(state.isLoading, isFalse);
       expect(state.errorMessage, isNull);
+      expect(
+        fakeAnalytics.eventNames,
+        ['login_method_selected', 'login_success'],
+      );
+      expect(
+        fakeAnalytics.calls[0].parameters,
+        {'method': 'google'},
+      );
     });
 
     test('clears loading + no error on Success(false) (cancel)', () async {
@@ -57,24 +156,46 @@ void main() {
       ).thenAnswer((_) async => const Result.success(false));
 
       await readController().signInWithGoogle();
+      await Future<void>.delayed(Duration.zero);
 
       final state = container.read(loginControllerProvider);
       expect(state.isLoading, isFalse);
       expect(state.errorMessage, isNull);
+      expect(
+        fakeAnalytics.eventNames,
+        ['login_method_selected', 'social_login_cancelled'],
+      );
+      expect(
+        fakeAnalytics.calls.last.parameters,
+        {'provider': 'google'},
+      );
     });
 
-    test('sets errorMessage on Failure', () async {
+    test('sets errorMessage on Failure and fires login_failure', () async {
       when(() => mockRepo.signInWithGoogle()).thenAnswer(
         (_) async => const Result.failure(ServerException('Google failed')),
       );
 
       await readController().signInWithGoogle();
+      await Future<void>.delayed(Duration.zero);
 
       final state = container.read(loginControllerProvider);
       expect(state.isLoading, isFalse);
       expect(state.errorMessage, 'Google failed');
+      expect(
+        fakeAnalytics.eventNames,
+        ['login_method_selected', 'login_failure'],
+      );
+      expect(
+        fakeAnalytics.calls.last.parameters,
+        {'method': 'google', 'error_code': 'server_exception'},
+      );
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // signInWithApple
+  // ---------------------------------------------------------------------------
 
   group('signInWithApple', () {
     test('clears loading + no error on Success(true)', () async {
@@ -83,10 +204,19 @@ void main() {
       ).thenAnswer((_) async => const Result.success(true));
 
       await readController().signInWithApple();
+      await Future<void>.delayed(Duration.zero);
 
       final state = container.read(loginControllerProvider);
       expect(state.isLoading, isFalse);
       expect(state.errorMessage, isNull);
+      expect(
+        fakeAnalytics.eventNames,
+        ['login_method_selected', 'login_success'],
+      );
+      expect(
+        fakeAnalytics.calls[0].parameters,
+        {'method': 'apple'},
+      );
     });
 
     test('clears loading + no error on Success(false) (cancel)', () async {
@@ -95,22 +225,68 @@ void main() {
       ).thenAnswer((_) async => const Result.success(false));
 
       await readController().signInWithApple();
+      await Future<void>.delayed(Duration.zero);
 
       final state = container.read(loginControllerProvider);
       expect(state.isLoading, isFalse);
       expect(state.errorMessage, isNull);
+      expect(
+        fakeAnalytics.eventNames,
+        ['login_method_selected', 'social_login_cancelled'],
+      );
+      expect(
+        fakeAnalytics.calls.last.parameters,
+        {'provider': 'apple'},
+      );
     });
 
-    test('sets errorMessage on Failure', () async {
+    test('sets errorMessage on Failure and fires login_failure', () async {
       when(() => mockRepo.signInWithApple()).thenAnswer(
         (_) async => const Result.failure(ServerException('Apple failed')),
       );
 
       await readController().signInWithApple();
+      await Future<void>.delayed(Duration.zero);
 
       final state = container.read(loginControllerProvider);
       expect(state.isLoading, isFalse);
       expect(state.errorMessage, 'Apple failed');
+      expect(
+        fakeAnalytics.eventNames,
+        ['login_method_selected', 'login_failure'],
+      );
+      expect(
+        fakeAnalytics.calls.last.parameters,
+        {'method': 'apple', 'error_code': 'server_exception'},
+      );
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // PII guard
+  // ---------------------------------------------------------------------------
+
+  test('no PII in any logged parameters', () async {
+    when(
+      () => mockRepo.signIn(any(), any()),
+    ).thenAnswer((_) async => const Result.success(null));
+
+    readController().updateEmail('secret@example.com');
+    readController().updatePassword('hunter2');
+    await readController().submit();
+    await Future<void>.delayed(Duration.zero);
+
+    final allValues = fakeAnalytics.calls
+        .expand((e) => e.parameters.values)
+        .toList();
+    for (final v in allValues) {
+      expect(v, isNot(contains('@')));
+      expect(v, isNot('hunter2'));
+    }
+    // Only allow-listed keys.
+    final allKeys = fakeAnalytics.calls
+        .expand((e) => e.parameters.keys)
+        .toSet();
+    expect(allKeys, {'method'});
   });
 }

--- a/test/features/auth/register/register_controller_test.dart
+++ b/test/features/auth/register/register_controller_test.dart
@@ -6,6 +6,10 @@ import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/auth/register/register_controller.dart';
+import 'package:nibbles/src/features/auth/register/register_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../../support/fake_analytics.dart';
 
 class MockAuthRepository extends Mock implements AuthRepository {}
 
@@ -14,11 +18,13 @@ class MockLocalFlagService extends Mock implements LocalFlagService {}
 void main() {
   late MockAuthRepository mockRepo;
   late MockLocalFlagService mockFlags;
+  late FakeAnalytics fakeAnalytics;
   late ProviderContainer container;
 
   setUp(() {
     mockRepo = MockAuthRepository();
     mockFlags = MockLocalFlagService();
+    fakeAnalytics = FakeAnalytics();
     when(() => mockRepo.isLoggedIn).thenReturn(false);
     when(
       () => mockRepo.authStateStream,
@@ -29,14 +35,67 @@ void main() {
       overrides: [
         authRepositoryProvider.overrideWithValue(mockRepo),
         localFlagServiceProvider.overrideWithValue(mockFlags),
+        analyticsProvider.overrideWithValue(fakeAnalytics),
       ],
-    );
+    )
+    // Hold the controller alive across awaits so state isn't lost to
+    // auto-dispose between assertions.
+    ..listen<RegisterState>(registerControllerProvider, (_, __) {});
   });
 
   tearDown(() => container.dispose());
 
   RegisterController readController() =>
       container.read(registerControllerProvider.notifier);
+
+  // ---------------------------------------------------------------------------
+  // submit() — email sign up
+  // ---------------------------------------------------------------------------
+
+  group('submit (email)', () {
+    test('returns true on Success and fires method_selected + success',
+        () async {
+      when(
+        () => mockRepo.signUp(any(), any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      final ok = await readController().submit();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(ok, isTrue);
+      expect(
+        fakeAnalytics.eventNames,
+        ['sign_up_method_selected', 'sign_up_success'],
+      );
+      expect(
+        fakeAnalytics.calls[0].parameters,
+        {'method': 'email'},
+      );
+    });
+
+    test('returns false on Failure and fires sign_up_failure', () async {
+      when(() => mockRepo.signUp(any(), any())).thenAnswer(
+        (_) async => const Result.failure(ServerException('email in use')),
+      );
+
+      final ok = await readController().submit();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(ok, isFalse);
+      expect(
+        fakeAnalytics.eventNames,
+        ['sign_up_method_selected', 'sign_up_failure'],
+      );
+      expect(
+        fakeAnalytics.calls[1].parameters,
+        {'method': 'email', 'error_code': 'server_exception'},
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // signInWithGoogle
+  // ---------------------------------------------------------------------------
 
   group('signInWithGoogle', () {
     test('returns true on Success(true), no error', () async {
@@ -45,39 +104,72 @@ void main() {
       ).thenAnswer((_) async => const Result.success(true));
 
       final ok = await readController().signInWithGoogle();
+      await Future<void>.delayed(Duration.zero);
 
       expect(ok, isTrue);
       final state = container.read(registerControllerProvider);
       expect(state.isLoading, isFalse);
       expect(state.errorMessage, isNull);
+      expect(
+        fakeAnalytics.eventNames,
+        ['sign_up_method_selected', 'sign_up_success'],
+      );
+      expect(
+        fakeAnalytics.calls[0].parameters,
+        {'method': 'google'},
+      );
     });
 
-    test('returns false on Success(false) (cancel), no error', () async {
+    test('returns false on Success(false) (cancel) and fires cancel event',
+        () async {
       when(
         () => mockRepo.signInWithGoogle(),
       ).thenAnswer((_) async => const Result.success(false));
 
       final ok = await readController().signInWithGoogle();
+      await Future<void>.delayed(Duration.zero);
 
       expect(ok, isFalse);
       final state = container.read(registerControllerProvider);
       expect(state.isLoading, isFalse);
       expect(state.errorMessage, isNull);
+      expect(
+        fakeAnalytics.eventNames,
+        ['sign_up_method_selected', 'social_login_cancelled'],
+      );
+      expect(
+        fakeAnalytics.calls.last.parameters,
+        {'provider': 'google'},
+      );
     });
 
-    test('returns false on Failure and sets errorMessage', () async {
+    test('returns false on Failure, sets errorMessage and fires failure event',
+        () async {
       when(() => mockRepo.signInWithGoogle()).thenAnswer(
         (_) async => const Result.failure(ServerException('Google failed')),
       );
 
       final ok = await readController().signInWithGoogle();
+      await Future<void>.delayed(Duration.zero);
 
       expect(ok, isFalse);
       final state = container.read(registerControllerProvider);
       expect(state.isLoading, isFalse);
       expect(state.errorMessage, 'Google failed');
+      expect(
+        fakeAnalytics.eventNames,
+        ['sign_up_method_selected', 'sign_up_failure'],
+      );
+      expect(
+        fakeAnalytics.calls.last.parameters,
+        {'method': 'google', 'error_code': 'server_exception'},
+      );
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // signInWithApple
+  // ---------------------------------------------------------------------------
 
   group('signInWithApple', () {
     test('returns true on Success(true), no error', () async {
@@ -86,24 +178,37 @@ void main() {
       ).thenAnswer((_) async => const Result.success(true));
 
       final ok = await readController().signInWithApple();
+      await Future<void>.delayed(Duration.zero);
 
       expect(ok, isTrue);
-      final state = container.read(registerControllerProvider);
-      expect(state.isLoading, isFalse);
-      expect(state.errorMessage, isNull);
+      expect(
+        fakeAnalytics.eventNames,
+        ['sign_up_method_selected', 'sign_up_success'],
+      );
+      expect(
+        fakeAnalytics.calls[0].parameters,
+        {'method': 'apple'},
+      );
     });
 
-    test('returns false on Success(false) (cancel), no error', () async {
+    test('returns false on Success(false) (cancel) and fires cancel event',
+        () async {
       when(
         () => mockRepo.signInWithApple(),
       ).thenAnswer((_) async => const Result.success(false));
 
       final ok = await readController().signInWithApple();
+      await Future<void>.delayed(Duration.zero);
 
       expect(ok, isFalse);
-      final state = container.read(registerControllerProvider);
-      expect(state.isLoading, isFalse);
-      expect(state.errorMessage, isNull);
+      expect(
+        fakeAnalytics.eventNames,
+        ['sign_up_method_selected', 'social_login_cancelled'],
+      );
+      expect(
+        fakeAnalytics.calls.last.parameters,
+        {'provider': 'apple'},
+      );
     });
 
     test('returns false on Failure and sets errorMessage', () async {
@@ -112,11 +217,20 @@ void main() {
       );
 
       final ok = await readController().signInWithApple();
+      await Future<void>.delayed(Duration.zero);
 
       expect(ok, isFalse);
       final state = container.read(registerControllerProvider);
       expect(state.isLoading, isFalse);
       expect(state.errorMessage, 'Apple failed');
+      expect(
+        fakeAnalytics.eventNames,
+        ['sign_up_method_selected', 'sign_up_failure'],
+      );
+      expect(
+        fakeAnalytics.calls.last.parameters,
+        {'method': 'apple', 'error_code': 'server_exception'},
+      );
     });
   });
 }

--- a/test/support/fake_analytics.dart
+++ b/test/support/fake_analytics.dart
@@ -1,0 +1,145 @@
+import 'package:nibbles/src/logging/analytics.dart';
+
+/// In-memory recorder used by auth controller tests. Replaces the real
+/// [Analytics] singleton (which would otherwise hit
+/// `FirebaseAnalytics.instance` and throw when Firebase is uninitialised in
+/// the test harness).
+///
+/// Each `log*` call appends a `(name, params)` tuple to [calls]. Tests assert
+/// against [calls] / [eventNames] to verify the controller fired the right
+/// event at the right state transition.
+class FakeAnalytics implements Analytics {
+  /// Every recorded call, in the order it fired.
+  final List<RecordedEvent> calls = [];
+
+  /// Convenience: just the event names, in order.
+  List<String> get eventNames => calls.map((c) => c.name).toList();
+
+  void _record(String name, [Map<String, Object>? params]) {
+    calls.add(RecordedEvent(name, params ?? const {}));
+  }
+
+  @override
+  Future<void> logAppOpen() async => _record('app_open');
+
+  @override
+  Future<void> logOnboardingStarted() async => _record('onboarding_started');
+
+  @override
+  Future<void> logOnboardingCompleted() async =>
+      _record('onboarding_completed');
+
+  @override
+  Future<void> logOnboardingStepViewed({required int step}) async =>
+      _record('onboarding_step_viewed', {'step': step});
+
+  @override
+  Future<void> logLoginMethodSelected({required AuthMethod method}) async =>
+      _record('login_method_selected', {'method': method.value});
+
+  @override
+  Future<void> logLoginSuccess({required AuthMethod method}) async =>
+      _record('login_success', {'method': method.value});
+
+  @override
+  Future<void> logLoginFailure({
+    required AuthMethod method,
+    required String errorCode,
+  }) async => _record('login_failure', {
+    'method': method.value,
+    'error_code': errorCode,
+  });
+
+  @override
+  Future<void> logSignUpMethodSelected({required AuthMethod method}) async =>
+      _record('sign_up_method_selected', {'method': method.value});
+
+  @override
+  Future<void> logSignUpSuccess({required AuthMethod method}) async =>
+      _record('sign_up_success', {'method': method.value});
+
+  @override
+  Future<void> logSignUpFailure({
+    required AuthMethod method,
+    required String errorCode,
+  }) async => _record('sign_up_failure', {
+    'method': method.value,
+    'error_code': errorCode,
+  });
+
+  @override
+  Future<void> logPasswordResetRequested() async =>
+      _record('password_reset_requested');
+
+  @override
+  Future<void> logSocialLoginCancelled({
+    required SocialProvider provider,
+  }) async => _record('social_login_cancelled', {'provider': provider.value});
+
+  @override
+  Future<void> logLogout() async => _record('logout');
+
+  @override
+  Future<void> logPaywallViewed() async => _record('paywall_viewed');
+
+  @override
+  Future<void> logSubscriptionStarted({required String productId}) async =>
+      _record('subscription_started', {'product_id': productId});
+
+  @override
+  Future<void> logSubscriptionRestored() async =>
+      _record('subscription_restored');
+
+  @override
+  Future<void> logAllergenLogCreated({required String allergenKey}) async =>
+      _record('allergen_log_created', {'allergen_key': allergenKey});
+
+  @override
+  Future<void> logAllergenMarkedSafe({required String allergenKey}) async =>
+      _record('allergen_marked_safe', {'allergen_key': allergenKey});
+
+  @override
+  Future<void> logReactionLogged({
+    required String allergenKey,
+    required String severity,
+  }) async => _record('reaction_logged', {
+    'allergen_key': allergenKey,
+    'severity': severity,
+  });
+
+  @override
+  Future<void> logAllergenAdvanced({
+    required String fromKey,
+    required String toKey,
+  }) async => _record('allergen_advanced', {
+    'from_key': fromKey,
+    'to_key': toKey,
+  });
+
+  @override
+  Future<void> logAllergenProgramCompleted() async =>
+      _record('allergen_program_completed');
+
+  @override
+  Future<void> logRecipeViewed({required String recipeId}) async =>
+      _record('recipe_viewed', {'recipe_id': recipeId});
+
+  @override
+  Future<void> logRecipeAddedToMealPlan({required String recipeId}) async =>
+      _record('recipe_added_to_meal_plan', {'recipe_id': recipeId});
+
+  @override
+  Future<void> logScreenView({required String screenName}) async =>
+      _record('screen_view', {'screen_name': screenName});
+}
+
+/// A single recorded analytics call.
+class RecordedEvent {
+  RecordedEvent(this.name, this.parameters);
+
+  final String name;
+  final Map<String, Object> parameters;
+
+  @override
+  String toString() => 'RecordedEvent($name, $parameters)';
+}


### PR DESCRIPTION
## Summary

Instruments the redesigned auth flows with non-PII Firebase Analytics events and Firebase Crashlytics non-fatals.

- Extends `Analytics` wrapper with the events called out in NIB-118: `login_method_selected`, `login_success`, `login_failure`, `sign_up_method_selected`, `sign_up_success`, `sign_up_failure`, `password_reset_requested`, `social_login_cancelled`. Replaces the prior dead `logSignUp`/`logLogin` placeholders. Adds an `analyticsProvider` so controllers can read the wrapper and tests can override it with a fake.
- Wires the new events in `login_controller`, `register_controller`, and `forgot_password_controller` at the documented state transitions: method selection fires when the user taps a button; success / failure fires after the `Result` resolves; `Result.success(false)` from the social flows (NIB-116 cancel signal) fires `social_login_cancelled`. All analytics calls are fire-and-forget (`unawaited(...catchError((_){}))`), never blocking navigation.
- `error_code` is derived from the `AppException` subtype only (`server_exception`, `network`, `unauthorized`, `not_found`, `unknown`) via a shared `authErrorCode()` mapper. Raw provider/Supabase messages never enter analytics parameters.
- `auth_repository` records the original error to Crashlytics with `reason: 'auth_unknown'` on every `on Object` catch path (signUp / signIn / signInWithGoogle / signInWithApple / signOut / resetPassword / updatePassword), before returning `Result.failure(UnknownException())`. The recorder is wrapped in try/catch so a Crashlytics failure cannot escalate the auth failure path. The recorder is injected for unit-testability, defaulting to `FirebaseCrashlytics.instance.recordError(...)` in production.
- No duplicate events (auth previously fired nothing). No PII anywhere (no email/password/userId/baby name in any parameter).

## Acceptance criteria

- [x] All listed events fire with the correct params; no PII.
- [x] Provider / UnknownException errors produce Crashlytics non-fatals with reason `auth_unknown`.
- [x] No duplicate events.
- [x] `flutter analyze` zero warnings; `flutter test` passes (controller tests assert analytics calls via `FakeAnalytics`; auth_repository tests assert the Crashlytics recorder receives the original error and that a thrown recorder does not escalate).

## Gate results

- `make gen` — clean, idempotent on second run; only `lib/src/logging/analytics.g.dart` newly generated (unrelated home_controller.g.dart drift reverted).
- `flutter analyze` — No issues found.
- `flutter test` — 178 tests, all pass.

## Test plan

- [ ] Smoke email login / sign up / forgot password against dev Supabase; confirm events show up in Firebase DebugView with the expected `method`, `error_code`, `provider` values.
- [ ] Trigger a forced exception in `signIn` to confirm a Crashlytics non-fatal with reason `auth_unknown` appears in the Crashlytics console.
- [ ] Cancel a Google / Apple flow at the native dialog; confirm `social_login_cancelled` fires once with the right `provider`.