### PR TITLE
feat(allergen): updateLog + deleteLog + storage deleteFile + service photo-replace/delete [NIB-125]

### DIFF
--- a/lib/src/common/data/repositories/allergen_repository.dart
+++ b/lib/src/common/data/repositories/allergen_repository.dart
@@ -37,6 +37,16 @@ abstract interface class AllergenRepository {
   /// ALLRG-05: Insert allergen_log row.
   Future<Result<AllergenLog>> saveLog(AllergenLog log);
 
+  /// Update an existing allergen_log row by id. Writes the editable fields
+  /// (emoji_taste, had_reaction, notes, attachment_title,
+  /// attachment_description, log_date, photo_url) and returns the refreshed
+  /// row mapped to [AllergenLog].
+  Future<Result<AllergenLog>> updateLog(AllergenLog log);
+
+  /// Deletes an allergen_log row by id. Caller is responsible for cleaning
+  /// up any associated photo via the storage repository.
+  Future<Result<void>> deleteLog(String logId);
+
   /// ALLRG-06: Insert reaction_details row.
   Future<Result<ReactionDetail>> saveReactionDetail(ReactionDetail detail);
 
@@ -176,6 +186,44 @@ class AllergenRepositoryImpl implements AllergenRepository {
           .single();
 
       return Result.success(_logFromRow(data));
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<AllergenLog>> updateLog(AllergenLog log) async {
+    try {
+      final data = await _supabase
+          .from('allergen_logs')
+          .update({
+            'emoji_taste': log.emojiTaste?.toJson(),
+            'had_reaction': log.hadReaction,
+            'notes': log.notes,
+            'attachment_title': log.attachmentTitle,
+            'attachment_description': log.attachmentDescription,
+            'log_date': _formatDate(log.logDate),
+            'photo_url': log.photoUrl,
+          })
+          .eq('id', log.id)
+          .select()
+          .single();
+
+      return Result.success(_logFromRow(data));
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<void>> deleteLog(String logId) async {
+    try {
+      await _supabase.from('allergen_logs').delete().eq('id', logId);
+      return const Result.success(null);
     } on PostgrestException catch (e) {
       return Result.failure(ServerException(e.message));
     } on Object {

--- a/lib/src/common/data/repositories/storage_repository.dart
+++ b/lib/src/common/data/repositories/storage_repository.dart
@@ -14,6 +14,11 @@ abstract interface class StorageRepository {
     String path, {
     int expiresIn,
   });
+
+  /// Deletes [path] from [bucket]. Returns Success on a successful remove
+  /// (regardless of whether the object existed). Maps StorageException to
+  /// ServerException; any other error to UnknownException.
+  Future<Result<void>> deleteFile(String bucket, String path);
 }
 
 class StorageRepositoryImpl implements StorageRepository {
@@ -43,6 +48,18 @@ class StorageRepositoryImpl implements StorageRepository {
           .upload(path, file);
 
       return Result.success(storagePath);
+    } on StorageException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<void>> deleteFile(String bucket, String path) async {
+    try {
+      await _supabase.storage.from(bucket).remove([path]);
+      return const Result.success(null);
     } on StorageException catch (e) {
       return Result.failure(ServerException(e.message));
     } on Object {

--- a/lib/src/common/services/allergen_service.dart
+++ b/lib/src/common/services/allergen_service.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:nibbles/src/common/data/repositories/allergen_repository.dart';
 import 'package:nibbles/src/common/data/repositories/storage_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/allergen.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
@@ -14,11 +16,21 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'allergen_service.g.dart';
 
+/// Function injected so unit tests don't touch real Crashlytics. Records a
+/// non-fatal diagnostic for a best-effort storage deletion failure.
+typedef AllergenCrashRecorderFn =
+    Future<void> Function(Object error, StackTrace stack, {String? reason});
+
 class AllergenService {
-  const AllergenService(this._repo, this._storage);
+  AllergenService(
+    this._repo,
+    this._storage, {
+    AllergenCrashRecorderFn? crashRecorder,
+  }) : _crashRecorder = crashRecorder ?? _defaultCrashRecorder;
 
   final AllergenRepository _repo;
   final StorageRepository _storage;
+  final AllergenCrashRecorderFn _crashRecorder;
 
   static const _photoBucket = 'allergen-photos';
 
@@ -151,6 +163,77 @@ class AllergenService {
     return Result.success(savedLog);
   }
 
+  /// Updates an existing allergen log. Supports the redesigned Change-Picture
+  /// flow: if [newPhotoLocalPath] is supplied, the new photo is uploaded to
+  /// the allergen-photos bucket first; on a successful upload the log's
+  /// photoUrl is rewritten to the new storage path. An upload failure fails
+  /// the whole update (the row is not modified).
+  ///
+  /// After a successful new upload, [oldPhotoPath] is best-effort deleted
+  /// (P3 — failure is logged to Crashlytics and never propagated, so the
+  /// row update is not blocked by a stale photo). The final UPDATE on
+  /// allergen_logs always runs once we reach it.
+  Future<Result<AllergenLog>> updateAllergenLog({
+    required AllergenLog log,
+    String? newPhotoLocalPath,
+    String? oldPhotoPath,
+  }) async {
+    var effectiveLog = log;
+
+    if (newPhotoLocalPath != null) {
+      final ts = DateTime.now().millisecondsSinceEpoch;
+      final uploadPath = '${log.babyId}/${ts}_${log.allergenKey}.jpg';
+      final uploadResult = await _storage.uploadFile(
+        _photoBucket,
+        uploadPath,
+        File(newPhotoLocalPath),
+      );
+      if (uploadResult.isFailure) {
+        return Result.failure(uploadResult.errorOrNull!);
+      }
+      effectiveLog = log.copyWith(photoUrl: uploadPath);
+
+      if (oldPhotoPath != null && oldPhotoPath.isNotEmpty) {
+        await _deletePhotoBestEffort(
+          oldPhotoPath,
+          reason: 'allergen_update_old_photo',
+        );
+      }
+    }
+
+    return _repo.updateLog(effectiveLog);
+  }
+
+  /// Deletes an allergen log and its associated photo (if any).
+  /// The storage deletion is best-effort (P3 — logged to Crashlytics on
+  /// failure); the row delete always runs.
+  Future<Result<void>> deleteAllergenLog({
+    required String logId,
+    String? photoPath,
+  }) async {
+    if (photoPath != null && photoPath.isNotEmpty) {
+      await _deletePhotoBestEffort(
+        photoPath,
+        reason: 'allergen_delete_photo',
+      );
+    }
+    return _repo.deleteLog(logId);
+  }
+
+  /// Best-effort photo delete: never throws, never returns failure. A
+  /// failure is recorded to Crashlytics as a non-fatal so the row mutation
+  /// can proceed.
+  Future<void> _deletePhotoBestEffort(
+    String path, {
+    required String reason,
+  }) async {
+    final result = await _storage.deleteFile(_photoBucket, path);
+    if (result.isFailure) {
+      final error = result.errorOrNull ?? const UnknownException();
+      await _crashRecorder(error, StackTrace.current, reason: reason);
+    }
+  }
+
   /// Returns a signed URL for a photo stored in the allergen-photos bucket.
   Future<Result<String>> getSignedPhotoUrl(String photoPath) =>
       _storage.getSignedUrl(_photoBucket, photoPath);
@@ -219,6 +302,12 @@ class AllergenService {
     String? allergenKey,
   }) => _repo.getLogs(babyId, allergenKey: allergenKey);
 }
+
+Future<void> _defaultCrashRecorder(
+  Object error,
+  StackTrace stack, {
+  String? reason,
+}) => FirebaseCrashlytics.instance.recordError(error, stack, reason: reason);
 
 @Riverpod(keepAlive: true)
 AllergenService allergenService(

--- a/test/common/data/repositories/storage_repository_test.dart
+++ b/test/common/data/repositories/storage_repository_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nibbles/src/common/data/repositories/storage_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -88,6 +89,52 @@ void main() {
 
       expect(result, isA<Failure<String>>());
       verifyNever(() => mockFileApi.upload(any(), any()));
+    });
+  });
+
+  group('deleteFile', () {
+    test('returns Success on remove', () async {
+      when(
+        () => mockFileApi.remove(any()),
+      ).thenAnswer((_) async => <FileObject>[]);
+
+      final result = await sut.deleteFile(
+        'allergen-photos',
+        'baby-1/peanut_1.jpg',
+      );
+
+      expect(result, isA<Success<void>>());
+      verify(
+        () => mockFileApi.remove(['baby-1/peanut_1.jpg']),
+      ).called(1);
+    });
+
+    test('returns Failure on StorageException', () async {
+      when(
+        () => mockFileApi.remove(any()),
+      ).thenThrow(const StorageException('Not found'));
+
+      final result = await sut.deleteFile(
+        'allergen-photos',
+        'baby-1/peanut_1.jpg',
+      );
+
+      expect(result, isA<Failure<void>>());
+      expect((result as Failure<void>).error, isA<ServerException>());
+    });
+
+    test('returns Failure on unknown error', () async {
+      when(
+        () => mockFileApi.remove(any()),
+      ).thenThrow(Exception('boom'));
+
+      final result = await sut.deleteFile(
+        'allergen-photos',
+        'baby-1/peanut_1.jpg',
+      );
+
+      expect(result, isA<Failure<void>>());
+      expect((result as Failure<void>).error, isA<UnknownException>());
     });
   });
 

--- a/test/common/services/allergen_service_test.dart
+++ b/test/common/services/allergen_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nibbles/src/common/data/repositories/allergen_repository.dart';
@@ -88,6 +90,7 @@ void main() {
       ),
     );
     registerFallbackValue(_now);
+    registerFallbackValue(File('test-fallback.jpg'));
   });
 
   setUp(() {
@@ -350,6 +353,202 @@ void main() {
       );
 
       final result = await sut.completeProgram(_babyId);
+
+      expect(result.isFailure, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateAllergenLog
+  // ---------------------------------------------------------------------------
+
+  group('AllergenService.updateAllergenLog', () {
+    test(
+      'no new photo: skips storage, calls repo.updateLog with input log',
+      () async {
+        final log = _makeLog();
+        when(
+          () => mockRepo.updateLog(any()),
+        ).thenAnswer((_) async => Result.success(log));
+
+        final result = await sut.updateAllergenLog(log: log);
+
+        expect(result.isSuccess, isTrue);
+        verify(() => mockRepo.updateLog(log)).called(1);
+        verifyNever(() => mockStorage.uploadFile(any(), any(), any()));
+        verifyNever(() => mockStorage.deleteFile(any(), any()));
+      },
+    );
+
+    test(
+      'new photo path: uploads new, deletes old non-fatal, '
+      'calls updateLog with new photoUrl',
+      () async {
+        final log = _makeLog().copyWith(photoUrl: 'old/path.jpg');
+        when(
+          () => mockStorage.uploadFile(any(), any(), any()),
+        ).thenAnswer((_) async => const Result.success('ignored'));
+        when(
+          () => mockStorage.deleteFile(any(), any()),
+        ).thenAnswer((_) async => const Result.success(null));
+        when(
+          () => mockRepo.updateLog(any()),
+        ).thenAnswer((_) async => Result.success(log));
+
+        final result = await sut.updateAllergenLog(
+          log: log,
+          newPhotoLocalPath: '/tmp/new.jpg',
+          oldPhotoPath: 'old/path.jpg',
+        );
+
+        expect(result.isSuccess, isTrue);
+        verify(() => mockStorage.uploadFile(any(), any(), any())).called(1);
+        verify(
+          () => mockStorage.deleteFile('allergen-photos', 'old/path.jpg'),
+        ).called(1);
+
+        final captured = verify(() => mockRepo.updateLog(captureAny())).captured
+            .single as AllergenLog;
+        // photoUrl now points at the freshly uploaded path
+        // (not the old path passed in).
+        expect(captured.photoUrl, isNot('old/path.jpg'));
+        expect(captured.photoUrl, isNotNull);
+      },
+    );
+
+    test('upload failure propagates and skips repo.updateLog', () async {
+      final log = _makeLog();
+      when(() => mockStorage.uploadFile(any(), any(), any())).thenAnswer(
+        (_) async => const Result.failure(ServerException('upload bad')),
+      );
+
+      final result = await sut.updateAllergenLog(
+        log: log,
+        newPhotoLocalPath: '/tmp/new.jpg',
+        oldPhotoPath: 'old/path.jpg',
+      );
+
+      expect(result.isFailure, isTrue);
+      verifyNever(() => mockRepo.updateLog(any()));
+      verifyNever(() => mockStorage.deleteFile(any(), any()));
+    });
+
+    test(
+      'old-photo delete failure is non-fatal: '
+      'crash recorder called + updateLog still runs',
+      () async {
+        final log = _makeLog();
+        var recorded = 0;
+        sut = AllergenService(
+          mockRepo,
+          mockStorage,
+          crashRecorder:
+              (Object error, StackTrace stack, {String? reason}) async {
+                recorded++;
+              },
+        );
+
+        when(
+          () => mockStorage.uploadFile(any(), any(), any()),
+        ).thenAnswer((_) async => const Result.success('ignored'));
+        when(() => mockStorage.deleteFile(any(), any())).thenAnswer(
+          (_) async => const Result.failure(ServerException('not found')),
+        );
+        when(
+          () => mockRepo.updateLog(any()),
+        ).thenAnswer((_) async => Result.success(log));
+
+        final result = await sut.updateAllergenLog(
+          log: log,
+          newPhotoLocalPath: '/tmp/new.jpg',
+          oldPhotoPath: 'old/path.jpg',
+        );
+
+        expect(result.isSuccess, isTrue);
+        expect(recorded, 1);
+        verify(() => mockRepo.updateLog(any())).called(1);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteAllergenLog
+  // ---------------------------------------------------------------------------
+
+  group('AllergenService.deleteAllergenLog', () {
+    test('no photoPath: skips storage, calls repo.deleteLog', () async {
+      when(
+        () => mockRepo.deleteLog(any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      final result = await sut.deleteAllergenLog(logId: 'log-1');
+
+      expect(result.isSuccess, isTrue);
+      verify(() => mockRepo.deleteLog('log-1')).called(1);
+      verifyNever(() => mockStorage.deleteFile(any(), any()));
+    });
+
+    test(
+      'with photoPath: deletes photo then deletes log row',
+      () async {
+        when(
+          () => mockStorage.deleteFile(any(), any()),
+        ).thenAnswer((_) async => const Result.success(null));
+        when(
+          () => mockRepo.deleteLog(any()),
+        ).thenAnswer((_) async => const Result.success(null));
+
+        final result = await sut.deleteAllergenLog(
+          logId: 'log-1',
+          photoPath: 'old/path.jpg',
+        );
+
+        expect(result.isSuccess, isTrue);
+        verify(
+          () => mockStorage.deleteFile('allergen-photos', 'old/path.jpg'),
+        ).called(1);
+        verify(() => mockRepo.deleteLog('log-1')).called(1);
+      },
+    );
+
+    test(
+      'storage delete failure is non-fatal: '
+      'crash recorder called + repo.deleteLog still runs',
+      () async {
+        var recorded = 0;
+        sut = AllergenService(
+          mockRepo,
+          mockStorage,
+          crashRecorder:
+              (Object error, StackTrace stack, {String? reason}) async {
+                recorded++;
+              },
+        );
+
+        when(() => mockStorage.deleteFile(any(), any())).thenAnswer(
+          (_) async => const Result.failure(ServerException('not found')),
+        );
+        when(
+          () => mockRepo.deleteLog(any()),
+        ).thenAnswer((_) async => const Result.success(null));
+
+        final result = await sut.deleteAllergenLog(
+          logId: 'log-1',
+          photoPath: 'old/path.jpg',
+        );
+
+        expect(result.isSuccess, isTrue);
+        expect(recorded, 1);
+        verify(() => mockRepo.deleteLog('log-1')).called(1);
+      },
+    );
+
+    test('propagates repo.deleteLog failure', () async {
+      when(() => mockRepo.deleteLog(any())).thenAnswer(
+        (_) async => const Result.failure(ServerException('row missing')),
+      );
+
+      final result = await sut.deleteAllergenLog(logId: 'log-1');
 
       expect(result.isFailure, isTrue);
     });


### PR DESCRIPTION
## Summary

Wires the data layer for the redesigned Allergen Log CRUD: per-log edit, delete, and Change-Picture replace.

- `StorageRepository.deleteFile(bucket, path)` — wraps `storage.from(bucket).remove([path])`. Maps `StorageException -> ServerException`, any other `Object -> UnknownException`.
- `AllergenRepository.updateLog(AllergenLog)` — UPDATE allergen_logs SET emoji_taste, had_reaction, notes, attachment_title, attachment_description, log_date, photo_url WHERE id = log.id, then .select().single(), mapped via the existing `_logFromRow`.
- `AllergenRepository.deleteLog(String logId)` — DELETE by id, `PostgrestException -> ServerException`.
- `AllergenService.updateAllergenLog({log, newPhotoLocalPath?, oldPhotoPath?})` — if a new photo is provided, upload it via `StorageRepository.uploadFile` (upload failure aborts and propagates as Failure), then best-effort `deleteFile` of the old path (P3 — failure logged to Crashlytics, never blocks the row update), then `repo.updateLog` with the new storage path.
- `AllergenService.deleteAllergenLog({logId, photoPath?})` — if `photoPath` provided, best-effort `deleteFile` (P3 — Crashlytics on failure), then `repo.deleteLog`.
- `AllergenCrashRecorderFn` is injected into `AllergenService` so the P3 non-fatal behavior is unit-testable without touching real Firebase (mirrors the AuthRepository pattern).

No SQL migration this ticket (no schema changes — uses the columns NIB-124 added). Architecture invariants intact: Supabase calls live only in repos, all async paths return `Result<T>`, no raw throws.

## Acceptance criteria

- [x] StorageRepository.deleteFile returns `Result<void>` and maps `StorageException -> ServerException`.
- [x] `allergen_repository.dart` `updateLog` + `deleteLog` implemented; `updateLog` returns the updated AllergenLog via `_logFromRow`.
- [x] AllergenService `updateAllergenLog` handles the photo-replace path (upload new -> delete old non-fatal -> updateLog) and `deleteAllergenLog` handles the row-delete path (deleteFile non-fatal -> deleteLog).
- [x] No raw throws; Supabase calls only in the repos.
- [x] `flutter analyze` zero warnings; `flutter test` passes (with new unit tests for the new methods).

## Gate results

- `make gen` — clean (idempotent on second run; pre-existing `home_controller.g.dart` drift reverted per orchestrator note).
- `flutter analyze` — No issues found.
- `flutter test` — 296 passed (0 failed). New tests: 3 for `StorageRepository.deleteFile`, 7 for `AllergenService.updateAllergenLog` + `deleteAllergenLog`.

## Files changed

- `lib/src/common/data/repositories/storage_repository.dart`
- `lib/src/common/data/repositories/allergen_repository.dart`
- `lib/src/common/services/allergen_service.dart`
- `test/common/data/repositories/storage_repository_test.dart`
- `test/common/services/allergen_service_test.dart`