### PR TITLE
feat(allergen): nullable taste + notes/attachment fields on allergen_log [NIB-124]

### DIFF
--- a/lib/src/common/data/repositories/allergen_repository.dart
+++ b/lib/src/common/data/repositories/allergen_repository.dart
@@ -161,9 +161,15 @@ class AllergenRepositoryImpl implements AllergenRepository {
           .insert({
             'baby_id': log.babyId,
             'allergen_key': log.allergenKey,
-            'emoji_taste': log.emojiTaste.toJson(),
             'had_reaction': log.hadReaction,
             'log_date': _formatDate(log.logDate),
+            if (log.emojiTaste != null)
+              'emoji_taste': log.emojiTaste!.toJson(),
+            if (log.notes != null) 'notes': log.notes,
+            if (log.attachmentTitle != null)
+              'attachment_title': log.attachmentTitle,
+            if (log.attachmentDescription != null)
+              'attachment_description': log.attachmentDescription,
             if (log.photoUrl != null) 'photo_url': log.photoUrl,
           })
           .select()
@@ -271,16 +277,24 @@ class AllergenRepositoryImpl implements AllergenRepository {
     );
   }
 
-  AllergenLog _logFromRow(Map<String, dynamic> row) => AllergenLog(
-    id: row['id'] as String,
-    babyId: row['baby_id'] as String,
-    allergenKey: row['allergen_key'] as String,
-    emojiTaste: EmojiTasteX.fromJson(row['emoji_taste'] as String),
-    hadReaction: row['had_reaction'] as bool,
-    logDate: DateTime.parse(row['log_date'] as String),
-    createdAt: DateTime.parse(row['created_at'] as String),
-    photoUrl: row['photo_url'] as String?,
-  );
+  AllergenLog _logFromRow(Map<String, dynamic> row) {
+    final tasteRaw = row['emoji_taste'] as String?;
+    final logDateRaw = row['log_date'] as String?;
+    final createdAt = DateTime.parse(row['created_at'] as String);
+    return AllergenLog(
+      id: row['id'] as String,
+      babyId: row['baby_id'] as String,
+      allergenKey: row['allergen_key'] as String,
+      hadReaction: row['had_reaction'] as bool,
+      logDate: logDateRaw != null ? DateTime.parse(logDateRaw) : createdAt,
+      createdAt: createdAt,
+      emojiTaste: tasteRaw != null ? EmojiTasteX.fromJson(tasteRaw) : null,
+      notes: row['notes'] as String?,
+      attachmentTitle: row['attachment_title'] as String?,
+      attachmentDescription: row['attachment_description'] as String?,
+      photoUrl: row['photo_url'] as String?,
+    );
+  }
 
   AllergenProgramState _programStateFromRow(Map<String, dynamic> row) =>
       AllergenProgramState(

--- a/lib/src/common/domain/entities/allergen_log.dart
+++ b/lib/src/common/domain/entities/allergen_log.dart
@@ -9,10 +9,13 @@ class AllergenLog with _$AllergenLog {
     required String id,
     required String babyId,
     required String allergenKey,
-    required EmojiTaste emojiTaste,
     required bool hadReaction,
     required DateTime logDate,
     required DateTime createdAt,
+    EmojiTaste? emojiTaste,
+    String? notes,
+    String? attachmentTitle,
+    String? attachmentDescription,
     String? photoUrl,
   }) = _AllergenLog;
 }

--- a/lib/src/common/domain/entities/allergen_log.freezed.dart
+++ b/lib/src/common/domain/entities/allergen_log.freezed.dart
@@ -20,10 +20,13 @@ mixin _$AllergenLog {
   String get id => throw _privateConstructorUsedError;
   String get babyId => throw _privateConstructorUsedError;
   String get allergenKey => throw _privateConstructorUsedError;
-  EmojiTaste get emojiTaste => throw _privateConstructorUsedError;
   bool get hadReaction => throw _privateConstructorUsedError;
   DateTime get logDate => throw _privateConstructorUsedError;
   DateTime get createdAt => throw _privateConstructorUsedError;
+  EmojiTaste? get emojiTaste => throw _privateConstructorUsedError;
+  String? get notes => throw _privateConstructorUsedError;
+  String? get attachmentTitle => throw _privateConstructorUsedError;
+  String? get attachmentDescription => throw _privateConstructorUsedError;
   String? get photoUrl => throw _privateConstructorUsedError;
 
   /// Create a copy of AllergenLog
@@ -44,10 +47,13 @@ abstract class $AllergenLogCopyWith<$Res> {
     String id,
     String babyId,
     String allergenKey,
-    EmojiTaste emojiTaste,
     bool hadReaction,
     DateTime logDate,
     DateTime createdAt,
+    EmojiTaste? emojiTaste,
+    String? notes,
+    String? attachmentTitle,
+    String? attachmentDescription,
     String? photoUrl,
   });
 }
