### PR TITLE
feat(onboarding): consent/housekeeping screen with age-gated checkboxes [NIB-100]

### DIFF
--- a/lib/src/features/onboarding/consent/onboarding_consent_screen.dart
+++ b/lib/src/features/onboarding/consent/onboarding_consent_screen.dart
@@ -2,74 +2,277 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/components.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
+import 'package:nibbles/src/utils/age_in_months.dart';
 
-/// Final onboarding stage. Visual reskin owned by NIB-100.
+/// Consent / housekeeping — final onboarding stage.
 ///
-/// Real logic (not a pure stub): on submit, calls `createBaby` via the hoisted
-/// controller. P1 surface — on failure, shows the error inline and DOES NOT
-/// flip `onboarding_done`, so kill-and-resume lands the user back here. On
-/// success, flips `onboarding_done` and routes to `/home`. Consent itself is
-/// ephemeral (NIB-120) and is NOT persisted.
-class OnboardingConsentScreen extends ConsumerWidget {
+/// Per NIB-100 (Figma 971:10184 / 971:10198): Quatrefoil + title1 +
+/// age-gated checkbox list (2 boxes if baby is >= 6 months old; 3 boxes if
+/// younger, with an extra "full responsibility" acknowledgement). CTA is
+/// disabled until every box is checked. Consent itself is EPHEMERAL per
+/// NIB-120 — checkbox state lives in this widget only, never persisted.
+///
+/// Submit path: validates name/DOB via [OnboardingController.submit] which
+/// creates the baby via the baby-profile service. On success this screen
+/// sets `onboarding_done` + navigates to `/home` (the GoRouter redirect
+/// cannot fire without the flag and nothing else flips it). On failure the
+/// inline P1 error from `state.submitErrorMessage` is shown with a Retry
+/// button.
+class OnboardingConsentScreen extends ConsumerStatefulWidget {
   const OnboardingConsentScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(onboardingControllerProvider);
+  ConsumerState<OnboardingConsentScreen> createState() =>
+      _OnboardingConsentScreenState();
+}
+
+class _OnboardingConsentScreenState
+    extends ConsumerState<OnboardingConsentScreen> {
+  // Default to the safer 2-checkbox path when DOB is missing (spec step 2).
+  static const int _defaultAgeMonths = 6;
+  static const int _earlySolidsThresholdMonths = 6;
+
+  late List<bool> _checks;
+
+  @override
+  void initState() {
+    super.initState();
+    final dob = ref.read(onboardingControllerProvider).dob;
+    final ageMonths = dob != null ? ageInMonths(dob) : _defaultAgeMonths;
+    _checks = List<bool>.filled(_countFor(ageMonths), false);
+  }
+
+  int _countFor(int ageMonths) =>
+      ageMonths >= _earlySolidsThresholdMonths ? 2 : 3;
+
+  bool get _allChecked => _checks.every((c) => c);
+
+  void _toggle(int index, {required bool value}) {
+    setState(() => _checks[index] = value);
+  }
+
+  Future<void> _onConfirm() async {
     final controller = ref.read(onboardingControllerProvider.notifier);
+    final ok = await controller.submit();
+    if (!ok || !mounted) return;
+    ref.read(localFlagServiceProvider).setOnboardingDone();
+    if (!mounted) return;
+    context.goNamed(AppRoute.home.name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final isSubmitting = ref.watch(
+      onboardingControllerProvider.select((s) => s.isSubmitting),
+    );
+    final errorMessage = ref.watch(
+      onboardingControllerProvider.select((s) => s.submitErrorMessage),
+    );
+
+    final canConfirm = _allChecked && !isSubmitting;
+    final ctaLabel = _allChecked ? 'Yes, I Understand' : 'Check confirmation';
 
     return Scaffold(
-      appBar: AppBar(title: const Text('TODO: consent')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CheckboxListTile(
-              key: const Key('onboarding_consent_checkbox'),
-              value: state.consentAccepted,
-              onChanged: (v) => controller.setConsentAccepted(
-                accepted: v ?? false,
-              ),
-              title: const Text('I agree (placeholder)'),
-            ),
-            if (state.submitErrorMessage != null) ...[
-              const SizedBox(height: 12),
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        elevation: 0,
+        leading: Navigator.of(context).canPop()
+            ? IconButton(
+                icon: const Icon(Icons.arrow_back_rounded),
+                onPressed: () => Navigator.of(context).pop(),
+              )
+            : null,
+      ),
+      body: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+            vertical: AppSizes.pagePaddingV,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Center(child: Quatrefoil()),
+              const SizedBox(height: AppSizes.lg),
               Text(
-                state.submitErrorMessage!,
-                key: const Key('onboarding_consent_error'),
-                style: const TextStyle(color: AppColors.error),
+                'Before we start, some housekeeping',
+                style: textTheme.displaySmall,
+              ),
+              const SizedBox(height: AppSizes.xl),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      for (var i = 0; i < _checks.length; i++) ...[
+                        _ConsentCheckboxRow(
+                          key: Key('onboarding_consent_checkbox_$i'),
+                          label: _labelFor(i, _checks.length),
+                          value: _checks[i],
+                          onChanged: (v) => _toggle(i, value: v),
+                        ),
+                        if (i < _checks.length - 1)
+                          const SizedBox(height: AppSizes.md),
+                      ],
+                      if (errorMessage != null) ...[
+                        const SizedBox(height: AppSizes.md),
+                        _InlineError(
+                          key: const Key('onboarding_consent_error'),
+                          message: errorMessage,
+                          onRetry: canConfirm ? _onConfirm : null,
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppSizes.md),
+              AppPillButton(
+                key: const Key('onboarding_consent_submit'),
+                label: ctaLabel,
+                onPressed: canConfirm ? _onConfirm : null,
               ),
             ],
-            const SizedBox(height: 24),
-            FilledButton(
-              key: const Key('onboarding_consent_submit'),
-              onPressed: (!state.consentAccepted || state.isSubmitting)
-                  ? null
-                  : () async {
-                      final ok = await controller.submit();
-                      if (!ok || !context.mounted) return;
-                      ref
-                          .read(localFlagServiceProvider)
-                          .setOnboardingDone();
-                      context.goNamed(AppRoute.home.name);
-                    },
-              child: state.isSubmitting
-                  ? const SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: AppColors.onPrimary,
-                      ),
-                    )
-                  : const Text('Submit'),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Copy for each checkbox row. Index 2 only renders when [count] == 3 (baby
+  /// younger than 6 months) and carries the early-solids acknowledgement.
+  String _labelFor(int index, int count) {
+    switch (index) {
+      case 0:
+        return 'I understand Nibbles is guidance, not medical advice.';
+      case 1:
+        return 'I will watch my baby closely during meals and stop if anything '
+            "doesn't feel right.";
+      case 2:
+        // Only shown when count == 3 — verbatim from the spec.
+        return 'I accept full responsibility for my decision to start solids '
+            'before 6 months.';
+      default:
+        return '';
+    }
+  }
+}
+
+/// Row composed of [AppCheckbox] + label text. Tapping the label toggles the
+/// checkbox so the whole row is a hit target (kit pattern).
+class _ConsentCheckboxRow extends StatelessWidget {
+  const _ConsentCheckboxRow({
+    required this.label,
+    required this.value,
+    required this.onChanged,
+    super.key,
+  });
+
+  final String label;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return InkWell(
+      borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      onTap: () => onChanged(!value),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSizes.sm),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              // Nudge the checkbox down so it visually aligns with the first
+              // line of label text (label has a 22pt line-height; checkbox 24).
+              padding: const EdgeInsets.only(top: 2),
+              child: AppCheckbox(
+                value: value,
+                onChanged: onChanged,
+              ),
+            ),
+            const SizedBox(width: AppSizes.sp12),
+            Expanded(
+              child: Text(
+                label,
+                style: textTheme.bodyLarge?.copyWith(
+                  color: AppColors.fgDefault,
+                ),
+              ),
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// P1 inline error surface — destructive-tinted panel with a Retry affordance.
+/// Retry is null while submit is in-flight or the boxes are unchecked, so the
+/// user can't fire a duplicate submit mid-request.
+class _InlineError extends StatelessWidget {
+  const _InlineError({
+    required this.message,
+    required this.onRetry,
+    super.key,
+  });
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Container(
+      padding: const EdgeInsets.all(AppSizes.md),
+      decoration: BoxDecoration(
+        color: AppColors.destructiveSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Icon(
+                Icons.error_outline_rounded,
+                color: AppColors.destructive,
+                size: AppSizes.iconMd,
+              ),
+              const SizedBox(width: AppSizes.sp12),
+              Expanded(
+                child: Text(
+                  message,
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: AppColors.destructive,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSizes.sm),
+          Align(
+            alignment: Alignment.centerRight,
+            child: AppPillButton(
+              key: const Key('onboarding_consent_retry'),
+              label: 'Retry',
+              variant: AppPillButtonVariant.secondary,
+              size: AppPillButtonSize.small,
+              expand: false,
+              onPressed: onRetry,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary

Reskin of `/onboarding/consent` (NIB-51 stub) per Figma 971:10184 / 971:10198.

- Quatrefoil illustration + title1 'Before we start, some housekeeping'.
- Age-gated checkbox list — 2 boxes when baby is >= 6 months old, 3 boxes when younger (third box = 'I accept full responsibility for my decision to start solids before 6 months', verbatim from spec).
- Age derived from `state.dob` via `ageInMonths`; defaults to the safer 2-checkbox path when DOB is missing.
- CTA renders as disabled grey `AppPillButton` labelled 'Check confirmation' until every box is checked, then flips to sage primary 'Yes, I Understand'. Also disabled while `state.isSubmitting`.
- Confirm calls `OnboardingController.submit()` which atomically creates the baby + allergen_program_state. On success the screen sets `onboarding_done` and routes to `/home`. On failure renders an inline P1 destructive panel with the controller's `submitErrorMessage` and a Retry CTA.
- No consent persistence anywhere — checkbox state is local widget state per NIB-120.
- No analytics this ticket — future polish.

## Acceptance criteria

- [x] Correct checkbox count by age (>=6mo = 2; <6mo = 3 incl 'full responsibility' line).
- [x] CTA enabled only when all boxes are checked AND not isSubmitting.
- [x] Confirm calls `OnboardingController.submit` which creates baby + allergen_program_state.
- [x] createBaby failure surfaces inline error (`state.submitErrorMessage`) + a Retry affordance.
- [x] No consent persistence (no DB column, no Hive flag, no entity field).
- [x] Matches Figma 971:10184 / 10198 at the token level (Quatrefoil, displaySmall, AppCheckbox, AppPillButton primary/disabled).
- [x] `flutter analyze` zero warnings; `flutter test` passes (235/235).

## Gate results

- `make gen`: clean (no diff on second run after reverting unrelated `home_controller.g.dart` base drift).
- `flutter analyze`: 0 issues.
- `flutter test`: 235 passed, 0 failed.

## Test plan

- [ ] DOB at exactly 6 months -> 2 checkboxes render.
- [ ] DOB at 5 months -> 3 checkboxes render, third row reads 'I accept full responsibility...'.
- [ ] No DOB captured (defensive fallback) -> 2 checkboxes render.
- [ ] All boxes unchecked -> CTA shows 'Check confirmation', disabled grey.
- [ ] All boxes checked -> CTA shows 'Yes, I Understand', sage primary.
- [ ] Tap confirm with no network -> inline P1 destructive panel + Retry button appears.
- [ ] Retry re-runs submit successfully -> navigates to `/home`.