### PR TITLE
feat(allergen): reskin tracker board with ring, segmented control, start-introduce cards [NIB-79]

### DIFF
--- a/lib/src/features/allergen/tracker/allergen_tracker_controller.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_controller.dart
@@ -1,16 +1,25 @@
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/allergen.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
-import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
-import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'allergen_tracker_controller.g.dart';
 
+/// Loads the data backing the redesigned Allergen Tracker board.
+///
+/// Composes three reads in parallel:
+///  - `getAllergenStatuses(babyId)` — the authoritative per-allergen status
+///    (NIB-126). Drives the ring, stat columns and per-card badges.
+///  - `getAllergens()`              — name + emoji + display order.
+///  - `getLogs(babyId)`             — raw logs for the Reaction Log list and
+///    the per-card 0/3 progress.
+///
+/// The legacy `getAllergenBoardSummary` + `getProgramState` +
+/// `advanceToNextAllergen` flow is intentionally not used here — the
+/// locked sequence is retired (NIB-120).
 @riverpod
 class AllergenTrackerController extends _$AllergenTrackerController {
   @override
@@ -18,60 +27,29 @@ class AllergenTrackerController extends _$AllergenTrackerController {
     final service = ref.read(allergenServiceProvider);
 
     final (
-      Result<List<AllergenBoardItem>> boardResult,
-      Result<AllergenProgramState> programResult,
+      Result<List<Allergen>> allergensResult,
+      Result<Map<String, AllergenStatus>> statusesResult,
+      Result<List<AllergenLog>> logsResult,
     ) = await (
-      service.getAllergenBoardSummary(babyId),
-      service.getProgramState(babyId),
+      service.getAllergens(),
+      service.getAllergenStatuses(babyId),
+      service.getLogs(babyId),
     ).wait;
 
-    if (boardResult.isFailure) throw boardResult.errorOrNull!;
-    if (programResult.isFailure) throw programResult.errorOrNull!;
+    if (allergensResult.isFailure) throw allergensResult.errorOrNull!;
+    if (statusesResult.isFailure) throw statusesResult.errorOrNull!;
+    if (logsResult.isFailure) throw logsResult.errorOrNull!;
 
-    final boardItems = boardResult.dataOrNull!;
-    final programState = programResult.dataOrNull!;
+    final allergens = List<Allergen>.of(allergensResult.dataOrNull!)
+      ..sort((a, b) => a.sequenceOrder.compareTo(b.sequenceOrder));
 
-    // Collect ALL logs across allergens, sorted by date desc.
-    final allEntries =
-        boardItems
-            .expand(
-              (AllergenBoardItem b) =>
-                  b.logs.map((AllergenLog l) => (allergen: b.allergen, log: l)),
-            )
-            .toList()
-          ..sort(
-            (
-              ({Allergen allergen, AllergenLog log}) a,
-              ({Allergen allergen, AllergenLog log}) b,
-            ) => b.log.createdAt.compareTo(a.log.createdAt),
-          );
-
-    final recent = allEntries.take(5).toList();
-    final recentLogs = <RecentLogEntry>[];
-    for (final entry in recent) {
-      ReactionSeverity? severity;
-      if (entry.log.hadReaction) {
-        final detailResult = await service.getReactionDetail(entry.log.id);
-        severity = detailResult.dataOrNull?.severity;
-      }
-      recentLogs.add(
-        RecentLogEntry(
-          allergenKey: entry.allergen.key,
-          allergenName: entry.allergen.name,
-          allergenEmoji: entry.allergen.emoji,
-          logDate: entry.log.logDate,
-          createdAt: entry.log.createdAt,
-          taste: entry.log.emojiTaste ?? EmojiTaste.neutral,
-          hadReaction: entry.log.hadReaction,
-          severity: severity,
-        ),
-      );
-    }
+    final logs = List<AllergenLog>.of(logsResult.dataOrNull!)
+      ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
 
     return AllergenTrackerState(
-      boardItems: boardItems,
-      programState: programState,
-      recentLogs: recentLogs,
+      allergens: allergens,
+      statuses: statusesResult.dataOrNull!,
+      logs: logs,
     );
   }
 }

--- a/lib/src/features/allergen/tracker/allergen_tracker_controller.g.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_controller.g.dart
@@ -7,7 +7,7 @@ part of 'allergen_tracker_controller.dart';
 // **************************************************************************
 
 String _$allergenTrackerControllerHash() =>
-    r'832f9369b10b71c1b3b002144cc16e6d0b55aaad';
+    r'1500b3df0eba3539b564a0212d62f6eeb0d6ade4';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -37,17 +37,69 @@ abstract class _$AllergenTrackerController
   FutureOr<AllergenTrackerState> build(String babyId);
 }
 
-/// See also [AllergenTrackerController].
+/// Loads the data backing the redesigned Allergen Tracker board.
+///
+/// Composes three reads in parallel:
+///  - `getAllergenStatuses(babyId)` — the authoritative per-allergen status
+///    (NIB-126). Drives the ring, stat columns and per-card badges.
+///  - `getAllergens()`              — name + emoji + display order.
+///  - `getLogs(babyId)`             — raw logs for the Reaction Log list and
+///    the per-card 0/3 progress.
+///
+/// The legacy `getAllergenBoardSummary` + `getProgramState` +
+/// `advanceToNextAllergen` flow is intentionally not used here — the
+/// locked sequence is retired (NIB-120).
+///
+/// Copied from [AllergenTrackerController].
 @ProviderFor(AllergenTrackerController)
 const allergenTrackerControllerProvider = AllergenTrackerControllerFamily();
 
-/// See also [AllergenTrackerController].
+/// Loads the data backing the redesigned Allergen Tracker board.
+///
+/// Composes three reads in parallel:
+///  - `getAllergenStatuses(babyId)` — the authoritative per-allergen status
+///    (NIB-126). Drives the ring, stat columns and per-card badges.
+///  - `getAllergens()`              — name + emoji + display order.
+///  - `getLogs(babyId)`             — raw logs for the Reaction Log list and
+///    the per-card 0/3 progress.
+///
+/// The legacy `getAllergenBoardSummary` + `getProgramState` +
+/// `advanceToNextAllergen` flow is intentionally not used here — the
+/// locked sequence is retired (NIB-120).
+///
+/// Copied from [AllergenTrackerController].
 class AllergenTrackerControllerFamily
     extends Family<AsyncValue<AllergenTrackerState>> {
-  /// See also [AllergenTrackerController].
+  /// Loads the data backing the redesigned Allergen Tracker board.
+  ///
+  /// Composes three reads in parallel:
+  ///  - `getAllergenStatuses(babyId)` — the authoritative per-allergen status
+  ///    (NIB-126). Drives the ring, stat columns and per-card badges.
+  ///  - `getAllergens()`              — name + emoji + display order.
+  ///  - `getLogs(babyId)`             — raw logs for the Reaction Log list and
+  ///    the per-card 0/3 progress.
+  ///
+  /// The legacy `getAllergenBoardSummary` + `getProgramState` +
+  /// `advanceToNextAllergen` flow is intentionally not used here — the
+  /// locked sequence is retired (NIB-120).
+  ///
+  /// Copied from [AllergenTrackerController].
   const AllergenTrackerControllerFamily();
 
-  /// See also [AllergenTrackerController].
+  /// Loads the data backing the redesigned Allergen Tracker board.
+  ///
+  /// Composes three reads in parallel:
+  ///  - `getAllergenStatuses(babyId)` — the authoritative per-allergen status
+  ///    (NIB-126). Drives the ring, stat columns and per-card badges.
+  ///  - `getAllergens()`              — name + emoji + display order.
+  ///  - `getLogs(babyId)`             — raw logs for the Reaction Log list and
+  ///    the per-card 0/3 progress.
+  ///
+  /// The legacy `getAllergenBoardSummary` + `getProgramState` +
+  /// `advanceToNextAllergen` flow is intentionally not used here — the
+  /// locked sequence is retired (NIB-120).
+  ///
+  /// Copied from [AllergenTrackerController].
   AllergenTrackerControllerProvider call(String babyId) {
     return AllergenTrackerControllerProvider(babyId);
   }
@@ -74,14 +126,40 @@ class AllergenTrackerControllerFamily
   String? get name => r'allergenTrackerControllerProvider';
 }
 
