### PR TITLE
chore(auth): widget + unit test coverage for redesigned auth [NIB-119]

### DIFF
--- a/test/common/services/auth_service_test.dart
+++ b/test/common/services/auth_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/repositories/baby_profile_repository.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
@@ -10,6 +11,9 @@ import 'package:nibbles/src/common/services/local_flag_service.dart';
 class MockAuthRepository extends Mock implements AuthRepository {}
 
 class MockLocalFlagService extends Mock implements LocalFlagService {}
+
+class MockBabyProfileRepository extends Mock
+    implements BabyProfileRepository {}
 
 void main() {
   late MockAuthRepository mockRepo;
@@ -225,5 +229,96 @@ void main() {
       expect(result.isFailure, isTrue);
       expect(container.read(authServiceProvider), isFalse);
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // NIB-119: gap coverage — no-name signUp contract + backfill happy path
+  // ---------------------------------------------------------------------------
+
+  group('AuthService.signUp (no-name contract)', () {
+    test(
+      'delegates to repository with email + password ONLY (no name argument)',
+      () async {
+        when(
+          () => mockRepo.signUp(any(), any()),
+        ).thenAnswer((_) async => const Result.success(null));
+
+        await sut.signUp('alice@example.com', 'password123');
+
+        // Forwards only the two arguments — no positional/named 'name' field.
+        verify(
+          () => mockRepo.signUp('alice@example.com', 'password123'),
+        ).called(1);
+        // Any other signUp shape must NOT exist on the contract.
+        verifyNever(
+          () => mockRepo.signUp(any(that: isNot('alice@example.com')), any()),
+        );
+      },
+    );
+  });
+
+  group('AuthService backfill on signIn', () {
+    test(
+      'when onboarding NOT done locally, queries the baby repo and '
+      'backfills both flags on a completed remote profile',
+      () async {
+        // Reset flags mock so isOnboardingBabySetupDone == false hits the
+        // backfill branch.
+        final mockFlagsBackfill = MockLocalFlagService();
+        when(mockFlagsBackfill.isOnboardingBabySetupDone).thenReturn(false);
+        when(mockFlagsBackfill.setOnboardingReadinessDone).thenAnswer((_) {});
+        when(mockFlagsBackfill.setOnboardingBabySetupDone).thenAnswer((_) {});
+
+        final mockBabyRepo = MockBabyProfileRepository();
+        when(mockBabyRepo.isOnboardingCompleted).thenAnswer((_) async => true);
+
+        when(
+          () => mockRepo.signIn(any(), any()),
+        ).thenAnswer((_) async => const Result.success(null));
+
+        final localContainer = ProviderContainer(
+          overrides: [
+            authRepositoryProvider.overrideWithValue(mockRepo),
+            localFlagServiceProvider.overrideWithValue(mockFlagsBackfill),
+            babyProfileRepositoryProvider.overrideWithValue(mockBabyRepo),
+          ],
+        );
+        addTearDown(localContainer.dispose);
+
+        final localSut = localContainer.read(authServiceProvider.notifier);
+        await localSut.signIn('alice@example.com', 'password123');
+
+        verify(mockBabyRepo.isOnboardingCompleted).called(1);
+        verify(mockFlagsBackfill.setOnboardingReadinessDone).called(1);
+        verify(mockFlagsBackfill.setOnboardingBabySetupDone).called(1);
+      },
+    );
+
+    test(
+      'when onboarding already done locally, does NOT hit the baby repo '
+      '(short-circuit)',
+      () async {
+        final mockBabyRepo = MockBabyProfileRepository();
+
+        when(
+          () => mockRepo.signIn(any(), any()),
+        ).thenAnswer((_) async => const Result.success(null));
+
+        // Default container already stubs isOnboardingBabySetupDone -> true.
+        final localContainer = ProviderContainer(
+          overrides: [
+            authRepositoryProvider.overrideWithValue(mockRepo),
+            localFlagServiceProvider.overrideWithValue(mockFlags),
+            babyProfileRepositoryProvider.overrideWithValue(mockBabyRepo),
+          ],
+        );
+        addTearDown(localContainer.dispose);
+
+        final localSut = localContainer.read(authServiceProvider.notifier);
+        await localSut.signIn('alice@example.com', 'password123');
+
+        verifyNever(mockBabyRepo.isOnboardingCompleted);
+      },
+    );
   });
 }

--- a/test/features/auth/forgot_password/forgot_password_screen_test.dart
+++ b/test/features/auth/forgot_password/forgot_password_screen_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
+import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/auth/forgot_password/forgot_password_screen.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockLocalFlagService extends Mock implements LocalFlagService {}
+
+// ---------------------------------------------------------------------------
+// Router + widget helper
+// ---------------------------------------------------------------------------
+
+GoRouter _routerFor(Widget screen) => GoRouter(
+  initialLocation: AppRoute.forgotPassword.path,
+  routes: [
+    GoRoute(path: AppRoute.forgotPassword.path, builder: (_, __) => screen),
+    GoRoute(
+      path: AppRoute.login.path,
+      name: AppRoute.login.name,
+      builder: (_, __) => const Scaffold(body: Text('Login stub')),
+    ),
+  ],
+);
+
+Widget _wrap(Widget screen, List<Override> overrides) => ProviderScope(
+  overrides: overrides,
+  child: MaterialApp.router(routerConfig: _routerFor(screen)),
+);
+
+void main() {
+  late MockAuthRepository mockRepo;
+  late MockLocalFlagService mockFlags;
+  late FakeAnalytics fakeAnalytics;
+
+  setUp(() {
+    mockRepo = MockAuthRepository();
+    mockFlags = MockLocalFlagService();
+    fakeAnalytics = FakeAnalytics();
+    when(() => mockRepo.isLoggedIn).thenReturn(false);
+    when(
+      () => mockRepo.authStateStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(mockFlags.isOnboardingBabySetupDone).thenReturn(true);
+  });
+
+  List<Override> buildOverrides() => [
+    authRepositoryProvider.overrideWithValue(mockRepo),
+    localFlagServiceProvider.overrideWithValue(mockFlags),
+    analyticsProvider.overrideWithValue(fakeAnalytics),
+  ];
+
+  testWidgets(
+    'renders butter back pill (top-left), email field, and bottom Confirm CTA',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(const ForgotPasswordScreen(), buildOverrides()),
+      );
+      await tester.pumpAndSettle();
+
+      // Butter back pill — exactly one AppRoundButton with the back arrow.
+      final backButtonFinder = find.byType(AppRoundButton);
+      expect(backButtonFinder, findsOneWidget);
+      final backBtn = tester.widget<AppRoundButton>(backButtonFinder);
+      expect(backBtn.tone, AppRoundButtonTone.butter);
+      expect(
+        find.descendant(
+          of: backButtonFinder,
+          matching: find.byIcon(Icons.arrow_back_rounded),
+        ),
+        findsOneWidget,
+      );
+
+      // Email field present.
+      expect(find.byKey(const Key('forgot_email_field')), findsOneWidget);
+
+      // Bottom-pinned Confirm CTA.
+      expect(find.byKey(const Key('forgot_submit_button')), findsOneWidget);
+      final pillButton = tester.widget<AppPillButton>(
+        find.byKey(const Key('forgot_submit_button')),
+      );
+      expect(pillButton.label, 'Confirm');
+    },
+  );
+
+  testWidgets('tapping back pill pops / navigates to login route', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(const ForgotPasswordScreen(), buildOverrides()),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(AppRoundButton));
+    await tester.pumpAndSettle();
+
+    // With no back-stack canPop is false, so the screen routes to login.
+    expect(find.text('Login stub'), findsOneWidget);
+  });
+
+  testWidgets(
+    'submit failure renders GENERIC enumeration-safe caption '
+    '(never "email not found")',
+    (tester) async {
+      when(() => mockRepo.resetPassword(any())).thenAnswer(
+        // Whatever the backend returns — even a leaky "User not found" —
+        // the screen must collapse it into the generic message.
+        (_) async => const Result.failure(ServerException('User not found.')),
+      );
+
+      await tester.pumpWidget(
+        _wrap(const ForgotPasswordScreen(), buildOverrides()),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('forgot_email_field')),
+        'jane@example.com',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('forgot_submit_button')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text("Couldn't send the reset link. Please try again."),
+        findsOneWidget,
+      );
+      // Enumeration safety: must NOT leak whether the email exists.
+      expect(find.textContaining('not found'), findsNothing);
+      expect(find.textContaining("doesn't exist"), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'success transitions to the confirmation sub-view '
+    '(check-your-email + back-to-login)',
+    (tester) async {
+      when(
+        () => mockRepo.resetPassword(any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      await tester.pumpWidget(
+        _wrap(const ForgotPasswordScreen(), buildOverrides()),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('forgot_email_field')),
+        'jane@example.com',
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const Key('forgot_submit_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Check your email'), findsOneWidget);
+      expect(
+        find.byKey(const Key('forgot_back_to_login')),
+        findsOneWidget,
+      );
+      // Input view is gone.
+      expect(find.byKey(const Key('forgot_email_field')), findsNothing);
+      expect(find.byKey(const Key('forgot_submit_button')), findsNothing);
+    },
+  );
+}

--- a/test/features/auth/login/login_screen_test.dart
+++ b/test/features/auth/login/login_screen_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/auth/login/login_screen.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockLocalFlagService extends Mock implements LocalFlagService {}
+
+// ---------------------------------------------------------------------------
+// Router + widget helper
+// ---------------------------------------------------------------------------
+
+GoRouter _routerFor(Widget screen) => GoRouter(
+  initialLocation: AppRoute.login.path,
+  routes: [
+    GoRoute(path: AppRoute.login.path, builder: (_, __) => screen),
+    GoRoute(
+      path: AppRoute.register.path,
+      name: AppRoute.register.name,
+      builder: (_, __) => const Scaffold(body: Text('Register stub')),
+    ),
+    GoRoute(
+      path: AppRoute.forgotPassword.path,
+      name: AppRoute.forgotPassword.name,
+      builder: (_, __) => const Scaffold(body: Text('Forgot stub')),
+    ),
+  ],
+);
+
+Widget _wrap(Widget screen, List<Override> overrides) => ProviderScope(
+  overrides: overrides,
+  child: MaterialApp.router(routerConfig: _routerFor(screen)),
+);
+
+void main() {
+  late MockAuthRepository mockRepo;
+  late MockLocalFlagService mockFlags;
+  late FakeAnalytics fakeAnalytics;
+
+  setUp(() {
+    mockRepo = MockAuthRepository();
+    mockFlags = MockLocalFlagService();
+    fakeAnalytics = FakeAnalytics();
+    when(() => mockRepo.isLoggedIn).thenReturn(false);
+    when(
+      () => mockRepo.authStateStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(mockFlags.isOnboardingBabySetupDone).thenReturn(true);
+  });
+
+  List<Override> buildOverrides() => [
+    authRepositoryProvider.overrideWithValue(mockRepo),
+    localFlagServiceProvider.overrideWithValue(mockFlags),
+    analyticsProvider.overrideWithValue(fakeAnalytics),
+  ];
+
+  testWidgets('renders BrandLogo, email + password fields, and submit', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BrandLogo), findsOneWidget);
+    expect(find.byKey(const Key('login_email_field')), findsOneWidget);
+    expect(find.byKey(const Key('login_password_field')), findsOneWidget);
+    expect(find.byKey(const Key('login_submit_button')), findsOneWidget);
+    // Greeting copy locks the NIB-107 redesign.
+    expect(find.text('Hi, Welcome!'), findsOneWidget);
+  });
+
+  testWidgets('social buttons (Google + Apple) are present', (tester) async {
+    await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('login_google_button')), findsOneWidget);
+    expect(find.byKey(const Key('login_apple_button')), findsOneWidget);
+  });
+
+  testWidgets(
+    'password toggle flips obscureText (eye -> eye-off icon swap)',
+    (tester) async {
+      await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      // Initial state: obscured -> visibility_off shown inside the password
+      // field's suffix slot. Scope by ancestor to ignore unrelated icons.
+      Finder iconInPasswordField(IconData icon) => find.descendant(
+        of: find.byKey(const Key('login_password_field')),
+        matching: find.byIcon(icon),
+      );
+
+      expect(
+        iconInPasswordField(Icons.visibility_off_outlined),
+        findsOneWidget,
+      );
+      expect(iconInPasswordField(Icons.visibility_outlined), findsNothing);
+
+      await tester.tap(iconInPasswordField(Icons.visibility_off_outlined));
+      await tester.pump();
+
+      expect(iconInPasswordField(Icons.visibility_outlined), findsOneWidget);
+      expect(
+        iconInPasswordField(Icons.visibility_off_outlined),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'submit failure renders destructive caption (not red field borders)',
+    (tester) async {
+      when(() => mockRepo.signIn(any(), any())).thenAnswer(
+        (_) async =>
+            const Result.failure(ServerException('Invalid login credentials.')),
+      );
+
+      await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('login_email_field')),
+        'jane@example.com',
+      );
+      await tester.enterText(
+        find.byKey(const Key('login_password_field')),
+        'badpassword',
+      );
+      await tester.tap(find.byKey(const Key('login_submit_button')));
+      await tester.pumpAndSettle();
+
+      // Caption text rendered verbatim — NIB-107 deviation: caption, not
+      // a red border on the field itself.
+      expect(find.text('Invalid login credentials.'), findsOneWidget);
+      // Fields themselves carry no errorText, so 'Please enter a valid email.'
+      // (the AppTextField helper text) must NOT be present.
+      expect(find.text('Please enter a valid email.'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Google tap calls controller.signInWithGoogle and logs analytics',
+    (tester) async {
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      final googleBtn = find.byKey(const Key('login_google_button'));
+      await tester.ensureVisible(googleBtn);
+      await tester.pumpAndSettle();
+      await tester.tap(googleBtn);
+      await tester.pumpAndSettle();
+
+      verify(() => mockRepo.signInWithGoogle()).called(1);
+      expect(
+        fakeAnalytics.eventNames,
+        containsAllInOrder(['login_method_selected', 'login_success']),
+      );
+    },
+  );
+
+  testWidgets(
+    'Apple tap calls controller.signInWithApple and logs analytics',
+    (tester) async {
+      when(
+        () => mockRepo.signInWithApple(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      final appleBtn = find.byKey(const Key('login_apple_button'));
+      await tester.ensureVisible(appleBtn);
+      await tester.pumpAndSettle();
+      await tester.tap(appleBtn);
+      await tester.pumpAndSettle();
+
+      verify(() => mockRepo.signInWithApple()).called(1);
+      expect(
+        fakeAnalytics.eventNames,
+        containsAllInOrder(['login_method_selected', 'login_success']),
+      );
+    },
+  );
+
+  testWidgets(
+    'cancel-OAuth (Success(false)) shows NO error caption',
+    (tester) async {
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(false));
+
+      await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      final googleBtn = find.byKey(const Key('login_google_button'));
+      await tester.ensureVisible(googleBtn);
+      await tester.pumpAndSettle();
+      await tester.tap(googleBtn);
+      await tester.pumpAndSettle();
+
+      // Nothing in the destructive caption slot — controller stays clean.
+      expect(find.textContaining('failed'), findsNothing);
+      expect(find.textContaining('cancel'), findsNothing);
+      // Cancellation logs the cancel event (no error UI).
+      expect(
+        fakeAnalytics.eventNames,
+        containsAllInOrder([
+          'login_method_selected',
+          'social_login_cancelled',
+        ]),
+      );
+    },
+  );
+}

--- a/test/features/auth/register/register_screen_test.dart
+++ b/test/features/auth/register/register_screen_test.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/auth/register/register_screen.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockLocalFlagService extends Mock implements LocalFlagService {}
+
+// ---------------------------------------------------------------------------
+// Router + widget helper
+// ---------------------------------------------------------------------------
+
+GoRouter _routerFor(Widget screen) => GoRouter(
+  initialLocation: AppRoute.register.path,
+  routes: [
+    GoRoute(path: AppRoute.register.path, builder: (_, __) => screen),
+    GoRoute(
+      path: AppRoute.login.path,
+      name: AppRoute.login.name,
+      builder: (_, __) => const Scaffold(body: Text('Login stub')),
+    ),
+    GoRoute(
+      path: AppRoute.onboardingBabySetup.path,
+      name: AppRoute.onboardingBabySetup.name,
+      builder: (_, __) =>
+          const Scaffold(body: Text('Baby setup stub')),
+    ),
+  ],
+);
+
+Widget _wrap(Widget screen, List<Override> overrides) => ProviderScope(
+  overrides: overrides,
+  child: MaterialApp.router(routerConfig: _routerFor(screen)),
+);
+
+void main() {
+  late MockAuthRepository mockRepo;
+  late MockLocalFlagService mockFlags;
+  late FakeAnalytics fakeAnalytics;
+
+  setUp(() {
+    mockRepo = MockAuthRepository();
+    mockFlags = MockLocalFlagService();
+    fakeAnalytics = FakeAnalytics();
+    when(() => mockRepo.isLoggedIn).thenReturn(false);
+    when(
+      () => mockRepo.authStateStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(mockFlags.isOnboardingBabySetupDone).thenReturn(true);
+  });
+
+  List<Override> buildOverrides() => [
+    authRepositoryProvider.overrideWithValue(mockRepo),
+    localFlagServiceProvider.overrideWithValue(mockFlags),
+    analyticsProvider.overrideWithValue(fakeAnalytics),
+  ];
+
+  testWidgets(
+    'renders BrandLogo, email + password fields, and submit — NO name field',
+    (tester) async {
+      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BrandLogo), findsOneWidget);
+      expect(find.byKey(const Key('register_email_field')), findsOneWidget);
+      expect(find.byKey(const Key('register_password_field')), findsOneWidget);
+      expect(find.byKey(const Key('register_submit_button')), findsOneWidget);
+
+      // NIB-107 redesign drops the name field entirely.
+      expect(find.text('Name'), findsNothing);
+      expect(find.text('Full name'), findsNothing);
+      expect(find.text('Your name'), findsNothing);
+      expect(find.byKey(const Key('register_name_field')), findsNothing);
+    },
+  );
+
+  testWidgets('social buttons (Google + Apple) are present', (tester) async {
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('register_google_button')), findsOneWidget);
+    expect(find.byKey(const Key('register_apple_button')), findsOneWidget);
+  });
+
+  testWidgets(
+    'valid-email checkmark appears only when EmailInput.isValid',
+    (tester) async {
+      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      Finder checkInEmailField() => find.descendant(
+        of: find.byKey(const Key('register_email_field')),
+        matching: find.byIcon(Icons.check_circle_rounded),
+      );
+
+      // Initial — empty field, no check.
+      expect(checkInEmailField(), findsNothing);
+
+      // Invalid input — no check.
+      await tester.enterText(
+        find.byKey(const Key('register_email_field')),
+        'not-an-email',
+      );
+      await tester.pump();
+      expect(checkInEmailField(), findsNothing);
+
+      // Valid input — check appears.
+      await tester.enterText(
+        find.byKey(const Key('register_email_field')),
+        'jane@example.com',
+      );
+      await tester.pump();
+      expect(checkInEmailField(), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'password toggle flips obscureText (eye -> eye-off icon swap)',
+    (tester) async {
+      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      Finder iconInPasswordField(IconData icon) => find.descendant(
+        of: find.byKey(const Key('register_password_field')),
+        matching: find.byIcon(icon),
+      );
+
+      expect(
+        iconInPasswordField(Icons.visibility_off_outlined),
+        findsOneWidget,
+      );
+      expect(iconInPasswordField(Icons.visibility_outlined), findsNothing);
+
+      await tester.tap(iconInPasswordField(Icons.visibility_off_outlined));
+      await tester.pump();
+
+      expect(iconInPasswordField(Icons.visibility_outlined), findsOneWidget);
+      expect(
+        iconInPasswordField(Icons.visibility_off_outlined),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'Google tap calls controller.signInWithGoogle and logs analytics',
+    (tester) async {
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      final googleBtn = find.byKey(const Key('register_google_button'));
+      await tester.ensureVisible(googleBtn);
+      await tester.pumpAndSettle();
+      await tester.tap(googleBtn);
+      await tester.pumpAndSettle();
+
+      verify(() => mockRepo.signInWithGoogle()).called(1);
+      expect(
+        fakeAnalytics.eventNames,
+        containsAllInOrder(['sign_up_method_selected', 'sign_up_success']),
+      );
+    },
+  );
+
+  testWidgets(
+    'Apple tap calls controller.signInWithApple and logs analytics',
+    (tester) async {
+      when(
+        () => mockRepo.signInWithApple(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      final appleBtn = find.byKey(const Key('register_apple_button'));
+      await tester.ensureVisible(appleBtn);
+      await tester.pumpAndSettle();
+      await tester.tap(appleBtn);
+      await tester.pumpAndSettle();
+
+      verify(() => mockRepo.signInWithApple()).called(1);
+      expect(
+        fakeAnalytics.eventNames,
+        containsAllInOrder(['sign_up_method_selected', 'sign_up_success']),
+      );
+    },
+  );
+
+  testWidgets(
+    'cancel-OAuth (Success(false)) shows NO error caption',
+    (tester) async {
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(false));
+
+      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      final googleBtn = find.byKey(const Key('register_google_button'));
+      await tester.ensureVisible(googleBtn);
+      await tester.pumpAndSettle();
+      await tester.tap(googleBtn);
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('failed'), findsNothing);
+      expect(find.textContaining('cancel'), findsNothing);
+      expect(
+        fakeAnalytics.eventNames,
+        containsAllInOrder([
+          'sign_up_method_selected',
+          'social_login_cancelled',
+        ]),
+      );
+    },
+  );
+
+  testWidgets(
+    'submit failure renders the controller error message verbatim',
+    (tester) async {
+      when(() => mockRepo.signUp(any(), any())).thenAnswer(
+        (_) async =>
+            const Result.failure(ServerException('Email already in use.')),
+      );
+
+      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      // Submit button is gated on isValid — enter a valid email + 8+ char pw.
+      await tester.enterText(
+        find.byKey(const Key('register_email_field')),
+        'jane@example.com',
+      );
+      await tester.enterText(
+        find.byKey(const Key('register_password_field')),
+        'password123',
+      );
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('register_submit_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Email already in use.'), findsOneWidget);
+    },
+  );
+}

--- a/test/features/auth/reset_password/reset_password_screen_test.dart
+++ b/test/features/auth/reset_password/reset_password_screen_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/auth/reset_password/reset_password_screen.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+class MockLocalFlagService extends Mock implements LocalFlagService {}
+
+// ---------------------------------------------------------------------------
+// Router + widget helper
+// ---------------------------------------------------------------------------
+
+GoRouter _routerFor(Widget screen) => GoRouter(
+  initialLocation: AppRoute.resetPassword.path,
+  routes: [
+    GoRoute(path: AppRoute.resetPassword.path, builder: (_, __) => screen),
+    GoRoute(
+      path: AppRoute.login.path,
+      name: AppRoute.login.name,
+      builder: (_, __) => const Scaffold(body: Text('Login stub')),
+    ),
+  ],
+);
+
+Widget _wrap(Widget screen, List<Override> overrides) => ProviderScope(
+  overrides: overrides,
+  child: MaterialApp.router(routerConfig: _routerFor(screen)),
+);
+
+void main() {
+  late MockAuthRepository mockRepo;
+  late MockLocalFlagService mockFlags;
+  late FakeAnalytics fakeAnalytics;
+
+  setUp(() {
+    mockRepo = MockAuthRepository();
+    mockFlags = MockLocalFlagService();
+    fakeAnalytics = FakeAnalytics();
+    when(() => mockRepo.isLoggedIn).thenReturn(false);
+    when(
+      () => mockRepo.authStateStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(mockFlags.isOnboardingBabySetupDone).thenReturn(true);
+  });
+
+  List<Override> buildOverrides() => [
+    authRepositoryProvider.overrideWithValue(mockRepo),
+    localFlagServiceProvider.overrideWithValue(mockFlags),
+    analyticsProvider.overrideWithValue(fakeAnalytics),
+  ];
+
+  testWidgets(
+    'renders 2 obscured password fields and a Confirm CTA',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(const ResetPasswordScreen(), buildOverrides()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('reset_password_new_field')), findsOneWidget);
+      expect(
+        find.byKey(const Key('reset_password_confirm_field')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('reset_password_submit_button')),
+        findsOneWidget,
+      );
+      final pill = tester.widget<AppPillButton>(
+        find.byKey(const Key('reset_password_submit_button')),
+      );
+      expect(pill.label, 'Confirm');
+
+      // Both visible TextField inputs are obscured (production has no
+      // visibility toggle here — see PR body NOTE for spec deviation).
+      final textFields = tester.widgetList<TextField>(
+        find.descendant(
+          of: find.byKey(const Key('reset_password_new_field')),
+          matching: find.byType(TextField),
+        ),
+      );
+      expect(textFields, isNotEmpty);
+      for (final tf in textFields) {
+        expect(tf.obscureText, isTrue);
+      }
+    },
+  );
+
+  testWidgets(
+    'confirm-mismatch shows inline error preserved from the redesign',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(const ResetPasswordScreen(), buildOverrides()),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('reset_password_new_field')),
+        'password123',
+      );
+      await tester.enterText(
+        find.byKey(const Key('reset_password_confirm_field')),
+        'mismatch456',
+      );
+      await tester.pump();
+
+      expect(find.text('Passwords do not match.'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'success on submit redirects to the login route',
+    (tester) async {
+      when(
+        () => mockRepo.updatePassword(any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      await tester.pumpWidget(
+        _wrap(const ResetPasswordScreen(), buildOverrides()),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('reset_password_new_field')),
+        'password123',
+      );
+      await tester.enterText(
+        find.byKey(const Key('reset_password_confirm_field')),
+        'password123',
+      );
+      await tester.pump();
+
+      await tester.tap(
+        find.byKey(const Key('reset_password_submit_button')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Login stub'), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Fills the widget-test gap for the redesigned auth screens (none existed on base after the NIB-107 redesign) and extends unit tests for the remaining auth paths NIB-116 / NIB-118 did not cover.

Scope is test-only: production code (screens, controllers, services, repository, analytics, design-system components) is **untouched**.

## What changed

- **New widget tests** under `test/features/auth/<screen>/`:
  - `login_screen_test.dart` — BrandLogo, fields, social buttons, password toggle, error caption (NIB-107 deviation: caption not red borders), Google/Apple tap routes through controller, cancel-OAuth path asserts no error UI.
  - `register_screen_test.dart` — BrandLogo, **no name field** (asserted explicitly), valid-email checkmark gated on `EmailInput.isValid`, password toggle, social buttons + tap, cancel-OAuth silent, error caption rendered verbatim.
  - `forgot_password_screen_test.dart` — butter back pill (top-left, navigates to login), bottom-pinned Confirm CTA, **generic enumeration-safe** error caption (never leaks "not found"), success transitions to confirmation sub-view.
  - `reset_password_screen_test.dart` — 2 obscured fields, confirm-mismatch inline error preserved, sage Confirm CTA, login redirect on success.
- **Unit-test extension** (`test/common/services/auth_service_test.dart`):
  - No-name signUp contract (`verify(() => mockRepo.signUp(email, password)).called(1)` — guarantees the controller never adds a name argument).
  - Backfill happy path on `signIn` when `isOnboardingBabySetupDone == false` — asserts the baby repo is queried and both flags are set.
  - Backfill short-circuit when the flag is already true — asserts the baby repo is never touched.

## NOTE / spec deviation (flag, do not fix here)

The ticket spec for reset_password says "2 fields with toggles". The actual production screen (`lib/src/features/auth/reset_password/reset_password_screen.dart`) hardcodes `obscureText: true` on both fields with no visibility toggle widget. Login and register have toggles; reset_password does not.

Per the orchestrator note ("If a widget test reveals an actual production gap, FLAG it in the PR body rather than secretly editing the screen — production fixes belong in a follow-up ticket"), the reset_password widget test asserts only what production currently does (2 obscured fields). Adding the toggle is a screen change and belongs in a follow-up.

## Acceptance criteria

- [x] New widget tests under `test/features/auth/<screen>/` pass.
- [x] No-name signUp asserted (register widget + service-level `verify`).
- [x] Cancel-OAuth path asserts no error caption.
- [x] All existing tests still green.
- [x] `flutter analyze` zero warnings; `flutter test` passes; count > base 178.

## Gate results

- `make gen` — clean, idempotent (second run reports `0 outputs / 0 actions`).
- `flutter analyze` — `No issues found!`
- `flutter test` — `+203: All tests passed!` (178 baseline + 25 new).

## Test plan

- [x] Run `flutter analyze` locally — zero issues.
- [x] Run `flutter test` locally — 203 pass, zero failures.