### PR TITLE
chore(allergen): analytics for log edit/delete + start-introduce + segment changed [NIB-102]

### DIFF
--- a/lib/src/features/allergen/log/allergen_log_controller.dart
+++ b/lib/src/features/allergen/log/allergen_log_controller.dart
@@ -152,6 +152,12 @@ class AllergenLogController extends _$AllergenLogController {
       }
 
       state = state.copyWith(isLoading: false, isSaved: true);
+      unawaited(
+        Analytics.instance.logAllergenLogEdited(
+          allergenKey: allergenKey,
+          hasAttachment: _hasAttachment(),
+        ),
+      );
       return;
     }
 
@@ -199,7 +205,21 @@ class AllergenLogController extends _$AllergenLogController {
       photoUploadFailed: photoFailed,
     );
     unawaited(
-      Analytics.instance.logAllergenLogCreated(allergenKey: allergenKey),
+      Analytics.instance.logAllergenLogCreated(
+        allergenKey: allergenKey,
+        hasAttachment: _hasAttachment(),
+      ),
     );
+  }
+
+  bool _hasAttachment() {
+    final title = state.attachmentTitle;
+    final description = state.attachmentDescription;
+    final photo = state.photoPath;
+    final existingPhoto = state.existingPhotoPath;
+    return (photo != null && photo.isNotEmpty) ||
+        (existingPhoto != null && existingPhoto.isNotEmpty) ||
+        (title != null && title.isNotEmpty) ||
+        (description != null && description.isNotEmpty);
   }
 }

--- a/lib/src/features/allergen/log/allergen_log_controller.g.dart
+++ b/lib/src/features/allergen/log/allergen_log_controller.g.dart
@@ -7,7 +7,7 @@ part of 'allergen_log_controller.dart';
 // **************************************************************************
 
 String _$allergenLogControllerHash() =>
-    r'fec3f134ae2c194ca27f9daade45b048149fa168';
+    r'fde5033f91fc059f4405bb5ee37c1ef397aa0b79';
 
 /// Controller backing the redesigned full-screen Allergen Log capture screen
 /// (NIB-127).

--- a/lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart
+++ b/lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -14,6 +16,7 @@ import 'package:nibbles/src/features/allergen/detail/allergen_detail_controller.
 import 'package:nibbles/src/features/allergen/log_detail/allergen_log_detail_controller.dart';
 import 'package:nibbles/src/features/allergen/log_detail/allergen_log_detail_state.dart';
 import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_controller.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
 /// Read-only Allergen Log Detail screen (NIB-127).
@@ -210,6 +213,10 @@ class _LogDetailView extends ConsumerWidget {
       );
       return;
     }
+
+    unawaited(
+      Analytics.instance.logAllergenLogDeleted(allergenKey: allergenKey),
+    );
 
     // Invalidate both upstream lists so a pop to either reflects the delete.
     ref

--- a/lib/src/features/allergen/tracker/allergen_tracker_screen.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -15,6 +17,7 @@ import 'package:nibbles/src/features/allergen/tracker/widgets/allergen_progress_
 import 'package:nibbles/src/features/allergen/tracker/widgets/reaction_log_row.dart';
 import 'package:nibbles/src/features/allergen/tracker/widgets/start_introduce_card.dart';
 import 'package:nibbles/src/features/allergen/tracker/widgets/tracker_header.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
 /// Redesigned Allergen Tracker board (NIB-79).
@@ -88,7 +91,7 @@ class _TrackerBodyState extends ConsumerState<_TrackerBody> {
             babyId: widget.babyId,
             state: state,
             segmentIndex: _segmentIndex,
-            onSegmentChanged: (i) => setState(() => _segmentIndex = i),
+            onSegmentChanged: _onSegmentChanged,
             onStartIntroduce: _startIntroduce,
           ),
         ),
@@ -96,7 +99,18 @@ class _TrackerBodyState extends ConsumerState<_TrackerBody> {
     );
   }
 
