### PR TITLE
feat(onboarding): rebuild intro carousel to new DS w/ 3 device-mockup slides [NIB-60]

### DIFF
--- a/lib/src/features/onboarding/intro/onboarding_intro_screen.dart
+++ b/lib/src/features/onboarding/intro/onboarding_intro_screen.dart
@@ -169,45 +169,38 @@ class _IntroSlide extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
-            vertical: AppSizes.lg,
-          ),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: constraints.maxHeight),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Expanded(
-                  child: Center(
-                    child: _DeviceMockupPlaceholder(slideIndex: slideIndex),
-                  ),
-                ),
-                const SizedBox(height: AppSizes.xl),
-                Text(
-                  data.title,
-                  textAlign: TextAlign.center,
-                  style: textTheme.headlineSmall?.copyWith(
-                    color: AppColors.greenDeep,
-                  ),
-                ),
-                const SizedBox(height: AppSizes.sp12),
-                Text(
-                  data.subtitle,
-                  textAlign: TextAlign.center,
-                  style: textTheme.bodyLarge?.copyWith(
-                    color: AppColors.fgDefault,
-                  ),
-                ),
-                const SizedBox(height: AppSizes.md),
-              ],
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.lg,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Center(
+              child: _DeviceMockupPlaceholder(slideIndex: slideIndex),
             ),
           ),
-        );
-      },
+          const SizedBox(height: AppSizes.xl),
+          Text(
+            data.title,
+            textAlign: TextAlign.center,
+            style: textTheme.headlineSmall?.copyWith(
+              color: AppColors.greenDeep,
+            ),
+          ),
+          const SizedBox(height: AppSizes.sp12),
+          Text(
+            data.subtitle,
+            textAlign: TextAlign.center,
+            style: textTheme.bodyLarge?.copyWith(
+              color: AppColors.fgDefault,
+            ),
+          ),
+          const SizedBox(height: AppSizes.md),
+        ],
+      ),
     );
   }
 }

