### PR TITLE
feat(onboarding): result screen ready/not-ready variants with X/5 badge [NIB-91]

### DIFF
--- a/lib/src/features/onboarding/result/onboarding_result_screen.dart
+++ b/lib/src/features/onboarding/result/onboarding_result_screen.dart
@@ -160,9 +160,10 @@ class _ResultCard extends StatelessWidget {
     final petalColor = ready ? AppColors.butterSoft : AppColors.greenTint;
     final coreColor = ready ? AppColors.greenDeep : AppColors.butter;
     final fgStrong = ready ? AppColors.greenDeep : AppColors.cream;
-    final fgSoft = ready
-        ? AppColors.greenDeep.withAlpha(204)
-        : AppColors.cream.withAlpha(230);
+    // Eyebrow uses the same on-card tone as the headline so the row reads as a
+    // single typographic pair — both tokens are kit foreground colors, no
+    // inline opacity. Sage card -> cream-on-green; butter card -> greenDeep.
+    final fgEyebrow = ready ? AppColors.greenDeep : AppColors.onGreen;
     final eyebrow = ready ? 'New Journey Unlock!' : 'Almost there';
     final headline = ready
         ? '$firstName is ready for solids at this time'
@@ -192,12 +193,11 @@ class _ResultCard extends StatelessWidget {
             _ScoreBadge(signsMet: signsMet, ready: ready),
             const SizedBox(height: AppSizes.md),
             Text(
-              eyebrow,
+              // Overline token (labelSmall): 10/700 h1.20 ls0.6 per kit —
+              // includes letterSpacing, no inline override needed.
+              eyebrow.toUpperCase(),
               textAlign: TextAlign.center,
-              style: textTheme.labelMedium?.copyWith(
-                color: fgSoft,
-                letterSpacing: 0.6,
-              ),
+              style: textTheme.labelSmall?.copyWith(color: fgEyebrow),
             ),
             const SizedBox(height: AppSizes.xs),
             Text(

--- a/lib/src/features/onboarding/result/onboarding_result_screen.dart
+++ b/lib/src/features/onboarding/result/onboarding_result_screen.dart
@@ -1,25 +1,310 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
+import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
+import 'package:nibbles/src/features/onboarding/onboarding_state.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Stub for OB readiness result. Visual reskin owned by NIB-91.
+/// Short labels for the 5 developmental signs surfaced on the result card.
+/// Index aligns with `readinessAnswers` on [OnboardingState] (set by the
+/// readiness screen). Kept terse — the question form lives on the readiness
+/// step; this screen summarizes.
+const List<String> _signLabels = [
+  'Holds head steady',
+  'Sits upright with minimal support',
+  'Tongue-thrust reflex gone',
+  'Shows interest in food',
+  'Brings objects to mouth',
+];
+
+/// NIB-91 — Readiness RESULT screen.
 ///
-/// Pass-through screen — no flag of its own. Advances to consent.
+/// Reads `readinessAnswers` (length 5) from the hoisted [OnboardingController]
+/// and renders one of two variants based on `signsMet >= 3` (NIB-120 majority
+/// gate). Soft-warn UX: Next routes to `/onboarding/consent` in BOTH variants.
+///
+/// * READY (signs_met >= 3): butter card, all 5 signs rendered with a green
+///   check, "New Journey Unlock!" headline.
+/// * NOT-READY (signs_met < 3): sage card, each sign rendered with the
+///   per-answer check or cross, "not ready" headline.
+///
+/// Back routes to `/onboarding/readiness` — the readiness screen `go`s here so
+/// the navigator stack typically can't pop; `goNamed` preserves the hoisted
+/// controller's captured answers (keepAlive).
 class OnboardingResultScreen extends ConsumerWidget {
   const OnboardingResultScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Defensive: the screen indexes `_signLabels` by the readiness-answer
+    // position. If either drifts from `readinessQuestionCount`, fail loudly in
+    // debug instead of silently mis-rendering.
+    assert(
+      _signLabels.length == readinessQuestionCount,
+      'Result sign label count drifted from OnboardingState seed',
+    );
+
+    final answers = ref.watch(
+      onboardingControllerProvider.select((s) => s.readinessAnswers),
+    );
+    final babyNameRaw = ref.watch(
+      onboardingControllerProvider.select((s) => s.babyName.value),
+    );
+
+    final firstName = _firstToken(babyNameRaw);
+    final signsMet = answers.where((a) => a ?? false).length;
+    final ready = signsMet >= readinessReadyThreshold;
+
     return Scaffold(
-      appBar: AppBar(title: const Text('TODO: result')),
-      body: Center(
-        child: FilledButton(
-          key: const Key('onboarding_result_next'),
-          onPressed: () => context.goNamed(AppRoute.onboardingConsent.name),
-          child: const Text('Next'),
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.background,
+        elevation: 0,
+        leadingWidth: AppSizes.roundButton + AppSizes.md,
+        leading: Padding(
+          padding: const EdgeInsets.only(left: AppSizes.md),
+          child: Center(
+            child: AppRoundButton(
+              icon: const Icon(Icons.arrow_back_rounded),
+              tone: AppRoundButtonTone.butter,
+              semanticLabel: 'Back',
+              onPressed: () => _onBack(context),
+            ),
+          ),
         ),
       ),
+      body: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSizes.pagePaddingH,
+            AppSizes.sm,
+            AppSizes.pagePaddingH,
+            AppSizes.pagePaddingV,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  child: _ResultCard(
+                    firstName: firstName,
+                    answers: answers,
+                    signsMet: signsMet,
+                    ready: ready,
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppSizes.lg),
+              AppPillButton(
+                key: const Key('onboarding_result_next'),
+                label: 'Next',
+                onPressed: () =>
+                    context.goNamed(AppRoute.onboardingConsent.name),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// First whitespace-separated token of [raw], or "your baby" fallback when
+  /// the name has not been captured yet. Mirrors the readiness screen so copy
+  /// stays consistent across both stages.
+  String _firstToken(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return 'your baby';
+    final idx = trimmed.indexOf(' ');
+    return idx < 0 ? trimmed : trimmed.substring(0, idx);
+  }
+
+  void _onBack(BuildContext context) {
+    // Readiness `go`s here, so the stack typically can't pop. Fall through to
+    // a named nav so back consistently returns to the questionnaire; the
+    // hoisted controller (keepAlive) preserves the captured answers.
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
+    context.goNamed(AppRoute.onboardingReadiness.name);
+  }
+}
+
+/// Majority gate per NIB-120: ready iff at least this many signs are met.
+const int readinessReadyThreshold = 3;
+
+class _ResultCard extends StatelessWidget {
+  const _ResultCard({
+    required this.firstName,
+    required this.answers,
+    required this.signsMet,
+    required this.ready,
+  });
+
+  final String firstName;
+  final List<bool?> answers;
+  final int signsMet;
+  final bool ready;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final cardColor = ready ? AppColors.butter : AppColors.green;
+    final petalColor = ready ? AppColors.butterSoft : AppColors.greenTint;
+    final coreColor = ready ? AppColors.greenDeep : AppColors.butter;
+    final fgStrong = ready ? AppColors.greenDeep : AppColors.cream;
+    final fgSoft = ready
+        ? AppColors.greenDeep.withAlpha(204)
+        : AppColors.cream.withAlpha(230);
+    final eyebrow = ready ? 'New Journey Unlock!' : 'Almost there';
+    final headline = ready
+        ? '$firstName is ready for solids at this time'
+        : '$firstName is not ready for solids at this time';
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: cardColor,
+        borderRadius: BorderRadius.circular(AppSizes.radius2xl),
+        boxShadow: AppSizes.shadowCardLifted,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSizes.lg,
+          AppSizes.xl,
+          AppSizes.lg,
+          AppSizes.lg,
+        ),
+        child: Column(
+          children: [
+            Quatrefoil(
+              size: AppSizes.xxxl,
+              petalColor: petalColor,
+              coreColor: coreColor,
+            ),
+            const SizedBox(height: AppSizes.md),
+            _ScoreBadge(signsMet: signsMet, ready: ready),
+            const SizedBox(height: AppSizes.md),
+            Text(
+              eyebrow,
+              textAlign: TextAlign.center,
+              style: textTheme.labelMedium?.copyWith(
+                color: fgSoft,
+                letterSpacing: 0.6,
+              ),
+            ),
+            const SizedBox(height: AppSizes.xs),
+            Text(
+              headline,
+              textAlign: TextAlign.center,
+              style: textTheme.displaySmall?.copyWith(color: fgStrong),
+            ),
+            const SizedBox(height: AppSizes.lg),
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: AppColors.cream,
+                borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.md,
+                  vertical: AppSizes.sp12,
+                ),
+                child: Column(
+                  children: List<Widget>.generate(_signLabels.length, (i) {
+                    // Ready variant: all rows render as positive (green check)
+                    // per spec Step 3, regardless of per-answer values. The
+                    // X/5 badge still reflects `signsMet` so the user sees
+                    // their actual score.
+                    final isPositive = ready || (answers[i] ?? false);
+                    return Padding(
+                      padding: EdgeInsets.only(
+                        top: i == 0 ? 0 : AppSizes.sp12,
+                      ),
+                      child: _SignRow(
+                        label: _signLabels[i],
+                        positive: isPositive,
+                      ),
+                    );
+                  }),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ScoreBadge extends StatelessWidget {
+  const _ScoreBadge({required this.signsMet, required this.ready});
+
+  final int signsMet;
+  final bool ready;
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = ready ? AppColors.greenDeep : AppColors.butter;
+    final fg = ready ? AppColors.cream : AppColors.greenDeep;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.md,
+          vertical: AppSizes.xs,
+        ),
+        child: Text(
+          '$signsMet / ${_signLabels.length} signs',
+          style: AppTypography.bodyBold.copyWith(color: fg),
+        ),
+      ),
+    );
+  }
+}
+
+class _SignRow extends StatelessWidget {
+  const _SignRow({required this.label, required this.positive});
+
+  final String label;
+  final bool positive;
+
+  @override
+  Widget build(BuildContext context) {
+    final markBg = positive ? AppColors.greenTint : AppColors.destructiveSoft;
+    final markFg = positive ? AppColors.greenDeep : AppColors.destructive;
+    final icon = positive ? Icons.check_rounded : Icons.close_rounded;
+
+    return Row(
+      children: [
+        Container(
+          width: AppSizes.iconMd,
+          height: AppSizes.iconMd,
+          decoration: BoxDecoration(
+            color: markBg,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(icon, color: markFg, size: AppSizes.iconSm),
+        ),
+        const SizedBox(width: AppSizes.sp12),
+        Expanded(
+          child: Text(
+            label,
+            style: AppTypography.bodyBold.copyWith(
+              color: AppColors.fgDefault,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary

Reskins the readiness RESULT screen (NIB-51 stub) per the redesign kit. Reads `readinessAnswers` (length 5) and `babyName` from the hoisted `OnboardingController` and renders one of two variants based on a soft-warn majority gate (NIB-120: ready iff `signs_met >= 3`).

- READY variant: butter card, "New Journey Unlock! [Name] is ready for solids at this time", all 5 signs rendered with a green check.
- NOT-READY variant: sage card, "[Name] is not ready for solids at this time", each sign rendered with check or cross per the corresponding `readinessAnswer`.
- X/5 badge reflects `signs_met` in both variants.
- Next routes to `/onboarding/consent` in BOTH variants (soft-warn).
- Back routes to `/onboarding/readiness` (readiness `go`s here, so the navigator stack typically can't pop; `goNamed` preserves answers via the keepAlive controller).
- DS tokens only — no hardcoded hex/sizes. AppPillButton + AppRoundButton + Quatrefoil composed; no shared DS edits.

### Notes

- Per spec: no analytics this ticket (future polish — `lib/src/logging/analytics.dart` untouched).
- Edge case (3-4/5 ready): badge shows actual `signs_met` while the row list shows all-green checks per literal spec Step 3. Visual contradiction is intentional / spec-faithful.
- Scope limited to `lib/src/features/onboarding/result/onboarding_result_screen.dart`. No changes to controller, state, routes, analytics, or other onboarding screens.

## Acceptance criteria

- [x] Correct variant shown based on `signs_met >= 3` (majority).
- [x] X/5 badge matches `signs_met`.
- [x] Both variants kit-faithful (only DS tokens; no hardcoded hex/sizes).
- [x] Next routes to `/onboarding/consent`; back to `/onboarding/readiness` preserves answers.
- [x] `flutter analyze` zero issues; `flutter test` passes (235 / 235).

## Gates

- `make gen` clean (idempotent — second pass produced no diff outside the known base-drift on `home_controller.g.dart`, which was reverted).
- `flutter analyze` — No issues found.
- `flutter test` — All 235 tests passed.