@@ -70,10 +76,13 @@ class _$AllergenLogCopyWithImpl<$Res, $Val extends AllergenLog>
     Object? id = null,
     Object? babyId = null,
     Object? allergenKey = null,
-    Object? emojiTaste = null,
     Object? hadReaction = null,
     Object? logDate = null,
     Object? createdAt = null,
+    Object? emojiTaste = freezed,
+    Object? notes = freezed,
+    Object? attachmentTitle = freezed,
+    Object? attachmentDescription = freezed,
     Object? photoUrl = freezed,
   }) {
     return _then(
@@ -90,10 +99,6 @@ class _$AllergenLogCopyWithImpl<$Res, $Val extends AllergenLog>
                 ? _value.allergenKey
                 : allergenKey // ignore: cast_nullable_to_non_nullable
                       as String,
-            emojiTaste: null == emojiTaste
-                ? _value.emojiTaste
-                : emojiTaste // ignore: cast_nullable_to_non_nullable
-                      as EmojiTaste,
             hadReaction: null == hadReaction
                 ? _value.hadReaction
                 : hadReaction // ignore: cast_nullable_to_non_nullable
@@ -106,6 +111,22 @@ class _$AllergenLogCopyWithImpl<$Res, $Val extends AllergenLog>
                 ? _value.createdAt
                 : createdAt // ignore: cast_nullable_to_non_nullable
                       as DateTime,
+            emojiTaste: freezed == emojiTaste
+                ? _value.emojiTaste
+                : emojiTaste // ignore: cast_nullable_to_non_nullable
+                      as EmojiTaste?,
+            notes: freezed == notes
+                ? _value.notes
+                : notes // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            attachmentTitle: freezed == attachmentTitle
+                ? _value.attachmentTitle
+                : attachmentTitle // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            attachmentDescription: freezed == attachmentDescription
+                ? _value.attachmentDescription
+                : attachmentDescription // ignore: cast_nullable_to_non_nullable
+                      as String?,
             photoUrl: freezed == photoUrl
                 ? _value.photoUrl
                 : photoUrl // ignore: cast_nullable_to_non_nullable
@@ -129,10 +150,13 @@ abstract class _$$AllergenLogImplCopyWith<$Res>
     String id,
     String babyId,
     String allergenKey,
-    EmojiTaste emojiTaste,
     bool hadReaction,
     DateTime logDate,
     DateTime createdAt,
+    EmojiTaste? emojiTaste,
+    String? notes,
+    String? attachmentTitle,
+    String? attachmentDescription,
     String? photoUrl,
   });
 }
@@ -154,10 +178,13 @@ class __$$AllergenLogImplCopyWithImpl<$Res>
     Object? id = null,
     Object? babyId = null,
     Object? allergenKey = null,
-    Object? emojiTaste = null,
     Object? hadReaction = null,
     Object? logDate = null,
     Object? createdAt = null,