--- a/lib/src/features/onboarding/intro/onboarding_intro_screen.dart
+++ b/lib/src/features/onboarding/intro/onboarding_intro_screen.dart
@@ -3,8 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
+/// Intro carousel — 3 butter-gradient slides with device-mockup illustrations.
+///
+/// Per NIB-60: butter-soft -> cream gradient bg, title2 heading, body sub,
+/// AppPillButton sage primary CTA, AppRoundButton butter back. Inline dot
+/// indicator (sage greenDeep widened pill on active). Last slide advances to
+/// /onboarding/name (route hoisted by NIB-51).
 class OnboardingIntroScreen extends ConsumerStatefulWidget {
   const OnboardingIntroScreen({super.key});
 
@@ -14,6 +23,27 @@ class OnboardingIntroScreen extends ConsumerStatefulWidget {
 }
 
 class _OnboardingIntroScreenState extends ConsumerState<OnboardingIntroScreen> {
+  static const _slides = <_IntroSlideData>[
+    _IntroSlideData(
+      title: 'Meal Prep Guidance',
+      subtitle:
+          'Step-by-step guidance to plan, prep, and serve baby-safe meals '
+          'with confidence.',
+    ),
+    _IntroSlideData(
+      title: 'Grocery Shopping',
+      subtitle:
+          'Auto-generated shopping lists from your meal plan, organized by '
+          'aisle so nothing gets missed.',
+    ),
+    _IntroSlideData(
+      title: 'Recipes & Meal Planning',
+      subtitle:
+          'A library of age-appropriate recipes, ready to drop into a weekly '
+          'plan tailored to your baby.',
+    ),
+  ];
+
   final _pageController = PageController();
   int _currentPage = 0;
 
@@ -23,173 +53,219 @@ class _OnboardingIntroScreenState extends ConsumerState<OnboardingIntroScreen> {
     super.dispose();
   }
 
+  bool get _isLast => _currentPage == _slides.length - 1;
+
+  void _onPrimaryPressed() {
+    if (_isLast) {
+      context.goNamed(AppRoute.onboardingName.name);
+      return;
+    }
+    _pageController.nextPage(
+      duration: const Duration(milliseconds: 280),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _onBackPressed() {
+    if (_currentPage == 0) return;
+    _pageController.previousPage(
+      duration: const Duration(milliseconds: 280),
+      curve: Curves.easeInOut,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.background,
-      body: SafeArea(
-        child: Column(
-          children: [
-            Expanded(
-              child: PageView(
-                controller: _pageController,
-                onPageChanged: (page) => setState(() => _currentPage = page),
-                children: const [_OB01Welcome(), _OB02ValueProp()],
-              ),
-            ),
-            _BottomSection(
-              currentPage: _currentPage,
-              onGetStarted: () => _pageController.nextPage(
-                duration: const Duration(milliseconds: 300),
-                curve: Curves.easeInOut,
-              ),
-              onNext: () => context.goNamed(AppRoute.onboardingName.name),
-            ),
-          ],
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [AppColors.butterSoft, AppColors.cream],
+          ),
         ),
-      ),
-    );
-  }
-}
-
-class _OB01Welcome extends StatelessWidget {
-  const _OB01Welcome();
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.pagePaddingH,
-        vertical: AppSizes.pagePaddingV,
-      ),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Container(
-            width: 96,
-            height: 96,
-            decoration: BoxDecoration(
-              color: AppColors.primary,
-              borderRadius: BorderRadius.circular(AppSizes.radiusXl),
-            ),
-            child: const Icon(
-              Icons.child_care_rounded,
-              color: AppColors.onPrimary,
-              size: AppSizes.iconXl,
-            ),
-          ),
-          const SizedBox(height: AppSizes.xl),
-          Text(
-            'Nibbles',
-            style: textTheme.displaySmall?.copyWith(
-              color: AppColors.primary,
-              fontWeight: FontWeight.w800,
-            ),
-          ),
-          const SizedBox(height: AppSizes.md),
-          Text(
-            'Your guide to introducing solids — safely, '
-            'confidently, one bite at a time.',
-            textAlign: TextAlign.center,
-            style: textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _OB02ValueProp extends StatelessWidget {
-  const _OB02ValueProp();
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.pagePaddingH,
-        vertical: AppSizes.pagePaddingV,
-      ),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Everything you need to get started',
-            style: textTheme.headlineMedium?.copyWith(
-              fontWeight: FontWeight.w800,
-            ),
-          ),
-          const SizedBox(height: AppSizes.xl),
-          const _FeatureRow(
-            icon: Icons.track_changes_rounded,
-            title: 'Allergen tracking',
-            subtitle: 'Introduce the top 9 allergens safely with guided steps.',
-          ),
-          const SizedBox(height: AppSizes.lg),
-          const _FeatureRow(
-            icon: Icons.calendar_month_rounded,
-            title: 'Meal planning',
-            subtitle: "Plan weekly meals tailored to your baby's progress.",
-          ),
-          const SizedBox(height: AppSizes.lg),
-          const _FeatureRow(
-            icon: Icons.menu_book_rounded,
-            title: 'Recipe library',
-            subtitle: 'Age-appropriate recipes your whole family will love.',
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _FeatureRow extends StatelessWidget {
-  const _FeatureRow({
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-  });
-
-  final IconData icon;
-  final String title;
-  final String subtitle;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Container(
-          padding: const EdgeInsets.all(AppSizes.sm),
-          decoration: BoxDecoration(
-            color: AppColors.primary.withAlpha(26),
-            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-          ),
-          child: Icon(icon, color: AppColors.primary, size: AppSizes.iconMd),
-        ),
-        const SizedBox(width: AppSizes.md),
-        Expanded(
+        child: SafeArea(
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                title,
-                style: textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w700,
+              _TopBar(
+                showBack: _currentPage > 0,
+                onBack: _onBackPressed,
+              ),
+              Expanded(
+                child: PageView.builder(
+                  controller: _pageController,
+                  itemCount: _slides.length,
+                  onPageChanged: (page) => setState(() => _currentPage = page),
+                  itemBuilder: (context, index) => _IntroSlide(
+                    data: _slides[index],
+                    slideIndex: index,
+                  ),
                 ),
               ),
-              const SizedBox(height: AppSizes.xs),
-              Text(
-                subtitle,
-                style: textTheme.bodySmall?.copyWith(color: AppColors.subtext),
+              _BottomSection(
+                currentPage: _currentPage,
+                slideCount: _slides.length,
+                primaryLabel: _isLast ? "Let's Go" : 'Continue',
+                onPrimary: _onPrimaryPressed,
               ),
             ],
           ),
         ),
-      ],
+      ),
+    );
+  }
+}
+
+class _IntroSlideData {
+  const _IntroSlideData({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+}
+
+class _TopBar extends StatelessWidget {
+  const _TopBar({required this.showBack, required this.onBack});
+
+  final bool showBack;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.md,
+        AppSizes.pagePaddingH,
+        0,
+      ),
+      child: Row(
+        children: [
+          AnimatedOpacity(
+            duration: const Duration(milliseconds: 200),
+            opacity: showBack ? 1 : 0,
+            child: IgnorePointer(
+              ignoring: !showBack,
+              child: AppRoundButton(
+                icon: const Icon(Icons.arrow_back),
+                tone: AppRoundButtonTone.butter,
+                onPressed: onBack,
+                semanticLabel: 'Back',
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _IntroSlide extends StatelessWidget {
+  const _IntroSlide({required this.data, required this.slideIndex});
+
+  final _IntroSlideData data;
+  final int slideIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+            vertical: AppSizes.lg,
+          ),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: Center(
+                    child: _DeviceMockupPlaceholder(slideIndex: slideIndex),
+                  ),
+                ),
+                const SizedBox(height: AppSizes.xl),
+                Text(
+                  data.title,
+                  textAlign: TextAlign.center,
+                  style: textTheme.headlineSmall?.copyWith(
+                    color: AppColors.greenDeep,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.sp12),
+                Text(
+                  data.subtitle,
+                  textAlign: TextAlign.center,
+                  style: textTheme.bodyLarge?.copyWith(
+                    color: AppColors.fgDefault,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.md),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Styled placeholder for the device-frame illustration.
+// TODO(NIB-60): replace with device-frame illustration from Figma export
+class _DeviceMockupPlaceholder extends StatelessWidget {
+  const _DeviceMockupPlaceholder({required this.slideIndex});
+
+  final int slideIndex;
+
+  static const _accents = <Color>[
+    AppColors.coralSoft,
+    AppColors.greenTint,
+    AppColors.butter,
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Device-frame mockup proportions ~ iPhone 9:19.5.
+        final maxWidth = constraints.maxWidth;
+        final maxHeight = constraints.maxHeight;
+        final widthFromHeight = maxHeight * 9 / 19.5;
+        final width = widthFromHeight.clamp(0.0, maxWidth * 0.72);
+        final height = width * 19.5 / 9;
+        return Container(
+          width: width,
+          height: height,
+          decoration: BoxDecoration(
+            color: AppColors.cream,
+            borderRadius: BorderRadius.circular(AppSizes.radius2xl),
+            border: Border.all(
+              color: AppColors.greenDeep.withAlpha(38),
+              width: 1.5,
+            ),
+            boxShadow: AppSizes.shadowCardLifted,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(AppSizes.md),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: _accents[slideIndex % _accents.length],
+                borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+              ),
+              child: Center(
+                child: Text(
+                  'Preview',
+                  style: AppTypography.caption.copyWith(
+                    color: AppColors.greenDeep,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }
@@ -197,49 +273,71 @@ class _FeatureRow extends StatelessWidget {
 class _BottomSection extends StatelessWidget {
   const _BottomSection({
     required this.currentPage,
-    required this.onGetStarted,
-    required this.onNext,
+    required this.slideCount,
+    required this.primaryLabel,
+    required this.onPrimary,
   });
 
   final int currentPage;
-  final VoidCallback onGetStarted;
-  final VoidCallback onNext;
+  final int slideCount;
+  final String primaryLabel;
+  final VoidCallback onPrimary;
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.pagePaddingH,
-        vertical: AppSizes.pagePaddingV,
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.md,
+        AppSizes.pagePaddingH,
+        AppSizes.pagePaddingV,
       ),
       child: Column(
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: List.generate(2, (i) {
-              final active = i == currentPage;
-              return AnimatedContainer(
-                duration: const Duration(milliseconds: 200),
-                margin: const EdgeInsets.symmetric(horizontal: 4),
-                width: active ? 20 : 8,
-                height: 8,
-                decoration: BoxDecoration(
-                  color: active ? AppColors.primary : AppColors.divider,
-                  borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-                ),
-              );
-            }),
+          _DotIndicator(
+            count: slideCount,
+            currentIndex: currentPage,
           ),
           const SizedBox(height: AppSizes.lg),
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton(
-              onPressed: currentPage == 0 ? onGetStarted : onNext,
-              child: Text(currentPage == 0 ? 'Get Started' : 'Next'),
-            ),
+          AppPillButton(
+            label: primaryLabel,
+            onPressed: onPrimary,
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Inline animated dot indicator. Active dot widens into a sage pill.
+/// Spec forbids extracting this into a shared widget.
+class _DotIndicator extends StatelessWidget {
+  const _DotIndicator({
+    required this.count,
+    required this.currentIndex,
+  });
+
+  final int count;
+  final int currentIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List<Widget>.generate(count, (i) {
+        final active = i == currentIndex;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 240),
+          curve: Curves.easeOut,
+          margin: const EdgeInsets.symmetric(horizontal: AppSizes.xs),
+          width: active ? AppSizes.sp20 : AppSizes.sm,
+          height: AppSizes.sm,
+          decoration: BoxDecoration(
+            color: active ? AppColors.greenDeep : AppColors.borderMuted,
+            borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+          ),
+        );
+      }),
     );
   }
 }


### PR DESCRIPTION
## Summary

Rebuilds `OnboardingIntroScreen` as a butter-gradient PageView with 3 device-mockup slides per the new DS — replacing the NIB-51 stub. Composes existing DS primitives only; no shared components touched.

## Changes

- 3 PageView slides: "Meal Prep Guidance", "Grocery Shopping", "Recipes & Meal Planning".
- Background: `AppColors.butterSoft` -> `AppColors.cream` linear gradient.
- Heading via `textTheme.headlineSmall` (title2 22/700) in `greenDeep`; sub via `bodyLarge`.
- Primary CTA: `AppPillButton` sage — "Continue" on slides 0-1, "Let's Go" on slide 2.
- Back affordance: `AppRoundButton` butter tone, fades out on slide 0.
- Inline animated dot indicator (sage `greenDeep` widened pill on active) — not extracted into a shared widget per spec.
- Device-frame illustration = styled placeholder `Container` (cream + shadowCardLifted + accent inner panel). No device-frame assets in `design/assets/` yet; TODO points to the Figma export.
- Last slide CTA navigates to `/onboarding/name` via `AppRoute.onboardingName.name`.
- Responsive: each slide wraps content in `SingleChildScrollView` + `LayoutBuilder` so small screens scroll, large screens still center.
- Tokens only — no hardcoded hex/sizes.

## Acceptance criteria

- [x] Carousel matches Figma slides visually with DS tokens (no hardcoded hex/sizes).
- [x] Dot indicator + swipe + CTA stay in sync via shared `PageController`.
- [x] Last slide advances to `/onboarding/name` (route from NIB-51).
- [x] `flutter analyze` + `riverpod_lint` zero warnings.
- [x] `flutter test` passes (228 / 228).

## Gates

- `make gen` clean and idempotent (second run yields no diff).
- `flutter analyze`: No issues found.
- `flutter test`: All 228 tests passed.

## Scope

Single file: `lib/src/features/onboarding/intro/onboarding_intro_screen.dart`. No shared DS components, routes, or hoisted onboarding controller/state modified.