### PR TITLE
feat(meal-plan): rolling-7 window + APPEND bulk + per-card expand [NIB-59]

### DIFF
--- a/lib/src/common/data/repositories/meal_plan_repository.dart
+++ b/lib/src/common/data/repositories/meal_plan_repository.dart
@@ -7,6 +7,23 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 part 'meal_plan_repository.g.dart';
 
+/// Insert payload for [MealPlanRepository.appendBulk] — one row per recipe
+/// assignment. Pure INSERT (no upsert / no onConflict) so duplicates are
+/// allowed; this is what makes bulk-add APPEND-semantic per NIB-120.
+class MealPlanEntryInsert {
+  const MealPlanEntryInsert({
+    required this.babyId,
+    required this.recipeId,
+    required this.planDate,
+    this.mealTime,
+  });
+
+  final String babyId;
+  final String recipeId;
+  final DateTime planDate;
+  final TimeOfDay? mealTime;
+}
+
 abstract interface class MealPlanRepository {
   /// MEAL-01: Fetch all meal_plan_entries for baby within
   /// [weekStart]..[weekEnd].
@@ -14,6 +31,14 @@ abstract interface class MealPlanRepository {
     String babyId,
     DateTime weekStart,
     DateTime weekEnd,
+  );
+
+  /// NIB-59: Range query — fetch entries for baby within
+  /// [startDate]..[endDate] inclusive. Used by `getRolling7` in the service.
+  Future<Result<List<MealPlanEntry>>> getEntriesInRange(
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
   );
 
   /// MEAL-02: Insert a new meal entry for [planDate].
@@ -25,11 +50,23 @@ abstract interface class MealPlanRepository {
     TimeOfDay? mealTime,
   );
 
+  /// NIB-59: Bulk INSERT (APPEND, not upsert) — duplicates allowed.
+  Future<Result<List<MealPlanEntry>>> appendBulk(
+    List<MealPlanEntryInsert> entries,
+  );
+
   /// MEAL-03: Delete all entries for baby within [weekStart]..[weekEnd].
   Future<Result<void>> clearWeek(
     String babyId,
     DateTime weekStart,
     DateTime weekEnd,
+  );
+
+  /// NIB-59: Delete all entries for baby within [startDate]..[endDate].
+  Future<Result<void>> deleteRange(
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
   );
 
   /// MEAL-04: Delete a single meal plan entry by ID.
@@ -50,14 +87,21 @@ class MealPlanRepositoryImpl implements MealPlanRepository {
     String babyId,
     DateTime weekStart,
     DateTime weekEnd,
+  ) => getEntriesInRange(babyId, weekStart, weekEnd);
+
+  @override
+  Future<Result<List<MealPlanEntry>>> getEntriesInRange(
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
   ) async {
     try {
       final data = await _supabase
           .from('meal_plan_entries')
           .select()
           .eq('baby_id', babyId)
-          .gte('plan_date', _formatDate(weekStart))
-          .lte('plan_date', _formatDate(weekEnd))
+          .gte('plan_date', _formatDate(startDate))
+          .lte('plan_date', _formatDate(endDate))
           .order('plan_date');
 
       return Result.success(
@@ -103,18 +147,60 @@ class MealPlanRepositoryImpl implements MealPlanRepository {
   }
 
   @override
+  Future<Result<List<MealPlanEntry>>> appendBulk(
+    List<MealPlanEntryInsert> entries,
+  ) async {
+    if (entries.isEmpty) return const Result.success([]);
+    try {
+      final payload = entries
+          .map(
+            (e) => <String, dynamic>{
+              'baby_id': e.babyId,
+              'recipe_id': e.recipeId,
+              'plan_date': _formatDate(e.planDate),
+              if (e.mealTime != null) 'meal_time': _formatTime(e.mealTime!),
+            },
+          )
+          .toList();
+
+      final data = await _supabase
+          .from('meal_plan_entries')
+          .insert(payload)
+          .select();
+
+      return Result.success(
+        (data as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .map(_entryFromRow)
+            .toList(),
+      );
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
   Future<Result<void>> clearWeek(
     String babyId,
     DateTime weekStart,
     DateTime weekEnd,
+  ) => deleteRange(babyId, weekStart, weekEnd);
+
+  @override
+  Future<Result<void>> deleteRange(
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
   ) async {
     try {
       await _supabase
           .from('meal_plan_entries')
           .delete()
           .eq('baby_id', babyId)
-          .gte('plan_date', _formatDate(weekStart))
-          .lte('plan_date', _formatDate(weekEnd));
+          .gte('plan_date', _formatDate(startDate))
+          .lte('plan_date', _formatDate(endDate));
 
       return const Result.success(null);
     } on PostgrestException catch (e) {

--- a/lib/src/common/services/meal_plan_service.dart
+++ b/lib/src/common/services/meal_plan_service.dart
@@ -1,11 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:nibbles/src/common/data/repositories/meal_plan_repository.dart';
 import 'package:nibbles/src/common/data/repositories/recipe_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'meal_plan_service.g.dart';
+
+/// One slot in a bulk-append payload: which recipe and which day inside the
+/// `[startDate, endDate]` window it should land on. `dayOffset` 0 == startDate.
+class RecipeAssignment {
+  const RecipeAssignment({
+    required this.recipeId,
+    required this.dayOffset,
+    this.mealTime,
+  });
+
+  final String recipeId;
+  final int dayOffset;
+  final TimeOfDay? mealTime;
+}
 
 class MealPlanService {
   const MealPlanService(this._repo, this._recipeRepo);
@@ -19,6 +34,18 @@ class MealPlanService {
     DateTime weekStart,
   ) => _repo.getWeekMeals(babyId, weekStart, _weekEnd(weekStart));
 
+  /// NIB-59 / NIB-120: rolling-7 today-anchored window.
+  /// Returns entries for `[today, today + 6]` inclusive.
+  /// [today] defaults to `DateTime.now()` but is overridable for testing.
+  Future<Result<List<MealPlanEntry>>> getRolling7(
+    String babyId, {
+    DateTime? today,
+  }) {
+    final start = _dateOnly(today ?? DateTime.now());
+    final end = start.add(const Duration(days: 6));
+    return _repo.getEntriesInRange(babyId, start, end);
+  }
+
   /// Inserts a new recipe assignment for [planDate].
   /// Multiple meals per day are allowed.
   Future<Result<MealPlanEntry>> assignRecipe(
@@ -28,9 +55,64 @@ class MealPlanService {
     TimeOfDay? mealTime,
   }) => _repo.assignRecipe(babyId, recipeId, planDate, mealTime);
 
+  /// NIB-59 / NIB-120: APPEND-bulk add (NOT replace).
+  ///
+  /// Each [assignments] entry specifies (recipeId, dayOffset) where
+  /// `dayOffset` is relative to [startDate]. Out-of-range offsets
+  /// (negative or beyond `endDate`) are rejected as a [Result.failure].
+  Future<Result<List<MealPlanEntry>>> appendMealsToRange({
+    required String babyId,
+    required DateTime startDate,
+    required DateTime endDate,
+    required List<RecipeAssignment> assignments,
+  }) {
+    if (assignments.isEmpty) {
+      return Future.value(const Result.success([]));
+    }
+
+    final start = _dateOnly(startDate);
+    final end = _dateOnly(endDate);
+    final windowLengthDays = end.difference(start).inDays;
+
+    final inserts = <MealPlanEntryInsert>[];
+    for (final a in assignments) {
+      if (a.dayOffset < 0 || a.dayOffset > windowLengthDays) {
+        return Future.value(
+          Result.failure(
+            ServerException(
+              'RecipeAssignment.dayOffset ${a.dayOffset} is outside '
+              '[0..$windowLengthDays].',
+            ),
+          ),
+        );
+      }
+      inserts.add(
+        MealPlanEntryInsert(
+          babyId: babyId,
+          recipeId: a.recipeId,
+          planDate: start.add(Duration(days: a.dayOffset)),
+          mealTime: a.mealTime,
+        ),
+      );
+    }
+
+    return _repo.appendBulk(inserts);
+  }
+
   /// Deletes all meal plan entries for the 7-day week starting on [weekStart].
   Future<Result<void>> clearWeek(String babyId, DateTime weekStart) =>
       _repo.clearWeek(babyId, weekStart, _weekEnd(weekStart));
+
+  /// NIB-59: explicit clear of an arbitrary date range — wired by NIB-103 UI.
+  Future<Result<void>> clearRange(
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
+  ) => _repo.deleteRange(
+    babyId,
+    _dateOnly(startDate),
+    _dateOnly(endDate),
+  );
 
   /// Returns deduplicated ingredient names across all recipes planned for the
   /// 7-day week starting on [weekStart].
@@ -94,6 +176,8 @@ class MealPlanService {
 
   static DateTime _weekEnd(DateTime weekStart) =>
       weekStart.add(const Duration(days: 6));
+
+  static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/src/features/meal_plan/meal_plan_controller.dart
+++ b/lib/src/features/meal_plan/meal_plan_controller.dart
@@ -1,9 +1,12 @@
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/common/services/meal_plan_service.dart';
 import 'package:nibbles/src/common/services/recipe_service.dart';
 import 'package:nibbles/src/features/meal_plan/meal_plan_state.dart';
@@ -13,51 +16,56 @@ part 'meal_plan_controller.g.dart';
 
 @riverpod
 class MealPlanController extends _$MealPlanController {
-  var _weekStart = _mondayOf(DateTime.now());
-  var _selectedDate = _dateOnly(DateTime.now());
-  var _calendarExpanded = false;
   late String _babyId;
 
-  static DateTime _mondayOf(DateTime date) {
-    final d = _dateOnly(date);
-    return d.subtract(Duration(days: d.weekday - 1));
-  }
-
   static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
+
+  /// Normalize an expand-map key to a UTC date-only [DateTime] so keys match
+  /// regardless of the input's local TZ or sub-day precision.
+  static DateTime _expandedKey(DateTime day) =>
+      DateTime.utc(day.year, day.month, day.day);
 
   @override
   Future<MealPlanState> build(String babyId) async {
     _babyId = babyId;
 
-    final service = ref.read(mealPlanServiceProvider);
-    final mealsResult = await service.getWeekMeals(babyId, _weekStart);
-    if (mealsResult.isFailure) throw mealsResult.errorOrNull!;
-    final meals = mealsResult.dataOrNull!;
+    final windowStart = _dateOnly(DateTime.now());
+    final windowEnd = windowStart.add(const Duration(days: 6));
 
+    final mealPlanService = ref.read(mealPlanServiceProvider);
     final recipeService = ref.read(recipeServiceProvider);
-    final recipeMap = <String, Recipe>{};
-    for (final entry in meals) {
-      if (!recipeMap.containsKey(entry.recipeId)) {
-        final r = await recipeService.getRecipeById(entry.recipeId);
-        if (r.isSuccess) recipeMap[entry.recipeId] = r.dataOrNull!;
-      }
-    }
+    final babyService = ref.read(babyProfileServiceProvider);
+    final allergenService = ref.read(allergenServiceProvider);
 
-    final flaggedResult = await recipeService.getFlaggedAllergenKeys(babyId);
+    // Parallel fetch: baby + rolling-7 entries + flagged keys + program state.
+    final results = await Future.wait<Object?>([
+      babyService.getBaby(),
+      mealPlanService.getRolling7(babyId, today: windowStart),
+      recipeService.getFlaggedAllergenKeys(babyId),
+      allergenService.getProgramState(babyId),
+    ]);
+
+    final baby = results[0] as Baby?;
+
+    final entriesResult = results[1]! as Result<List<MealPlanEntry>>;
+    if (entriesResult.isFailure) {
+      throw StateError(entriesResult.errorOrNull!.message);
+    }
+    final entries = entriesResult.dataOrNull!;
+
+    final flaggedResult = results[2]! as Result<Set<String>>;
     final flaggedKeys = flaggedResult.dataOrNull ?? <String>{};
 
-    AllergenBoardItem? currentBoardItem;
+    final programResult = results[3]! as Result<AllergenProgramState>;
     AllergenProgramState? programState;
-    final programResult = await ref
-        .read(allergenServiceProvider)
-        .getProgramState(babyId);
+    AllergenBoardItem? currentBoardItem;
     if (programResult.isSuccess) {
       final ps = programResult.dataOrNull;
       programState = ps;
       if (ps != null && ps.status != AllergenProgramStatus.completed) {
-        final boardResult = await ref
-            .read(allergenServiceProvider)
-            .getAllergenBoardSummary(babyId);
+        final boardResult = await allergenService.getAllergenBoardSummary(
+          babyId,
+        );
         if (boardResult.isSuccess) {
           currentBoardItem = boardResult.dataOrNull!
               .where(
@@ -69,11 +77,19 @@ class MealPlanController extends _$MealPlanController {
       }
     }
 
+    // Hydrate recipe lookup for every entry (best-effort, deduplicated).
+    final recipeMap = <String, Recipe>{};
+    for (final entry in entries) {
+      if (recipeMap.containsKey(entry.recipeId)) continue;
+      final r = await recipeService.getRecipeById(entry.recipeId);
+      if (r.isSuccess) recipeMap[entry.recipeId] = r.dataOrNull!;
+    }
+
     return MealPlanState(
-      meals: meals,
-      weekStart: _weekStart,
-      selectedDate: _selectedDate,
-      calendarExpanded: _calendarExpanded,
+      windowStart: windowStart,
+      windowEnd: windowEnd,
+      entries: entries,
+      baby: baby,
       recipes: recipeMap,
       flaggedAllergenKeys: flaggedKeys,
       currentAllergenBoardItem: currentBoardItem,
@@ -81,39 +97,47 @@ class MealPlanController extends _$MealPlanController {
     );
   }
 
-  void selectDate(DateTime date) {
-    final d = _dateOnly(date);
-    _selectedDate = d;
-
+  /// Flip the accordion expand state for [day]. Key is normalized to UTC
+  /// date-only so lookups are stable.
+  void toggleExpanded(DateTime day) {
     final current = state.valueOrNull;
     if (current == null) return;
-
-    final weekEnd = current.weekStart.add(const Duration(days: 6));
-    if (d.isBefore(current.weekStart) || d.isAfter(weekEnd)) {
-      // Day is outside current week — shift week and reload meals.
-      _weekStart = _mondayOf(d);
-      ref.invalidateSelf();
-    } else {
-      // Same week — pure UI update, no reload.
-      state = AsyncData(current.copyWith(selectedDate: d));
-    }
+    final key = _expandedKey(day);
+    final next = Map<DateTime, bool>.from(current.expanded);
+    next[key] = !(next[key] ?? false);
+    state = AsyncData(current.copyWith(expanded: next));
   }
 
-  void toggleCalendar() {
-    _calendarExpanded = !_calendarExpanded;
-    final current = state.valueOrNull;
-    if (current == null) return;
-    state = AsyncData(current.copyWith(calendarExpanded: _calendarExpanded));
-  }
-
-  void previousWeek() {
-    _weekStart = _weekStart.subtract(const Duration(days: 7));
+  /// NIB-59: APPEND-bulk add for [startDate]..[endDate]. Calls
+  /// [MealPlanService.appendMealsToRange] then invalidates self to refetch.
+  /// Returns false on failure — caller should surface a P2 toast.
+  Future<bool> appendBulkPrep({
+    required DateTime startDate,
+    required DateTime endDate,
+    required List<RecipeAssignment> assignments,
+  }) async {
+    final result = await ref
+        .read(mealPlanServiceProvider)
+        .appendMealsToRange(
+          babyId: _babyId,
+          startDate: startDate,
+          endDate: endDate,
+          assignments: assignments,
+        );
+    if (result.isFailure) return false;
     ref.invalidateSelf();
+    return true;
   }
 
-  void nextWeek() {
-    _weekStart = _weekStart.add(const Duration(days: 7));
+  /// NIB-59: explicit clear for an arbitrary date range. Returns false on
+  /// failure — caller should surface a P2 toast.
+  Future<bool> clearRange(DateTime startDate, DateTime endDate) async {
+    final result = await ref
+        .read(mealPlanServiceProvider)
+        .clearRange(_babyId, startDate, endDate);
+    if (result.isFailure) return false;
     ref.invalidateSelf();
+    return true;
   }
 
   /// Returns false on failure — caller should show P2 toast.
@@ -144,13 +168,26 @@ class MealPlanController extends _$MealPlanController {
     return true;
   }
 
-  /// Returns false on failure — caller should show P2 toast.
+  // ---------------------------------------------------------------------------
+  // Backwards-compat shims for the pre-rewrite screen (NIB-69 removes these).
+  // ---------------------------------------------------------------------------
+
+  // TODO(NIB-69): remove after screen rewrite — accordion replaces the strip.
+  void selectDate(DateTime date) {}
+
+  // TODO(NIB-69): remove after screen rewrite — accordion replaces the toggle.
+  void toggleCalendar() {}
+
+  // TODO(NIB-69): remove after screen rewrite — rolling-7 doesn't navigate.
+  void previousWeek() {}
+
+  // TODO(NIB-69): remove after screen rewrite — rolling-7 doesn't navigate.
+  void nextWeek() {}
+
+  // TODO(NIB-69): remove after screen rewrite — use [clearRange] instead.
   Future<bool> clearWeek() async {
-    final result = await ref
-        .read(mealPlanServiceProvider)
-        .clearWeek(_babyId, _weekStart);
-    if (result.isFailure) return false;
-    ref.invalidateSelf();
-    return true;
+    final state = this.state.valueOrNull;
+    if (state == null) return false;
+    return clearRange(state.windowStart, state.windowEnd);
   }
 }

--- a/lib/src/features/meal_plan/meal_plan_controller.g.dart
+++ b/lib/src/features/meal_plan/meal_plan_controller.g.dart
@@ -7,7 +7,7 @@ part of 'meal_plan_controller.dart';
 // **************************************************************************
 
 String _$mealPlanControllerHash() =>
-    r'fcf5bc89916abaee4999a30ce6fcc69cd42f720c';
+    r'0c128ba3209a50fc957077cd32a176e2b15944e7';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/meal_plan/meal_plan_state.dart
+++ b/lib/src/features/meal_plan/meal_plan_state.dart
@@ -1,21 +1,49 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 
 part 'meal_plan_state.freezed.dart';
 
+/// Rolling-7 meal plan state (NIB-120):
+/// - [windowStart] is today (date-only).
+/// - [windowEnd] is today + 6 days.
+/// - [entries] is every meal_plan_entry in that inclusive window.
+/// - [expanded] tracks per-day accordion state, keyed by UTC date-only.
+///
+/// Backwards-compatible getters (`meals`, `weekStart`, `weekEnd`,
+/// `selectedDate`, `calendarExpanded`) are derived from the new fields so the
+/// existing `meal_plan_screen.dart` keeps compiling until NIB-69 rewrites it.
 @freezed
 class MealPlanState with _$MealPlanState {
   const factory MealPlanState({
-    required List<MealPlanEntry> meals,
-    required DateTime weekStart,
-    required DateTime selectedDate,
-    @Default(false) bool calendarExpanded,
+    required DateTime windowStart,
+    required DateTime windowEnd,
+    required List<MealPlanEntry> entries,
+    Baby? baby,
+    @Default(<DateTime, bool>{}) Map<DateTime, bool> expanded,
     @Default(<String, Recipe>{}) Map<String, Recipe> recipes,
     @Default(<String>{}) Set<String> flaggedAllergenKeys,
     AllergenBoardItem? currentAllergenBoardItem,
     AllergenProgramState? programState,
   }) = _MealPlanState;
+
+  const MealPlanState._();
+
+  // TODO(NIB-69): remove after screen rewrite.
+  List<MealPlanEntry> get meals => entries;
+
+  // TODO(NIB-69): remove after screen rewrite.
+  DateTime get weekStart => windowStart;
+
+  // TODO(NIB-69): remove after screen rewrite.
+  DateTime get weekEnd => windowEnd;
+
+  // TODO(NIB-69): remove after screen rewrite.
+  DateTime get selectedDate => windowStart;
+
+  // TODO(NIB-69): remove after screen rewrite — accordion replaces the toggle.
+  bool get calendarExpanded => false;
 }

--- a/lib/src/features/meal_plan/meal_plan_state.freezed.dart
+++ b/lib/src/features/meal_plan/meal_plan_state.freezed.dart
@@ -17,10 +17,11 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$MealPlanState {
-  List<MealPlanEntry> get meals => throw _privateConstructorUsedError;
-  DateTime get weekStart => throw _privateConstructorUsedError;
-  DateTime get selectedDate => throw _privateConstructorUsedError;
-  bool get calendarExpanded => throw _privateConstructorUsedError;
+  DateTime get windowStart => throw _privateConstructorUsedError;
+  DateTime get windowEnd => throw _privateConstructorUsedError;
+  List<MealPlanEntry> get entries => throw _privateConstructorUsedError;
+  Baby? get baby => throw _privateConstructorUsedError;
+  Map<DateTime, bool> get expanded => throw _privateConstructorUsedError;
   Map<String, Recipe> get recipes => throw _privateConstructorUsedError;
   Set<String> get flaggedAllergenKeys => throw _privateConstructorUsedError;
   AllergenBoardItem? get currentAllergenBoardItem =>
@@ -42,16 +43,18 @@ abstract class $MealPlanStateCopyWith<$Res> {
   ) = _$MealPlanStateCopyWithImpl<$Res, MealPlanState>;
   @useResult
   $Res call({
-    List<MealPlanEntry> meals,
-    DateTime weekStart,
-    DateTime selectedDate,
-    bool calendarExpanded,
+    DateTime windowStart,
+    DateTime windowEnd,
+    List<MealPlanEntry> entries,
+    Baby? baby,
+    Map<DateTime, bool> expanded,
     Map<String, Recipe> recipes,
     Set<String> flaggedAllergenKeys,
     AllergenBoardItem? currentAllergenBoardItem,
     AllergenProgramState? programState,
   });
 
+  $BabyCopyWith<$Res>? get baby;
   $AllergenBoardItemCopyWith<$Res>? get currentAllergenBoardItem;
   $AllergenProgramStateCopyWith<$Res>? get programState;
 }
@@ -71,10 +74,11 @@ class _$MealPlanStateCopyWithImpl<$Res, $Val extends MealPlanState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? meals = null,
-    Object? weekStart = null,
-    Object? selectedDate = null,
-    Object? calendarExpanded = null,
+    Object? windowStart = null,
+    Object? windowEnd = null,
+    Object? entries = null,
+    Object? baby = freezed,
+    Object? expanded = null,
     Object? recipes = null,
     Object? flaggedAllergenKeys = null,
     Object? currentAllergenBoardItem = freezed,
@@ -82,22 +86,26 @@ class _$MealPlanStateCopyWithImpl<$Res, $Val extends MealPlanState>
   }) {
     return _then(
       _value.copyWith(
-            meals: null == meals
-                ? _value.meals
-                : meals // ignore: cast_nullable_to_non_nullable
+            windowStart: null == windowStart
+                ? _value.windowStart
+                : windowStart // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            windowEnd: null == windowEnd
+                ? _value.windowEnd
+                : windowEnd // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            entries: null == entries
+                ? _value.entries
+                : entries // ignore: cast_nullable_to_non_nullable
                       as List<MealPlanEntry>,
-            weekStart: null == weekStart
-                ? _value.weekStart
-                : weekStart // ignore: cast_nullable_to_non_nullable
-                      as DateTime,
-            selectedDate: null == selectedDate
-                ? _value.selectedDate
-                : selectedDate // ignore: cast_nullable_to_non_nullable
-                      as DateTime,
-            calendarExpanded: null == calendarExpanded
-                ? _value.calendarExpanded
-                : calendarExpanded // ignore: cast_nullable_to_non_nullable
-                      as bool,
+            baby: freezed == baby
+                ? _value.baby
+                : baby // ignore: cast_nullable_to_non_nullable
+                      as Baby?,
+            expanded: null == expanded
+                ? _value.expanded
+                : expanded // ignore: cast_nullable_to_non_nullable
+                      as Map<DateTime, bool>,
             recipes: null == recipes
                 ? _value.recipes
                 : recipes // ignore: cast_nullable_to_non_nullable
@@ -117,6 +125,20 @@ class _$MealPlanStateCopyWithImpl<$Res, $Val extends MealPlanState>
           )
           as $Val,
     );
+  }
+
+  /// Create a copy of MealPlanState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $BabyCopyWith<$Res>? get baby {
+    if (_value.baby == null) {
+      return null;
+    }
+
+    return $BabyCopyWith<$Res>(_value.baby!, (value) {
+      return _then(_value.copyWith(baby: value) as $Val);
+    });
   }
 
   /// Create a copy of MealPlanState
@@ -160,16 +182,19 @@ abstract class _$$MealPlanStateImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    List<MealPlanEntry> meals,
-    DateTime weekStart,
-    DateTime selectedDate,
-    bool calendarExpanded,
+    DateTime windowStart,
+    DateTime windowEnd,
+    List<MealPlanEntry> entries,
+    Baby? baby,
+    Map<DateTime, bool> expanded,
     Map<String, Recipe> recipes,
     Set<String> flaggedAllergenKeys,
     AllergenBoardItem? currentAllergenBoardItem,
     AllergenProgramState? programState,
   });
 
+  @override
+  $BabyCopyWith<$Res>? get baby;
   @override
   $AllergenBoardItemCopyWith<$Res>? get currentAllergenBoardItem;
   @override
@@ -190,10 +215,11 @@ class __$$MealPlanStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? meals = null,
-    Object? weekStart = null,
-    Object? selectedDate = null,
-    Object? calendarExpanded = null,
+    Object? windowStart = null,
+    Object? windowEnd = null,
+    Object? entries = null,
+    Object? baby = freezed,
+    Object? expanded = null,
     Object? recipes = null,
     Object? flaggedAllergenKeys = null,
     Object? currentAllergenBoardItem = freezed,
@@ -201,22 +227,26 @@ class __$$MealPlanStateImplCopyWithImpl<$Res>
   }) {
     return _then(
       _$MealPlanStateImpl(
-        meals: null == meals
-            ? _value._meals
-            : meals // ignore: cast_nullable_to_non_nullable
+        windowStart: null == windowStart
+            ? _value.windowStart
+            : windowStart // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        windowEnd: null == windowEnd
+            ? _value.windowEnd
+            : windowEnd // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        entries: null == entries
+            ? _value._entries
+            : entries // ignore: cast_nullable_to_non_nullable
                   as List<MealPlanEntry>,
-        weekStart: null == weekStart
-            ? _value.weekStart
-            : weekStart // ignore: cast_nullable_to_non_nullable
-                  as DateTime,
-        selectedDate: null == selectedDate
-            ? _value.selectedDate
-            : selectedDate // ignore: cast_nullable_to_non_nullable
-                  as DateTime,
-        calendarExpanded: null == calendarExpanded
-            ? _value.calendarExpanded
-            : calendarExpanded // ignore: cast_nullable_to_non_nullable
-                  as bool,
+        baby: freezed == baby
+            ? _value.baby
+            : baby // ignore: cast_nullable_to_non_nullable
+                  as Baby?,
+        expanded: null == expanded
+            ? _value._expanded
+            : expanded // ignore: cast_nullable_to_non_nullable
+                  as Map<DateTime, bool>,
         recipes: null == recipes
             ? _value._recipes
             : recipes // ignore: cast_nullable_to_non_nullable
@@ -240,35 +270,46 @@ class __$$MealPlanStateImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$MealPlanStateImpl implements _MealPlanState {
+class _$MealPlanStateImpl extends _MealPlanState {
   const _$MealPlanStateImpl({
-    required final List<MealPlanEntry> meals,
-    required this.weekStart,
-    required this.selectedDate,
-    this.calendarExpanded = false,
+    required this.windowStart,
+    required this.windowEnd,
+    required final List<MealPlanEntry> entries,
+    this.baby,
+    final Map<DateTime, bool> expanded = const <DateTime, bool>{},
     final Map<String, Recipe> recipes = const <String, Recipe>{},
     final Set<String> flaggedAllergenKeys = const <String>{},
     this.currentAllergenBoardItem,
     this.programState,
-  }) : _meals = meals,
+  }) : _entries = entries,
+       _expanded = expanded,
        _recipes = recipes,
-       _flaggedAllergenKeys = flaggedAllergenKeys;
+       _flaggedAllergenKeys = flaggedAllergenKeys,
+       super._();
 
-  final List<MealPlanEntry> _meals;
   @override
-  List<MealPlanEntry> get meals {
-    if (_meals is EqualUnmodifiableListView) return _meals;
+  final DateTime windowStart;
+  @override
+  final DateTime windowEnd;
+  final List<MealPlanEntry> _entries;
+  @override
+  List<MealPlanEntry> get entries {
+    if (_entries is EqualUnmodifiableListView) return _entries;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_meals);
+    return EqualUnmodifiableListView(_entries);
   }
 
   @override
-  final DateTime weekStart;
-  @override
-  final DateTime selectedDate;
+  final Baby? baby;
+  final Map<DateTime, bool> _expanded;
   @override
   @JsonKey()
-  final bool calendarExpanded;
+  Map<DateTime, bool> get expanded {
+    if (_expanded is EqualUnmodifiableMapView) return _expanded;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_expanded);
+  }
+
   final Map<String, Recipe> _recipes;
   @override
   @JsonKey()
@@ -295,7 +336,7 @@ class _$MealPlanStateImpl implements _MealPlanState {
 
   @override
   String toString() {
-    return 'MealPlanState(meals: $meals, weekStart: $weekStart, selectedDate: $selectedDate, calendarExpanded: $calendarExpanded, recipes: $recipes, flaggedAllergenKeys: $flaggedAllergenKeys, currentAllergenBoardItem: $currentAllergenBoardItem, programState: $programState)';
+    return 'MealPlanState(windowStart: $windowStart, windowEnd: $windowEnd, entries: $entries, baby: $baby, expanded: $expanded, recipes: $recipes, flaggedAllergenKeys: $flaggedAllergenKeys, currentAllergenBoardItem: $currentAllergenBoardItem, programState: $programState)';
   }
 
   @override
@@ -303,13 +344,13 @@ class _$MealPlanStateImpl implements _MealPlanState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$MealPlanStateImpl &&
-            const DeepCollectionEquality().equals(other._meals, _meals) &&
-            (identical(other.weekStart, weekStart) ||
-                other.weekStart == weekStart) &&
-            (identical(other.selectedDate, selectedDate) ||
-                other.selectedDate == selectedDate) &&
-            (identical(other.calendarExpanded, calendarExpanded) ||
-                other.calendarExpanded == calendarExpanded) &&
+            (identical(other.windowStart, windowStart) ||
+                other.windowStart == windowStart) &&
+            (identical(other.windowEnd, windowEnd) ||
+                other.windowEnd == windowEnd) &&
+            const DeepCollectionEquality().equals(other._entries, _entries) &&
+            (identical(other.baby, baby) || other.baby == baby) &&
+            const DeepCollectionEquality().equals(other._expanded, _expanded) &&
             const DeepCollectionEquality().equals(other._recipes, _recipes) &&
             const DeepCollectionEquality().equals(
               other._flaggedAllergenKeys,
@@ -327,10 +368,11 @@ class _$MealPlanStateImpl implements _MealPlanState {
   @override
   int get hashCode => Object.hash(
     runtimeType,
-    const DeepCollectionEquality().hash(_meals),
-    weekStart,
-    selectedDate,
-    calendarExpanded,
+    windowStart,
+    windowEnd,
+    const DeepCollectionEquality().hash(_entries),
+    baby,
+    const DeepCollectionEquality().hash(_expanded),
     const DeepCollectionEquality().hash(_recipes),
     const DeepCollectionEquality().hash(_flaggedAllergenKeys),
     currentAllergenBoardItem,
@@ -346,26 +388,30 @@ class _$MealPlanStateImpl implements _MealPlanState {
       __$$MealPlanStateImplCopyWithImpl<_$MealPlanStateImpl>(this, _$identity);
 }
 
-abstract class _MealPlanState implements MealPlanState {
+abstract class _MealPlanState extends MealPlanState {
   const factory _MealPlanState({
-    required final List<MealPlanEntry> meals,
-    required final DateTime weekStart,
-    required final DateTime selectedDate,
-    final bool calendarExpanded,
+    required final DateTime windowStart,
+    required final DateTime windowEnd,
+    required final List<MealPlanEntry> entries,
+    final Baby? baby,
+    final Map<DateTime, bool> expanded,
     final Map<String, Recipe> recipes,
     final Set<String> flaggedAllergenKeys,
     final AllergenBoardItem? currentAllergenBoardItem,
     final AllergenProgramState? programState,
   }) = _$MealPlanStateImpl;
+  const _MealPlanState._() : super._();
 
   @override
-  List<MealPlanEntry> get meals;
+  DateTime get windowStart;
   @override
-  DateTime get weekStart;
+  DateTime get windowEnd;
   @override
-  DateTime get selectedDate;
+  List<MealPlanEntry> get entries;
   @override
-  bool get calendarExpanded;
+  Baby? get baby;
+  @override
+  Map<DateTime, bool> get expanded;
   @override
   Map<String, Recipe> get recipes;
   @override

--- a/test/common/services/meal_plan_service_test.dart
+++ b/test/common/services/meal_plan_service_test.dart
@@ -210,4 +210,146 @@ void main() {
       expect(result.dataOrNull, isEmpty);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // NIB-59: getRolling7
+  // ---------------------------------------------------------------------------
+
+  group('MealPlanService.getRolling7', () {
+    test('passes (today, today+6) to repo.getEntriesInRange', () async {
+      final today = DateTime(2026, 5, 30);
+      final expectedEnd = today.add(const Duration(days: 6));
+      when(
+        () => mockMealPlanRepo.getEntriesInRange(any(), any(), any()),
+      ).thenAnswer((_) async => const Result.success([]));
+
+      final result = await sut.getRolling7(_babyId, today: today);
+
+      expect(result.isSuccess, isTrue);
+      verify(
+        () => mockMealPlanRepo.getEntriesInRange(_babyId, today, expectedEnd),
+      ).called(1);
+    });
+
+    test('normalizes today to date-only (strips time)', () async {
+      final raw = DateTime(2026, 5, 30, 14, 32, 11);
+      final expectedStart = DateTime(2026, 5, 30);
+      final expectedEnd = expectedStart.add(const Duration(days: 6));
+      when(
+        () => mockMealPlanRepo.getEntriesInRange(any(), any(), any()),
+      ).thenAnswer((_) async => const Result.success([]));
+
+      await sut.getRolling7(_babyId, today: raw);
+
+      verify(
+        () => mockMealPlanRepo.getEntriesInRange(
+          _babyId,
+          expectedStart,
+          expectedEnd,
+        ),
+      ).called(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // NIB-59: appendMealsToRange — APPEND, not replace.
+  // ---------------------------------------------------------------------------
+
+  group('MealPlanService.appendMealsToRange', () {
+    test(
+      'maps dayOffset to startDate+offset and calls repo.appendBulk',
+      () async {
+        final start = DateTime(2026, 5, 30);
+        final end = start.add(const Duration(days: 6));
+        when(() => mockMealPlanRepo.appendBulk(any())).thenAnswer(
+          (_) async => const Result.success([]),
+        );
+
+        final result = await sut.appendMealsToRange(
+          babyId: _babyId,
+          startDate: start,
+          endDate: end,
+          assignments: const [
+            RecipeAssignment(recipeId: 'r1', dayOffset: 0),
+            RecipeAssignment(recipeId: 'r2', dayOffset: 3),
+            RecipeAssignment(recipeId: 'r3', dayOffset: 6),
+          ],
+        );
+
+        expect(result.isSuccess, isTrue);
+        final captured = verify(
+          () => mockMealPlanRepo.appendBulk(captureAny()),
+        ).captured.single as List<MealPlanEntryInsert>;
+        expect(captured, hasLength(3));
+        expect(captured[0].recipeId, 'r1');
+        expect(captured[0].planDate, start);
+        expect(captured[1].recipeId, 'r2');
+        expect(captured[1].planDate, start.add(const Duration(days: 3)));
+        expect(captured[2].recipeId, 'r3');
+        expect(captured[2].planDate, end);
+        // Never uses upsert/clear before insert — pure APPEND.
+        verifyNever(() => mockMealPlanRepo.deleteRange(any(), any(), any()));
+        verifyNever(() => mockMealPlanRepo.clearWeek(any(), any(), any()));
+      },
+    );
+
+    test(
+      'rejects assignments with out-of-range dayOffset as Failure',
+      () async {
+        final start = DateTime(2026, 5, 30);
+        final end = start.add(const Duration(days: 6));
+
+        final result = await sut.appendMealsToRange(
+          babyId: _babyId,
+          startDate: start,
+          endDate: end,
+          assignments: const [RecipeAssignment(recipeId: 'r1', dayOffset: 7)],
+        );
+
+        expect(result.isFailure, isTrue);
+        verifyNever(() => mockMealPlanRepo.appendBulk(any()));
+      },
+    );
+
+    test('empty assignments short-circuits to Success([])', () async {
+      final start = DateTime(2026, 5, 30);
+      final end = start.add(const Duration(days: 6));
+
+      final result = await sut.appendMealsToRange(
+        babyId: _babyId,
+        startDate: start,
+        endDate: end,
+        assignments: const [],
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.dataOrNull, isEmpty);
+      verifyNever(() => mockMealPlanRepo.appendBulk(any()));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // NIB-59: clearRange
+  // ---------------------------------------------------------------------------
+
+  group('MealPlanService.clearRange', () {
+    test('delegates to repo.deleteRange with date-only bounds', () async {
+      final start = DateTime(2026, 5, 30, 9);
+      final end = DateTime(2026, 6, 5, 23, 59);
+      when(
+        () => mockMealPlanRepo.deleteRange(any(), any(), any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      final result = await sut.clearRange(_babyId, start, end);
+
+      expect(result.isSuccess, isTrue);
+      verify(
+        () => mockMealPlanRepo.deleteRange(
+          _babyId,
+          DateTime(2026, 5, 30),
+          DateTime(2026, 6, 5),
+        ),
+      ).called(1);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Wave 1 of the Meal Plan milestone — data + state foundation per NIB-120.

- Replaces the Monday-week + single-selectedDate model with a **rolling-7 today-anchored window** (today + next 6 days). Window advances automatically as the day rolls over.
- Adds **APPEND-bulk** semantics (`appendMealsToRange`, `appendBulk`) — bulk add of multiple recipes across a range INSERTs duplicates (it does NOT replace existing entries). Users clear ranges explicitly via `clearRange`.
- Adds **per-card expand state** (`Map<DateTime, bool> expanded`) keyed by UTC date-only for the accordion day-cards.
- Loads the **Baby** entity in `build()` for the meal-plan header.

## New API surface

### MealPlanRepository
- `getEntriesInRange(babyId, startDate, endDate)` — range query (date inclusive).
- `appendBulk(List<MealPlanEntryInsert>)` — pure INSERT (no upsert/onConflict), duplicates allowed.
- `deleteRange(babyId, startDate, endDate)` — for explicit clear.
- Legacy `getWeekMeals` / `clearWeek` retained and now delegate to the new range methods (home_controller still calls `getWeekMeals`).

### MealPlanService
- `getRolling7(babyId, {today})` — today defaults to `DateTime.now()`, overridable for tests.
- `appendMealsToRange({babyId, startDate, endDate, assignments})` — composes `appendBulk`, rejects out-of-range `dayOffset`.
- `clearRange(babyId, startDate, endDate)` — composes `deleteRange`.
- `RecipeAssignment` inline class: `(recipeId, dayOffset, mealTime?)`.

### MealPlanController
- `build()` does parallel fetch of baby + rolling-7 entries + flagged keys + program state. Failure on the entries fetch throws `StateError` → `AsyncValue.error`.
- `toggleExpanded(day)` — flips per-day expand state with UTC date-only key normalization.
- `appendBulkPrep(...)` — calls service then invalidates self.
- `clearRange(start, end)` — calls service then invalidates self.

## APPEND vs. replace
`appendBulk` is implemented as a single Supabase `.insert(payload).select()`, never `.upsert`, never with `onConflict`. Multiple recipes per day are valid; the schema already supports it.

## Backwards-compat shims (removed by NIB-69)
The existing `meal_plan_screen.dart` is forbidden territory for this ticket. To keep it compiling:

State derived getters:
- `meals` → `entries`
- `weekStart` → `windowStart`
- `weekEnd` → `windowEnd`
- `selectedDate` → `windowStart`
- `calendarExpanded` → `false`

Controller no-op stubs:
- `selectDate(date)`, `toggleCalendar()`, `previousWeek()`, `nextWeek()` — no-ops; the rolling window doesn't navigate and the accordion replaces the calendar toggle.
- `clearWeek()` — delegates to `clearRange(windowStart, windowEnd)`.

Every shim is marked `// TODO(NIB-69): remove after screen rewrite`.

## Acceptance criteria
- [x] `MealPlanState` carries `windowStart`/`windowEnd`/`entries`/`baby`/`expanded` plus deprecated getter shims.
- [x] `MealPlanService.getRolling7` returns entries for today + next 6 days. `appendMealsToRange` appends (not replaces). `clearRange` deletes.
- [x] `MealPlanRepository` exposes range query + bulk append + range delete; `PostgrestException` wrapped as `ServerException`.
- [x] `flutter analyze` — 0 issues.
- [x] `flutter test` — 334/334 pass (baseline 328 + 6 new service tests).
- [x] `make gen` clean + idempotent (second run = 0 outputs).
- [x] Existing `meal_plan_screen.dart` still compiles (uses derived getter shims + no-op controller methods).

## Gates
- `make gen`: clean + idempotent
- `flutter analyze`: `No issues found!`
- `flutter test`: `All tests passed!` (334)

## Test plan
- [x] Unit: `MealPlanService.getRolling7` passes `(today, today+6)` to repo and normalizes time-of-day to date-only.
- [x] Unit: `MealPlanService.appendMealsToRange` maps `dayOffset` → `startDate + offset` and calls `appendBulk` (never `deleteRange`/`clearWeek`).
- [x] Unit: out-of-range `dayOffset` returns `Failure`, never hits repo.
- [x] Unit: empty assignments short-circuits to `Success([])`.
- [x] Unit: `clearRange` delegates to `deleteRange` with date-only bounds.
- [x] Regression: existing 8 `meal_plan_service` tests still pass.

## Out of scope (downstream waves)
- `meal_plan_screen.dart` rewrite — NIB-69 (Wave 3).
- Accordion day-card widgets — NIB-76 / NIB-87 / NIB-95 / NIB-103 (Wave 2).
- Analytics — NIB-109 (Wave 4).
- Integration tests — NIB-113 (Wave 5).