-/// See also [AllergenTrackerController].
+/// Loads the data backing the redesigned Allergen Tracker board.
+///
+/// Composes three reads in parallel:
+///  - `getAllergenStatuses(babyId)` — the authoritative per-allergen status
+///    (NIB-126). Drives the ring, stat columns and per-card badges.
+///  - `getAllergens()`              — name + emoji + display order.
+///  - `getLogs(babyId)`             — raw logs for the Reaction Log list and
+///    the per-card 0/3 progress.
+///
+/// The legacy `getAllergenBoardSummary` + `getProgramState` +
+/// `advanceToNextAllergen` flow is intentionally not used here — the
+/// locked sequence is retired (NIB-120).
+///
+/// Copied from [AllergenTrackerController].
 class AllergenTrackerControllerProvider
     extends
         AutoDisposeAsyncNotifierProviderImpl<
           AllergenTrackerController,
           AllergenTrackerState
         > {
-  /// See also [AllergenTrackerController].
+  /// Loads the data backing the redesigned Allergen Tracker board.
+  ///
+  /// Composes three reads in parallel:
+  ///  - `getAllergenStatuses(babyId)` — the authoritative per-allergen status
+  ///    (NIB-126). Drives the ring, stat columns and per-card badges.
+  ///  - `getAllergens()`              — name + emoji + display order.
+  ///  - `getLogs(babyId)`             — raw logs for the Reaction Log list and
+  ///    the per-card 0/3 progress.
+  ///
+  /// The legacy `getAllergenBoardSummary` + `getProgramState` +
+  /// `advanceToNextAllergen` flow is intentionally not used here — the
+  /// locked sequence is retired (NIB-120).
+  ///
+  /// Copied from [AllergenTrackerController].
   AllergenTrackerControllerProvider(String babyId)
     : this._internal(
         () => AllergenTrackerController()..babyId = babyId,

--- a/lib/src/features/allergen/tracker/allergen_tracker_screen.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_screen.dart
@@ -3,16 +3,29 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
-import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
-import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/features/allergen/log/allergen_log_sheet.dart';
 import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_controller.dart';
 import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_state.dart';
+import 'package:nibbles/src/features/allergen/tracker/widgets/allergen_progress_card.dart';
+import 'package:nibbles/src/features/allergen/tracker/widgets/reaction_log_row.dart';
+import 'package:nibbles/src/features/allergen/tracker/widgets/start_introduce_card.dart';
+import 'package:nibbles/src/features/allergen/tracker/widgets/tracker_header.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
+/// Redesigned Allergen Tracker board (NIB-79).
+///
+/// Layout: butter-soft header + segmented control (`Ongoing` | `Big 11`) with
+/// a coral progress ring (safeCount / 9) and stat columns above it. The
+/// Ongoing tab lists allergens with at least one log (inProgress/safe/flagged)
+/// followed by a Reaction Log list. The Big 11 tab is a long-scrolling
+/// grouped list of all 9 canonical allergens — Not-Started ones expose a
+/// Start Introduce CTA that opens the existing log capture sheet.
 class AllergenTrackerScreen extends ConsumerWidget {
   const AllergenTrackerScreen({super.key});
 
@@ -21,14 +34,18 @@ class AllergenTrackerScreen extends ConsumerWidget {
     final babyIdAsync = ref.watch(currentBabyIdProvider);
 
     return babyIdAsync.when(
-      loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
+      loading: () => const Scaffold(
+        backgroundColor: AppColors.background,
+        body: Center(child: CircularProgressIndicator()),
+      ),
       error: (_, __) => const Scaffold(
+        backgroundColor: AppColors.background,
         body: Center(child: Text('Could not load baby profile.')),
       ),
       data: (babyId) {
         if (babyId == null) {
           return const Scaffold(
+            backgroundColor: AppColors.background,
             body: Center(child: Text('No baby profile found.')),
           );
         }
@@ -38,641 +55,416 @@ class AllergenTrackerScreen extends ConsumerWidget {
   }
 }
 
-class _TrackerBody extends ConsumerWidget {
+class _TrackerBody extends ConsumerStatefulWidget {
   const _TrackerBody({required this.babyId});
 
   final String babyId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final trackerAsync = ref.watch(allergenTrackerControllerProvider(babyId));
+  ConsumerState<_TrackerBody> createState() => _TrackerBodyState();
+}
 
-    return DefaultTabController(
-      length: 2,
-      child: Scaffold(
-        backgroundColor: AppColors.background,
-        appBar: AppBar(
-          backgroundColor: AppColors.surface,
-          elevation: 0,
-          title: Text(
-            'Allergen Tracker',
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          bottom: const TabBar(
-            labelColor: AppColors.primary,
-            unselectedLabelColor: AppColors.subtext,
-            indicatorColor: AppColors.primary,
-            tabs: [
-              Tab(text: 'Overview'),
-              Tab(text: 'All Allergens'),
-            ],
-          ),
-        ),
-        body: trackerAsync.when(
+class _TrackerBodyState extends ConsumerState<_TrackerBody> {
+  // 0 = Ongoing, 1 = Big 11. Held locally — never persisted.
+  int _segmentIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final trackerAsync = ref.watch(
+      allergenTrackerControllerProvider(widget.babyId),
+    );
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        bottom: false,
+        child: trackerAsync.when(
           loading: () => const Center(child: CircularProgressIndicator()),
-          error: (e, _) => Center(
-            child: Padding(
-              padding: const EdgeInsets.all(AppSizes.pagePaddingH),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    'Could not load tracker.',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: AppSizes.sm),
-                  FilledButton(
-                    onPressed: () => ref.invalidate(
-                      allergenTrackerControllerProvider(babyId),
-                    ),
-                    child: const Text('Retry'),
-                  ),
-                ],
-              ),
+          error: (err, _) => _ErrorState(
+            onRetry: () => ref.invalidate(
+              allergenTrackerControllerProvider(widget.babyId),
             ),
           ),
-          data: (state) => TabBarView(
-            children: [
-              _OverviewTab(state: state, babyId: babyId),
-              _BoardTab(state: state, babyId: babyId),
-            ],
+          data: (state) => _TrackerContent(
+            babyId: widget.babyId,
+            state: state,
+            segmentIndex: _segmentIndex,
+            onSegmentChanged: (i) => setState(() => _segmentIndex = i),
+            onStartIntroduce: _startIntroduce,
           ),
         ),
       ),
     );
   }
+
+  Future<void> _startIntroduce(Allergen allergen) async {
+    final logged = await showAllergenLogSheet(
+      context,
+      babyId: widget.babyId,
+      allergenKey: allergen.key,
+      allergenName: allergen.name,
+      allergenEmoji: allergen.emoji,
+    );
+
+    if ((logged ?? false) && mounted) {
+      ref.invalidate(allergenTrackerControllerProvider(widget.babyId));
+    }
+  }
 }
 
-// ---------------------------------------------------------------------------
-// AL-01 — Overview Tab
-// ---------------------------------------------------------------------------
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.onRetry});
 
-class _OverviewTab extends StatelessWidget {
-  const _OverviewTab({required this.state, required this.babyId});
+  final VoidCallback onRetry;
 
-  final AllergenTrackerState state;
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(AppSizes.pagePaddingH),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'Could not load tracker.',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: AppSizes.md),
+          AppPillButton(
+            label: 'Retry',
+            onPressed: onRetry,
+            size: AppPillButtonSize.small,
+            expand: false,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrackerContent extends ConsumerWidget {
+  const _TrackerContent({
+    required this.babyId,
+    required this.state,
+    required this.segmentIndex,
+    required this.onSegmentChanged,
+    required this.onStartIntroduce,
+  });
+
   final String babyId;
-
-  int get _introducedCount => state.boardItems
-      .where(
-        (b) =>
-            b.status == AllergenStatus.safe ||
-            b.status == AllergenStatus.flagged,
-      )
-      .length;
+  final AllergenTrackerState state;
+  final int segmentIndex;
+  final ValueChanged<int> onSegmentChanged;
+  final void Function(Allergen allergen) onStartIntroduce;
 
   int get _safeCount =>
-      state.boardItems.where((b) => b.status == AllergenStatus.safe).length;
+      state.statuses.values.where((s) => s == AllergenStatus.safe).length;
 
   int get _flaggedCount =>
-      state.boardItems.where((b) => b.status == AllergenStatus.flagged).length;
+      state.statuses.values.where((s) => s == AllergenStatus.flagged).length;
 
-  bool get _hasAnyLogs => state.boardItems.any((b) => b.logs.isNotEmpty);
+  int get _notTriedCount => state.statuses.values
+      .where((s) => s == AllergenStatus.notStarted)
+      .length;
 
-  int get _currentLogCount {
-    final currentKey = state.programState.currentAllergenKey;
-    final currentItem = state.boardItems
-        .where((b) => b.allergen.key == currentKey)
-        .firstOrNull;
-    return currentItem?.logs.length ?? 0;
-  }
-
-  AllergenBoardItem? get _currentItem {
-    final currentKey = state.programState.currentAllergenKey;
-    return state.boardItems
-        .where((b) => b.allergen.key == currentKey)
-        .firstOrNull;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return SingleChildScrollView(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.pagePaddingH,
-        vertical: AppSizes.pagePaddingV,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          // Progress circle
-          Center(
-            child: _ProgressCircle(introduced: _introducedCount, total: 9),
-          ),
-          const SizedBox(height: AppSizes.lg),
-
-          // Stat chips
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              _StatChip(
-                label: 'Safe',
-                count: _safeCount,
-                color: AppColors.allergenSafe,
-              ),
-              const SizedBox(width: AppSizes.md),
-              _StatChip(
-                label: 'Flagged',
-                count: _flaggedCount,
-                color: AppColors.allergenFlagged,
-              ),
-            ],
-          ),
-          const SizedBox(height: AppSizes.lg),
-
-          // Today's checklist card
-          if (!_hasAnyLogs)
-            _EmptyState(currentItem: _currentItem)
-          else
-            _CurrentAllergenCard(
-              currentItem: _currentItem,
-              logCount: _currentLogCount,
-            ),
-
-          // Recent logs (all exposures)
-          if (state.recentLogs.isNotEmpty) ...[
-            const SizedBox(height: AppSizes.lg),
-            Text('Recent Logs', style: textTheme.titleMedium),
-            const SizedBox(height: AppSizes.sm),
-            ...state.recentLogs.map(
-              (entry) => _LogRow(
-                entry: entry,
-                onTap: () => context.pushNamed(
-                  AppRoute.allergenDetail.name,
-                  pathParameters: {'allergenKey': entry.allergenKey},
-                ),
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _ProgressCircle extends StatelessWidget {
-  const _ProgressCircle({required this.introduced, required this.total});
-
-  final int introduced;
-  final int total;
-
-  @override
-  Widget build(BuildContext context) {
-    final progress = total > 0 ? introduced / total : 0.0;
-    final textTheme = Theme.of(context).textTheme;
-
-    return SizedBox(
-      width: 160,
-      height: 160,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          SizedBox.expand(
-            child: CircularProgressIndicator(
-              value: progress,
-              strokeWidth: 12,
-              backgroundColor: AppColors.divider,
-              valueColor: const AlwaysStoppedAnimation<Color>(
-                AppColors.primary,
-              ),
-            ),
-          ),
-          Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                '$introduced/$total',
-                style: textTheme.headlineMedium?.copyWith(
-                  color: AppColors.primary,
-                  fontWeight: FontWeight.w800,
-                ),
-              ),
-              Text('introduced', style: textTheme.bodySmall),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _StatChip extends StatelessWidget {
-  const _StatChip({
-    required this.label,
-    required this.count,
-    required this.color,
-  });
-
-  final String label;
-  final int count;
-  final Color color;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.md,
-        vertical: AppSizes.sm,
-      ),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-        border: Border.all(color: color.withValues(alpha: 0.4)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            width: 8,
-            height: 8,
-            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-          ),
-          const SizedBox(width: AppSizes.xs),
-          Text(
-            '$count $label',
-            style: Theme.of(
-              context,
-            ).textTheme.labelMedium?.copyWith(color: color),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _EmptyState extends StatelessWidget {
-  const _EmptyState({required this.currentItem});
-
-  final AllergenBoardItem? currentItem;
-
-  @override
-  Widget build(BuildContext context) {
-    final emoji = currentItem?.allergen.emoji ?? '🥜';
-    final name = currentItem?.allergen.name ?? 'Peanut';
-
-    return Container(
-      padding: const EdgeInsets.all(AppSizes.cardPadding),
-      decoration: BoxDecoration(
-        color: AppColors.surfaceVariant,
-        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-      ),
-      child: Column(
-        children: [
-          Text(emoji, style: const TextStyle(fontSize: 40)),
-          const SizedBox(height: AppSizes.sm),
-          Text(
-            'Start your allergen journey!',
-            style: Theme.of(context).textTheme.titleSmall,
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: AppSizes.xs),
-          Text(
-            'Begin with $emoji $name.',
-            style: Theme.of(
-              context,
-            ).textTheme.bodyMedium?.copyWith(color: AppColors.subtext),
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _CurrentAllergenCard extends StatelessWidget {
-  const _CurrentAllergenCard({
-    required this.currentItem,
-    required this.logCount,
-  });
-
-  final AllergenBoardItem? currentItem;
-  final int logCount;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final emoji = currentItem?.allergen.emoji ?? '';
-    final name = currentItem?.allergen.name ?? 'Current Allergen';
-    final isComplete = logCount >= 3;
-
-    return Container(
-      padding: const EdgeInsets.all(AppSizes.cardPadding),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-        border: Border.all(color: AppColors.divider),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.04),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Row(
-        children: [
-          Text(emoji, style: const TextStyle(fontSize: 32)),
-          const SizedBox(width: AppSizes.md),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Current allergen', style: textTheme.bodySmall),
-                const SizedBox(height: 2),
-                Text(name, style: textTheme.titleMedium),
-              ],
-            ),
-          ),
-          Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSizes.sm,
-              vertical: AppSizes.xs,
-            ),
-            decoration: BoxDecoration(
-              color: isComplete
-                  ? AppColors.allergenSafe.withValues(alpha: 0.12)
-                  : AppColors.surfaceVariant,
-              borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-            ),
-            child: Text(
-              '$logCount of 3 logged',
-              style: textTheme.labelSmall?.copyWith(
-                color: isComplete ? AppColors.allergenSafe : AppColors.subtext,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _LogRow extends StatelessWidget {
-  const _LogRow({required this.entry, required this.onTap});
-
-  final RecentLogEntry entry;
-  final VoidCallback onTap;
-
-  String get _tasteEmoji => switch (entry.taste) {
-    EmojiTaste.love => '😍',
-    EmojiTaste.neutral => '😐',
-    EmojiTaste.dislike => '😣',
-  };
-
-  String get _badgeLabel {
-    if (!entry.hadReaction) return 'No Reaction';
-    return switch (entry.severity) {
-      ReactionSeverity.mild => 'Mild',
-      ReactionSeverity.moderate => 'Moderate',
-      ReactionSeverity.severe => 'Severe',
-      null => 'Reaction',
-    };
-  }
-
-  Color get _badgeColor {
-    if (!entry.hadReaction) return AppColors.allergenSafe;
-    return switch (entry.severity) {
-      ReactionSeverity.mild => AppColors.warning,
-      ReactionSeverity.moderate => AppColors.secondary,
-      ReactionSeverity.severe => AppColors.allergenFlagged,
-      null => AppColors.subtext,
-    };
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final date = entry.logDate;
-    final dateStr =
-        '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}/${date.year}';
-
-    return Padding(
-      padding: const EdgeInsets.only(bottom: AppSizes.sm),
-      child: GestureDetector(
-        onTap: onTap,
-        child: Container(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.cardPadding,
-            vertical: AppSizes.sm,
-          ),
-          decoration: BoxDecoration(
-            color: AppColors.surface,
-            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-            border: Border.all(color: AppColors.divider),
-          ),
-          child: Row(
-            children: [
-              Text(entry.allergenEmoji, style: const TextStyle(fontSize: 20)),
-              const SizedBox(width: AppSizes.sm),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(entry.allergenName, style: textTheme.labelLarge),
-                    Row(
-                      children: [
-                        Text(dateStr, style: textTheme.bodySmall),
-                        const SizedBox(width: AppSizes.xs),
-                        Text(_tasteEmoji, style: const TextStyle(fontSize: 14)),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.sm,
-                  vertical: 3,
-                ),
-                decoration: BoxDecoration(
-                  color: _badgeColor.withValues(alpha: 0.12),
-                  borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-                ),
-                child: Text(
-                  _badgeLabel,
-                  style: textTheme.labelSmall?.copyWith(color: _badgeColor),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// AL-02 — Board Tab
-// ---------------------------------------------------------------------------
-
-class _BoardTab extends ConsumerWidget {
-  const _BoardTab({required this.state, required this.babyId});
-
-  final AllergenTrackerState state;
-  final String babyId;
+  bool get _isBig11 => segmentIndex == 1;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentKey = state.programState.currentAllergenKey;
+    // Baby is needed for the Reaction Log row avatar. The currentBabyIdProvider
+    // upstream already guarantees a baby exists; we read it again here for the
+    // initial. Falls back to a neutral glyph when the read is still in flight.
+    final babyAsync = ref.watch(_currentBabyProvider);
+    final babyInitial = babyAsync.maybeWhen(
+      data: (b) => (b?.name.isNotEmpty ?? false)
+          ? b!.name[0].toUpperCase()
+          : '?',
+      orElse: () => '?',
+    );
 
-    return ListView.separated(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.pagePaddingH,
-        vertical: AppSizes.pagePaddingV,
-      ),
-      itemCount: state.boardItems.length,
-      separatorBuilder: (_, __) => const SizedBox(height: AppSizes.sm),
-      itemBuilder: (context, index) {
-        final item = state.boardItems[index];
-        final isCurrent = item.allergen.key == currentKey;
-        return _AllergenBoardRow(
-          item: item,
-          isCurrent: isCurrent,
-          onTap: () => context.pushNamed(
-            AppRoute.allergenDetail.name,
-            pathParameters: {'allergenKey': item.allergen.key},
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(child: _TrackerAppBar(onBack: () => context.pop())),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSizes.pagePaddingH,
+              AppSizes.sm,
+              AppSizes.pagePaddingH,
+              AppSizes.sp12,
+            ),
+            child: TrackerHeader(
+              safeCount: _safeCount,
+              flaggedCount: _flaggedCount,
+              notTriedCount: _notTriedCount,
+              showNotTried: _isBig11,
+            ),
           ),
-        );
-      },
+        ),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.pagePaddingH,
+            ),
+            child: AppSegmentedControl(
+              segments: const ['Ongoing', 'Big 11'],
+              selectedIndex: segmentIndex,
+              onChanged: onSegmentChanged,
+            ),
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: AppSizes.md)),
+        if (_isBig11)
+          _Big11List(
+            allergens: state.allergens,
+            statuses: state.statuses,
+            logs: state.logs,
+            onStartIntroduce: onStartIntroduce,
+            onAllergenTap: (a) => _openAllergenDetail(context, a.key),
+          )
+        else
+          _OngoingList(
+            babyId: babyId,
+            babyInitial: babyInitial,
+            allergens: state.allergens,
+            statuses: state.statuses,
+            logs: state.logs,
+            onAllergenTap: (a) => _openAllergenDetail(context, a.key),
+          ),
+        const SliverToBoxAdapter(child: SizedBox(height: AppSizes.xl)),
+      ],
+    );
+  }
+
+  void _openAllergenDetail(BuildContext context, String allergenKey) {
+    context.pushNamed(
+      AppRoute.allergenDetail.name,
+      pathParameters: {'allergenKey': allergenKey},
     );
   }
 }
 
-class _AllergenBoardRow extends StatelessWidget {
-  const _AllergenBoardRow({
-    required this.item,
-    required this.isCurrent,
-    required this.onTap,
+/// Local provider used to fetch the Baby for the Reaction Log avatar initial.
+/// Scoped here because the tracker is the only consumer that needs the full
+/// Baby object (the rest of the screen only needs the id).
+final _currentBabyProvider = FutureProvider.autoDispose<Baby?>((ref) async {
+  final service = ref.watch(babyProfileServiceProvider);
+  return service.getBaby();
+});
+
+class _TrackerAppBar extends StatelessWidget {
+  const _TrackerAppBar({required this.onBack});
+
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH - 4,
+        AppSizes.sm,
+        AppSizes.pagePaddingH - 4,
+        0,
+      ),
+      child: Row(
+        children: [
+          AppRoundButton(
+            icon: const Icon(Icons.arrow_back_ios_new_rounded),
+            onPressed: onBack,
+            semanticLabel: 'Back',
+          ),
+          Expanded(
+            child: Text(
+              'Allergen Tracker',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: AppColors.fgStrong,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSizes.roundButton),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ongoing tab — allergens with at least one log + Reaction Log feed.
+// ---------------------------------------------------------------------------
+
+class _OngoingList extends StatelessWidget {
+  const _OngoingList({
+    required this.babyId,
+    required this.babyInitial,
+    required this.allergens,
+    required this.statuses,
+    required this.logs,
+    required this.onAllergenTap,
   });
 
-  final AllergenBoardItem item;
-  final bool isCurrent;
-  final VoidCallback onTap;
+  final String babyId;
+  final String babyInitial;
+  final List<Allergen> allergens;
+  final Map<String, AllergenStatus> statuses;
+  final List<AllergenLog> logs;
+  final void Function(Allergen) onAllergenTap;
 
-  Color get _statusColor {
-    return switch (item.status) {
-      AllergenStatus.safe => AppColors.allergenSafe,
-      AllergenStatus.flagged => AppColors.allergenFlagged,
-      AllergenStatus.inProgress => AppColors.allergenInProgress,
-      AllergenStatus.notStarted => AppColors.allergenNotStarted,
-    };
-  }
-
-  String get _statusLabel {
-    return switch (item.status) {
-      AllergenStatus.safe => 'Safe',
-      AllergenStatus.flagged => 'Flagged',
-      AllergenStatus.inProgress => 'In Progress',
-      AllergenStatus.notStarted => 'Not Started',
-    };
-  }
+  List<Allergen> get _ongoing => allergens
+      .where(
+        (a) =>
+            (statuses[a.key] ?? AllergenStatus.notStarted) !=
+            AllergenStatus.notStarted,
+      )
+      .toList(growable: false);
 
   @override
   Widget build(BuildContext context) {
+    final ongoing = _ongoing;
     final textTheme = Theme.of(context).textTheme;
 
-    return GestureDetector(
-      onTap: onTap,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        padding: const EdgeInsets.all(AppSizes.cardPadding),
-        decoration: BoxDecoration(
-          color: isCurrent
-              ? AppColors.primary.withValues(alpha: 0.06)
-              : AppColors.surface,
-          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-          border: Border.all(
-            color: isCurrent ? AppColors.primary : AppColors.divider,
-            width: isCurrent ? 1.5 : 1,
-          ),
-        ),
-        child: Row(
-          children: [
-            // Emoji + name
-            Text(item.allergen.emoji, style: const TextStyle(fontSize: 24)),
-            const SizedBox(width: AppSizes.sm),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Text(item.allergen.name, style: textTheme.labelLarge),
-                      if (isCurrent) ...[
-                        const SizedBox(width: AppSizes.xs),
-                        Text(
-                          '→ Current',
-                          style: textTheme.labelSmall?.copyWith(
-                            color: AppColors.primary,
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-                  const SizedBox(height: AppSizes.xs),
-                  // 3 day-slot dot indicators
-                  Row(
-                    children: List.generate(3, (i) {
-                      final log = i < item.logs.length ? item.logs[i] : null;
-                      return Padding(
-                        padding: const EdgeInsets.only(right: 6),
-                        child: _DotIndicator(log: log),
-                      );
-                    }),
-                  ),
-                ],
+    if (ongoing.isEmpty && logs.isEmpty) {
+      return const SliverToBoxAdapter(child: _OngoingEmptyState());
+    }
+
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
+      sliver: SliverList(
+        delegate: SliverChildListDelegate(<Widget>[
+          if (ongoing.isNotEmpty) ...[
+            Text('In progress', style: textTheme.titleMedium),
+            const SizedBox(height: AppSizes.sm),
+            for (final a in ongoing) ...[
+              AllergenProgressCard(
+                allergen: a,
+                status: statuses[a.key] ?? AllergenStatus.notStarted,
+                cleanLogCount: logs
+                    .where((l) => l.allergenKey == a.key && !l.hadReaction)
+                    .length,
+                totalLogCount:
+                    logs.where((l) => l.allergenKey == a.key).length,
+                onTap: () => onAllergenTap(a),
               ),
-            ),
-            const SizedBox(width: AppSizes.sm),
-            // Status badge
-            Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSizes.sm,
-                vertical: 4,
-              ),
-              decoration: BoxDecoration(
-                color: _statusColor.withValues(alpha: 0.12),
-                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-              ),
-              child: Text(
-                _statusLabel,
-                style: textTheme.labelSmall?.copyWith(color: _statusColor),
-              ),
-            ),
+              const SizedBox(height: AppSizes.sm),
+            ],
+            const SizedBox(height: AppSizes.sm),
           ],
-        ),
+          if (logs.isNotEmpty) ...[
+            Text('Reaction Log', style: textTheme.titleMedium),
+            const SizedBox(height: AppSizes.sm),
+            for (final entry in _reverseIndexed(logs)) ...[
+              ReactionLogRow(
+                log: entry.log,
+                logIndex: entry.index,
+                babyInitial: babyInitial,
+                // TODO(NIB-93): route to read-only log detail when that
+                // screen exists; for now we route to the allergen detail.
+                onTap: () => onAllergenTap(
+                  _allergenForKey(entry.log.allergenKey),
+                ),
+              ),
+              const SizedBox(height: AppSizes.sm),
+            ],
+          ],
+        ]),
+      ),
+    );
+  }
+
+  Allergen _allergenForKey(String key) =>
+      allergens.firstWhere((a) => a.key == key);
+
+  /// Returns logs newest-first while keeping a deterministic 1-based "Log N"
+  /// numbering. N is the position in the original (oldest-first) sequence,
+  /// so newer logs show higher numbers regardless of display order.
+  Iterable<_IndexedLog> _reverseIndexed(List<AllergenLog> sorted) sync* {
+    for (var i = sorted.length - 1; i >= 0; i--) {
+      yield _IndexedLog(log: sorted[i], index: i + 1);
+    }
+  }
+}
+
+class _IndexedLog {
+  const _IndexedLog({required this.log, required this.index});
+  final AllergenLog log;
+  final int index;
+}
+
+class _OngoingEmptyState extends StatelessWidget {
+  const _OngoingEmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.lg,
+      ),
+      child: EmptyState(
+        title: 'No introductions yet',
+        subtitle:
+            'Switch to Big 11 to choose an allergen and tap '
+            "'Start Introduce' to begin.",
       ),
     );
   }
 }
 
-class _DotIndicator extends StatelessWidget {
-  const _DotIndicator({required this.log});
+// ---------------------------------------------------------------------------
+// Big 11 tab — long-scrolling grouped list of all 9 canonical allergens.
+// ---------------------------------------------------------------------------
 
-  final AllergenLog? log;
+class _Big11List extends StatelessWidget {
+  const _Big11List({
+    required this.allergens,
+    required this.statuses,
+    required this.logs,
+    required this.onStartIntroduce,
+    required this.onAllergenTap,
+  });
+
+  final List<Allergen> allergens;
+  final Map<String, AllergenStatus> statuses;
+  final List<AllergenLog> logs;
+  final void Function(Allergen) onStartIntroduce;
+  final void Function(Allergen) onAllergenTap;
 
   @override
   Widget build(BuildContext context) {
-    if (log == null) {
-      return Container(
-        width: 12,
-        height: 12,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          border: Border.all(color: AppColors.allergenNotStarted, width: 1.5),
-        ),
-      );
-    }
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
+      sliver: SliverList(
+        delegate: SliverChildBuilderDelegate(
+          (context, index) {
+            final allergen = allergens[index];
+            final status =
+                statuses[allergen.key] ?? AllergenStatus.notStarted;
+            final card = status == AllergenStatus.notStarted
+                ? StartIntroduceCard(
+                    allergen: allergen,
+                    onStartIntroduce: () => onStartIntroduce(allergen),
+                  )
+                : AllergenProgressCard(
+                    allergen: allergen,
+                    status: status,
+                    cleanLogCount: logs
+                        .where(
+                          (l) =>
+                              l.allergenKey == allergen.key && !l.hadReaction,
+                        )
+                        .length,
+                    totalLogCount: logs
+                        .where((l) => l.allergenKey == allergen.key)
+                        .length,
+                    onTap: () => onAllergenTap(allergen),
+                  );
 
-    return Container(
-      width: 12,
-      height: 12,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: log!.hadReaction
-            ? AppColors.allergenFlagged
-            : AppColors.allergenSafe,
+            return Padding(
+              padding: const EdgeInsets.only(bottom: AppSizes.sm),
+              child: card,
+            );
+          },
+          childCount: allergens.length,
+        ),
       ),
     );
   }

--- a/lib/src/features/allergen/tracker/allergen_tracker_state.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_state.dart
@@ -1,30 +1,28 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
-import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
-import 'package:nibbles/src/common/domain/enums/reaction_severity.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 
 part 'allergen_tracker_state.freezed.dart';
 
+/// State for the redesigned Allergen Tracker board (NIB-79).
+///
+/// Post-NIB-126 the per-allergen status is derived from logs via
+/// `AllergenService.getAllergenStatuses`. There is no longer a locked
+/// sequence or `currentAllergenKey` — every `notStarted` allergen can be
+/// introduced via the Start Introduce CTA.
 @freezed
 class AllergenTrackerState with _$AllergenTrackerState {
   const factory AllergenTrackerState({
-    required List<AllergenBoardItem> boardItems,
-    required AllergenProgramState programState,
-    required List<RecentLogEntry> recentLogs,
-  }) = _AllergenTrackerState;
-}
+    /// All 9 canonical allergens ordered by `sequenceOrder` (display order).
+    required List<Allergen> allergens,
 
-@freezed
-class RecentLogEntry with _$RecentLogEntry {
-  const factory RecentLogEntry({
-    required String allergenKey,
-    required String allergenName,
-    required String allergenEmoji,
-    required DateTime logDate,
-    required DateTime createdAt,
-    required EmojiTaste taste,
-    required bool hadReaction,
-    required ReactionSeverity? severity,
-  }) = _RecentLogEntry;
+    /// `kAllergenKeys` → derived [AllergenStatus]. Guaranteed to contain
+    /// every canonical key.
+    required Map<String, AllergenStatus> statuses,
+
+    /// All logs for the baby, sorted oldest → newest by `createdAt`.
+    /// Used to render the per-card 0/3 progress and the Reaction Log list.
+    required List<AllergenLog> logs,
+  }) = _AllergenTrackerState;
 }

--- a/lib/src/features/allergen/tracker/allergen_tracker_state.freezed.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_state.freezed.dart
@@ -17,9 +17,17 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$AllergenTrackerState {
-  List<AllergenBoardItem> get boardItems => throw _privateConstructorUsedError;
-  AllergenProgramState get programState => throw _privateConstructorUsedError;
-  List<RecentLogEntry> get recentLogs => throw _privateConstructorUsedError;
+  /// All 9 canonical allergens ordered by `sequenceOrder` (display order).
+  List<Allergen> get allergens => throw _privateConstructorUsedError;
+
+  /// `kAllergenKeys` → derived [AllergenStatus]. Guaranteed to contain
+  /// every canonical key.
+  Map<String, AllergenStatus> get statuses =>
+      throw _privateConstructorUsedError;
+
+  /// All logs for the baby, sorted oldest → newest by `createdAt`.
+  /// Used to render the per-card 0/3 progress and the Reaction Log list.
+  List<AllergenLog> get logs => throw _privateConstructorUsedError;
 
   /// Create a copy of AllergenTrackerState
   /// with the given fields replaced by the non-null parameter values.
@@ -36,12 +44,10 @@ abstract class $AllergenTrackerStateCopyWith<$Res> {
   ) = _$AllergenTrackerStateCopyWithImpl<$Res, AllergenTrackerState>;
   @useResult
   $Res call({
-    List<AllergenBoardItem> boardItems,
-    AllergenProgramState programState,
-    List<RecentLogEntry> recentLogs,
+    List<Allergen> allergens,
+    Map<String, AllergenStatus> statuses,
+    List<AllergenLog> logs,
   });
-
-  $AllergenProgramStateCopyWith<$Res> get programState;
 }
 
 /// @nodoc
@@ -62,37 +68,27 @@ class _$AllergenTrackerStateCopyWithImpl<
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? boardItems = null,
-    Object? programState = null,
-    Object? recentLogs = null,
+    Object? allergens = null,
+    Object? statuses = null,
+    Object? logs = null,
   }) {
     return _then(
       _value.copyWith(
-            boardItems: null == boardItems
-                ? _value.boardItems
-                : boardItems // ignore: cast_nullable_to_non_nullable
-                      as List<AllergenBoardItem>,
-            programState: null == programState
-                ? _value.programState
-                : programState // ignore: cast_nullable_to_non_nullable
-                      as AllergenProgramState,
-            recentLogs: null == recentLogs
-                ? _value.recentLogs
-                : recentLogs // ignore: cast_nullable_to_non_nullable
-                      as List<RecentLogEntry>,
+            allergens: null == allergens
+                ? _value.allergens
+                : allergens // ignore: cast_nullable_to_non_nullable
+                      as List<Allergen>,
+            statuses: null == statuses
+                ? _value.statuses
+                : statuses // ignore: cast_nullable_to_non_nullable
+                      as Map<String, AllergenStatus>,
+            logs: null == logs
+                ? _value.logs
+                : logs // ignore: cast_nullable_to_non_nullable
+                      as List<AllergenLog>,
           )
           as $Val,
     );
-  }
-
-  /// Create a copy of AllergenTrackerState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $AllergenProgramStateCopyWith<$Res> get programState {
-    return $AllergenProgramStateCopyWith<$Res>(_value.programState, (value) {
-      return _then(_value.copyWith(programState: value) as $Val);
-    });
   }
 }
 
@@ -106,13 +102,10 @@ abstract class _$$AllergenTrackerStateImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    List<AllergenBoardItem> boardItems,
-    AllergenProgramState programState,
-    List<RecentLogEntry> recentLogs,
+    List<Allergen> allergens,
+    Map<String, AllergenStatus> statuses,
+    List<AllergenLog> logs,
   });
-
-  @override
-  $AllergenProgramStateCopyWith<$Res> get programState;
 }
 
 /// @nodoc
@@ -129,24 +122,24 @@ class __$$AllergenTrackerStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? boardItems = null,
-    Object? programState = null,
-    Object? recentLogs = null,
+    Object? allergens = null,
+    Object? statuses = null,
+    Object? logs = null,
   }) {
     return _then(
       _$AllergenTrackerStateImpl(
-        boardItems: null == boardItems
-            ? _value._boardItems
-            : boardItems // ignore: cast_nullable_to_non_nullable
-                  as List<AllergenBoardItem>,
-        programState: null == programState
-            ? _value.programState
-            : programState // ignore: cast_nullable_to_non_nullable
-                  as AllergenProgramState,
-        recentLogs: null == recentLogs
-            ? _value._recentLogs
-            : recentLogs // ignore: cast_nullable_to_non_nullable
-                  as List<RecentLogEntry>,
+        allergens: null == allergens
+            ? _value._allergens
+            : allergens // ignore: cast_nullable_to_non_nullable
+                  as List<Allergen>,
+        statuses: null == statuses
+            ? _value._statuses
+            : statuses // ignore: cast_nullable_to_non_nullable
+                  as Map<String, AllergenStatus>,
+        logs: null == logs
+            ? _value._logs
+            : logs // ignore: cast_nullable_to_non_nullable
+                  as List<AllergenLog>,
       ),
     );
   }
@@ -156,33 +149,53 @@ class __$$AllergenTrackerStateImplCopyWithImpl<$Res>
 
 class _$AllergenTrackerStateImpl implements _AllergenTrackerState {
   const _$AllergenTrackerStateImpl({
-    required final List<AllergenBoardItem> boardItems,
-    required this.programState,
-    required final List<RecentLogEntry> recentLogs,
-  }) : _boardItems = boardItems,
-       _recentLogs = recentLogs;
+    required final List<Allergen> allergens,
+    required final Map<String, AllergenStatus> statuses,
+    required final List<AllergenLog> logs,
+  }) : _allergens = allergens,
+       _statuses = statuses,
+       _logs = logs;
 
-  final List<AllergenBoardItem> _boardItems;
+  /// All 9 canonical allergens ordered by `sequenceOrder` (display order).
+  final List<Allergen> _allergens;
+
+  /// All 9 canonical allergens ordered by `sequenceOrder` (display order).
   @override
-  List<AllergenBoardItem> get boardItems {
-    if (_boardItems is EqualUnmodifiableListView) return _boardItems;
+  List<Allergen> get allergens {
+    if (_allergens is EqualUnmodifiableListView) return _allergens;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_boardItems);
+    return EqualUnmodifiableListView(_allergens);
   }
 
+  /// `kAllergenKeys` → derived [AllergenStatus]. Guaranteed to contain
+  /// every canonical key.
+  final Map<String, AllergenStatus> _statuses;
+
+  /// `kAllergenKeys` → derived [AllergenStatus]. Guaranteed to contain
+  /// every canonical key.
   @override
-  final AllergenProgramState programState;
-  final List<RecentLogEntry> _recentLogs;
-  @override
-  List<RecentLogEntry> get recentLogs {
-    if (_recentLogs is EqualUnmodifiableListView) return _recentLogs;
+  Map<String, AllergenStatus> get statuses {
+    if (_statuses is EqualUnmodifiableMapView) return _statuses;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_recentLogs);
+    return EqualUnmodifiableMapView(_statuses);
+  }
+
+  /// All logs for the baby, sorted oldest → newest by `createdAt`.
+  /// Used to render the per-card 0/3 progress and the Reaction Log list.
+  final List<AllergenLog> _logs;
+
+  /// All logs for the baby, sorted oldest → newest by `createdAt`.
+  /// Used to render the per-card 0/3 progress and the Reaction Log list.
+  @override
+  List<AllergenLog> get logs {
+    if (_logs is EqualUnmodifiableListView) return _logs;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_logs);
   }
 
   @override
   String toString() {
-    return 'AllergenTrackerState(boardItems: $boardItems, programState: $programState, recentLogs: $recentLogs)';
+    return 'AllergenTrackerState(allergens: $allergens, statuses: $statuses, logs: $logs)';
   }
 
   @override
@@ -191,23 +204,19 @@ class _$AllergenTrackerStateImpl implements _AllergenTrackerState {
         (other.runtimeType == runtimeType &&
             other is _$AllergenTrackerStateImpl &&
             const DeepCollectionEquality().equals(
-              other._boardItems,
-              _boardItems,
+              other._allergens,
+              _allergens,
             ) &&
-            (identical(other.programState, programState) ||
-                other.programState == programState) &&
-            const DeepCollectionEquality().equals(
-              other._recentLogs,
-              _recentLogs,
-            ));
+            const DeepCollectionEquality().equals(other._statuses, _statuses) &&
+            const DeepCollectionEquality().equals(other._logs, _logs));
   }
 
   @override
   int get hashCode => Object.hash(
     runtimeType,
-    const DeepCollectionEquality().hash(_boardItems),
-    programState,
-    const DeepCollectionEquality().hash(_recentLogs),
+    const DeepCollectionEquality().hash(_allergens),
+    const DeepCollectionEquality().hash(_statuses),
+    const DeepCollectionEquality().hash(_logs),
   );
 
   /// Create a copy of AllergenTrackerState
@@ -225,17 +234,24 @@ class _$AllergenTrackerStateImpl implements _AllergenTrackerState {
 
 abstract class _AllergenTrackerState implements AllergenTrackerState {
   const factory _AllergenTrackerState({
-    required final List<AllergenBoardItem> boardItems,
-    required final AllergenProgramState programState,
-    required final List<RecentLogEntry> recentLogs,
+    required final List<Allergen> allergens,
+    required final Map<String, AllergenStatus> statuses,
+    required final List<AllergenLog> logs,
   }) = _$AllergenTrackerStateImpl;
 
+  /// All 9 canonical allergens ordered by `sequenceOrder` (display order).
   @override
-  List<AllergenBoardItem> get boardItems;
+  List<Allergen> get allergens;
+
+  /// `kAllergenKeys` → derived [AllergenStatus]. Guaranteed to contain
+  /// every canonical key.
   @override
-  AllergenProgramState get programState;
+  Map<String, AllergenStatus> get statuses;
+
+  /// All logs for the baby, sorted oldest → newest by `createdAt`.
+  /// Used to render the per-card 0/3 progress and the Reaction Log list.
   @override
-  List<RecentLogEntry> get recentLogs;
+  List<AllergenLog> get logs;
 
   /// Create a copy of AllergenTrackerState
   /// with the given fields replaced by the non-null parameter values.
@@ -243,307 +259,4 @@ abstract class _AllergenTrackerState implements AllergenTrackerState {
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AllergenTrackerStateImplCopyWith<_$AllergenTrackerStateImpl>
   get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-mixin _$RecentLogEntry {
-  String get allergenKey => throw _privateConstructorUsedError;
-  String get allergenName => throw _privateConstructorUsedError;
-  String get allergenEmoji => throw _privateConstructorUsedError;
-  DateTime get logDate => throw _privateConstructorUsedError;
-  DateTime get createdAt => throw _privateConstructorUsedError;
-  EmojiTaste get taste => throw _privateConstructorUsedError;
-  bool get hadReaction => throw _privateConstructorUsedError;
-  ReactionSeverity? get severity => throw _privateConstructorUsedError;
-
-  /// Create a copy of RecentLogEntry
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $RecentLogEntryCopyWith<RecentLogEntry> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $RecentLogEntryCopyWith<$Res> {
-  factory $RecentLogEntryCopyWith(
-    RecentLogEntry value,
-    $Res Function(RecentLogEntry) then,
-  ) = _$RecentLogEntryCopyWithImpl<$Res, RecentLogEntry>;
-  @useResult
-  $Res call({
-    String allergenKey,
-    String allergenName,
-    String allergenEmoji,
-    DateTime logDate,
-    DateTime createdAt,
-    EmojiTaste taste,
-    bool hadReaction,
-    ReactionSeverity? severity,
-  });
-}
-
-/// @nodoc
-class _$RecentLogEntryCopyWithImpl<$Res, $Val extends RecentLogEntry>
-    implements $RecentLogEntryCopyWith<$Res> {
-  _$RecentLogEntryCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of RecentLogEntry
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? allergenKey = null,
-    Object? allergenName = null,
-    Object? allergenEmoji = null,
-    Object? logDate = null,
-    Object? createdAt = null,
-    Object? taste = null,
-    Object? hadReaction = null,
-    Object? severity = freezed,
-  }) {
-    return _then(
-      _value.copyWith(
-            allergenKey: null == allergenKey
-                ? _value.allergenKey
-                : allergenKey // ignore: cast_nullable_to_non_nullable
-                      as String,
-            allergenName: null == allergenName
-                ? _value.allergenName
-                : allergenName // ignore: cast_nullable_to_non_nullable
-                      as String,
-            allergenEmoji: null == allergenEmoji
-                ? _value.allergenEmoji
-                : allergenEmoji // ignore: cast_nullable_to_non_nullable
-                      as String,
-            logDate: null == logDate
-                ? _value.logDate
-                : logDate // ignore: cast_nullable_to_non_nullable
-                      as DateTime,
-            createdAt: null == createdAt
-                ? _value.createdAt
-                : createdAt // ignore: cast_nullable_to_non_nullable
-                      as DateTime,
-            taste: null == taste
-                ? _value.taste
-                : taste // ignore: cast_nullable_to_non_nullable
-                      as EmojiTaste,
-            hadReaction: null == hadReaction
-                ? _value.hadReaction
-                : hadReaction // ignore: cast_nullable_to_non_nullable
-                      as bool,
-            severity: freezed == severity
-                ? _value.severity
-                : severity // ignore: cast_nullable_to_non_nullable
-                      as ReactionSeverity?,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$RecentLogEntryImplCopyWith<$Res>
-    implements $RecentLogEntryCopyWith<$Res> {
-  factory _$$RecentLogEntryImplCopyWith(
-    _$RecentLogEntryImpl value,
-    $Res Function(_$RecentLogEntryImpl) then,
-  ) = __$$RecentLogEntryImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({
-    String allergenKey,
-    String allergenName,
-    String allergenEmoji,
-    DateTime logDate,
-    DateTime createdAt,
-    EmojiTaste taste,
-    bool hadReaction,
-    ReactionSeverity? severity,
-  });
-}
-
-/// @nodoc
-class __$$RecentLogEntryImplCopyWithImpl<$Res>
-    extends _$RecentLogEntryCopyWithImpl<$Res, _$RecentLogEntryImpl>
-    implements _$$RecentLogEntryImplCopyWith<$Res> {
-  __$$RecentLogEntryImplCopyWithImpl(
-    _$RecentLogEntryImpl _value,
-    $Res Function(_$RecentLogEntryImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of RecentLogEntry
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? allergenKey = null,
-    Object? allergenName = null,
-    Object? allergenEmoji = null,
-    Object? logDate = null,
-    Object? createdAt = null,
-    Object? taste = null,
-    Object? hadReaction = null,
-    Object? severity = freezed,
-  }) {
-    return _then(
-      _$RecentLogEntryImpl(
-        allergenKey: null == allergenKey
-            ? _value.allergenKey
-            : allergenKey // ignore: cast_nullable_to_non_nullable
-                  as String,
-        allergenName: null == allergenName
-            ? _value.allergenName
-            : allergenName // ignore: cast_nullable_to_non_nullable
-                  as String,
-        allergenEmoji: null == allergenEmoji
-            ? _value.allergenEmoji
-            : allergenEmoji // ignore: cast_nullable_to_non_nullable
-                  as String,
-        logDate: null == logDate
-            ? _value.logDate
-            : logDate // ignore: cast_nullable_to_non_nullable
-                  as DateTime,
-        createdAt: null == createdAt
-            ? _value.createdAt
-            : createdAt // ignore: cast_nullable_to_non_nullable
-                  as DateTime,
-        taste: null == taste
-            ? _value.taste
-            : taste // ignore: cast_nullable_to_non_nullable
-                  as EmojiTaste,
-        hadReaction: null == hadReaction
-            ? _value.hadReaction
-            : hadReaction // ignore: cast_nullable_to_non_nullable
-                  as bool,
-        severity: freezed == severity
-            ? _value.severity
-            : severity // ignore: cast_nullable_to_non_nullable
-                  as ReactionSeverity?,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-
-class _$RecentLogEntryImpl implements _RecentLogEntry {
-  const _$RecentLogEntryImpl({
-    required this.allergenKey,
-    required this.allergenName,
-    required this.allergenEmoji,
-    required this.logDate,
-    required this.createdAt,
-    required this.taste,
-    required this.hadReaction,
-    required this.severity,
-  });
-
-  @override
-  final String allergenKey;
-  @override
-  final String allergenName;
-  @override
-  final String allergenEmoji;
-  @override
-  final DateTime logDate;
-  @override
-  final DateTime createdAt;
-  @override
-  final EmojiTaste taste;
-  @override
-  final bool hadReaction;
-  @override
-  final ReactionSeverity? severity;
-
-  @override
-  String toString() {
-    return 'RecentLogEntry(allergenKey: $allergenKey, allergenName: $allergenName, allergenEmoji: $allergenEmoji, logDate: $logDate, createdAt: $createdAt, taste: $taste, hadReaction: $hadReaction, severity: $severity)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$RecentLogEntryImpl &&
-            (identical(other.allergenKey, allergenKey) ||
-                other.allergenKey == allergenKey) &&
-            (identical(other.allergenName, allergenName) ||
-                other.allergenName == allergenName) &&
-            (identical(other.allergenEmoji, allergenEmoji) ||
-                other.allergenEmoji == allergenEmoji) &&
-            (identical(other.logDate, logDate) || other.logDate == logDate) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.taste, taste) || other.taste == taste) &&
-            (identical(other.hadReaction, hadReaction) ||
-                other.hadReaction == hadReaction) &&
-            (identical(other.severity, severity) ||
-                other.severity == severity));
-  }
-
-  @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    allergenKey,
-    allergenName,
-    allergenEmoji,
-    logDate,
-    createdAt,
-    taste,
-    hadReaction,
-    severity,
-  );
-
-  /// Create a copy of RecentLogEntry
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$RecentLogEntryImplCopyWith<_$RecentLogEntryImpl> get copyWith =>
-      __$$RecentLogEntryImplCopyWithImpl<_$RecentLogEntryImpl>(
-        this,
-        _$identity,
-      );
-}
-
-abstract class _RecentLogEntry implements RecentLogEntry {
-  const factory _RecentLogEntry({
-    required final String allergenKey,
-    required final String allergenName,
-    required final String allergenEmoji,
-    required final DateTime logDate,
-    required final DateTime createdAt,
-    required final EmojiTaste taste,
-    required final bool hadReaction,
-    required final ReactionSeverity? severity,
-  }) = _$RecentLogEntryImpl;
-
-  @override
-  String get allergenKey;
-  @override
-  String get allergenName;
-  @override
-  String get allergenEmoji;
-  @override
-  DateTime get logDate;
-  @override
-  DateTime get createdAt;
-  @override
-  EmojiTaste get taste;
-  @override
-  bool get hadReaction;
-  @override
-  ReactionSeverity? get severity;
-
-  /// Create a copy of RecentLogEntry
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$RecentLogEntryImplCopyWith<_$RecentLogEntryImpl> get copyWith =>
-      throw _privateConstructorUsedError;
 }

--- a/lib/src/features/allergen/tracker/widgets/allergen_progress_card.dart
+++ b/lib/src/features/allergen/tracker/widgets/allergen_progress_card.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+
+/// Card for an allergen the user is currently introducing or has finished.
+///
+/// Variants:
+///  - [AllergenStatus.inProgress] — coral linear bar (N/3).
+///  - [AllergenStatus.safe]       — green linear bar (3/3) + Safe chip.
+///  - [AllergenStatus.flagged]    — coral bar filled, plus a Flagged chip.
+class AllergenProgressCard extends StatelessWidget {
+  const AllergenProgressCard({
+    required this.allergen,
+    required this.status,
+    required this.cleanLogCount,
+    required this.totalLogCount,
+    required this.onTap,
+    super.key,
+  });
+
+  final Allergen allergen;
+  final AllergenStatus status;
+
+  /// Logs without `hadReaction == true`. Drives the 0/3 bar fill.
+  final int cleanLogCount;
+
+  /// All logs for this allergen (used for "Log N total" caption).
+  final int totalLogCount;
+
+  final VoidCallback onTap;
+
+  AppLinearProgressVariant get _variant {
+    switch (status) {
+      case AllergenStatus.safe:
+        return AppLinearProgressVariant.green;
+      case AllergenStatus.flagged:
+      case AllergenStatus.inProgress:
+      case AllergenStatus.notStarted:
+        return AppLinearProgressVariant.coral;
+    }
+  }
+
+  /// 0..1 — clamps clean logs at 3 (the "introduced" target).
+  double get _progress => (cleanLogCount.clamp(0, 3)) / 3;
+
+  Widget? get _trailingChip {
+    switch (status) {
+      case AllergenStatus.safe:
+        return const AppChip(label: 'Safe', tone: AppChipTone.safe);
+      case AllergenStatus.flagged:
+        return const AppChip(label: 'Flagged', tone: AppChipTone.flag);
+      case AllergenStatus.inProgress:
+      case AllergenStatus.notStarted:
+        return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final trailingChip = _trailingChip;
+
+    return AppCard(
+      onTap: onTap,
+      child: Row(
+        children: [
+          Container(
+            width: AppSizes.avatarMd,
+            height: AppSizes.avatarMd,
+            decoration: const BoxDecoration(
+              color: AppColors.coralSoft,
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              allergen.emoji,
+              style: const TextStyle(fontSize: 24, height: 1),
+            ),
+          ),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        allergen.name,
+                        style: textTheme.labelLarge,
+                      ),
+                    ),
+                    if (trailingChip != null) trailingChip,
+                  ],
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  '${cleanLogCount.clamp(0, 3)}/3 times',
+                  style: textTheme.bodySmall,
+                ),
+                const SizedBox(height: AppSizes.sm),
+                AppLinearProgress(value: _progress, variant: _variant),
+                if (totalLogCount > cleanLogCount) ...[
+                  const SizedBox(height: AppSizes.xs),
+                  Text(
+                    '$totalLogCount log${totalLogCount == 1 ? '' : 's'} total',
+                    style: textTheme.bodySmall,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/allergen/tracker/widgets/reaction_log_row.dart
+++ b/lib/src/features/allergen/tracker/widgets/reaction_log_row.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
+
+/// Single row in the Reaction Log list.
+///
+/// Layout: baby-avatar circle · `Log N` headline · Safe / Unsafe chip ·
+/// notes preview · optional attachment chip. `emojiTaste` is nullable
+/// post-NIB-124 — falls back to [EmojiTaste.neutral] for the legacy badge
+/// display ONLY (no value is persisted from this widget).
+class ReactionLogRow extends StatelessWidget {
+  const ReactionLogRow({
+    required this.log,
+    required this.logIndex,
+    required this.babyInitial,
+    required this.onTap,
+    super.key,
+  });
+
+  /// The underlying log row.
+  final AllergenLog log;
+
+  /// 1-based index used in the `Log N` headline.
+  final int logIndex;
+
+  /// First letter of the baby's name. Used to draw the avatar glyph.
+  final String babyInitial;
+
+  /// Row tap target. Routes to the read-only log detail when that screen
+  /// exists; for now the tracker screen routes to the allergen detail
+  /// (NIB-93 will land the dedicated read-only log view).
+  final VoidCallback? onTap;
+
+  String get _tasteGlyph {
+    final taste = log.emojiTaste ?? EmojiTaste.neutral;
+    switch (taste) {
+      case EmojiTaste.love:
+        return '😍';
+      case EmojiTaste.neutral:
+        return '😐';
+      case EmojiTaste.dislike:
+        return '😣';
+    }
+  }
+
+  String get _attachmentLabel {
+    final title = log.attachmentTitle;
+    if (title != null && title.isNotEmpty) return title;
+    return 'Photo';
+  }
+
+  bool get _hasAttachment =>
+      (log.photoUrl != null && log.photoUrl!.isNotEmpty) ||
+      (log.attachmentTitle != null && log.attachmentTitle!.isNotEmpty);
+
+  bool get _hasNotes => log.notes != null && log.notes!.trim().isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final statusChip = log.hadReaction
+        ? const AppChip(label: 'Unsafe', tone: AppChipTone.flag)
+        : const AppChip(label: 'Safe', tone: AppChipTone.safe);
+
+    return AppCard(
+      onTap: onTap,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Baby avatar with the legacy taste badge as a corner glyph.
+          SizedBox(
+            width: AppSizes.avatarMd,
+            height: AppSizes.avatarMd,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                Container(
+                  width: AppSizes.avatarMd,
+                  height: AppSizes.avatarMd,
+                  decoration: const BoxDecoration(
+                    color: AppColors.greenTint,
+                    shape: BoxShape.circle,
+                  ),
+                  alignment: Alignment.center,
+                  child: Text(
+                    babyInitial,
+                    style: textTheme.titleSmall?.copyWith(
+                      color: AppColors.greenDeep,
+                    ),
+                  ),
+                ),
+                Positioned(
+                  right: -2,
+                  bottom: -2,
+                  child: Container(
+                    padding: const EdgeInsets.all(2),
+                    decoration: const BoxDecoration(
+                      color: AppColors.surface,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Text(
+                      _tasteGlyph,
+                      style: const TextStyle(fontSize: 12, height: 1),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Log $logIndex',
+                        style: textTheme.labelLarge,
+                      ),
+                    ),
+                    statusChip,
+                  ],
+                ),
+                if (_hasNotes) ...[
+                  const SizedBox(height: AppSizes.xs),
+                  Text(
+                    log.notes!.trim(),
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: AppColors.fgMuted,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+                if (_hasAttachment) ...[
+                  const SizedBox(height: AppSizes.sm),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: AppChip(
+                      label: _attachmentLabel,
+                      tone: AppChipTone.mute,
+                      emoji: '📎',
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/allergen/tracker/widgets/start_introduce_card.dart
+++ b/lib/src/features/allergen/tracker/widgets/start_introduce_card.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+
+/// Card for an allergen that hasn't been logged yet (status `notStarted`).
+///
+/// Renders the allergen icon + name and a small Start Introduce CTA that
+/// opens the existing log capture sheet for that allergen (the saved log
+/// flips the derived status to `inProgress` on next read — there is no
+/// server-side "mark started" write).
+class StartIntroduceCard extends StatelessWidget {
+  const StartIntroduceCard({
+    required this.allergen,
+    required this.onStartIntroduce,
+    super.key,
+  });
+
+  final Allergen allergen;
+  final VoidCallback onStartIntroduce;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return AppCard(
+      variant: AppCardVariant.dashed,
+      child: Row(
+        children: [
+          Container(
+            width: AppSizes.avatarMd,
+            height: AppSizes.avatarMd,
+            decoration: const BoxDecoration(
+              color: AppColors.surfaceVariant,
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              allergen.emoji,
+              style: const TextStyle(fontSize: 24, height: 1),
+            ),
+          ),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(allergen.name, style: textTheme.labelLarge),
+                const SizedBox(height: 2),
+                Text('Not tried yet', style: textTheme.bodySmall),
+              ],
+            ),
+          ),
+          const SizedBox(width: AppSizes.sm),
+          AppPillButton(
+            label: 'Start Introduce',
+            onPressed: onStartIntroduce,
+            size: AppPillButtonSize.small,
+            expand: false,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/allergen/tracker/widgets/tracker_header.dart
+++ b/lib/src/features/allergen/tracker/widgets/tracker_header.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/components.dart';
+
+/// Header block above the segmented control on the Allergen Tracker.
+///
+/// Renders the coral progress ring (safeCount / 9) on the left and a vertical
+/// stack of stat columns on the right. The visible columns are decided by
+/// the caller via [showNotTried] — `Not Tried` is rendered on the Big 11 tab
+/// only (per spec rule 8).
+class TrackerHeader extends StatelessWidget {
+  const TrackerHeader({
+    required this.safeCount,
+    required this.flaggedCount,
+    required this.notTriedCount,
+    required this.showNotTried,
+    super.key,
+  });
+
+  final int safeCount;
+  final int flaggedCount;
+  final int notTriedCount;
+  final bool showNotTried;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        AppProgressRing(value: safeCount, max: 9),
+        const SizedBox(width: AppSizes.lg),
+        Expanded(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _StatRow(
+                label: 'Safe',
+                value: safeCount,
+                color: AppColors.safeFg,
+              ),
+              const SizedBox(height: AppSizes.sm),
+              _StatRow(
+                label: 'Not Safe',
+                value: flaggedCount,
+                color: AppColors.flagFg,
+              ),
+              if (showNotTried) ...[
+                const SizedBox(height: AppSizes.sm),
+                _StatRow(
+                  label: 'Not Tried',
+                  value: notTriedCount,
+                  color: AppColors.fgMuted,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatRow extends StatelessWidget {
+  const _StatRow({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final int value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Row(
+      children: [
+        Container(
+          width: AppSizes.sm,
+          height: AppSizes.sm,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: AppSizes.sm),
+        Expanded(
+          child: Text(
+            label,
+            style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
+          ),
+        ),
+        Text(
+          '$value',
+          style: textTheme.titleMedium?.copyWith(color: color),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Reskin the Allergen Tracker board (AL-01 / AL-02) to match the new design system per NIB-120 / NIB-126. Out-of-sequence introduce is allowed; per-allergen status is now derived from logs via `AllergenService.getAllergenStatuses(babyId)` (the legacy locked-sequence advance flow is dropped from this screen).

### Files changed
- `allergen_tracker_state.dart` / `.freezed.dart` — reshape state around `allergens`, `statuses`, raw `logs`. Drops `programState` and `RecentLogEntry`.
- `allergen_tracker_controller.dart` / `.g.dart` — compose `getAllergens` + `getAllergenStatuses` + `getLogs` in parallel; no more `getAllergenBoardSummary` / `getProgramState` / per-log `getReactionDetail` N+1.
- `allergen_tracker_screen.dart` — segmented header + ring + stat columns; Ongoing tab (in-progress allergens + Reaction Log list); Big 11 tab (all 9 keys, Start Introduce CTA on `notStarted`).
- `widgets/tracker_header.dart` — ring + stat-columns block (Safe / Not Safe / Not Tried).
- `widgets/allergen_progress_card.dart` — coral / green linear progress card for inProgress / safe / flagged.
- `widgets/start_introduce_card.dart` — dashed card with Start Introduce pill CTA.
- `widgets/reaction_log_row.dart` — avatar + Log N headline + Safe/Unsafe chip + notes + optional attachment chip.

### Figma frames referenced
- Ongoing tab — node `1089-17373`
- Big 11 long-scroll — node `1116-18287`
- Section ref — node `1089-17372`

Figma MCP (`figma-dev`) was unreachable during the build; the implementation is driven by the local `design/preview/*.html` mockups (especially `allergens.html`, `components-segmented.html`, `components-progress.html`, `components-cards.html`, `components-chips.html`, `components-empty-state.html`) and `design/colors_and_type.css`. The high-level IA (ring + stat columns header above the segmented control, Ongoing groups in-progress allergens above the Reaction Log list, Big 11 long-scrolls all 9 canonical keys) is the most reasonable read of the spec and previews — if the Figma board diverges, it can be tweaked in a follow-up since the building blocks are all already DS components.

### Design-system components consumed (no shared file modified)
- `AppSegmentedControl` (Ongoing / Big 11)
- `AppProgressRing` (safeCount / 9)
- `AppLinearProgress` (coral / green 0..1 per card)
- `AppCard` (plain + dashed variants)
- `AppChip` (`safe`, `flag`, `mute` tones for status / attachment pills)
- `AppPillButton` (Start Introduce CTA, small)
- `AppRoundButton` (back chevron)
- `EmptyState` (Ongoing-tab zero-data)

### Spec interpretation notes
- **Progress ring** — per spec rule 9, this is `safeCount / 9` (not `introducedCount / 9`). Original AL-01 wording 'currentSequenceOrder / 9' is interpreted as `safeCount / 9` post-NIB-120.
- **Big 11 vs 9** — segment label is verbatim 'Big 11' but the list renders the 9 canonical keys from `kAllergenKeys` (NIB-126).
- **`emojiTaste` nullable** — reaction-log row falls back to `EmojiTaste.neutral` for the legacy taste glyph display ONLY (no persisted value is touched).
- **Row tap (Reaction Log)** — routes to existing allergen detail by `allergenKey` with a `// TODO(NIB-93)` for the dedicated read-only log detail view (that route is being carved out in NIB-93).
- **Out-of-sequence introduce** — Start Introduce simply opens the existing `showAllergenLogSheet`; the first saved log flips the derived status to `inProgress` on next read (no server-side mark-started call).

### Acceptance checklist
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — all 304 existing tests pass; no new tests added (per spec — testing is NIB-110 at end of milestone)
- [x] `make gen` clean + idempotent (the `home_controller.g.dart` riverpod-hash drift documented in the orchestrator notes was reverted before staging)
- [x] Zero `Nunito`, zero `withAlpha`, zero `Color(0xff…)`, zero `AllergenStatus.completed` in changed files
- [x] No files outside `lib/src/features/allergen/tracker/**` modified

### Follow-up TODOs (out of scope for this ticket)
- **TODO(NIB-93)** — when the read-only allergen-log detail route lands, swap the Reaction Log row `onTap` from the allergen detail to the dedicated log detail. Currently a stale `TODO(NIB-24)` comment in `allergen_detail_screen.dart` (line 334) also references `allergenTrackerControllerProvider` invalidation in a state that no longer exists — left untouched per scope rule, but worth cleaning up alongside NIB-93.
- **TODO(analytics gap)** — `Analytics.logAllergenStartIntroduce` and `logAllergenSegmentChanged` do not exist yet. Per spec rule 11, NOT added here (`logging/analytics.dart` is owned by NIB-102 in this milestone). The closest existing event, `logAllergenLogCreated`, is already fired by the log capture sheet on save, so the 'started' moment is implicitly captured. No new analytics calls are wired here.
- **AL-08 reachability** — dropping the advance flow from this screen orphans `allergen/complete` (AL-08). Nothing on the tracker calls `AllergenService.completeProgram` anymore; the only remaining trigger is the home-screen `_proceedToNext` path, which still operates on the legacy locked-sequence advance. After NIB-93 and the broader home re-skin land, the program-completion trigger likely needs to move into the new derived-status pipeline (e.g. auto-complete when all 9 statuses are `safe`). Flagged here, no fix in this PR.

### Tokens / DS gaps observed
- No new tokens were needed — everything maps to existing `AppColors` (`safeFg`, `flagFg`, `fgMuted`, `greenTint`, `coralSoft`, `coralDeep`, `surfaceVariant`) and `AppSizes`.
- The kit `.card` default padding (16h x 12v) matched the visual spec for every card on this screen — `AppCard` was consumed unchanged.