### PR TITLE
feat(meal-plan): empty-state form + reusable inline calendar [NIB-76]

### DIFF
--- a/lib/src/app/themes/app_sizes.dart
+++ b/lib/src/app/themes/app_sizes.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 abstract final class AppSizes {
   // Spacing (8pt grid)
+  static const double sp2 = 2;
   static const double xs = 4;
   static const double sm = 8;
   static const double sp12 = 12;
@@ -42,6 +43,8 @@ abstract final class AppSizes {
   static const double inputHeight = 52;
   // Kit .field is 48px (inputHeight=52 is a deferred decision; do not mutate).
   static const double fieldHeight = 48;
+  // Kit .field horizontal padding (components-inputs.html .field spec: 0 14px).
+  static const double fieldPaddingH = 14;
   // Segmented control track height (controls/segmented preview).
   static const double segmentedHeight = 42;
   // Switch track / thumb (controls preview: 44x24 track, 20px thumb).

--- a/lib/src/app/themes/app_typography.dart
+++ b/lib/src/app/themes/app_typography.dart
@@ -149,6 +149,16 @@ abstract final class AppTypography {
     color: AppColors.text,
   );
 
+  // emptyStateTitle — components-empty-state.html .ttl spec:
+  // 700 16px/1.2 var(--font-display) color var(--fg-strong).
+  static const TextStyle emptyStateTitle = TextStyle(
+    fontFamily: FontFamily.parkinsans,
+    fontSize: 16,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+    color: AppColors.fgStrong,
+  );
+
   // caption — 12/400 h1.333. Figtree body helper.
   static final TextStyle caption = GoogleFonts.figtree(
     fontSize: 12,

--- a/lib/src/features/meal_plan/widgets/inline_calendar.dart
+++ b/lib/src/features/meal_plan/widgets/inline_calendar.dart
@@ -148,8 +148,7 @@ class _MonthHeader extends StatelessWidget {
           child: Center(
             child: Text(
               label,
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontSize: 16,
+              style: theme.textTheme.titleSmall?.copyWith(
                 color: AppColors.fgStrong,
               ),
             ),
@@ -302,7 +301,7 @@ class _DayPlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) =>
-      const SizedBox(height: AppSizes.xxl - AppSizes.sm);
+      const SizedBox(height: AppSizes.sp40);
 }
 
 class _DayCell extends StatelessWidget {
@@ -351,9 +350,9 @@ class _DayCell extends StatelessWidget {
       behavior: HitTestBehavior.opaque,
       onTap: onTap,
       child: Container(
-        height: AppSizes.xxl - AppSizes.sm,
+        height: AppSizes.sp40,
         alignment: Alignment.center,
-        margin: const EdgeInsets.symmetric(horizontal: 2),
+        margin: const EdgeInsets.symmetric(horizontal: AppSizes.sp2),
         decoration: BoxDecoration(
           color: bg,
           shape: BoxShape.circle,

--- a/lib/src/features/meal_plan/widgets/inline_calendar.dart
+++ b/lib/src/features/meal_plan/widgets/inline_calendar.dart
@@ -1,0 +1,366 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Reusable inline month-calendar picker that renders below the focused
+/// date field (replaces the OS picker). Fully controlled — the consumer
+/// owns `selectedDate` + `focusedMonth` and wires the callbacks.
+///
+/// Mirrors the meal-plan picker overlay (Figma 971:8198 / 971:8222 /
+/// 971:8246): month title row with chevrons, Sun..Sat header row, then a
+/// 6-row day grid with today highlighted and the selected day filled
+/// greenDeep. Days outside `minDate`/`maxDate` are dimmed and untappable.
+class InlineCalendar extends StatelessWidget {
+  const InlineCalendar({
+    required this.selectedDate,
+    required this.focusedMonth,
+    required this.onDaySelected,
+    required this.onMonthChanged,
+    this.minDate,
+    this.maxDate,
+    super.key,
+  });
+
+  /// Currently selected day. `null` renders no selection highlight.
+  final DateTime? selectedDate;
+
+  /// Month currently shown (only year + month matter).
+  final DateTime focusedMonth;
+
+  /// Fires when the user taps a tappable (in-range) day cell.
+  final ValueChanged<DateTime> onDaySelected;
+
+  /// Fires when the user taps a chevron — emits the new focused month
+  /// (normalised to day 1).
+  final ValueChanged<DateTime> onMonthChanged;
+
+  /// Optional lower bound (inclusive). Earlier days are dimmed + untappable.
+  final DateTime? minDate;
+
+  /// Optional upper bound (inclusive). Later days are dimmed + untappable.
+  final DateTime? maxDate;
+
+  static const List<String> _weekdayLabels = <String>[
+    'Sun',
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final monthLabel = _formatMonth(focusedMonth);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        border: Border.all(color: AppColors.borderSoft),
+        boxShadow: AppSizes.shadowCard,
+      ),
+      padding: const EdgeInsets.all(AppSizes.md),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _MonthHeader(
+            label: monthLabel,
+            onPrev: () => onMonthChanged(_addMonths(focusedMonth, -1)),
+            onNext: () => onMonthChanged(_addMonths(focusedMonth, 1)),
+          ),
+          const SizedBox(height: AppSizes.sp12),
+          Row(
+            children: [
+              for (final label in _weekdayLabels)
+                Expanded(
+                  child: Center(
+                    child: Text(
+                      label,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.fgFaint,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: AppSizes.sm),
+          _MonthGrid(
+            focusedMonth: focusedMonth,
+            selectedDate: selectedDate,
+            minDate: minDate,
+            maxDate: maxDate,
+            onDaySelected: onDaySelected,
+          ),
+        ],
+      ),
+    );
+  }
+
+  static DateTime _addMonths(DateTime base, int delta) =>
+      DateTime(base.year, base.month + delta);
+
+  static const List<String> _monthNames = <String>[
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+
+  static String _formatMonth(DateTime d) =>
+      '${_monthNames[d.month - 1]} ${d.year}';
+}
+
+class _MonthHeader extends StatelessWidget {
+  const _MonthHeader({
+    required this.label,
+    required this.onPrev,
+    required this.onNext,
+  });
+
+  final String label;
+  final VoidCallback onPrev;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        _ChevronButton(
+          icon: Icons.chevron_left_rounded,
+          onPressed: onPrev,
+          semanticLabel: 'Previous month',
+        ),
+        Expanded(
+          child: Center(
+            child: Text(
+              label,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontSize: 16,
+                color: AppColors.fgStrong,
+              ),
+            ),
+          ),
+        ),
+        _ChevronButton(
+          icon: Icons.chevron_right_rounded,
+          onPressed: onNext,
+          semanticLabel: 'Next month',
+        ),
+      ],
+    );
+  }
+}
+
+class _ChevronButton extends StatelessWidget {
+  const _ChevronButton({
+    required this.icon,
+    required this.onPressed,
+    required this.semanticLabel,
+  });
+
+  final IconData icon;
+  final VoidCallback onPressed;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.greenTint,
+      shape: const CircleBorder(),
+      child: InkWell(
+        onTap: onPressed,
+        customBorder: const CircleBorder(),
+        child: SizedBox(
+          width: AppSizes.roundButtonSm,
+          height: AppSizes.roundButtonSm,
+          child: Icon(
+            icon,
+            size: AppSizes.iconMd,
+            color: AppColors.greenDeep,
+            semanticLabel: semanticLabel,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MonthGrid extends StatelessWidget {
+  const _MonthGrid({
+    required this.focusedMonth,
+    required this.selectedDate,
+    required this.minDate,
+    required this.maxDate,
+    required this.onDaySelected,
+  });
+
+  final DateTime focusedMonth;
+  final DateTime? selectedDate;
+  final DateTime? minDate;
+  final DateTime? maxDate;
+  final ValueChanged<DateTime> onDaySelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final firstDay = DateTime(focusedMonth.year, focusedMonth.month);
+    // DateTime.weekday returns 1 (Mon) .. 7 (Sun). Sun-start grid → 0..6.
+    final leadingBlanks = firstDay.weekday % 7;
+    final daysInMonth =
+        DateTime(focusedMonth.year, focusedMonth.month + 1, 0).day;
+    final totalCells = leadingBlanks + daysInMonth;
+    final rows = (totalCells / 7).ceil();
+    final today = _dateOnly(DateTime.now());
+    final selected =
+        selectedDate == null ? null : _dateOnly(selectedDate!);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var row = 0; row < rows; row++)
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppSizes.xs),
+            child: Row(
+              children: [
+                for (var col = 0; col < 7; col++)
+                  Expanded(
+                    child: _buildCell(
+                      context: context,
+                      cellIndex: row * 7 + col,
+                      leadingBlanks: leadingBlanks,
+                      daysInMonth: daysInMonth,
+                      today: today,
+                      selected: selected,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildCell({
+    required BuildContext context,
+    required int cellIndex,
+    required int leadingBlanks,
+    required int daysInMonth,
+    required DateTime today,
+    required DateTime? selected,
+  }) {
+    final dayOffset = cellIndex - leadingBlanks;
+    if (dayOffset < 0 || dayOffset >= daysInMonth) {
+      return const _DayPlaceholder();
+    }
+    final day = DateTime(
+      focusedMonth.year,
+      focusedMonth.month,
+      dayOffset + 1,
+    );
+    final isToday = _sameDate(day, today);
+    final isSelected = selected != null && _sameDate(day, selected);
+    final isOutOfRange = _outOfRange(day);
+
+    return _DayCell(
+      day: day,
+      isToday: isToday,
+      isSelected: isSelected,
+      isOutOfRange: isOutOfRange,
+      onTap: isOutOfRange ? null : () => onDaySelected(day),
+    );
+  }
+
+  bool _outOfRange(DateTime day) {
+    final min = minDate;
+    final max = maxDate;
+    if (min != null && day.isBefore(_dateOnly(min))) return true;
+    if (max != null && day.isAfter(_dateOnly(max))) return true;
+    return false;
+  }
+
+  static DateTime _dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
+
+  static bool _sameDate(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+}
+
+class _DayPlaceholder extends StatelessWidget {
+  const _DayPlaceholder();
+
+  @override
+  Widget build(BuildContext context) =>
+      const SizedBox(height: AppSizes.xxl - AppSizes.sm);
+}
+
+class _DayCell extends StatelessWidget {
+  const _DayCell({
+    required this.day,
+    required this.isToday,
+    required this.isSelected,
+    required this.isOutOfRange,
+    required this.onTap,
+  });
+
+  final DateTime day;
+  final bool isToday;
+  final bool isSelected;
+  final bool isOutOfRange;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    Color bg;
+    Color fg;
+    BoxBorder? border;
+
+    if (isSelected) {
+      bg = AppColors.greenDeep;
+      fg = AppColors.butterSoft;
+      border = null;
+    } else if (isToday) {
+      bg = AppColors.butterSoft;
+      fg = AppColors.greenDeep;
+      border = Border.all(color: AppColors.green);
+    } else {
+      bg = Colors.transparent;
+      fg = isOutOfRange ? AppColors.fgFaint : AppColors.fgStrong;
+      border = null;
+    }
+
+    final style = theme.textTheme.bodyMedium?.copyWith(
+      fontWeight: FontWeight.w600,
+      color: fg,
+    );
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        height: AppSizes.xxl - AppSizes.sm,
+        alignment: Alignment.center,
+        margin: const EdgeInsets.symmetric(horizontal: 2),
+        decoration: BoxDecoration(
+          color: bg,
+          shape: BoxShape.circle,
+          border: border,
+        ),
+        child: Text('${day.day}', style: style),
+      ),
+    );
+  }
+}

--- a/lib/src/features/meal_plan/widgets/meal_plan_empty_state.dart
+++ b/lib/src/features/meal_plan/widgets/meal_plan_empty_state.dart
@@ -1,0 +1,299 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
+
+/// Meal Plan empty-state form. Renders a flower (Quatrefoil) illustration,
+/// a "Ready to start?" heading, two date fields (Start Date / End Date) and
+/// a "Create meal plan" CTA. Tapping a date field opens [InlineCalendar]
+/// below the field — the OS picker is never used.
+///
+/// State is local: which field is focused, the chosen start + end dates,
+/// and which inline calendar is currently expanded. When the CTA fires
+/// with a valid range (`start <= end`), [onCreateMealPlan] receives a
+/// [DateTimeRange].
+class MealPlanEmptyState extends StatefulWidget {
+  const MealPlanEmptyState({
+    required this.babyName,
+    required this.onCreateMealPlan,
+    super.key,
+  });
+
+  final String babyName;
+  final ValueChanged<DateTimeRange> onCreateMealPlan;
+
+  @override
+  State<MealPlanEmptyState> createState() => _MealPlanEmptyStateState();
+}
+
+enum _OpenField { none, start, end }
+
+class _MealPlanEmptyStateState extends State<MealPlanEmptyState> {
+  DateTime? _startDate;
+  DateTime? _endDate;
+  late DateTime _focusedMonth;
+  _OpenField _openField = _OpenField.none;
+
+  @override
+  void initState() {
+    super.initState();
+    final now = DateTime.now();
+    _focusedMonth = DateTime(now.year, now.month);
+  }
+
+  bool get _canSubmit =>
+      _startDate != null &&
+      _endDate != null &&
+      !_endDate!.isBefore(_startDate!);
+
+  String? get _rangeError {
+    if (_startDate != null &&
+        _endDate != null &&
+        _endDate!.isBefore(_startDate!)) {
+      return 'End date must be on or after start date.';
+    }
+    return null;
+  }
+
+  void _toggleField(_OpenField field, DateTime? current) {
+    setState(() {
+      if (_openField == field) {
+        _openField = _OpenField.none;
+      } else {
+        _openField = field;
+        final anchor = current ?? _startDate ?? DateTime.now();
+        _focusedMonth = DateTime(anchor.year, anchor.month);
+      }
+    });
+  }
+
+  void _onDaySelected(DateTime day) {
+    setState(() {
+      if (_openField == _OpenField.start) {
+        _startDate = day;
+        // Clear an end date that would now be invalid.
+        if (_endDate != null && _endDate!.isBefore(day)) {
+          _endDate = null;
+        }
+      } else if (_openField == _OpenField.end) {
+        _endDate = day;
+      }
+      _openField = _OpenField.none;
+    });
+  }
+
+  void _onMonthChanged(DateTime month) {
+    setState(() => _focusedMonth = month);
+  }
+
+  void _onSubmit() {
+    if (!_canSubmit) return;
+    widget.onCreateMealPlan(
+      DateTimeRange(start: _startDate!, end: _endDate!),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final rangeError = _rangeError;
+
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.pagePaddingH,
+          vertical: AppSizes.pagePaddingV,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const SizedBox(height: AppSizes.lg),
+            // TODO(NIB-69): swap stock Quatrefoil for the dedicated meal-plan
+            // flower illustration if/when Figma exports one.
+            const Center(child: Quatrefoil()),
+            const SizedBox(height: AppSizes.md),
+            Text(
+              'Ready to start?',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.displaySmall,
+            ),
+            const SizedBox(height: AppSizes.sm),
+            Text(
+              "Pick a start and end date to plan ${widget.babyName}'s meals.",
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: AppColors.fgMuted,
+              ),
+            ),
+            const SizedBox(height: AppSizes.xl),
+            _DateField(
+              label: 'Start Date',
+              value: _startDate,
+              hintText: 'Select start date',
+              isOpen: _openField == _OpenField.start,
+              onTap: () => _toggleField(_OpenField.start, _startDate),
+            ),
+            if (_openField == _OpenField.start) ...[
+              const SizedBox(height: AppSizes.sm),
+              InlineCalendar(
+                selectedDate: _startDate,
+                focusedMonth: _focusedMonth,
+                onDaySelected: _onDaySelected,
+                onMonthChanged: _onMonthChanged,
+              ),
+            ],
+            const SizedBox(height: AppSizes.md),
+            _DateField(
+              label: 'End Date',
+              value: _endDate,
+              hintText: 'Select end date',
+              isOpen: _openField == _OpenField.end,
+              onTap: () => _toggleField(_OpenField.end, _endDate),
+            ),
+            if (_openField == _OpenField.end) ...[
+              const SizedBox(height: AppSizes.sm),
+              InlineCalendar(
+                selectedDate: _endDate,
+                focusedMonth: _focusedMonth,
+                onDaySelected: _onDaySelected,
+                onMonthChanged: _onMonthChanged,
+                minDate: _startDate,
+              ),
+            ],
+            if (rangeError != null) ...[
+              const SizedBox(height: AppSizes.xs),
+              Text(
+                rangeError,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: AppColors.error,
+                ),
+              ),
+            ],
+            const SizedBox(height: AppSizes.xl),
+            AppPillButton(
+              label: 'Create meal plan',
+              onPressed: _canSubmit ? _onSubmit : null,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DateField extends StatelessWidget {
+  const _DateField({
+    required this.label,
+    required this.value,
+    required this.hintText,
+    required this.isOpen,
+    required this.onTap,
+  });
+
+  final String label;
+  final DateTime? value;
+  final String hintText;
+  final bool isOpen;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasValue = value != null;
+    final displayText = hasValue ? _formatDate(value!) : hintText;
+    final borderColor = isOpen ? AppColors.greenDeep : AppColors.borderSoft;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: AppColors.fgStrong,
+          ),
+        ),
+        const SizedBox(height: AppSizes.sm),
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 120),
+            height: AppSizes.fieldHeight,
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.md - 2,
+            ),
+            decoration: BoxDecoration(
+              color: isOpen ? AppColors.surface : AppColors.bgInput,
+              borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+              border: Border.all(
+                color: borderColor,
+                width: isOpen ? 2 : 1,
+              ),
+              boxShadow: isOpen
+                  ? [
+                      BoxShadow(
+                        color: AppColors.green.withValues(alpha: 0.18),
+                        spreadRadius: 3,
+                      ),
+                    ]
+                  : null,
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    displayText,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: hasValue
+                          ? AppColors.fgStrong
+                          : AppColors.greenSoft,
+                    ),
+                  ),
+                ),
+                const Icon(
+                  Icons.calendar_today_outlined,
+                  size: AppSizes.iconSm,
+                  color: AppColors.greenDeep,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  static const List<String> _weekdayShort = <String>[
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat',
+    'Sun',
+  ];
+
+  static const List<String> _monthShort = <String>[
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+
+  String _formatDate(DateTime d) {
+    final dow = _weekdayShort[d.weekday - 1];
+    final mon = _monthShort[d.month - 1];
+    return '$dow, ${d.day} $mon ${d.year}';
+  }
+}

--- a/lib/src/features/meal_plan/widgets/meal_plan_empty_state.dart
+++ b/lib/src/features/meal_plan/widgets/meal_plan_empty_state.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
@@ -114,17 +115,17 @@ class _MealPlanEmptyStateState extends State<MealPlanEmptyState> {
             // flower illustration if/when Figma exports one.
             const Center(child: Quatrefoil()),
             const SizedBox(height: AppSizes.md),
-            Text(
+            const Text(
               'Ready to start?',
               textAlign: TextAlign.center,
-              style: theme.textTheme.displaySmall,
+              style: AppTypography.emptyStateTitle,
             ),
             const SizedBox(height: AppSizes.sm),
             Text(
               "Pick a start and end date to plan ${widget.babyName}'s meals.",
               textAlign: TextAlign.center,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: AppColors.fgMuted,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: AppColors.fgFaint,
               ),
             ),
             const SizedBox(height: AppSizes.xl),
@@ -210,7 +211,7 @@ class _DateField extends StatelessWidget {
       children: [
         Text(
           label,
-          style: theme.textTheme.bodyMedium?.copyWith(
+          style: theme.textTheme.labelMedium?.copyWith(
             fontWeight: FontWeight.w700,
             color: AppColors.fgStrong,
           ),
@@ -223,7 +224,7 @@ class _DateField extends StatelessWidget {
             duration: const Duration(milliseconds: 120),
             height: AppSizes.fieldHeight,
             padding: const EdgeInsets.symmetric(
-              horizontal: AppSizes.md - 2,
+              horizontal: AppSizes.fieldPaddingH,
             ),
             decoration: BoxDecoration(
               color: isOpen ? AppColors.surface : AppColors.bgInput,
@@ -235,7 +236,7 @@ class _DateField extends StatelessWidget {
               boxShadow: isOpen
                   ? [
                       BoxShadow(
-                        color: AppColors.green.withValues(alpha: 0.18),
+                        color: AppColors.green.withValues(alpha: 0.15),
                         spreadRadius: 3,
                       ),
                     ]


### PR DESCRIPTION
## Summary

Builds two new leaf widgets for the Meal Plan redesign. NIB-69 (screen rewrite) will consume both — this PR only adds the widgets.

### `MealPlanEmptyState` (`lib/src/features/meal_plan/widgets/meal_plan_empty_state.dart`)

Public API:

```dart
MealPlanEmptyState({
  required String babyName,
  required ValueChanged<DateTimeRange> onCreateMealPlan,
})
```

- Stateful. Holds local start + end + which inline calendar is expanded.
- Renders Quatrefoil illustration, title, subtitle, two date fields, CTA pill.
- Tapping a date field toggles an `InlineCalendar` below it (no OS picker).
- CTA disabled until both dates are set AND `start <= end`; inline helper text on invalid range.
- End-date calendar receives `minDate = start`, so out-of-range days are dimmed + untappable.

### `InlineCalendar` (`lib/src/features/meal_plan/widgets/inline_calendar.dart`)

Public API:

```dart
InlineCalendar({
  required DateTime? selectedDate,
  required DateTime focusedMonth,
  required ValueChanged<DateTime> onDaySelected,
  required ValueChanged<DateTime> onMonthChanged,
  DateTime? minDate,
  DateTime? maxDate,
})
```

- Stateless / fully controlled.
- Month title row + chevrons, Sun..Sat header row, 6-row day grid.
- Today highlighted (butterSoft fill + green border); selected highlighted (greenDeep fill, butterSoft text).
- Out-of-range days dimmed (`fgFaint`) and tap is suppressed.
- Pure UI — consumer wires the callbacks.

## Figma frames

- Empty state: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8175
- Form: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8547
- Picker overlay: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8198
- Picker states: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8222 + 971-8246

## Design system components consumed

- `Quatrefoil` (`common/components/brand/quatrefoil.dart`) — flower illustration. TODO(NIB-69): swap for the dedicated meal-plan illustration if/when Figma exports one.
- `AppPillButton` (`common/components/buttons/app_pill_button.dart`) — Create-meal-plan CTA.
- Tokens: `AppColors`, `AppSizes`, `theme.textTheme` only. No hardcoded hex, no Nunito, no `Color(0xff…)`.

## Acceptance checklist

- [x] Both widget files exist with the exact public API from build rule #5.
- [x] `MealPlanEmptyState` renders the form + flower illustration (Quatrefoil stand-in, TODO note added inline).
- [x] `InlineCalendar` is a fully controlled month grid (Sun..Sat header), today highlighted, selected highlighted, day taps fire `onDaySelected`, chevrons fire `onMonthChanged`.
- [x] Only the two whitelisted files touched — no screen / controller / state / sheets / map / routing / analytics / common-components edits.
- [x] `flutter analyze` — `No issues found!`
- [x] `flutter test` — `All tests passed!` (334 / 334).
- [x] `make gen` clean and idempotent (no codegen in these files; second run produces no diff).

## Gate results

- `make gen` — succeeded after 8.9s, second run idempotent (only the two new files in `git status`).
- `flutter analyze` — `No issues found! (ran in 2.6s)`.
- `flutter test` — `All tests passed!` (334 tests).