### PR TITLE
feat(meal-plan): multi-select Browse Meal sheet w/ recommendations + search [NIB-87]

### DIFF
--- a/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
+++ b/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
@@ -489,7 +489,7 @@ class _StickyAddBar extends StatelessWidget {
             backgroundColor: AppColors.primary,
             foregroundColor: AppColors.onPrimary,
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+              borderRadius: BorderRadius.circular(AppSizes.radiusFull),
             ),
           ),
           child: Text(

--- a/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
+++ b/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nibbles/src/app/constants/allergen_emoji.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
@@ -494,9 +495,8 @@ class _StickyAddBar extends StatelessWidget {
           ),
           child: Text(
             'Add ($count)',
-            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+            style: AppTypography.button.copyWith(
               color: AppColors.onPrimary,
-              fontWeight: FontWeight.w700,
             ),
           ),
         ),

--- a/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
+++ b/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
@@ -1,0 +1,506 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nibbles/src/app/constants/allergen_emoji.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/helpers/derive_allergen_status.dart';
+import 'package:nibbles/src/common/services/recipe_service.dart';
+import 'package:nibbles/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart';
+import 'package:nibbles/src/features/meal_plan/sheets/widgets/recommendation_carousel_section.dart';
+
+/// Bottom sheet shown via [showModalBottomSheet]. Returns the picked recipes
+/// or null on cancel. Multi-select Browse Meal sheet for the meal-plan
+/// mapper flow (NIB-87).
+///
+/// Surfaces:
+///   * "Recommendation for {ongoing allergen}" carousel — only when an
+///     `AllergenStatus.inProgress` allergen exists per
+///     [AllergenService.getAllergenStatuses].
+///   * Tag-derived carousels — grouped by allergen tag on the loaded recipes.
+///   * Searchable master list with selected / unselected counters.
+///   * Sticky "Add (N)" CTA returning the picked [Recipe] list.
+///
+/// Flagged-allergen recipes (those tagged with any key returned by
+/// [RecipeService.getFlaggedAllergenKeys]) are rendered visually disabled
+/// and are non-interactive in every surface.
+Future<List<Recipe>?> showBrowseMealSheet(
+  BuildContext context, {
+  required String babyId,
+  required DateTime startDate,
+  required DateTime endDate,
+}) {
+  return showModalBottomSheet<List<Recipe>>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppSizes.radiusLg),
+      ),
+    ),
+    builder: (_) => _BrowseMealSheet(
+      babyId: babyId,
+      startDate: startDate,
+      endDate: endDate,
+    ),
+  );
+}
+
+class _BrowseMealSheet extends ConsumerStatefulWidget {
+  const _BrowseMealSheet({
+    required this.babyId,
+    required this.startDate,
+    required this.endDate,
+  });
+
+  final String babyId;
+  final DateTime startDate;
+  final DateTime endDate;
+
+  @override
+  ConsumerState<_BrowseMealSheet> createState() => _BrowseMealSheetState();
+}
+
+class _BrowseMealSheetState extends ConsumerState<_BrowseMealSheet> {
+  final TextEditingController _searchController = TextEditingController();
+  final Set<String> _selectedRecipeIds = {};
+
+  List<Recipe>? _recipes;
+  Set<String> _flaggedKeys = {};
+  String? _ongoingAllergenKey;
+  String _query = '';
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    final recipeService = ref.read(recipeServiceProvider);
+    final allergenService = ref.read(allergenServiceProvider);
+
+    final recipesResult = await recipeService.getAllRecipes(widget.babyId);
+    final flaggedResult = await recipeService.getFlaggedAllergenKeys(
+      widget.babyId,
+    );
+    final statusesResult = await allergenService.getAllergenStatuses(
+      widget.babyId,
+    );
+
+    if (!mounted) return;
+
+    if (recipesResult.isFailure ||
+        flaggedResult.isFailure ||
+        statusesResult.isFailure) {
+      setState(() {
+        _error = "Couldn't load recipes.";
+        _loading = false;
+      });
+      return;
+    }
+
+    final statuses = statusesResult.dataOrNull ?? const {};
+    // First kAllergenKeys-order key whose status is inProgress.
+    String? ongoing;
+    for (final key in kAllergenKeys) {
+      if (statuses[key] == AllergenStatus.inProgress) {
+        ongoing = key;
+        break;
+      }
+    }
+
+    setState(() {
+      _recipes = recipesResult.dataOrNull;
+      _flaggedKeys = flaggedResult.dataOrNull ?? {};
+      _ongoingAllergenKey = ongoing;
+      _loading = false;
+    });
+  }
+
+  bool _isUnsafe(Recipe r) => r.allergenTags.any(_flaggedKeys.contains);
+
+  List<String> _flaggedTagsFor(Recipe r) =>
+      r.allergenTags.where(_flaggedKeys.contains).toList();
+
+  void _toggleRecipe(Recipe r) {
+    if (_isUnsafe(r)) return;
+    setState(() {
+      if (_selectedRecipeIds.contains(r.id)) {
+        _selectedRecipeIds.remove(r.id);
+      } else {
+        _selectedRecipeIds.add(r.id);
+      }
+    });
+  }
+
+  void _confirm() {
+    final all = _recipes ?? const <Recipe>[];
+    final byId = {for (final r in all) r.id: r};
+    final picked = _selectedRecipeIds
+        .map((id) => byId[id])
+        .whereType<Recipe>()
+        .toList();
+    Navigator.of(context).pop(picked);
+  }
+
+  List<Recipe> get _searchResults {
+    final all = _recipes ?? const <Recipe>[];
+    if (_query.isEmpty) return all;
+    final q = _query.toLowerCase();
+    return all.where((r) => r.title.toLowerCase().contains(q)).toList();
+  }
+
+  List<Recipe> _recommendationsFor(String allergenKey) {
+    final all = _recipes ?? const <Recipe>[];
+    return all
+        .where((r) => r.allergenTags.contains(allergenKey))
+        .toList(growable: false);
+  }
+
+  /// Tag-derived groups: one carousel per allergen key present in the loaded
+  /// recipes, ordered by [kAllergenKeys], excluding the ongoing-allergen key
+  /// (already surfaced) and any flagged keys.
+  List<MapEntry<String, List<Recipe>>> _tagGroups() {
+    final all = _recipes ?? const <Recipe>[];
+    if (all.isEmpty) return const [];
+    final groups = <String, List<Recipe>>{};
+    for (final key in kAllergenKeys) {
+      if (key == _ongoingAllergenKey) continue;
+      if (_flaggedKeys.contains(key)) continue;
+      final list = all
+          .where((r) => r.allergenTags.contains(key))
+          .toList(growable: false);
+      if (list.isEmpty) continue;
+      groups[key] = list;
+    }
+    return groups.entries.toList(growable: false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final maxHeight = mediaQuery.size.height * 0.92;
+
+    return SafeArea(
+      top: false,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: maxHeight),
+        child: Padding(
+          padding: EdgeInsets.only(bottom: mediaQuery.viewInsets.bottom),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: AppSizes.sm),
+              _GrabHandle(),
+              const SizedBox(height: AppSizes.md),
+              _Header(
+                startDate: widget.startDate,
+                endDate: widget.endDate,
+              ),
+              const SizedBox(height: AppSizes.md),
+              Expanded(child: _body()),
+              if (!_loading && _error == null) _StickyAddBar(
+                count: _selectedRecipeIds.length,
+                onPressed: _selectedRecipeIds.isEmpty ? null : _confirm,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _body() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return _ErrorPlaceholder(message: _error!, onRetry: _load);
+    }
+    final recipes = _recipes ?? const <Recipe>[];
+    if (recipes.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSizes.pagePaddingH),
+          child: Text(
+            'No recipes available.',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: AppColors.fgMuted,
+            ),
+          ),
+        ),
+      );
+    }
+    return _content();
+  }
+
+  Widget _content() {
+    final totalCount = (_recipes ?? const <Recipe>[]).length;
+    final selectedCount = _selectedRecipeIds.length;
+    final unselectedCount = (totalCount - selectedCount).clamp(0, totalCount);
+    final searchResults = _searchResults;
+    final ongoingKey = _ongoingAllergenKey;
+    final ongoingRecipes = ongoingKey == null
+        ? const <Recipe>[]
+        : _recommendationsFor(ongoingKey);
+    final tagGroups = _tagGroups();
+
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: Column(
+            children: [
+              if (ongoingKey != null && ongoingRecipes.isNotEmpty)
+                RecommendationCarouselSection(
+                  title: 'Recommendation for '
+                      '${AllergenEmoji.get(ongoingKey)} '
+                      '${_displayName(ongoingKey)}',
+                  recipes: ongoingRecipes,
+                  selectedIds: _selectedRecipeIds,
+                  isUnsafe: _isUnsafe,
+                  onToggle: _toggleRecipe,
+                ),
+              for (final group in tagGroups)
+                RecommendationCarouselSection(
+                  title: '${AllergenEmoji.get(group.key)} '
+                      '${_displayName(group.key)} recipes',
+                  recipes: group.value,
+                  selectedIds: _selectedRecipeIds,
+                  isUnsafe: _isUnsafe,
+                  onToggle: _toggleRecipe,
+                ),
+              const SizedBox(height: AppSizes.sm),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.pagePaddingH,
+                ),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    'All recipes',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppSizes.sm),
+              BrowseMealSearchField(
+                controller: _searchController,
+                onChanged: (v) => setState(() => _query = v),
+              ),
+              const SizedBox(height: AppSizes.sm),
+              SelectionCounters(
+                selectedCount: selectedCount,
+                unselectedCount: unselectedCount,
+              ),
+              const SizedBox(height: AppSizes.sm),
+            ],
+          ),
+        ),
+        if (searchResults.isEmpty)
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.all(AppSizes.pagePaddingH),
+              child: Text(
+                _query.isEmpty
+                    ? 'No recipes available.'
+                    : 'No results for "$_query".',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: AppColors.fgMuted,
+                ),
+              ),
+            ),
+          )
+        else
+          SliverList.separated(
+            itemCount: searchResults.length,
+            separatorBuilder: (_, __) => const Divider(
+              height: 1,
+              thickness: AppSizes.dividerThickness,
+              color: AppColors.borderSoft,
+            ),
+            itemBuilder: (context, index) {
+              final recipe = searchResults[index];
+              return BrowseMealRecipeRow(
+                recipe: recipe,
+                selected: _selectedRecipeIds.contains(recipe.id),
+                unsafe: _isUnsafe(recipe),
+                flaggedTags: _flaggedTagsFor(recipe),
+                onTap: () => _toggleRecipe(recipe),
+              );
+            },
+          ),
+        const SliverToBoxAdapter(child: SizedBox(height: AppSizes.md)),
+      ],
+    );
+  }
+
+  String _displayName(String key) => key.replaceAll('_', ' ');
+}
+
+class _GrabHandle extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 36,
+      height: 4,
+      decoration: BoxDecoration(
+        color: AppColors.divider,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.startDate, required this.endDate});
+
+  final DateTime startDate;
+  final DateTime endDate;
+
+  String _format(DateTime d) {
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    return '${months[d.month - 1]} ${d.day}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final sameDay = startDate.year == endDate.year &&
+        startDate.month == endDate.month &&
+        startDate.day == endDate.day;
+    final range = sameDay
+        ? _format(startDate)
+        : '${_format(startDate)} – ${_format(endDate)}';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Browse Meals', style: textTheme.titleLarge),
+          const SizedBox(height: 2),
+          Text(
+            range,
+            style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorPlaceholder extends StatelessWidget {
+  const _ErrorPlaceholder({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSizes.pagePaddingH),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              size: AppSizes.iconLg,
+              color: AppColors.destructive,
+            ),
+            const SizedBox(height: AppSizes.sm),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
+            ),
+            const SizedBox(height: AppSizes.md),
+            OutlinedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StickyAddBar extends StatelessWidget {
+  const _StickyAddBar({required this.count, required this.onPressed});
+
+  final int count;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: AppColors.surface,
+        border: Border(
+          top: BorderSide(color: AppColors.borderSoft),
+        ),
+      ),
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.md,
+        AppSizes.pagePaddingH,
+        AppSizes.md,
+      ),
+      child: SizedBox(
+        width: double.infinity,
+        height: AppSizes.buttonHeight,
+        child: FilledButton(
+          onPressed: onPressed,
+          style: FilledButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            foregroundColor: AppColors.onPrimary,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            ),
+          ),
+          child: Text(
+            'Add ($count)',
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: AppColors.onPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart
+++ b/lib/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart
@@ -1,0 +1,381 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/constants/allergen_emoji.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+
+/// Vertical recipe card used inside the recommendation carousels of the
+/// Browse Meal sheet. Displays thumbnail, title, age range and a selection
+/// indicator. When [unsafe] is true the card is visually disabled and
+/// non-interactive.
+class BrowseMealRecipeCard extends StatelessWidget {
+  const BrowseMealRecipeCard({
+    required this.recipe,
+    required this.selected,
+    required this.unsafe,
+    required this.onTap,
+    super.key,
+  });
+
+  final Recipe recipe;
+  final bool selected;
+  final bool unsafe;
+  final VoidCallback onTap;
+
+  static const double _cardWidth = 160;
+  static const double _imageHeight = 100;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final borderColor = selected
+        ? AppColors.primary
+        : AppColors.borderSoft;
+
+    return Opacity(
+      opacity: unsafe ? 0.5 : 1,
+      child: GestureDetector(
+        onTap: unsafe ? null : onTap,
+        child: Container(
+          width: _cardWidth,
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            border: Border.all(color: borderColor, width: selected ? 2 : 1),
+            boxShadow: AppSizes.shadowCard,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Stack(
+                children: [
+                  ClipRRect(
+                    borderRadius: const BorderRadius.only(
+                      topLeft: Radius.circular(AppSizes.radiusMd),
+                      topRight: Radius.circular(AppSizes.radiusMd),
+                    ),
+                    child: _Thumbnail(url: recipe.thumbnailUrl),
+                  ),
+                  if (unsafe)
+                    Positioned(
+                      top: AppSizes.xs,
+                      right: AppSizes.xs,
+                      child: _UnsafeBadge(),
+                    )
+                  else
+                    Positioned(
+                      top: AppSizes.xs,
+                      right: AppSizes.xs,
+                      child: _SelectIndicator(selected: selected),
+                    ),
+                ],
+              ),
+              Padding(
+                padding: const EdgeInsets.all(AppSizes.sm),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      recipe.title,
+                      style: textTheme.labelLarge?.copyWith(fontSize: 13),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: AppSizes.xs),
+                    Text(
+                      recipe.ageRange,
+                      style: textTheme.bodySmall?.copyWith(
+                        color: AppColors.fgMuted,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Thumbnail extends StatelessWidget {
+  const _Thumbnail({required this.url});
+
+  final String? url;
+
+  @override
+  Widget build(BuildContext context) {
+    const height = BrowseMealRecipeCard._imageHeight;
+    const width = BrowseMealRecipeCard._cardWidth;
+
+    if (url == null || url!.isEmpty) {
+      return Container(
+        width: width,
+        height: height,
+        color: AppColors.surfaceVariant,
+        child: const Icon(
+          Icons.restaurant_outlined,
+          color: AppColors.hint,
+          size: AppSizes.iconLg,
+        ),
+      );
+    }
+    return CachedNetworkImage(
+      imageUrl: url!,
+      width: width,
+      height: height,
+      fit: BoxFit.cover,
+      placeholder: (_, __) => Container(
+        width: width,
+        height: height,
+        color: AppColors.surfaceVariant,
+      ),
+      errorWidget: (_, __, ___) => Container(
+        width: width,
+        height: height,
+        color: AppColors.surfaceVariant,
+        child: const Icon(
+          Icons.restaurant_outlined,
+          color: AppColors.hint,
+          size: AppSizes.iconLg,
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectIndicator extends StatelessWidget {
+  const _SelectIndicator({required this.selected});
+
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 24,
+      height: 24,
+      decoration: BoxDecoration(
+        color: selected ? AppColors.primary : AppColors.surface,
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: selected ? AppColors.primary : AppColors.borderMuted,
+        ),
+      ),
+      child: selected
+          ? const Icon(
+              Icons.check,
+              size: 16,
+              color: AppColors.onPrimary,
+            )
+          : null,
+    );
+  }
+}
+
+class _UnsafeBadge extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.sm,
+        vertical: 2,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.destructiveSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(
+            Icons.warning_amber_rounded,
+            size: 12,
+            color: AppColors.destructive,
+          ),
+          const SizedBox(width: 2),
+          Text(
+            'Flagged',
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: AppColors.destructive,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// List row used inside the searchable master list of the Browse Meal sheet.
+class BrowseMealRecipeRow extends StatelessWidget {
+  const BrowseMealRecipeRow({
+    required this.recipe,
+    required this.selected,
+    required this.unsafe,
+    required this.flaggedTags,
+    required this.onTap,
+    super.key,
+  });
+
+  final Recipe recipe;
+  final bool selected;
+  final bool unsafe;
+  final List<String> flaggedTags;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Opacity(
+      opacity: unsafe ? 0.5 : 1,
+      child: InkWell(
+        onTap: unsafe ? null : onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+            vertical: AppSizes.sm + AppSizes.xs,
+          ),
+          child: Row(
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+                child: _RowThumbnail(url: recipe.thumbnailUrl),
+              ),
+              const SizedBox(width: AppSizes.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      recipe.title,
+                      style: textTheme.labelLarge,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 2),
+                    if (unsafe)
+                      Row(
+                        children: [
+                          const Icon(
+                            Icons.warning_amber_rounded,
+                            size: 13,
+                            color: AppColors.destructive,
+                          ),
+                          const SizedBox(width: AppSizes.xs),
+                          Expanded(
+                            child: Text(
+                              'Not safe: ${_formatFlaggedTags(flaggedTags)}',
+                              style: textTheme.bodySmall?.copyWith(
+                                color: AppColors.destructive,
+                                fontWeight: FontWeight.w600,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      )
+                    else
+                      Text(
+                        recipe.ageRange,
+                        style: textTheme.bodySmall,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSizes.sm),
+              _RowSelectIndicator(selected: selected, disabled: unsafe),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RowThumbnail extends StatelessWidget {
+  const _RowThumbnail({required this.url});
+
+  final String? url;
+
+  @override
+  Widget build(BuildContext context) {
+    const size = 56.0;
+
+    if (url == null || url!.isEmpty) {
+      return Container(
+        width: size,
+        height: size,
+        color: AppColors.surfaceVariant,
+        child: const Icon(
+          Icons.restaurant_outlined,
+          color: AppColors.hint,
+          size: AppSizes.iconMd,
+        ),
+      );
+    }
+    return CachedNetworkImage(
+      imageUrl: url!,
+      width: size,
+      height: size,
+      fit: BoxFit.cover,
+      placeholder: (_, __) => Container(
+        width: size,
+        height: size,
+        color: AppColors.surfaceVariant,
+      ),
+      errorWidget: (_, __, ___) => Container(
+        width: size,
+        height: size,
+        color: AppColors.surfaceVariant,
+        child: const Icon(
+          Icons.restaurant_outlined,
+          color: AppColors.hint,
+          size: AppSizes.iconMd,
+        ),
+      ),
+    );
+  }
+}
+
+String _formatFlaggedTags(List<String> tags) => tags
+    .map((t) => '${AllergenEmoji.get(t)} ${t.replaceAll('_', ' ')}')
+    .join(', ');
+
+class _RowSelectIndicator extends StatelessWidget {
+  const _RowSelectIndicator({required this.selected, required this.disabled});
+
+  final bool selected;
+  final bool disabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final fill = selected ? AppColors.primary : AppColors.surface;
+    final border = selected
+        ? AppColors.primary
+        : (disabled ? AppColors.borderSoft : AppColors.borderMuted);
+    return Container(
+      width: AppSizes.checkbox,
+      height: AppSizes.checkbox,
+      decoration: BoxDecoration(
+        color: fill,
+        borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+        border: Border.all(color: border),
+      ),
+      child: selected
+          ? const Icon(
+              Icons.check,
+              size: 16,
+              color: AppColors.onPrimary,
+            )
+          : null,
+    );
+  }
+}

--- a/lib/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart
+++ b/lib/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart
@@ -78,7 +78,7 @@ class BrowseMealRecipeCard extends StatelessWidget {
                   children: [
                     Text(
                       recipe.title,
-                      style: textTheme.labelLarge?.copyWith(fontSize: 13),
+                      style: textTheme.labelMedium,
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -194,13 +194,13 @@ class _UnsafeBadge extends StatelessWidget {
           const Icon(
             Icons.warning_amber_rounded,
             size: 12,
-            color: AppColors.destructive,
+            color: AppColors.flagFg,
           ),
           const SizedBox(width: 2),
           Text(
             'Flagged',
             style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: AppColors.destructive,
+              color: AppColors.flagFg,
               letterSpacing: 0,
             ),
           ),
@@ -264,14 +264,14 @@ class BrowseMealRecipeRow extends StatelessWidget {
                           const Icon(
                             Icons.warning_amber_rounded,
                             size: 13,
-                            color: AppColors.destructive,
+                            color: AppColors.flagFg,
                           ),
                           const SizedBox(width: AppSizes.xs),
                           Expanded(
                             child: Text(
                               'Not safe: ${_formatFlaggedTags(flaggedTags)}',
                               style: textTheme.bodySmall?.copyWith(
-                                color: AppColors.destructive,
+                                color: AppColors.flagFg,
                                 fontWeight: FontWeight.w600,
                               ),
                               maxLines: 1,

--- a/lib/src/features/meal_plan/sheets/widgets/recommendation_carousel_section.dart
+++ b/lib/src/features/meal_plan/sheets/widgets/recommendation_carousel_section.dart
@@ -85,12 +85,12 @@ class BrowseMealSearchField extends StatelessWidget {
         textInputAction: TextInputAction.search,
         decoration: InputDecoration(
           hintText: 'Search recipes',
-          prefixIcon: const Icon(Icons.search, color: AppColors.hint),
+          prefixIcon: const Icon(Icons.search, color: AppColors.greenDeep),
           filled: true,
           fillColor: AppColors.bgInput,
           border: OutlineInputBorder(
             borderSide: BorderSide.none,
-            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            borderRadius: BorderRadius.circular(AppSizes.radiusFull),
           ),
           contentPadding: const EdgeInsets.symmetric(
             horizontal: AppSizes.md,

--- a/lib/src/features/meal_plan/sheets/widgets/recommendation_carousel_section.dart
+++ b/lib/src/features/meal_plan/sheets/widgets/recommendation_carousel_section.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart';
+
+/// Horizontal carousel of recipe cards under a labeled section header.
+class RecommendationCarouselSection extends StatelessWidget {
+  const RecommendationCarouselSection({
+    required this.title,
+    required this.recipes,
+    required this.selectedIds,
+    required this.isUnsafe,
+    required this.onToggle,
+    super.key,
+  });
+
+  final String title;
+  final List<Recipe> recipes;
+  final Set<String> selectedIds;
+  final bool Function(Recipe recipe) isUnsafe;
+  final void Function(Recipe recipe) onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    if (recipes.isEmpty) return const SizedBox.shrink();
+    final textTheme = Theme.of(context).textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+          ),
+          child: Text(title, style: textTheme.titleMedium),
+        ),
+        const SizedBox(height: AppSizes.sm),
+        SizedBox(
+          height: 220,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.pagePaddingH,
+              vertical: AppSizes.xs,
+            ),
+            itemCount: recipes.length,
+            separatorBuilder: (_, __) => const SizedBox(width: AppSizes.sm),
+            itemBuilder: (context, index) {
+              final recipe = recipes[index];
+              final unsafe = isUnsafe(recipe);
+              return BrowseMealRecipeCard(
+                recipe: recipe,
+                selected: selectedIds.contains(recipe.id),
+                unsafe: unsafe,
+                onTap: () => onToggle(recipe),
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: AppSizes.md),
+      ],
+    );
+  }
+}
+
+/// Search text field used at the top of the master list section.
+class BrowseMealSearchField extends StatelessWidget {
+  const BrowseMealSearchField({
+    required this.controller,
+    required this.onChanged,
+    super.key,
+  });
+
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
+      child: TextField(
+        controller: controller,
+        onChanged: onChanged,
+        textInputAction: TextInputAction.search,
+        decoration: InputDecoration(
+          hintText: 'Search recipes',
+          prefixIcon: const Icon(Icons.search, color: AppColors.hint),
+          filled: true,
+          fillColor: AppColors.bgInput,
+          border: OutlineInputBorder(
+            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.md,
+            vertical: AppSizes.sm,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Counter chip showing the selected and unselected counts.
+class SelectionCounters extends StatelessWidget {
+  const SelectionCounters({
+    required this.selectedCount,
+    required this.unselectedCount,
+    super.key,
+  });
+
+  final int selectedCount;
+  final int unselectedCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
+      child: Row(
+        children: [
+          _Counter(
+            label: '$selectedCount selected',
+            background: AppColors.greenTint,
+            foreground: AppColors.greenDeep,
+          ),
+          const SizedBox(width: AppSizes.sm),
+          _Counter(
+            label: '$unselectedCount unselected',
+            background: AppColors.surfaceVariant,
+            foreground: AppColors.fgMuted,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Counter extends StatelessWidget {
+  const _Counter({
+    required this.label,
+    required this.background,
+    required this.foreground,
+  });
+
+  final String label;
+  final Color background;
+  final Color foreground;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.sp12,
+        vertical: AppSizes.xs,
+      ),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: foreground,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds the multi-select Browse Meal bottom sheet for the meal-plan mapper flow (NIB-87). Returns the picked `Recipe` list to the caller — wiring is handled separately by NIB-95 / NIB-69 (untouched here).

## Public API

```dart
/// Bottom sheet shown via showModalBottomSheet. Returns the picked recipes
/// or null on cancel.
Future<List<Recipe>?> showBrowseMealSheet(
  BuildContext context, {
  required String babyId,
  required DateTime startDate,
  required DateTime endDate,
});
```

## Figma frames

- Mapper flow: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8263
- Recommendations: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8264
- List + counters: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8334

## Data sources (read-only via Riverpod)

- Ongoing allergen — `AllergenService.getAllergenStatuses(babyId)`; first `kAllergenKeys`-order key with `AllergenStatus.inProgress`. Section is hidden entirely when none. The deprecated `programState.currentAllergenKey` path is NOT used.
- Flagged keys — `RecipeService.getFlaggedAllergenKeys(babyId)`. Recipes carrying any flagged key are rendered disabled and non-interactive in every surface (carousel + master list).
- Recipes — `RecipeService.getAllRecipes(babyId)`.

## DS consumed

- `AppColors` (primary, surface, surfaceVariant, borderSoft, borderMuted, destructive, destructiveSoft, greenTint, greenDeep, fgMuted, bgInput, onPrimary, divider, hint).
- `AppSizes` (spacing scale, radii, `shadowCard`, `buttonHeight`, `checkbox`, `dividerThickness`).
- `AppTypography` via `Theme.of(context).textTheme` (`titleLarge`, `titleMedium`, `labelLarge`, `bodyMedium`, `bodySmall`, `labelSmall`).
- No hex, no `withValues`/`withAlpha`, no Nunito, no `AllergenStatus.completed`.

## Acceptance criteria

- [x] `showBrowseMealSheet` exposed; takes `babyId` + range; returns the selected `Recipe` list or null.
- [x] Recommendation carousel renders only when an `inProgress` allergen exists per NIB-126.
- [x] Flagged recipes visually disabled and non-selectable (carousel + list).
- [x] Search filters by title (case-insensitive contains).
- [x] "Add (N)" returns the picked list and resolves selection from the full loaded list (selection survives search filtering).
- [x] Inline error placeholder with Retry on any service `Result.failure` — no raw throws.
- [x] `flutter analyze` — 0 issues.
- [x] `flutter test` — 334 / 334 passing (no test changes; NIB-113 owns tests).
- [x] `make gen` clean + idempotent (second run produces no diff against committed files in this branch).

## Files touched

Only the new directory `lib/src/features/meal_plan/sheets/`:
- `lib/src/features/meal_plan/sheets/browse_meal_sheet.dart`
- `lib/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart`
- `lib/src/features/meal_plan/sheets/widgets/recommendation_carousel_section.dart`

Strictly avoided: `meal_plan_screen.dart`, `meal_plan_controller.*`, `meal_plan/widgets/**`, `meal_plan/map/**`, `routing/**`, `logging/analytics.dart`, `common/services/**`, `common/components/**`.

## Gate results

| Gate | Result |
|---|---|
| `make gen` | OK — idempotent on re-run |
| `flutter analyze` | No issues found |
| `flutter test` | All tests passed (334) |