### PR TITLE
chore(infra): default gender to preferNotToSay in createBaby [NIB-123]

### DIFF
--- a/lib/src/common/data/repositories/baby_profile_repository.dart
+++ b/lib/src/common/data/repositories/baby_profile_repository.dart
@@ -10,7 +10,13 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 part 'baby_profile_repository.g.dart';
 
 abstract interface class BabyProfileRepository {
-  Future<Result<Baby>> createBaby(String name, DateTime dob, Gender gender);
+  /// Gender is optional — the redesigned onboarding (NIB-120) drops the
+  /// selector. Defaults to [Gender.preferNotToSay] when omitted.
+  Future<Result<Baby>> createBaby(
+    String name,
+    DateTime dob, [
+    Gender gender = Gender.preferNotToSay,
+  ]);
   Future<Baby?> getBaby();
   Future<Result<Baby>> updateBaby(
     String babyId,
@@ -37,9 +43,9 @@ class BabyProfileRepositoryImpl implements BabyProfileRepository {
   @override
   Future<Result<Baby>> createBaby(
     String name,
-    DateTime dob,
-    Gender gender,
-  ) async {
+    DateTime dob, [
+    Gender gender = Gender.preferNotToSay,
+  ]) async {
     try {
       final data = await _supabase
           .from('babies')

--- a/lib/src/common/services/baby_profile_service.dart
+++ b/lib/src/common/services/baby_profile_service.dart
@@ -14,11 +14,14 @@ class BabyProfileService {
 
   /// Creates baby row + allergen_program_state row atomically (sequential).
   /// If allergen_program_state insert fails, returns Failure.
+  ///
+  /// Gender is optional — the redesigned onboarding (NIB-120) drops the
+  /// selector. Defaults to [Gender.preferNotToSay] when omitted.
   Future<Result<Baby>> createBaby(
     String name,
-    DateTime dob,
-    Gender gender,
-  ) async {
+    DateTime dob, [
+    Gender gender = Gender.preferNotToSay,
+  ]) async {
     final babyResult = await _repo.createBaby(name, dob, gender);
     if (babyResult.isFailure) return babyResult;
 

--- a/test/common/services/baby_profile_service_test.dart
+++ b/test/common/services/baby_profile_service_test.dart
@@ -95,6 +95,34 @@ void main() {
       expect(result.isFailure, isTrue);
       verifyNever(() => mockRepo.createAllergenProgramState(any()));
     });
+
+    test(
+      'succeeds with NO gender argument — defaults to preferNotToSay '
+      'and remains atomic',
+      () async {
+        when(
+          () => mockRepo.createBaby(any(), any(), any()),
+        ).thenAnswer((_) async => Result.success(_fakeBaby));
+        when(
+          () => mockRepo.createAllergenProgramState(any()),
+        ).thenAnswer((_) async => const Result.success(null));
+
+        final result = await sut.createBaby('Lily', DateTime(2024, 6));
+
+        expect(result.isSuccess, isTrue);
+        verify(
+          () => mockRepo.createBaby(
+            'Lily',
+            DateTime(2024, 6),
+            // Explicit Gender.preferNotToSay is the assertion of this test —
+            // mocktail needs the literal value to match the captured argument.
+            // ignore: avoid_redundant_argument_values
+            Gender.preferNotToSay,
+          ),
+        ).called(1);
+        verify(() => mockRepo.createAllergenProgramState('baby-001')).called(1);
+      },
+    );
   });
 
   group('BabyProfileService.getBaby', () {


### PR DESCRIPTION
## Summary
Aligns the data layer with the NIB-120 redesigned onboarding decisions: gender selector is dropped from the UI, so `createBaby` accepts gender as an optional positional that defaults to `Gender.preferNotToSay`. No schema migration, no consent persistence, no name split — `babies.name` stays a single column.

## Changes
- `BabyProfileRepository.createBaby` (interface + impl): `gender` now optional `[Gender gender = Gender.preferNotToSay]`.
- `BabyProfileService.createBaby` mirrors the same optional default and forwards as before.
- New unit test: `createBaby` succeeds with no gender argument, defaults to `preferNotToSay`, and the baby + `allergen_program_state` insert remains atomic.

## Acceptance criteria
- [x] `createBaby` succeeds with NO gender argument (defaults to `preferNotToSay`).
- [x] No schema migration; no consent column added.
- [x] `baby_mapper` round-trips correctly (`_parseGender` already maps unknown → `preferNotToSay`).
- [x] Supabase calls remain only in the repository.
- [x] `createBaby` still atomic (baby + `allergen_program_state` peanut/seq1/in_progress).
- [x] No DTOs above the repository; `Result<T>` preserved end-to-end.
- [x] Locked allergen sequence + seeding unchanged.

## Gate results
- `make gen`: clean, idempotent (no diff on second run).
- `flutter analyze`: No issues found.
- `flutter test`: All 204 tests passed.