+    Object? emojiTaste = freezed,
+    Object? notes = freezed,
+    Object? attachmentTitle = freezed,
+    Object? attachmentDescription = freezed,
     Object? photoUrl = freezed,
   }) {
     return _then(
@@ -174,10 +201,6 @@ class __$$AllergenLogImplCopyWithImpl<$Res>
             ? _value.allergenKey
             : allergenKey // ignore: cast_nullable_to_non_nullable
                   as String,
-        emojiTaste: null == emojiTaste
-            ? _value.emojiTaste
-            : emojiTaste // ignore: cast_nullable_to_non_nullable
-                  as EmojiTaste,
         hadReaction: null == hadReaction
             ? _value.hadReaction
             : hadReaction // ignore: cast_nullable_to_non_nullable
@@ -190,6 +213,22 @@ class __$$AllergenLogImplCopyWithImpl<$Res>
             ? _value.createdAt
             : createdAt // ignore: cast_nullable_to_non_nullable
                   as DateTime,
+        emojiTaste: freezed == emojiTaste
+            ? _value.emojiTaste
+            : emojiTaste // ignore: cast_nullable_to_non_nullable
+                  as EmojiTaste?,
+        notes: freezed == notes
+            ? _value.notes
+            : notes // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        attachmentTitle: freezed == attachmentTitle
+            ? _value.attachmentTitle
+            : attachmentTitle // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        attachmentDescription: freezed == attachmentDescription
+            ? _value.attachmentDescription
+            : attachmentDescription // ignore: cast_nullable_to_non_nullable
+                  as String?,
         photoUrl: freezed == photoUrl
             ? _value.photoUrl
             : photoUrl // ignore: cast_nullable_to_non_nullable
@@ -206,10 +245,13 @@ class _$AllergenLogImpl implements _AllergenLog {
     required this.id,
     required this.babyId,
     required this.allergenKey,
-    required this.emojiTaste,
     required this.hadReaction,
     required this.logDate,
     required this.createdAt,
+    this.emojiTaste,
+    this.notes,
+    this.attachmentTitle,
+    this.attachmentDescription,
     this.photoUrl,
   });
 
@@ -220,19 +262,25 @@ class _$AllergenLogImpl implements _AllergenLog {
   @override
   final String allergenKey;
   @override
-  final EmojiTaste emojiTaste;
-  @override
   final bool hadReaction;
   @override
   final DateTime logDate;
   @override
   final DateTime createdAt;
   @override
+  final EmojiTaste? emojiTaste;
+  @override
+  final String? notes;
+  @override
+  final String? attachmentTitle;
+  @override
+  final String? attachmentDescription;
+  @override
   final String? photoUrl;
 
   @override
   String toString() {
-    return 'AllergenLog(id: $id, babyId: $babyId, allergenKey: $allergenKey, emojiTaste: $emojiTaste, hadReaction: $hadReaction, logDate: $logDate, createdAt: $createdAt, photoUrl: $photoUrl)';
+    return 'AllergenLog(id: $id, babyId: $babyId, allergenKey: $allergenKey, hadReaction: $hadReaction, logDate: $logDate, createdAt: $createdAt, emojiTaste: $emojiTaste, notes: $notes, attachmentTitle: $attachmentTitle, attachmentDescription: $attachmentDescription, photoUrl: $photoUrl)';
   }
 
   @override
@@ -244,13 +292,18 @@ class _$AllergenLogImpl implements _AllergenLog {
             (identical(other.babyId, babyId) || other.babyId == babyId) &&
             (identical(other.allergenKey, allergenKey) ||
                 other.allergenKey == allergenKey) &&
-            (identical(other.emojiTaste, emojiTaste) ||
-                other.emojiTaste == emojiTaste) &&
             (identical(other.hadReaction, hadReaction) ||
                 other.hadReaction == hadReaction) &&
             (identical(other.logDate, logDate) || other.logDate == logDate) &&
             (identical(other.createdAt, createdAt) ||
                 other.createdAt == createdAt) &&
+            (identical(other.emojiTaste, emojiTaste) ||
+                other.emojiTaste == emojiTaste) &&
+            (identical(other.notes, notes) || other.notes == notes) &&
+            (identical(other.attachmentTitle, attachmentTitle) ||
+                other.attachmentTitle == attachmentTitle) &&
+            (identical(other.attachmentDescription, attachmentDescription) ||
+                other.attachmentDescription == attachmentDescription) &&
             (identical(other.photoUrl, photoUrl) ||
                 other.photoUrl == photoUrl));
   }
@@ -261,10 +314,13 @@ class _$AllergenLogImpl implements _AllergenLog {
     id,
     babyId,
     allergenKey,
-    emojiTaste,
     hadReaction,
     logDate,
     createdAt,
+    emojiTaste,
+    notes,
+    attachmentTitle,
+    attachmentDescription,
     photoUrl,
   );
 
@@ -282,10 +338,13 @@ abstract class _AllergenLog implements AllergenLog {
     required final String id,
     required final String babyId,
     required final String allergenKey,
-    required final EmojiTaste emojiTaste,
     required final bool hadReaction,
     required final DateTime logDate,
     required final DateTime createdAt,
+    final EmojiTaste? emojiTaste,
+    final String? notes,
+    final String? attachmentTitle,
+    final String? attachmentDescription,
     final String? photoUrl,
   }) = _$AllergenLogImpl;
 
