### PR TITLE
feat(meal-plan): DS clear-week confirm dialog leaf widget [NIB-103]

### DIFF
--- a/lib/src/features/meal_plan/widgets/clear_confirm_dialog.dart
+++ b/lib/src/features/meal_plan/widgets/clear_confirm_dialog.dart
@@ -13,6 +13,10 @@ import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 Future<bool?> showClearMealPlanConfirm(BuildContext context) {
   return showDialog<bool>(
     context: context,
+    // Spec NIB-103 build-rule 5 requires `barrierDismissible: true` to be
+    // passed explicitly even though it matches the default.
+    // ignore: avoid_redundant_argument_values
+    barrierDismissible: true,
     builder: (ctx) => const _ClearConfirmDialog(),
   );
 }

--- a/lib/src/features/meal_plan/widgets/clear_confirm_dialog.dart
+++ b/lib/src/features/meal_plan/widgets/clear_confirm_dialog.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+
+/// Shows the DS clear-week confirm dialog (Figma 971:8151).
+///
+/// Returns `true` if the user tapped Delete, `false` if Cancel, and `null`
+/// if dismissed via the barrier. Leaf widget — NIB-69 will swap the legacy
+/// Material `AlertDialog` call site in `meal_plan_screen.dart` over to this.
+Future<bool?> showClearMealPlanConfirm(BuildContext context) {
+  return showDialog<bool>(
+    context: context,
+    builder: (ctx) => const _ClearConfirmDialog(),
+  );
+}
+
+class _ClearConfirmDialog extends StatelessWidget {
+  const _ClearConfirmDialog();
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: AppColors.cream,
+      insetPadding: const EdgeInsets.symmetric(horizontal: AppSizes.lg),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSizes.lg,
+          AppSizes.lg,
+          AppSizes.lg,
+          AppSizes.lg,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Quatrefoil(size: AppSizes.avatarLg),
+            const SizedBox(height: AppSizes.md),
+            Text(
+              'Are you sure you want to delete?',
+              style: Theme.of(context).textTheme.titleMedium ??
+                  AppTypography.sectionTitle,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSizes.lg),
+            Row(
+              children: [
+                Expanded(
+                  child: AppPillButton(
+                    label: 'Cancel',
+                    variant: AppPillButtonVariant.ghost,
+                    onPressed: () => Navigator.pop(context, false),
+                  ),
+                ),
+                const SizedBox(width: AppSizes.sm),
+                Expanded(
+                  child: AppPillButton(
+                    label: 'Delete',
+                    variant: AppPillButtonVariant.destructive,
+                    onPressed: () => Navigator.pop(context, true),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Adds the DS centered confirm dialog used to replace the legacy Material `AlertDialog` for the clear-week / clear-day action on Meal Plan. Leaf widget only — NIB-69 will swap callers when the screen is rewritten.

## Public API
```dart
/// Returns true on Delete, false on Cancel, null on barrier dismiss.
Future<bool?> showClearMealPlanConfirm(BuildContext context);
```
Internally uses `showDialog<bool>` with `barrierDismissible: true`. Calls `Navigator.pop(context, true)` on Delete, `Navigator.pop(context, false)` on Cancel.

## Figma
- Clear flow: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8089
- Confirm dialog: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8151

## DS components consumed
- `Quatrefoil` (brand flower mark — reused as the in-dialog illustration, mirrors usage in onboarding/splash).
- `AppPillButton` (variants: `ghost` for Cancel, `destructive` for Delete).
- Tokens: `AppColors.cream`, `AppSizes.radiusLg`, `AppSizes.lg/md/sm`, `AppSizes.avatarLg`, `Theme.textTheme.titleMedium`.

## Files touched (allowed list only)
- `lib/src/features/meal_plan/widgets/clear_confirm_dialog.dart` (NEW)

No other files modified. `meal_plan_screen.dart`, controller/state, sibling widgets (empty state, inline calendar, recipe-select / shopping-list modals), sheets, map, routing, analytics — all untouched (owned by NIB-69 / 76 / 87 / 95).

## Call-site wiring
Intentionally NOT wired in this ticket. NIB-69 owns swapping the existing `_confirmClearDay` Material `AlertDialog` in `meal_plan_screen.dart` to call `showClearMealPlanConfirm`.

## Acceptance criteria
- [x] `clear_confirm_dialog.dart` exposes `showClearMealPlanConfirm(BuildContext)` returning `Future<bool?>`.
- [x] Centered cream card (radius lg = 16), Parkinsans titleMedium, flower mark, Cancel + Delete pills horizontally.
- [x] `flutter analyze` — `No issues found!`.
- [x] `flutter test` — `All tests passed!`.
- [x] `make gen` clean (no surprise diff on second run; unrelated home_controller.g.dart base drift reverted).
- [x] No files outside the allowed list modified.

## Gate results
- `make gen`: succeeded (281 outputs, idempotent on second run).
- `flutter analyze`: 0 issues.
- `flutter test`: all tests passed.

## Test plan
- [ ] After NIB-69 swaps the caller, visually verify dialog matches Figma 971:8151 on dev simulator (iOS + Android).
- [ ] Confirm `true` returned on Delete, `false` on Cancel, `null` on tap-outside.