### PR TITLE
feat(allergen): derive per-allergen status from logs [NIB-126]

### DIFF
--- a/.claude/rules/domain.md
+++ b/.claude/rules/domain.md
@@ -12,7 +12,9 @@
 - `ReactionSeverity`: `mild` · `moderate` · `severe`
 - `ShoppingListSource`: `recipe` · `mealPlan` · `manual`
 
-## Allergen sequence (locked)
+## Allergen sequence (display order only)
 peanut(1) → egg(2) → dairy(3) → tree_nuts(4) → sesame(5) → soy(6) → wheat(7) → fish(8) → shellfish(9)
+
+This is the DISPLAYED ORDER only. The locked-sequence advancement rule is retired (NIB-120 / NIB-126): the user picks which allergen to introduce next, and per-allergen `AllergenStatus` is DERIVED from `allergen_logs` rows via `deriveStatusForLogs` — not from `allergen_program_state`. No enforcement of the peanut→…→shellfish order at the service or repo layer.
 
 ⚠️ sesame and soy share emoji 🫘 — flag with designer if visual distinction needed.

--- a/lib/src/common/services/allergen_service.dart
+++ b/lib/src/common/services/allergen_service.dart
@@ -12,6 +12,7 @@ import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
 import 'package:nibbles/src/common/domain/entities/reaction_detail.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