@@ -296,13 +355,19 @@ abstract class _AllergenLog implements AllergenLog {
   @override
   String get allergenKey;
   @override
-  EmojiTaste get emojiTaste;
-  @override
   bool get hadReaction;
   @override
   DateTime get logDate;
   @override
   DateTime get createdAt;
+  @override
+  EmojiTaste? get emojiTaste;
+  @override
+  String? get notes;
+  @override
+  String? get attachmentTitle;
+  @override
+  String? get attachmentDescription;
   @override
   String? get photoUrl;
 

--- a/lib/src/common/domain/entities/reaction_detail.dart
+++ b/lib/src/common/domain/entities/reaction_detail.dart
@@ -3,6 +3,12 @@ import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
 
 part 'reaction_detail.freezed.dart';
 
+/// Legacy structured-reaction record from M3 capture (severity + symptoms).
+///
+/// Deprecated by NIB-124: the redesigned log flow collapses reactions to a
+/// single `hadReaction` toggle plus log-level `notes` on `AllergenLog`.
+/// Kept so the M3 capture screens (AL-04/AL-05/AL-06) keep compiling until
+/// NIB-125 / NIB-126 replace them. Do not use in new code.
 @freezed
 class ReactionDetail with _$ReactionDetail {
   const factory ReactionDetail({

--- a/lib/src/common/services/allergen_service.dart
+++ b/lib/src/common/services/allergen_service.dart
@@ -83,20 +83,31 @@ class AllergenService {
   /// Saves an allergen log. Multiple logs per day are allowed.
   /// If [photo] is provided, uploads it first; photo upload failure is P2
   /// (log saves without photo, caller should show a toast).
+  ///
+  /// [emojiTaste], [notes], [attachmentTitle], [attachmentDescription] and
+  /// [logDate] are part of the redesigned NIB-124 capture model. They are
+  /// optional so existing M3 callers stay compatible while the new flow is
+  /// being built (NIB-125 / NIB-126). [reactionDetail] is legacy and only
+  /// written when supplied by the M3 capture screens.
   Future<Result<AllergenLog>> saveAllergenLog({
     required String babyId,
     required String allergenKey,
-    required EmojiTaste emojiTaste,
     required bool hadReaction,
+    EmojiTaste? emojiTaste,
+    String? notes,
+    String? attachmentTitle,
+    String? attachmentDescription,
+    DateTime? logDate,
     ReactionDetail? reactionDetail,
     File? photo,
   }) async {
-    final today = DateTime.now();
+    final now = DateTime.now();
+    final effectiveLogDate = logDate ?? now;
 
     // Upload photo if provided (P2 — failure is non-blocking).
     String? photoPath;
     if (photo != null) {
-      final ts = today.millisecondsSinceEpoch;
+      final ts = now.millisecondsSinceEpoch;
       final uploadPath = '$babyId/${ts}_$allergenKey.jpg';
       final uploadResult = await _storage.uploadFile(
         _photoBucket,
@@ -114,10 +125,13 @@ class AllergenService {
         id: '',
         babyId: babyId,
         allergenKey: allergenKey,
-        emojiTaste: emojiTaste,
         hadReaction: hadReaction,
-        logDate: today,
-        createdAt: today,
+        logDate: effectiveLogDate,
+        createdAt: now,
+        emojiTaste: emojiTaste,
+        notes: notes,
+        attachmentTitle: attachmentTitle,
+        attachmentDescription: attachmentDescription,
         photoUrl: photoPath,
       ),
     );

--- a/lib/src/features/allergen/detail/widgets/log_entry_card.dart
+++ b/lib/src/features/allergen/detail/widgets/log_entry_card.dart
@@ -103,7 +103,9 @@ class _LogEntryCardState extends State<LogEntryCard> {
                         ),
                         const SizedBox(height: 2),
                         Text(
-                          _tasteLabel(widget.log.emojiTaste),
+                          _tasteLabel(
+                            widget.log.emojiTaste ?? EmojiTaste.neutral,
+                          ),
                           style: textTheme.bodySmall?.copyWith(
                             color: AppColors.subtext,
                           ),

--- a/lib/src/features/allergen/log/allergen_log_controller.dart
+++ b/lib/src/features/allergen/log/allergen_log_controller.dart
@@ -92,7 +92,7 @@ class AllergenLogController extends _$AllergenLogController {
     final result = await service.saveAllergenLog(
       babyId: babyId,
       allergenKey: allergenKey,
-      emojiTaste: state.taste!,
+      emojiTaste: state.taste,
       hadReaction: state.hadReaction,
       reactionDetail: reactionDetail,
       photo: state.photoPath != null ? File(state.photoPath!) : null,

--- a/lib/src/features/allergen/log/allergen_log_controller.g.dart
+++ b/lib/src/features/allergen/log/allergen_log_controller.g.dart
@@ -7,7 +7,7 @@ part of 'allergen_log_controller.dart';
 // **************************************************************************
 
 String _$allergenLogControllerHash() =>
-    r'c8fa20d95a2c77bde5f15052bd2afbf8af10c9ca';
+    r'a9db53cba10c35b5d4fb9f15719eee44c9485f04';
 
 /// See also [AllergenLogController].
 @ProviderFor(AllergenLogController)

--- a/lib/src/features/allergen/tracker/allergen_tracker_controller.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_controller.dart
@@ -3,6 +3,7 @@ import 'package:nibbles/src/common/domain/entities/allergen.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
+import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
 import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_state.dart';
@@ -60,7 +61,7 @@ class AllergenTrackerController extends _$AllergenTrackerController {
           allergenEmoji: entry.allergen.emoji,
           logDate: entry.log.logDate,
           createdAt: entry.log.createdAt,
-          taste: entry.log.emojiTaste,
+          taste: entry.log.emojiTaste ?? EmojiTaste.neutral,
           hadReaction: entry.log.hadReaction,
           severity: severity,
         ),

--- a/lib/src/features/allergen/tracker/allergen_tracker_controller.g.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_controller.g.dart
@@ -7,7 +7,7 @@ part of 'allergen_tracker_controller.dart';
 // **************************************************************************
 
 String _$allergenTrackerControllerHash() =>
-    r'4756aa24c39da5031d07b48fa29b2a4111d99026';
+    r'832f9369b10b71c1b3b002144cc16e6d0b55aaad';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/home/home_screen.dart
+++ b/lib/src/features/home/home_screen.dart
@@ -644,7 +644,9 @@ class _IntroductionDots extends StatelessWidget {
             child: filled
                 ? Center(
                     child: Text(
-                      isReaction ? '⚠️' : _tasteEmoji(log.emojiTaste),
+                      isReaction
+                          ? '⚠️'
+                          : _tasteEmoji(log.emojiTaste ?? EmojiTaste.neutral),
                       style: const TextStyle(fontSize: 14),
                     ),
                   )

--- a/supabase/migrations/20240101000015_redesign_allergen_logs.sql
+++ b/supabase/migrations/20240101000015_redesign_allergen_logs.sql
@@ -1,0 +1,23 @@
+-- NIB-124: Align allergen_logs with the redesigned log capture (NIB-120).
+--
+-- Reaction capture collapses to a single hadReaction toggle; taste, severity
+-- and structured symptoms are dropped from the new flow. The schema keeps
+-- emoji_taste so historical rows render, but it is no longer required.
+-- New columns capture log-level notes, an attachment title/description, and
+-- preserve the existing log_date for editable dates.
+--
+-- Old M3 capture screens (AL-04/AL-05/AL-06) still compile against the
+-- pre-redesign Dart APIs; emoji_taste being nullable is the only schema
+-- change those screens depend on. NIB-125 / NIB-126 will replace them.
+
+ALTER TABLE allergen_logs
+  ALTER COLUMN emoji_taste DROP NOT NULL;
+
+ALTER TABLE allergen_logs
+  ADD COLUMN IF NOT EXISTS notes TEXT;
+
+ALTER TABLE allergen_logs
+  ADD COLUMN IF NOT EXISTS attachment_title TEXT;
+
+ALTER TABLE allergen_logs
+  ADD COLUMN IF NOT EXISTS attachment_description TEXT;


### PR DESCRIPTION
## Summary

Aligns the data layer with the redesigned single-screen allergen log capture (NIB-120). Reaction collapses to a `hadReaction` toggle; taste, severity and structured symptoms are out of the new flow. Adds log-level notes and an attachment title/description, and keeps `logDate` editable.

The old M3 capture screens (AL-04/AL-05/AL-06) still compile — NIB-125 / NIB-126 will replace them. `emojiTaste` is made nullable end-to-end rather than dropped; M3 callers fall back to `EmojiTaste.neutral` at display sites only.

## Config blocker — DB migration

Apply `supabase/migrations/20240101000015_redesign_allergen_logs.sql` on Supabase **dev + prod** before merging.

The Dart code is null-safe so it compiles + lints pre-migration, but runtime inserts against the redesigned flow need the new columns to exist and `emoji_taste` to be nullable. (Same posture as NIB-117 social-login.)

Migration deltas:
- `ALTER COLUMN emoji_taste DROP NOT NULL`
- `ADD COLUMN notes TEXT`
- `ADD COLUMN attachment_title TEXT`
- `ADD COLUMN attachment_description TEXT`

`had_reaction` and `log_date` already exist on the live schema (see `20240101000004_create_allergen_logs.sql`), so the spec's `ADD COLUMN` for those is intentionally omitted.

## Changes

- Entity: `EmojiTaste? emojiTaste`; new `notes`, `attachmentTitle`, `attachmentDescription`.
- Repository `_logFromRow`: null-safe read of `emoji_taste` and `log_date` (fallback `created_at`); reads new nullable columns.
- Repository `saveLog`: only emits `emoji_taste` when non-null; writes new columns when supplied.
- Service `saveAllergenLog`: accepts `EmojiTaste?`, `notes`, `attachmentTitle`, `attachmentDescription`, `DateTime? logDate`; no invented defaults.
- M3 capture controller: passes nullable taste through.
- Display sites (`home_screen`, `log_entry_card`, `tracker_controller`): minimal-touch fallback to `EmojiTaste.neutral`.
- `ReactionDetail`: doc-deprecated only (annotation would trip `deprecated_member_use_from_same_package`).

## Acceptance criteria

- [x] `AllergenLog` carries `hadReaction` + `notes` + `attachmentTitle` + `attachmentDescription` + `logDate`.
- [x] `emojiTaste` is nullable.
- [x] `saveAllergenLog` accepts a log with no taste/severity (only `hadReaction` + optional notes/attachments).
- [x] Existing M3 screens still compile (nullable propagation + neutral fallback at display sites).
- [x] Supabase only in the repository; `Result<T>` preserved; no DTOs above the repo.
- [x] `supabase/migrations/` SQL file committed.
- [x] `flutter analyze` zero warnings; `flutter test` passes.

## Gate results

- `make gen`: clean (and stable on a second run; unrelated `home_controller.g.dart` base-drift reverted).
- `flutter analyze`: `No issues found! (ran in 1.7s)`
- `flutter test`: `All tests passed! (285)`

## Test plan

- [ ] Apply the migration on dev.
- [ ] Insert a log with `hadReaction=true`, `notes`, `attachmentTitle`, `attachmentDescription`, no `emoji_taste` — verify row writes.
- [ ] Insert a legacy-shape log with `emoji_taste` set — verify backwards-compatible read on the M3 screens.
- [ ] Verify the M3 capture flow still saves end-to-end on dev (sanity until NIB-125/126 replace it).