+  void _onSegmentChanged(int index) {
+    setState(() => _segmentIndex = index);
+    final segment = index == 1 ? 'big_11' : 'ongoing';
+    unawaited(
+      Analytics.instance.logAllergenSegmentChanged(segment: segment),
+    );
+  }
+
   Future<void> _startIntroduce(Allergen allergen) async {
+    unawaited(
+      Analytics.instance.logAllergenStartIntroduce(allergenKey: allergen.key),
+    );
     final logged = await context.pushNamed<bool>(
       AppRoute.allergenLogCreate.name,
       pathParameters: {'allergenKey': allergen.key},

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -174,10 +174,50 @@ class Analytics {
   // Allergen tracker
   // ---------------------------------------------------------------------------
 
-  Future<void> logAllergenLogCreated({required String allergenKey}) async {
+  Future<void> logAllergenLogCreated({
+    required String allergenKey,
+    bool hasAttachment = false,
+  }) async {
     await _logEvent(
       'allergen_log_created',
+      parameters: {
+        'allergen_key': allergenKey,
+        'has_attachment': hasAttachment,
+      },
+    );
+  }
+
+  Future<void> logAllergenLogEdited({
+    required String allergenKey,
+    required bool hasAttachment,
+  }) async {
+    await _logEvent(
+      'allergen_log_edited',
+      parameters: {
+        'allergen_key': allergenKey,
+        'has_attachment': hasAttachment,
+      },
+    );
+  }
+
+  Future<void> logAllergenLogDeleted({required String allergenKey}) async {
+    await _logEvent(
+      'allergen_log_deleted',
       parameters: {'allergen_key': allergenKey},
+    );
+  }
+
+  Future<void> logAllergenStartIntroduce({required String allergenKey}) async {
+    await _logEvent(
+      'allergen_start_introduce',
+      parameters: {'allergen_key': allergenKey},
+    );
+  }
+
+  Future<void> logAllergenSegmentChanged({required String segment}) async {
+    await _logEvent(
+      'allergen_segment_changed',
+      parameters: {'segment': segment},
     );
   }
 

--- a/test/support/fake_analytics.dart
+++ b/test/support/fake_analytics.dart
@@ -91,8 +91,34 @@ class FakeAnalytics implements Analytics {
       _record('subscription_restored');
 
   @override
-  Future<void> logAllergenLogCreated({required String allergenKey}) async =>
-      _record('allergen_log_created', {'allergen_key': allergenKey});
+  Future<void> logAllergenLogCreated({
+    required String allergenKey,
+    bool hasAttachment = false,
+  }) async => _record('allergen_log_created', {
+    'allergen_key': allergenKey,
+    'has_attachment': hasAttachment,
+  });
+
+  @override
+  Future<void> logAllergenLogEdited({
+    required String allergenKey,
+    required bool hasAttachment,
+  }) async => _record('allergen_log_edited', {
+    'allergen_key': allergenKey,
+    'has_attachment': hasAttachment,
+  });
+
+  @override
+  Future<void> logAllergenLogDeleted({required String allergenKey}) async =>
+      _record('allergen_log_deleted', {'allergen_key': allergenKey});
+
+  @override
+  Future<void> logAllergenStartIntroduce({required String allergenKey}) async =>
+      _record('allergen_start_introduce', {'allergen_key': allergenKey});
+
+  @override
+  Future<void> logAllergenSegmentChanged({required String segment}) async =>
+      _record('allergen_segment_changed', {'segment': segment});
 
   @override
   Future<void> logAllergenMarkedSafe({required String allergenKey}) async =>


### PR DESCRIPTION
## Summary

Instruments the redesigned allergen flows for analytics on success paths only. No PII; parameters are `allergen_key` (stable lowercase snake_case) plus small primitives.

## Events added / extended

| Event | Params | Fire site |
|---|---|---|
| `allergen_log_created` (extended) | `allergen_key: String`, `has_attachment: bool` (default `false`) | `lib/src/features/allergen/log/allergen_log_controller.dart:208` — after `Result.success` from `saveAllergenLog` in `submit()` |
| `allergen_log_edited` (new) | `allergen_key: String`, `has_attachment: bool` | `lib/src/features/allergen/log/allergen_log_controller.dart:156` — after `Result.success` from `updateAllergenLog` in `submit()` |
| `allergen_log_deleted` (new) | `allergen_key: String` | `lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart:217` — after `Result.success` from `deleteAllergenLog` in the popup-menu delete handler |
| `allergen_start_introduce` (new) | `allergen_key: String` | `lib/src/features/allergen/tracker/allergen_tracker_screen.dart:100` — at the top of `_startIntroduce`, BEFORE the route push (fire-and-forget) |
| `allergen_segment_changed` (new) | `segment: String` (`'ongoing'` or `'big_11'`) | `lib/src/features/allergen/tracker/allergen_tracker_screen.dart:99` — `_onSegmentChanged` callback bound to the segmented control's `onChanged` |

`has_attachment` is computed from `photoPath`, `existingPhotoPath`, `attachmentTitle`, or `attachmentDescription` being non-empty on the controller state. All fires use `unawaited(...)` (fire-and-forget — never blocks UI).

## Crashlytics non-fatal photo-delete coverage

Verified — both the `deleteAllergenLog` path and the `updateAllergenLog` photo-replace path go through `_deletePhotoBestEffort` in `lib/src/common/services/allergen_service.dart`, which calls the injected `AllergenCrashRecorderFn` (wired by NIB-125). No service modifications in this PR.

## Acceptance criteria

- [x] `analytics.dart` exposes 4 new methods + extended `logAllergenLogCreated` signature; matches existing project pattern (`Future<void>` + `await _logEvent(...)`).
- [x] Event fires placed AFTER `Result.success` only (never on failure).
- [x] All event params are primitives, no PII (no baby IDs, log IDs, notes, photo paths, dates).
- [x] `flutter analyze` 0 issues.
- [x] Existing tests pass (`flutter test` — All tests passed!, 304 tests).
- [x] `make gen` clean + idempotent (second run produced 0 outputs / 0 actions).
- [x] PR body lists each new event, params, exact file:line of each fire site, and Crashlytics coverage note.

## Files changed

- `lib/src/logging/analytics.dart`
- `lib/src/features/allergen/log/allergen_log_controller.dart`
- `lib/src/features/allergen/log/allergen_log_controller.g.dart` (generator hash bump)
- `lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart`
- `lib/src/features/allergen/tracker/allergen_tracker_screen.dart`
- `test/support/fake_analytics.dart` (mirror new interface so existing tests compile)

## Gate results

- `make gen`: succeeded; second run idempotent.
- `flutter analyze`: No issues found! (ran in 2.7s).
- `flutter test`: All tests passed! (304 tests).