### PR TITLE
feat(allergen): AL-08 program-completion trigger on log save [NIB-128]

### DIFF
--- a/lib/src/common/services/local_flag_service.dart
+++ b/lib/src/common/services/local_flag_service.dart
@@ -72,6 +72,12 @@ class LocalFlagService {
   /// Marks the completion screen as shown for `babyId`.
   void setProgramCompletionShown(String babyId) =>
       _box.put('program_completion_shown_$babyId', true);
+
+  /// Awaitable variant of [setProgramCompletionShown]. Used by the AL-08
+  /// reachability gate in `allergen_log_screen.dart` (NIB-128) so the flag
+  /// flip is durable BEFORE we route to `/home/allergen/complete`.
+  Future<void> markProgramCompletionShown(String babyId) =>
+      _box.put('program_completion_shown_$babyId', true);
 }
 
 @riverpod

--- a/lib/src/features/allergen/log/allergen_log_screen.dart
+++ b/lib/src/features/allergen/log/allergen_log_screen.dart
@@ -5,11 +5,16 @@ import 'package:image_picker/image_picker.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/allergen/log/allergen_log_controller.dart';
 import 'package:nibbles/src/features/allergen/log/allergen_log_state.dart';
 import 'package:nibbles/src/features/allergen/log/widgets/photo_capture_button.dart';
 import 'package:nibbles/src/features/allergen/log/widgets/taste_selector.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 /// Full-screen Allergen Log capture / edit screen (NIB-127).
 ///
@@ -92,7 +97,10 @@ class _AllergenLogScreenState extends ConsumerState<AllergenLogScreen> {
 
     _syncControllersFromState(state);
 
-    ref.listen<AllergenLogState>(allergenLogControllerProvider, (_, next) {
+    ref.listen<AllergenLogState>(allergenLogControllerProvider, (
+      _,
+      next,
+    ) async {
       if (!next.isSaved || !context.mounted) return;
 
       if (next.photoUploadFailed) {
@@ -103,6 +111,42 @@ class _AllergenLogScreenState extends ConsumerState<AllergenLogScreen> {
           ),
         );
       }
+
+      // AL-08 reachability gate (NIB-128). After a successful save (CREATE or
+      // EDIT) re-derive per-allergen statuses; if every allergen is `safe`
+      // AND the per-baby `program_completion_shown_{babyId}` flag is unset,
+      // flip the flag and route to /home/allergen/complete instead of popping.
+      // On any read failure (status read, missing baby) we fall through to
+      // the existing pop — the success path must NOT be blocked on a stale
+      // status read. NIB-102 fires its analytics events independently on the
+      // controller side; this navigation happens after that and both paths
+      // coexist.
+      final babyId = ref.read(currentBabyIdProvider).valueOrNull;
+      if (babyId != null) {
+        final flagService = ref.read(localFlagServiceProvider);
+        if (!flagService.isProgramCompletionShown(babyId)) {
+          final statusesResult = await ref
+              .read(allergenServiceProvider)
+              .getAllergenStatuses(babyId);
+          if (!context.mounted) return;
+          final statuses = statusesResult.dataOrNull;
+          if (statuses != null) {
+            final allSafe =
+                statuses.isNotEmpty &&
+                statuses.values.every(
+                  (AllergenStatus s) => s == AllergenStatus.safe,
+                );
+            if (allSafe) {
+              await flagService.markProgramCompletionShown(babyId);
+              if (!context.mounted) return;
+              context.goNamed(AppRoute.allergenComplete.name);
+              return;
+            }
+          }
+        }
+      }
+
+      if (!context.mounted) return;
       context.pop(true);
     });
 


### PR DESCRIPTION
## Summary

Reinstates the AL-08 "all allergens introduced" celebration screen, which became unreachable when NIB-93 removed the legacy "Proceed to Next Allergen" CTA. Reachability now lives on the log save path.

## Gate logic (verbatim)

In the success branch of `ref.listen` on `AllergenLogState` (i.e. after the controller flips `state.isSaved = true`, covering both CREATE and EDIT modes), and before the existing `context.pop(true)`:

1. Read `babyId` via `ref.read(currentBabyIdProvider).valueOrNull` (mirrors the controller's approach). If null, skip the AL-08 check and fall through to pop.
2. Read `LocalFlagService.isProgramCompletionShown(babyId)`. If already true, skip and fall through to pop.
3. `await ref.read(allergenServiceProvider).getAllergenStatuses(babyId)`. On `Result.failure` (i.e. `dataOrNull == null`), skip and fall through to pop — the success path must not be blocked on a stale status read (per the P3 read-failure convention).
4. On success: check that the returned `Map<String, AllergenStatus>` is non-empty and every value equals `AllergenStatus.safe`.
5. If all-safe AND flag unset: `await LocalFlagService.markProgramCompletionShown(babyId)`, guard `context.mounted`, then `context.goNamed(AppRoute.allergenComplete.name)` and return (no pop).
6. Otherwise pop as today via `context.pop(true)`.

Edit-mode submit follows the same gate so a user editing an old log that completes the program still sees AL-08 once.

## Local-flag key shape

`program_completion_shown_{babyId}` in the `local_flags` Hive box, scoped per baby, defaults to `false`. Matches the existing read API (`isProgramCompletionShown`) and the existing sync setter (`setProgramCompletionShown`) used by `allergen_complete_controller.dart`. This PR adds an awaitable variant `Future<void> markProgramCompletionShown(String babyId)` for the gate, so the flag flip is durable before navigation.

## Notes

- Re-enables AL-08 reachability without restoring auto-advance.
- NIB-102 fires its analytics events INDEPENDENTLY in the controller; AL-08 navigation happens after that on the screen side, so both paths coexist with zero overlap.
- No schema migration, no Supabase change.

## Acceptance criteria

- [x] `LocalFlagService.isProgramCompletionShown(String babyId)` returns `bool` from `program_completion_shown_{babyId}` key, defaults to `false` if absent (pre-existing, retained).
- [x] `LocalFlagService.markProgramCompletionShown(String babyId)` is `Future<void>` that sets that key to `true`.
- [x] `allergen_log_screen.dart` post-submit success path reads status map, gates on flag + all-safe, marks flag, routes to `/home/allergen/complete` exactly ONCE per baby per program-completion event. If the status read fails, falls through to the existing pop.
- [x] `flutter analyze`: 0 issues.
- [x] `flutter test`: 304 tests pass (no new tests this ticket — NIB-110 owns testing).
- [x] `make gen` clean + idempotent (this ticket adds no @riverpod/@freezed/@JsonSerializable).
- [x] No files outside the allowed list modified.

## Gate results

- `make gen`: clean, idempotent (only intended diff after second pass).
- `flutter analyze`: No issues found.
- `flutter test`: All 304 tests passed.