### PR TITLE
feat(onboarding): reskin name screen with first+optional last fields [NIB-66]

### DIFF
--- a/lib/src/features/onboarding/name/onboarding_name_screen.dart
+++ b/lib/src/features/onboarding/name/onboarding_name_screen.dart
@@ -1,29 +1,169 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/domain/formz/baby_name_input.dart';
 import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Stub for OB name capture. Visual reskin owned by NIB-66.
-///
-/// Writes a default name into the hoisted controller and advances. End-to-end
-/// flow navigability is the acceptance criterion for NIB-51; the real text
-/// field comes with the reskin.
-class OnboardingNameScreen extends ConsumerWidget {
+/// OB name capture (Figma 971:10266 default / 971:10279 error / 1025:7285
+/// filled). Per NIB-120 the DATA is a SINGLE `name` column — the UI shows
+/// two fields but writes the concatenated `'First Last'.trim()` string to
+/// the hoisted [OnboardingController]. State persists across back-nav by
+/// reading `state.babyName.value` on init and splitting on the LAST space
+/// for a simple round-trip.
+class OnboardingNameScreen extends ConsumerStatefulWidget {
   const OnboardingNameScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<OnboardingNameScreen> createState() =>
+      _OnboardingNameScreenState();
+}
+
+class _OnboardingNameScreenState extends ConsumerState<OnboardingNameScreen> {
+  late final TextEditingController _firstNameController;
+  late final TextEditingController _lastNameController;
+  bool _firstDirty = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final stored = ref.read(onboardingControllerProvider).babyName.value;
+    final (first, last) = _splitStored(stored);
+    _firstNameController = TextEditingController(text: first);
+    _lastNameController = TextEditingController(text: last);
+    // If we re-entered with a previously-valid name, treat first as already
+    // dirty so the Next CTA matches the visible filled state.
+    _firstDirty = first.trim().isNotEmpty;
+  }
+
+  /// Splits the persisted single name on the LAST space — simple round-trip
+  /// that matches how the screen joins on write. A single token populates
+  /// First only.
+  (String first, String last) _splitStored(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return ('', '');
+    final idx = trimmed.lastIndexOf(' ');
+    if (idx < 0) return (trimmed, '');
+    final first = trimmed.substring(0, idx).trim();
+    final last = trimmed.substring(idx + 1).trim();
+    return (first, last);
+  }
+
+  @override
+  void dispose() {
+    _firstNameController.dispose();
+    _lastNameController.dispose();
+    super.dispose();
+  }
+
+  String get _firstTrimmed => _firstNameController.text.trim();
+  String get _lastTrimmed => _lastNameController.text.trim();
+
+  bool get _firstNameValid =>
+      const BabyNameInput.dirty().validator(_firstTrimmed) == null;
+
+  // Last name optional, but if filled must respect the same <=50 cap.
+  bool get _lastNameValid => _lastTrimmed.length <= 50;
+
+  bool get _canSubmit => _firstNameValid && _lastNameValid;
+
+  String? get _firstErrorText {
+    if (!_firstDirty) return null;
+    if (_firstNameValid) return null;
+    return 'You must fill the name';
+  }
+
+  void _onFirstChanged(String _) {
+    setState(() => _firstDirty = true);
+  }
+
+  void _onLastChanged(String _) {
+    setState(() {});
+  }
+
+  void _onNext() {
+    if (!_canSubmit) return;
+    final first = _firstTrimmed;
+    final last = _lastTrimmed;
+    final joined = last.isEmpty ? first : '$first $last';
+    ref.read(onboardingControllerProvider.notifier).updateName(joined);
+    context.goNamed(AppRoute.onboardingDob.name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final errorText = _firstErrorText;
+
     return Scaffold(
-      appBar: AppBar(title: const Text('TODO: name')),
-      body: Center(
-        child: FilledButton(
-          key: const Key('onboarding_name_next'),
-          onPressed: () {
-            ref.read(onboardingControllerProvider.notifier).updateName('Baby');
-            context.goNamed(AppRoute.onboardingDob.name);
-          },
-          child: const Text('Next'),
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        elevation: 0,
+        leading: Navigator.of(context).canPop()
+            ? IconButton(
+                icon: const Icon(Icons.arrow_back_rounded),
+                onPressed: () => Navigator.of(context).pop(),
+              )
+            : null,
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+            vertical: AppSizes.pagePaddingV,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                "What is your baby's name?",
+                style: textTheme.displaySmall,
+              ),
+              const SizedBox(height: AppSizes.sm),
+              Text(
+                "We'll use this to personalise your meal plans and progress.",
+                style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
+              ),
+              const SizedBox(height: AppSizes.xl),
+              AppTextField(
+                key: const Key('onboarding_first_name_field'),
+                label: 'First Name',
+                hintText: 'Asther',
+                controller: _firstNameController,
+                textInputAction: TextInputAction.next,
+                onChanged: _onFirstChanged,
+              ),
+              if (errorText != null) ...[
+                const SizedBox(height: AppSizes.xs),
+                Text(
+                  errorText,
+                  style: textTheme.bodySmall?.copyWith(
+                    color: AppColors.destructive,
+                  ),
+                ),
+              ],
+              const SizedBox(height: AppSizes.md),
+              AppTextField(
+                key: const Key('onboarding_last_name_field'),
+                label: 'Last Name (Optional)',
+                hintText: 'Putra',
+                controller: _lastNameController,
+                textInputAction: TextInputAction.done,
+                onChanged: _onLastChanged,
+                onSubmitted: (_) => _onNext(),
+              ),
+              const Spacer(),
+              AppPillButton(
+                key: const Key('onboarding_name_next'),
+                label: 'Next',
+                onPressed: _canSubmit ? _onNext : null,
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary

Reskins `/onboarding/name` per Figma 971:10266 / 971:10279 / 1025:7285. Renders two `AppTextField`s (First Name required, Last Name optional) while keeping the single-column `name` data contract from NIB-120 — on Next the screen concatenates `'First Last'.trim()` and writes it via `OnboardingController.updateName(...)`. State persists across back-nav by reading `state.babyName.value` on init and splitting on the LAST space.

## Acceptance criteria

- [x] First Name required with maroon inline error caption ('You must fill the name'); Last Name optional.
- [x] Next disabled until first name valid (non-empty trimmed, <=50 chars per existing `BabyNameInput`).
- [x] State persists when navigating forward/back within onboarding (reads from + writes to `OnboardingController.babyName`).
- [x] Matches Figma 971:10266/10279/1025:7285 at the token level — `displaySmall` title, `bodyMedium` + `fgMuted` subtitle, `AppTextField` for fields, `AppPillButton` primary for Next, `AppColors.destructive` for the error caption, all spacing via `AppSizes`.
- [x] `flutter analyze` + `riverpod_lint` zero warnings.
- [x] `flutter test` passes (228/228).

## Notes / deviations

- Error caption is rendered as a standalone `Text` under the field (matches the NIB-107 deviation). `AppTextField.errorText` is intentionally NOT used because it both changes the border color and renders `AppColors.error` (bright red) instead of `AppColors.destructive` (maroon) — shared-component scope is off-limits per the orchestrator notes.
- Controller signature mismatch resolved per source-of-truth: `OnboardingController.updateName(String)` wraps in `BabyNameInput.dirty(value)` internally, so the screen passes the concatenated trimmed string. Controller and state are not modified.
- `tooLong` (>50 chars) is enforced by validation (Next stays disabled) but no separate caption is shown — only the 'You must fill the name' caption from the spec.
- Both `TextEditingController`s are disposed; `setState` is called on every change so the Next button enable/disable and the error caption track input live.

## Gate results

- `make gen`: clean (idempotent on second run after reverting the known stale `home_controller.g.dart` drift from `redesign`).
- `flutter analyze`: No issues found.
- `flutter test`: All 228 tests passed.

## Files changed

- `lib/src/features/onboarding/name/onboarding_name_screen.dart`