+import 'package:nibbles/src/common/services/helpers/derive_allergen_status.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'allergen_service.g.dart';
@@ -285,11 +286,42 @@ class AllergenService {
   /// - any hadReaction  → [AllergenStatus.flagged]
   /// - 3+ no reaction   → [AllergenStatus.safe]  (NEVER `completed`)
   /// - 1–2 no reaction  → [AllergenStatus.inProgress]
-  AllergenStatus deriveStatus(List<AllergenLog> logs) {
-    if (logs.isEmpty) return AllergenStatus.notStarted;
-    if (logs.any((l) => l.hadReaction)) return AllergenStatus.flagged;
-    if (logs.length >= 3) return AllergenStatus.safe;
-    return AllergenStatus.inProgress;
+  ///
+  /// Thin wrapper around the pure top-level [deriveStatusForLogs] helper —
+  /// kept so existing call sites stay compatible.
+  AllergenStatus deriveStatus(List<AllergenLog> logs) =>
+      deriveStatusForLogs(logs);
+
+  /// Returns a map of every one of the 9 canonical allergen keys to its
+  /// derived [AllergenStatus] for [babyId].
+  ///
+  /// Per NIB-120 the per-allergen status is derived from `allergen_logs`,
+  /// not from `allergen_program_state`. The 9 keys (peanut → … → shellfish)
+  /// remain the displayed ORDER; advancement is no longer locked to that
+  /// sequence.
+  ///
+  /// Every key in [kAllergenKeys] is guaranteed to be present in the result
+  /// map; allergens with no logs default to [AllergenStatus.notStarted].
+  Future<Result<Map<String, AllergenStatus>>> getAllergenStatuses(
+    String babyId,
+  ) async {
+    final logsResult = await _repo.getLogs(babyId);
+    if (logsResult.isFailure) {
+      return Result.failure(logsResult.errorOrNull!);
+    }
+
+    final allLogs = logsResult.dataOrNull!;
+    final byKey = <String, List<AllergenLog>>{};
+    for (final log in allLogs) {
+      (byKey[log.allergenKey] ??= <AllergenLog>[]).add(log);
+    }
+
+    final statuses = <String, AllergenStatus>{
+      for (final key in kAllergenKeys)
+        key: deriveStatusForLogs(byKey[key] ?? const <AllergenLog>[]),
+    };
+
+    return Result.success(statuses);
   }
 
   /// Returns all 9 allergens ordered by sequence_order.

--- a/lib/src/common/services/helpers/derive_allergen_status.dart
+++ b/lib/src/common/services/helpers/derive_allergen_status.dart
@@ -1,0 +1,34 @@
+import 'package:nibbles/src/app/constants/allergen_emoji.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+
+/// Canonical, ordered list of the 9 allergen keys.
+///
+/// Order matches the display sequence (peanut → egg → … → shellfish).
+/// Per NIB-120 the sequence is the displayed ORDER only — advancement is
+/// derived from logs, the user picks which allergen to introduce next.
+///
+/// Sourced from [AllergenEmoji.map] so a single literal owns the
+/// canonical set.
+final List<String> kAllergenKeys = List<String>.unmodifiable(
+  AllergenEmoji.map.keys,
+);
+
+/// Derives the [AllergenStatus] for a single allergen from its [logs].
+///
+/// Rules (NIB-120, locked):
+///  - 0 logs                       → [AllergenStatus.notStarted]
+///  - ANY log with hadReaction     → [AllergenStatus.flagged]
+///    (dominates over every other rule, including 3+ clean logs)
+///  - ≥3 logs all with hadReaction=false → [AllergenStatus.safe]
+///  - ≥1 clean log AND <3 clean logs → [AllergenStatus.inProgress]
+///
+/// Pure, side-effect-free, directly unit-testable without a service
+/// instance.
+AllergenStatus deriveStatusForLogs(Iterable<AllergenLog> logs) {
+  final list = logs.toList(growable: false);
+  if (list.isEmpty) return AllergenStatus.notStarted;
+  if (list.any((l) => l.hadReaction)) return AllergenStatus.flagged;
+  if (list.length >= 3) return AllergenStatus.safe;
+  return AllergenStatus.inProgress;
+}

--- a/test/common/services/allergen_service_test.dart
+++ b/test/common/services/allergen_service_test.dart
@@ -15,6 +15,7 @@ import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
 import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/helpers/derive_allergen_status.dart';
 
 class MockAllergenRepository extends Mock implements AllergenRepository {}
 
@@ -273,6 +274,69 @@ void main() {
       );
 
       final result = await sut.getAllergenBoardSummary(_babyId);
+
+      expect(result.isFailure, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getAllergenStatuses (NIB-126: derived from logs, not program state)
+  // ---------------------------------------------------------------------------
+
+  group('AllergenService.getAllergenStatuses', () {
+    test(
+      'returns every canonical allergen key with the correct derived status '
+      'and defaults absent allergens to notStarted',
+      () async {
+        final eggReaction = _makeLog(
+          id: 'log-e1',
+          allergenKey: 'egg',
+          hadReaction: true,
+        );
+        final dairyClean1 = _makeLog(id: 'log-d1', allergenKey: 'dairy');
+        final dairyClean2 = _makeLog(id: 'log-d2', allergenKey: 'dairy');
+        final dairyClean3 = _makeLog(id: 'log-d3', allergenKey: 'dairy');
+        final peanutClean = _makeLog(id: 'log-p1');
+
+        when(() => mockRepo.getLogs(any())).thenAnswer(
+          (_) async => Result.success([
+            eggReaction,
+            dairyClean1,
+            dairyClean2,
+            dairyClean3,
+            peanutClean,
+          ]),
+        );
+
+        final result = await sut.getAllergenStatuses(_babyId);
+
+        expect(result.isSuccess, isTrue);
+        final statuses = result.dataOrNull!;
+        // Every canonical key is present.
+        for (final key in kAllergenKeys) {
+          expect(statuses.containsKey(key), isTrue, reason: 'missing $key');
+        }
+        // 3 clean dairy logs → safe.
+        expect(statuses['dairy'], AllergenStatus.safe);
+        // 1 reaction-flagged egg log → flagged.
+        expect(statuses['egg'], AllergenStatus.flagged);
+        // 1 clean peanut log → inProgress.
+        expect(statuses['peanut'], AllergenStatus.inProgress);
+        // Untouched allergens default to notStarted.
+        expect(statuses['shellfish'], AllergenStatus.notStarted);
+        expect(statuses['fish'], AllergenStatus.notStarted);
+        // Only the bare-minimum repo call is used (no Supabase, no state read).
+        verify(() => mockRepo.getLogs(_babyId)).called(1);
+        verifyNever(() => mockRepo.getProgramState(any()));
+      },
+    );
+
+    test('propagates repository failure', () async {
+      when(() => mockRepo.getLogs(any())).thenAnswer(
+        (_) async => const Result.failure(ServerException('DB error')),
+      );
+
+      final result = await sut.getAllergenStatuses(_babyId);
 
       expect(result.isFailure, isTrue);
     });

--- a/test/common/services/helpers/derive_allergen_status_test.dart
+++ b/test/common/services/helpers/derive_allergen_status_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/services/helpers/derive_allergen_status.dart';
+
+final _now = DateTime(2026, 5, 30);
+
+AllergenLog _log({String id = 'l', bool hadReaction = false}) => AllergenLog(
+  id: id,
+  babyId: 'baby-1',
+  allergenKey: 'peanut',
+  hadReaction: hadReaction,
+  logDate: _now,
+  createdAt: _now,
+);
+
+void main() {
+  group('deriveStatusForLogs (NIB-126 rule table)', () {
+    test('0 logs → notStarted', () {
+      expect(deriveStatusForLogs(const []), AllergenStatus.notStarted);
+    });
+
+    test('1 clean log → inProgress', () {
+      expect(deriveStatusForLogs([_log()]), AllergenStatus.inProgress);
+    });
+
+    test('3 clean logs → safe (NEVER completed)', () {
+      final logs = [
+        _log(id: 'a'),
+        _log(id: 'b'),
+        _log(id: 'c'),
+      ];
+      expect(deriveStatusForLogs(logs), AllergenStatus.safe);
+      // Canonical rule: passed allergens are `safe`, not `completed`.
+      expect(
+        AllergenStatus.values.map((e) => e.name),
+        isNot(contains('completed')),
+      );
+    });
+
+    test('1 reaction-flagged log → flagged', () {
+      expect(
+        deriveStatusForLogs([_log(hadReaction: true)]),
+        AllergenStatus.flagged,
+      );
+    });
+
+    test(
+      '3 clean logs THEN 1 reaction-flagged log → flagged '
+      '(regression: flagged dominates over safe)',
+      () {
+        final logs = [
+          _log(id: 'a'),
+          _log(id: 'b'),
+          _log(id: 'c'),
+          _log(id: 'd', hadReaction: true),
+        ];
+        expect(deriveStatusForLogs(logs), AllergenStatus.flagged);
+      },
+    );
+  });
+
+  group('kAllergenKeys', () {
+    test('contains all 9 canonical keys in display order', () {
+      expect(kAllergenKeys, hasLength(9));
+      expect(
+        kAllergenKeys,
+        equals(const [
+          'peanut',
+          'egg',
+          'dairy',
+          'tree_nuts',
+          'sesame',
+          'soy',
+          'wheat',
+          'fish',
+          'shellfish',
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Per NIB-120, per-allergen status is now DERIVED from `allergen_logs` rows rather than from `allergen_program_state`. The 9-allergen sequence (peanut → … → shellfish) becomes display-only — the user picks which allergen to introduce next.

Adds:
- `deriveStatusForLogs(Iterable<AllergenLog>)` — pure, top-level, directly unit-testable helper implementing the 4-rule table.
- `kAllergenKeys` — canonical 9-key list sourced from `AllergenEmoji.map`.
- `AllergenService.getAllergenStatuses(babyId)` — `Result<Map<String, AllergenStatus>>` with every canonical key present (default `notStarted`); only repo call is `getLogs(babyId)`, no Supabase, no program-state read.

Existing `AllergenProgramState`-based APIs are intentionally left intact for NIB-79 / NIB-93 to migrate the board UI and remove the legacy path.

## Acceptance criteria
- [x] `getAllergenStatuses(babyId)` returns `Result<Map<String, AllergenStatus>>` with all 9 keys present.
- [x] `deriveStatusForLogs` implements the 4-rule table exactly (flagged dominates over safe / inProgress).
- [x] No Supabase calls in the service; only repo call is `getLogs(babyId)`.
- [x] `Result<T>` preserved; no raw throws.
- [x] `.claude/rules/domain.md` updated — sequence is now display-only.
- [x] Zero analyzer warnings; tests pass (5 new tests added).
- [x] No schema migration; existing tracker / board UI / AllergenProgramState entity untouched.

## Gate results
- `make gen` — clean, idempotent on second run.
- `flutter analyze` — `No issues found! (ran in 3.4s)`
- `flutter test` — `+304: All tests passed!`