### PR TITLE
feat(meal-plan): map meals screen — assign picked recipes to days + bulk commit [NIB-95]

### DIFF
--- a/lib/src/features/meal_plan/map/map_meals_controller.dart
+++ b/lib/src/features/meal_plan/map/map_meals_controller.dart
@@ -1,0 +1,96 @@
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:nibbles/src/features/meal_plan/map/map_meals_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'map_meals_controller.g.dart';
+
+/// Drives the NIB-95 Map Meals Plan screen.
+///
+/// Holds the picked recipes + date range (handed in via [MapMealsArgs]),
+/// the currently selected day chip, and the in-progress recipe→day
+/// assignments. Bulk-commits via [MealPlanService.appendMealsToRange]
+/// (APPEND only — no replace semantics per NIB-120).
+@riverpod
+class MapMealsController extends _$MapMealsController {
+  static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
+
+  @override
+  MapMealsState build(MapMealsArgs args) {
+    final start = _dateOnly(args.startDate);
+    final end = _dateOnly(args.endDate);
+    return MapMealsState(
+      pickedRecipes: args.pickedRecipes,
+      startDate: start,
+      endDate: end,
+      selectedDay: start,
+    );
+  }
+
+  /// Switches the active day chip.
+  void selectDay(DateTime day) {
+    state = state.copyWith(selectedDay: _dateOnly(day));
+  }
+
+  /// Adds (or overwrites) the assignment for [recipeId] to the currently
+  /// selected day on the state.
+  void assignToSelectedDay(String recipeId) {
+    final next = Map<String, DateTime>.from(state.assignments);
+    next[recipeId] = state.selectedDay;
+    state = state.copyWith(assignments: next, errorMessage: null);
+  }
+
+  /// Removes [recipeId] from the assignments map.
+  void unassign(String recipeId) {
+    final next = Map<String, DateTime>.from(state.assignments)
+      ..remove(recipeId);
+    state = state.copyWith(assignments: next, errorMessage: null);
+  }
+
+  /// Bulk-commits the assignments via [MealPlanService.appendMealsToRange].
+  ///
+  /// Returns true on success (caller pops with `true`). On failure leaves
+  /// `errorMessage` set so the screen can show the P1 retry dialog.
+  Future<bool> commit() async {
+    if (state.assignments.isEmpty) return false;
+
+    state = state.copyWith(isCommitting: true, errorMessage: null);
+
+    final babyId = await ref.read(currentBabyIdProvider.future);
+    if (babyId == null) {
+      state = state.copyWith(
+        isCommitting: false,
+        errorMessage: 'No baby profile found.',
+      );
+      return false;
+    }
+
+    final start = state.startDate;
+    final assignments = state.assignments.entries.map((entry) {
+      final day = _dateOnly(entry.value);
+      final offset = day.difference(start).inDays;
+      return RecipeAssignment(recipeId: entry.key, dayOffset: offset);
+    }).toList();
+
+    final result = await ref
+        .read(mealPlanServiceProvider)
+        .appendMealsToRange(
+          babyId: babyId,
+          startDate: state.startDate,
+          endDate: state.endDate,
+          assignments: assignments,
+        );
+
+    if (result.isFailure) {
+      state = state.copyWith(
+        isCommitting: false,
+        errorMessage: result.errorOrNull?.message ?? 'Failed to save plan.',
+      );
+      return false;
+    }
+
+    state = state.copyWith(isCommitting: false);
+    return true;
+  }
+}

--- a/lib/src/features/meal_plan/map/map_meals_controller.g.dart
+++ b/lib/src/features/meal_plan/map/map_meals_controller.g.dart
@@ -1,0 +1,207 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'map_meals_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$mapMealsControllerHash() =>
+    r'e4d7781e7268d1aa30b0fcce773b320022803c30';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$MapMealsController
+    extends BuildlessAutoDisposeNotifier<MapMealsState> {
+  late final MapMealsArgs args;
+
+  MapMealsState build(MapMealsArgs args);
+}
+
+/// Drives the NIB-95 Map Meals Plan screen.
+///
+/// Holds the picked recipes + date range (handed in via [MapMealsArgs]),
+/// the currently selected day chip, and the in-progress recipe→day
+/// assignments. Bulk-commits via [MealPlanService.appendMealsToRange]
+/// (APPEND only — no replace semantics per NIB-120).
+///
+/// Copied from [MapMealsController].
+@ProviderFor(MapMealsController)
+const mapMealsControllerProvider = MapMealsControllerFamily();
+
+/// Drives the NIB-95 Map Meals Plan screen.
+///
+/// Holds the picked recipes + date range (handed in via [MapMealsArgs]),
+/// the currently selected day chip, and the in-progress recipe→day
+/// assignments. Bulk-commits via [MealPlanService.appendMealsToRange]
+/// (APPEND only — no replace semantics per NIB-120).
+///
+/// Copied from [MapMealsController].
+class MapMealsControllerFamily extends Family<MapMealsState> {
+  /// Drives the NIB-95 Map Meals Plan screen.
+  ///
+  /// Holds the picked recipes + date range (handed in via [MapMealsArgs]),
+  /// the currently selected day chip, and the in-progress recipe→day
+  /// assignments. Bulk-commits via [MealPlanService.appendMealsToRange]
+  /// (APPEND only — no replace semantics per NIB-120).
+  ///
+  /// Copied from [MapMealsController].
+  const MapMealsControllerFamily();
+
+  /// Drives the NIB-95 Map Meals Plan screen.
+  ///
+  /// Holds the picked recipes + date range (handed in via [MapMealsArgs]),
+  /// the currently selected day chip, and the in-progress recipe→day
+  /// assignments. Bulk-commits via [MealPlanService.appendMealsToRange]
+  /// (APPEND only — no replace semantics per NIB-120).
+  ///
+  /// Copied from [MapMealsController].
+  MapMealsControllerProvider call(MapMealsArgs args) {
+    return MapMealsControllerProvider(args);
+  }
+
+  @override
+  MapMealsControllerProvider getProviderOverride(
+    covariant MapMealsControllerProvider provider,
+  ) {
+    return call(provider.args);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'mapMealsControllerProvider';
+}
+
+/// Drives the NIB-95 Map Meals Plan screen.
+///
+/// Holds the picked recipes + date range (handed in via [MapMealsArgs]),
+/// the currently selected day chip, and the in-progress recipe→day
+/// assignments. Bulk-commits via [MealPlanService.appendMealsToRange]
+/// (APPEND only — no replace semantics per NIB-120).
+///
+/// Copied from [MapMealsController].
+class MapMealsControllerProvider
+    extends AutoDisposeNotifierProviderImpl<MapMealsController, MapMealsState> {
+  /// Drives the NIB-95 Map Meals Plan screen.
+  ///
+  /// Holds the picked recipes + date range (handed in via [MapMealsArgs]),
+  /// the currently selected day chip, and the in-progress recipe→day
+  /// assignments. Bulk-commits via [MealPlanService.appendMealsToRange]
+  /// (APPEND only — no replace semantics per NIB-120).
+  ///
+  /// Copied from [MapMealsController].
+  MapMealsControllerProvider(MapMealsArgs args)
+    : this._internal(
+        () => MapMealsController()..args = args,
+        from: mapMealsControllerProvider,
+        name: r'mapMealsControllerProvider',
+        debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+            ? null
+            : _$mapMealsControllerHash,
+        dependencies: MapMealsControllerFamily._dependencies,
+        allTransitiveDependencies:
+            MapMealsControllerFamily._allTransitiveDependencies,
+        args: args,
+      );
+
+  MapMealsControllerProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.args,
+  }) : super.internal();
+
+  final MapMealsArgs args;
+
+  @override
+  MapMealsState runNotifierBuild(covariant MapMealsController notifier) {
+    return notifier.build(args);
+  }
+
+  @override
+  Override overrideWith(MapMealsController Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: MapMealsControllerProvider._internal(
+        () => create()..args = args,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        args: args,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeNotifierProviderElement<MapMealsController, MapMealsState>
+  createElement() {
+    return _MapMealsControllerProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MapMealsControllerProvider && other.args == args;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, args.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin MapMealsControllerRef on AutoDisposeNotifierProviderRef<MapMealsState> {
+  /// The parameter `args` of this provider.
+  MapMealsArgs get args;
+}
+
+class _MapMealsControllerProviderElement
+    extends
+        AutoDisposeNotifierProviderElement<MapMealsController, MapMealsState>
+    with MapMealsControllerRef {
+  _MapMealsControllerProviderElement(super.provider);
+
+  @override
+  MapMealsArgs get args => (origin as MapMealsControllerProvider).args;
+}
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/meal_plan/map/map_meals_screen.dart
+++ b/lib/src/features/meal_plan/map/map_meals_screen.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart'
+    show MealPlanService;
+import 'package:nibbles/src/features/meal_plan/map/map_meals_controller.dart';
+import 'package:nibbles/src/features/meal_plan/map/map_meals_state.dart';
+import 'package:nibbles/src/features/meal_plan/map/widgets/day_chip_row.dart';
+import 'package:nibbles/src/features/meal_plan/map/widgets/picked_recipe_row.dart';
+import 'package:nibbles/src/features/meal_plan/map/widgets/selected_day_slot_list.dart';
+
+/// Map Meals Plan full-screen (NIB-95).
+///
+/// Takes a list of picked recipes + a date range (handed in via
+/// [MapMealsArgs] through `GoRouterState.extra` from NIB-87's Browse Meal
+/// sheet) and lets the user assign each picked recipe to a day in the
+/// range. On commit, calls [MealPlanService.appendMealsToRange] (APPEND
+/// only — no replace per NIB-120). On success pops with `true`. On
+/// failure shows a blocking P1 retry dialog.
+class MapMealsScreen extends ConsumerWidget {
+  const MapMealsScreen({required this.args, super.key});
+
+  final MapMealsArgs args;
+
+  static const _weekdayName = <int, String>{
+    DateTime.monday: 'Monday',
+    DateTime.tuesday: 'Tuesday',
+    DateTime.wednesday: 'Wednesday',
+    DateTime.thursday: 'Thursday',
+    DateTime.friday: 'Friday',
+    DateTime.saturday: 'Saturday',
+    DateTime.sunday: 'Sunday',
+  };
+
+  static const _weekdayShort = <int, String>{
+    DateTime.monday: 'Mon',
+    DateTime.tuesday: 'Tue',
+    DateTime.wednesday: 'Wed',
+    DateTime.thursday: 'Thu',
+    DateTime.friday: 'Fri',
+    DateTime.saturday: 'Sat',
+    DateTime.sunday: 'Sun',
+  };
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(mapMealsControllerProvider(args));
+    final notifier = ref.read(mapMealsControllerProvider(args).notifier);
+
+    return Scaffold(
+      backgroundColor: AppColors.cream,
+      appBar: _MapMealsAppBar(state: state),
+      body: SafeArea(
+        top: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const SizedBox(height: AppSizes.md),
+            DayChipRow(
+              startDate: state.startDate,
+              endDate: state.endDate,
+              selectedDay: state.selectedDay,
+              onSelect: notifier.selectDay,
+            ),
+            const SizedBox(height: AppSizes.md),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.pagePaddingH,
+                ),
+                children: [
+                  _SelectedDayHeader(state: state, weekdayNames: _weekdayName),
+                  const SizedBox(height: AppSizes.sm),
+                  SelectedDaySlotList(
+                    recipes: state.recipesForSelectedDay(),
+                    onRemove: notifier.unassign,
+                  ),
+                  const SizedBox(height: AppSizes.lg),
+                  Text(
+                    'Meals Picked — ${state.totalCount} selected',
+                    style: AppTypography.sectionTitle,
+                  ),
+                  const SizedBox(height: AppSizes.sm),
+                  for (var i = 0; i < state.pickedRecipes.length; i++) ...[
+                    if (i != 0) const SizedBox(height: AppSizes.sm),
+                    PickedRecipeRow(
+                      recipe: state.pickedRecipes[i],
+                      onTap: () => notifier.assignToSelectedDay(
+                        state.pickedRecipes[i].id,
+                      ),
+                      assignedLabel: _assignedLabelFor(
+                        state.pickedRecipes[i],
+                        state,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: AppSizes.xl),
+                ],
+              ),
+            ),
+            _CommitBar(state: state, onCommit: () => _onCommit(context, ref)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String? _assignedLabelFor(Recipe recipe, MapMealsState state) {
+    final assignedDay = state.assignments[recipe.id];
+    if (assignedDay == null) return null;
+    final abbrev = _weekdayShort[assignedDay.weekday] ?? '';
+    return '$abbrev ${assignedDay.day}';
+  }
+
+  Future<void> _onCommit(BuildContext context, WidgetRef ref) async {
+    final notifier = ref.read(mapMealsControllerProvider(args).notifier);
+    final success = await notifier.commit();
+    if (!context.mounted) return;
+    if (success) {
+      context.pop(true);
+      return;
+    }
+    await _showRetryDialog(context, ref);
+  }
+
+  Future<void> _showRetryDialog(BuildContext context, WidgetRef ref) async {
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) {
+        return AlertDialog(
+          backgroundColor: AppColors.surface,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+          ),
+          title: const Text(
+            "Couldn't save your plan",
+            style: AppTypography.sectionTitle,
+          ),
+          content: Text(
+            'Please try again',
+            style: AppTypography.textTheme.bodyMedium,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: Text(
+                'Cancel',
+                style: AppTypography.button.copyWith(color: AppColors.fgMuted),
+              ),
+            ),
+            FilledButton(
+              style: FilledButton.styleFrom(
+                backgroundColor: AppColors.greenDeep,
+                foregroundColor: AppColors.onGreen,
+              ),
+              onPressed: () {
+                Navigator.of(dialogContext).pop();
+                _onCommit(context, ref);
+              },
+              child: Text('Retry', style: AppTypography.button),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _MapMealsAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const _MapMealsAppBar({required this.state});
+
+  final MapMealsState state;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(AppSizes.appBarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      backgroundColor: AppColors.cream,
+      surfaceTintColor: AppColors.cream,
+      elevation: 0,
+      scrolledUnderElevation: 0,
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back, color: AppColors.fgDefault),
+        onPressed: () => Navigator.of(context).maybePop(),
+      ),
+      title: Text('Map Meals Plan', style: AppTypography.textTheme.titleLarge),
+      centerTitle: false,
+      actions: [
+        Padding(
+          padding: const EdgeInsets.only(right: AppSizes.pagePaddingH),
+          child: Center(
+            child: Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.sp12,
+                vertical: AppSizes.xs,
+              ),
+              decoration: BoxDecoration(
+                color: AppColors.greenTint,
+                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              ),
+              child: Text(
+                '${state.filledCount} of ${state.totalCount} slots filled',
+                style: AppTypography.caption.copyWith(
+                  color: AppColors.greenDeep,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SelectedDayHeader extends StatelessWidget {
+  const _SelectedDayHeader({required this.state, required this.weekdayNames});
+
+  final MapMealsState state;
+  final Map<int, String> weekdayNames;
+
+  @override
+  Widget build(BuildContext context) {
+    final dayName = weekdayNames[state.selectedDay.weekday] ?? '';
+    final n = state.recipesForSelectedDay().length;
+    final m = state.totalCount;
+    return Text(
+      'Meals for $dayName ($n/$m)',
+      style: AppTypography.sectionTitle,
+    );
+  }
+}
+
+class _CommitBar extends StatelessWidget {
+  const _CommitBar({required this.state, required this.onCommit});
+
+  final MapMealsState state;
+  final VoidCallback onCommit;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasAssignments = state.assignments.isNotEmpty;
+    final disabled = !hasAssignments || state.isCommitting;
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSizes.pagePaddingH,
+          AppSizes.sm,
+          AppSizes.pagePaddingH,
+          AppSizes.sp12,
+        ),
+        child: SizedBox(
+          width: double.infinity,
+          height: AppSizes.buttonHeight,
+          child: FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: disabled
+                  ? AppColors.borderMuted
+                  : AppColors.greenDeep,
+              foregroundColor: AppColors.onGreen,
+              disabledBackgroundColor: AppColors.borderMuted,
+              disabledForegroundColor: AppColors.fgFaint,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              ),
+            ),
+            onPressed: disabled ? null : onCommit,
+            child: state.isCommitting
+                ? const SizedBox(
+                    width: AppSizes.iconSm,
+                    height: AppSizes.iconSm,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: AppColors.onGreen,
+                    ),
+                  )
+                : Text('Mapp Meal Plan', style: AppTypography.button),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/meal_plan/map/map_meals_state.dart
+++ b/lib/src/features/meal_plan/map/map_meals_state.dart
@@ -1,0 +1,56 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+
+part 'map_meals_state.freezed.dart';
+
+/// Route payload for the Map Meals Plan screen (NIB-95).
+///
+/// Handed in via `GoRouterState.extra` from NIB-87's Browse Meal sheet.
+/// Carried as a freezed value so the controller family key has stable
+/// equality (lists/dates are deep-compared rather than identity-compared).
+@freezed
+class MapMealsArgs with _$MapMealsArgs {
+  const factory MapMealsArgs({
+    required List<Recipe> pickedRecipes,
+    required DateTime startDate,
+    required DateTime endDate,
+  }) = _MapMealsArgs;
+}
+
+/// NIB-95 Map Meals Plan screen state.
+///
+/// `assignments` is `recipeId -> DateTime` (one slot per recipe). The user
+/// taps a picked recipe row to assign it to [selectedDay]; tapping again
+/// after picking a different chip re-assigns it.
+@freezed
+class MapMealsState with _$MapMealsState {
+  const factory MapMealsState({
+    required List<Recipe> pickedRecipes,
+    required DateTime startDate,
+    required DateTime endDate,
+    required DateTime selectedDay,
+    @Default(<String, DateTime>{}) Map<String, DateTime> assignments,
+    @Default(false) bool isCommitting,
+    String? errorMessage,
+  }) = _MapMealsState;
+
+  const MapMealsState._();
+
+  /// Number of slots filled (length of [assignments]) — for the AppBar chip.
+  int get filledCount => assignments.length;
+
+  /// Total picked recipes — for the AppBar chip's denominator.
+  int get totalCount => pickedRecipes.length;
+
+  /// Recipes assigned to [selectedDay].
+  List<Recipe> recipesForSelectedDay() {
+    final key = _dateKey(selectedDay);
+    final ids = assignments.entries
+        .where((e) => _dateKey(e.value) == key)
+        .map((e) => e.key)
+        .toSet();
+    return pickedRecipes.where((r) => ids.contains(r.id)).toList();
+  }
+
+  static String _dateKey(DateTime dt) => '${dt.year}-${dt.month}-${dt.day}';
+}

--- a/lib/src/features/meal_plan/map/map_meals_state.freezed.dart
+++ b/lib/src/features/meal_plan/map/map_meals_state.freezed.dart
@@ -1,0 +1,507 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'map_meals_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$MapMealsArgs {
+  List<Recipe> get pickedRecipes => throw _privateConstructorUsedError;
+  DateTime get startDate => throw _privateConstructorUsedError;
+  DateTime get endDate => throw _privateConstructorUsedError;
+
+  /// Create a copy of MapMealsArgs
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $MapMealsArgsCopyWith<MapMealsArgs> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MapMealsArgsCopyWith<$Res> {
+  factory $MapMealsArgsCopyWith(
+    MapMealsArgs value,
+    $Res Function(MapMealsArgs) then,
+  ) = _$MapMealsArgsCopyWithImpl<$Res, MapMealsArgs>;
+  @useResult
+  $Res call({List<Recipe> pickedRecipes, DateTime startDate, DateTime endDate});
+}
+
+/// @nodoc
+class _$MapMealsArgsCopyWithImpl<$Res, $Val extends MapMealsArgs>
+    implements $MapMealsArgsCopyWith<$Res> {
+  _$MapMealsArgsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of MapMealsArgs
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pickedRecipes = null,
+    Object? startDate = null,
+    Object? endDate = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            pickedRecipes: null == pickedRecipes
+                ? _value.pickedRecipes
+                : pickedRecipes // ignore: cast_nullable_to_non_nullable
+                      as List<Recipe>,
+            startDate: null == startDate
+                ? _value.startDate
+                : startDate // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            endDate: null == endDate
+                ? _value.endDate
+                : endDate // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$MapMealsArgsImplCopyWith<$Res>
+    implements $MapMealsArgsCopyWith<$Res> {
+  factory _$$MapMealsArgsImplCopyWith(
+    _$MapMealsArgsImpl value,
+    $Res Function(_$MapMealsArgsImpl) then,
+  ) = __$$MapMealsArgsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<Recipe> pickedRecipes, DateTime startDate, DateTime endDate});
+}
+
+/// @nodoc
+class __$$MapMealsArgsImplCopyWithImpl<$Res>
+    extends _$MapMealsArgsCopyWithImpl<$Res, _$MapMealsArgsImpl>
+    implements _$$MapMealsArgsImplCopyWith<$Res> {
+  __$$MapMealsArgsImplCopyWithImpl(
+    _$MapMealsArgsImpl _value,
+    $Res Function(_$MapMealsArgsImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of MapMealsArgs
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pickedRecipes = null,
+    Object? startDate = null,
+    Object? endDate = null,
+  }) {
+    return _then(
+      _$MapMealsArgsImpl(
+        pickedRecipes: null == pickedRecipes
+            ? _value._pickedRecipes
+            : pickedRecipes // ignore: cast_nullable_to_non_nullable
+                  as List<Recipe>,
+        startDate: null == startDate
+            ? _value.startDate
+            : startDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        endDate: null == endDate
+            ? _value.endDate
+            : endDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$MapMealsArgsImpl implements _MapMealsArgs {
+  const _$MapMealsArgsImpl({
+    required final List<Recipe> pickedRecipes,
+    required this.startDate,
+    required this.endDate,
+  }) : _pickedRecipes = pickedRecipes;
+
+  final List<Recipe> _pickedRecipes;
+  @override
+  List<Recipe> get pickedRecipes {
+    if (_pickedRecipes is EqualUnmodifiableListView) return _pickedRecipes;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_pickedRecipes);
+  }
+
+  @override
+  final DateTime startDate;
+  @override
+  final DateTime endDate;
+
+  @override
+  String toString() {
+    return 'MapMealsArgs(pickedRecipes: $pickedRecipes, startDate: $startDate, endDate: $endDate)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MapMealsArgsImpl &&
+            const DeepCollectionEquality().equals(
+              other._pickedRecipes,
+              _pickedRecipes,
+            ) &&
+            (identical(other.startDate, startDate) ||
+                other.startDate == startDate) &&
+            (identical(other.endDate, endDate) || other.endDate == endDate));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    const DeepCollectionEquality().hash(_pickedRecipes),
+    startDate,
+    endDate,
+  );
+
+  /// Create a copy of MapMealsArgs
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MapMealsArgsImplCopyWith<_$MapMealsArgsImpl> get copyWith =>
+      __$$MapMealsArgsImplCopyWithImpl<_$MapMealsArgsImpl>(this, _$identity);
+}
+
+abstract class _MapMealsArgs implements MapMealsArgs {
+  const factory _MapMealsArgs({
+    required final List<Recipe> pickedRecipes,
+    required final DateTime startDate,
+    required final DateTime endDate,
+  }) = _$MapMealsArgsImpl;
+
+  @override
+  List<Recipe> get pickedRecipes;
+  @override
+  DateTime get startDate;
+  @override
+  DateTime get endDate;
+
+  /// Create a copy of MapMealsArgs
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$MapMealsArgsImplCopyWith<_$MapMealsArgsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$MapMealsState {
+  List<Recipe> get pickedRecipes => throw _privateConstructorUsedError;
+  DateTime get startDate => throw _privateConstructorUsedError;
+  DateTime get endDate => throw _privateConstructorUsedError;
+  DateTime get selectedDay => throw _privateConstructorUsedError;
+  Map<String, DateTime> get assignments => throw _privateConstructorUsedError;
+  bool get isCommitting => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+
+  /// Create a copy of MapMealsState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $MapMealsStateCopyWith<MapMealsState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MapMealsStateCopyWith<$Res> {
+  factory $MapMealsStateCopyWith(
+    MapMealsState value,
+    $Res Function(MapMealsState) then,
+  ) = _$MapMealsStateCopyWithImpl<$Res, MapMealsState>;
+  @useResult
+  $Res call({
+    List<Recipe> pickedRecipes,
+    DateTime startDate,
+    DateTime endDate,
+    DateTime selectedDay,
+    Map<String, DateTime> assignments,
+    bool isCommitting,
+    String? errorMessage,
+  });
+}
+
+/// @nodoc
+class _$MapMealsStateCopyWithImpl<$Res, $Val extends MapMealsState>
+    implements $MapMealsStateCopyWith<$Res> {
+  _$MapMealsStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of MapMealsState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pickedRecipes = null,
+    Object? startDate = null,
+    Object? endDate = null,
+    Object? selectedDay = null,
+    Object? assignments = null,
+    Object? isCommitting = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            pickedRecipes: null == pickedRecipes
+                ? _value.pickedRecipes
+                : pickedRecipes // ignore: cast_nullable_to_non_nullable
+                      as List<Recipe>,
+            startDate: null == startDate
+                ? _value.startDate
+                : startDate // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            endDate: null == endDate
+                ? _value.endDate
+                : endDate // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            selectedDay: null == selectedDay
+                ? _value.selectedDay
+                : selectedDay // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            assignments: null == assignments
+                ? _value.assignments
+                : assignments // ignore: cast_nullable_to_non_nullable
+                      as Map<String, DateTime>,
+            isCommitting: null == isCommitting
+                ? _value.isCommitting
+                : isCommitting // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$MapMealsStateImplCopyWith<$Res>
+    implements $MapMealsStateCopyWith<$Res> {
+  factory _$$MapMealsStateImplCopyWith(
+    _$MapMealsStateImpl value,
+    $Res Function(_$MapMealsStateImpl) then,
+  ) = __$$MapMealsStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    List<Recipe> pickedRecipes,
+    DateTime startDate,
+    DateTime endDate,
+    DateTime selectedDay,
+    Map<String, DateTime> assignments,
+    bool isCommitting,
+    String? errorMessage,
+  });
+}
+
+/// @nodoc
+class __$$MapMealsStateImplCopyWithImpl<$Res>
+    extends _$MapMealsStateCopyWithImpl<$Res, _$MapMealsStateImpl>
+    implements _$$MapMealsStateImplCopyWith<$Res> {
+  __$$MapMealsStateImplCopyWithImpl(
+    _$MapMealsStateImpl _value,
+    $Res Function(_$MapMealsStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of MapMealsState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pickedRecipes = null,
+    Object? startDate = null,
+    Object? endDate = null,
+    Object? selectedDay = null,
+    Object? assignments = null,
+    Object? isCommitting = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _$MapMealsStateImpl(
+        pickedRecipes: null == pickedRecipes
+            ? _value._pickedRecipes
+            : pickedRecipes // ignore: cast_nullable_to_non_nullable
+                  as List<Recipe>,
+        startDate: null == startDate
+            ? _value.startDate
+            : startDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        endDate: null == endDate
+            ? _value.endDate
+            : endDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        selectedDay: null == selectedDay
+            ? _value.selectedDay
+            : selectedDay // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        assignments: null == assignments
+            ? _value._assignments
+            : assignments // ignore: cast_nullable_to_non_nullable
+                  as Map<String, DateTime>,
+        isCommitting: null == isCommitting
+            ? _value.isCommitting
+            : isCommitting // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$MapMealsStateImpl extends _MapMealsState {
+  const _$MapMealsStateImpl({
+    required final List<Recipe> pickedRecipes,
+    required this.startDate,
+    required this.endDate,
+    required this.selectedDay,
+    final Map<String, DateTime> assignments = const <String, DateTime>{},
+    this.isCommitting = false,
+    this.errorMessage,
+  }) : _pickedRecipes = pickedRecipes,
+       _assignments = assignments,
+       super._();
+
+  final List<Recipe> _pickedRecipes;
+  @override
+  List<Recipe> get pickedRecipes {
+    if (_pickedRecipes is EqualUnmodifiableListView) return _pickedRecipes;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_pickedRecipes);
+  }
+
+  @override
+  final DateTime startDate;
+  @override
+  final DateTime endDate;
+  @override
+  final DateTime selectedDay;
+  final Map<String, DateTime> _assignments;
+  @override
+  @JsonKey()
+  Map<String, DateTime> get assignments {
+    if (_assignments is EqualUnmodifiableMapView) return _assignments;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_assignments);
+  }
+
+  @override
+  @JsonKey()
+  final bool isCommitting;
+  @override
+  final String? errorMessage;
+
+  @override
+  String toString() {
+    return 'MapMealsState(pickedRecipes: $pickedRecipes, startDate: $startDate, endDate: $endDate, selectedDay: $selectedDay, assignments: $assignments, isCommitting: $isCommitting, errorMessage: $errorMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MapMealsStateImpl &&
+            const DeepCollectionEquality().equals(
+              other._pickedRecipes,
+              _pickedRecipes,
+            ) &&
+            (identical(other.startDate, startDate) ||
+                other.startDate == startDate) &&
+            (identical(other.endDate, endDate) || other.endDate == endDate) &&
+            (identical(other.selectedDay, selectedDay) ||
+                other.selectedDay == selectedDay) &&
+            const DeepCollectionEquality().equals(
+              other._assignments,
+              _assignments,
+            ) &&
+            (identical(other.isCommitting, isCommitting) ||
+                other.isCommitting == isCommitting) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    const DeepCollectionEquality().hash(_pickedRecipes),
+    startDate,
+    endDate,
+    selectedDay,
+    const DeepCollectionEquality().hash(_assignments),
+    isCommitting,
+    errorMessage,
+  );
+
+  /// Create a copy of MapMealsState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MapMealsStateImplCopyWith<_$MapMealsStateImpl> get copyWith =>
+      __$$MapMealsStateImplCopyWithImpl<_$MapMealsStateImpl>(this, _$identity);
+}
+
+abstract class _MapMealsState extends MapMealsState {
+  const factory _MapMealsState({
+    required final List<Recipe> pickedRecipes,
+    required final DateTime startDate,
+    required final DateTime endDate,
+    required final DateTime selectedDay,
+    final Map<String, DateTime> assignments,
+    final bool isCommitting,
+    final String? errorMessage,
+  }) = _$MapMealsStateImpl;
+  const _MapMealsState._() : super._();
+
+  @override
+  List<Recipe> get pickedRecipes;
+  @override
+  DateTime get startDate;
+  @override
+  DateTime get endDate;
+  @override
+  DateTime get selectedDay;
+  @override
+  Map<String, DateTime> get assignments;
+  @override
+  bool get isCommitting;
+  @override
+  String? get errorMessage;
+
+  /// Create a copy of MapMealsState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$MapMealsStateImplCopyWith<_$MapMealsStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/meal_plan/map/widgets/day_chip_row.dart
+++ b/lib/src/features/meal_plan/map/widgets/day_chip_row.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+
+/// Horizontal day chip row for the Map Meals Plan screen (NIB-95).
+///
+/// Renders one chip per day in `[startDate, endDate]`. Selected chip uses
+/// [AppColors.greenDeep]; unselected chips show the day abbreviation and
+/// numeric date in muted text on cream.
+class DayChipRow extends StatelessWidget {
+  const DayChipRow({
+    required this.startDate,
+    required this.endDate,
+    required this.selectedDay,
+    required this.onSelect,
+    super.key,
+  });
+
+  final DateTime startDate;
+  final DateTime endDate;
+  final DateTime selectedDay;
+  final ValueChanged<DateTime> onSelect;
+
+  static const _weekdayAbbrev = <int, String>{
+    DateTime.monday: 'Mon',
+    DateTime.tuesday: 'Tue',
+    DateTime.wednesday: 'Wed',
+    DateTime.thursday: 'Thu',
+    DateTime.friday: 'Fri',
+    DateTime.saturday: 'Sat',
+    DateTime.sunday: 'Sun',
+  };
+
+  List<DateTime> _days() {
+    final start = DateTime(startDate.year, startDate.month, startDate.day);
+    final end = DateTime(endDate.year, endDate.month, endDate.day);
+    final count = end.difference(start).inDays + 1;
+    return List<DateTime>.generate(count, (i) => start.add(Duration(days: i)));
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  @override
+  Widget build(BuildContext context) {
+    final days = _days();
+    return SizedBox(
+      height: AppSizes.dayChipH,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
+        itemCount: days.length,
+        separatorBuilder: (_, __) => const SizedBox(width: AppSizes.sm),
+        itemBuilder: (context, index) {
+          final day = days[index];
+          final isSelected = _isSameDay(day, selectedDay);
+          return _DayChip(
+            day: day,
+            isSelected: isSelected,
+            onTap: () => onSelect(day),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _DayChip extends StatelessWidget {
+  const _DayChip({
+    required this.day,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final DateTime day;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final abbrev = DayChipRow._weekdayAbbrev[day.weekday] ?? '';
+    final bg = isSelected ? AppColors.greenDeep : AppColors.surface;
+    final fg = isSelected ? AppColors.onGreen : AppColors.fgDefault;
+    final borderColor = isSelected ? AppColors.greenDeep : AppColors.borderSoft;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: AppSizes.dayChipW,
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+          border: Border.all(color: borderColor),
+        ),
+        padding: const EdgeInsets.symmetric(
+          vertical: AppSizes.sp12,
+          horizontal: AppSizes.sm,
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              abbrev,
+              style: AppTypography.caption.copyWith(
+                color: fg,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: AppSizes.xs),
+            Text(
+              '${day.day}',
+              style: AppTypography.sectionTitle.copyWith(color: fg),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/meal_plan/map/widgets/picked_recipe_row.dart
+++ b/lib/src/features/meal_plan/map/widgets/picked_recipe_row.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/constants/allergen_emoji.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+
+/// A single picked-recipe row for the Map Meals Plan screen (NIB-95).
+///
+/// Renders thumbnail + title + allergen tag chips. Tap-to-assign drives
+/// the controller's `assignToSelectedDay`. If [assignedLabel] is non-null
+/// the row shows a trailing day badge (e.g. "Tue 3") so the user can see
+/// at a glance which day a picked recipe already lives on.
+class PickedRecipeRow extends StatelessWidget {
+  const PickedRecipeRow({
+    required this.recipe,
+    required this.onTap,
+    this.assignedLabel,
+    super.key,
+  });
+
+  final Recipe recipe;
+  final VoidCallback onTap;
+  final String? assignedLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+      child: Container(
+        padding: const EdgeInsets.all(AppSizes.sp12),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+          border: Border.all(color: AppColors.borderSoft),
+        ),
+        child: Row(
+          children: [
+            _Thumbnail(url: recipe.thumbnailUrl),
+            const SizedBox(width: AppSizes.sp12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    recipe.title,
+                    style: AppTypography.bodyBold,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (recipe.allergenTags.isNotEmpty) ...[
+                    const SizedBox(height: AppSizes.xs),
+                    _TagsRow(tags: recipe.allergenTags),
+                  ],
+                ],
+              ),
+            ),
+            if (assignedLabel != null) ...[
+              const SizedBox(width: AppSizes.sm),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.sm,
+                  vertical: AppSizes.xs,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.greenTint,
+                  borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+                ),
+                child: Text(
+                  assignedLabel!,
+                  style: AppTypography.caption.copyWith(
+                    color: AppColors.greenDeep,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Thumbnail extends StatelessWidget {
+  const _Thumbnail({required this.url});
+
+  final String? url;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      child: Container(
+        width: AppSizes.iconXl,
+        height: AppSizes.iconXl,
+        color: AppColors.surfaceVariant,
+        child: url == null
+            ? const Icon(
+                Icons.restaurant,
+                color: AppColors.fgFaint,
+                size: AppSizes.iconMd,
+              )
+            : Image.network(
+                url!,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => const Icon(
+                  Icons.restaurant,
+                  color: AppColors.fgFaint,
+                  size: AppSizes.iconMd,
+                ),
+              ),
+      ),
+    );
+  }
+}
+
+class _TagsRow extends StatelessWidget {
+  const _TagsRow({required this.tags});
+
+  final List<String> tags;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: AppSizes.xs,
+      runSpacing: AppSizes.xs,
+      children: tags
+          .take(3)
+          .map(
+            (t) => Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.sm,
+                vertical: 2,
+              ),
+              decoration: BoxDecoration(
+                color: AppColors.coralSoft,
+                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              ),
+              child: Text(
+                '${AllergenEmoji.get(t)} ${t.replaceAll('_', ' ')}',
+                style: AppTypography.caption.copyWith(
+                  color: AppColors.coralDeep,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart
+++ b/lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+
+/// "Meals for {Day}" panel for the Map Meals Plan screen (NIB-95).
+///
+/// Shows the recipes currently assigned to the selected day. If empty,
+/// renders the dashed "No Meals Mapped Yet" placeholder. Each assigned
+/// row exposes a remove button that unassigns the recipe.
+class SelectedDaySlotList extends StatelessWidget {
+  const SelectedDaySlotList({
+    required this.recipes,
+    required this.onRemove,
+    super.key,
+  });
+
+  final List<Recipe> recipes;
+  final ValueChanged<String> onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    if (recipes.isEmpty) {
+      return const _EmptyDayPlaceholder();
+    }
+
+    return Column(
+      children: [
+        for (var i = 0; i < recipes.length; i++) ...[
+          if (i != 0) const SizedBox(height: AppSizes.sm),
+          _AssignedRow(
+            recipe: recipes[i],
+            onRemove: () => onRemove(recipes[i].id),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _AssignedRow extends StatelessWidget {
+  const _AssignedRow({required this.recipe, required this.onRemove});
+
+  final Recipe recipe;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.sp12,
+        vertical: AppSizes.sp12,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.greenTint,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        border: Border.all(color: AppColors.green),
+      ),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.check_circle,
+            color: AppColors.greenDeep,
+            size: AppSizes.iconMd,
+          ),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: Text(
+              recipe.title,
+              style: AppTypography.bodyBold.copyWith(
+                color: AppColors.greenDeep,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          IconButton(
+            onPressed: onRemove,
+            icon: const Icon(
+              Icons.close,
+              color: AppColors.greenDeep,
+              size: AppSizes.iconSm,
+            ),
+            visualDensity: VisualDensity.compact,
+            splashRadius: AppSizes.iconMd,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyDayPlaceholder extends StatelessWidget {
+  const _EmptyDayPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: const _DashedBorderPainter(),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.md,
+          vertical: AppSizes.lg,
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          'No Meals Mapped Yet',
+          style: AppTypography.bodyBold.copyWith(color: AppColors.fgMuted),
+        ),
+      ),
+    );
+  }
+}
+
+class _DashedBorderPainter extends CustomPainter {
+  const _DashedBorderPainter();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = AppColors.borderMuted
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = AppSizes.dividerThickness;
+
+    const dashWidth = 6.0;
+    const dashGap = 4.0;
+    const radius = AppSizes.radiusLg;
+
+    final rrect = RRect.fromRectAndRadius(
+      Offset.zero & size,
+      const Radius.circular(radius),
+    );
+
+    final path = Path()..addRRect(rrect);
+    final metrics = path.computeMetrics();
+    for (final metric in metrics) {
+      var distance = 0.0;
+      while (distance < metric.length) {
+        final next = distance + dashWidth;
+        canvas.drawPath(
+          metric.extractPath(distance, next.clamp(0.0, metric.length)),
+          paint,
+        );
+        distance = next + dashGap;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _DashedBorderPainter oldDelegate) => false;
+}

--- a/lib/src/routing/route_enums.dart
+++ b/lib/src/routing/route_enums.dart
@@ -26,6 +26,7 @@ enum AppRoute {
   paywall(path: '/subscription/paywall', name: 'paywall'),
   home(path: '/home', name: 'home'),
   mealPlan(path: '/home/meal', name: 'meal-plan'),
+  mealPlanMap(path: '/home/meal/map', name: 'meal-plan-map'),
   shoppingList(path: '/home/shopping-list', name: 'shopping-list'),
   recipeLibrary(path: '/home/recipe', name: 'recipe-library'),
   allergenTracker(path: '/home/allergen/tracker', name: 'allergen-tracker'),

--- a/lib/src/routing/routes.dart
+++ b/lib/src/routing/routes.dart
@@ -14,6 +14,8 @@ import 'package:nibbles/src/features/auth/register/register_screen.dart';
 import 'package:nibbles/src/features/auth/reset_password/reset_password_screen.dart';
 import 'package:nibbles/src/features/home/home_screen.dart';
 import 'package:nibbles/src/features/home/home_shell_screen.dart';
+import 'package:nibbles/src/features/meal_plan/map/map_meals_screen.dart';
+import 'package:nibbles/src/features/meal_plan/map/map_meals_state.dart';
 import 'package:nibbles/src/features/meal_plan/meal_plan_screen.dart';
 import 'package:nibbles/src/features/onboarding/baby_setup/onboarding_baby_setup_screen.dart';
 import 'package:nibbles/src/features/onboarding/consent/onboarding_consent_screen.dart';
@@ -326,6 +328,17 @@ GoRouter goRouter(Ref ref) {
                 path: AppRoute.mealPlan.path,
                 name: AppRoute.mealPlan.name,
                 builder: (context, state) => const MealPlanScreen(),
+                routes: [
+                  GoRoute(
+                    path: 'map',
+                    name: AppRoute.mealPlanMap.name,
+                    parentNavigatorKey: rootNavigatorKey,
+                    builder: (context, state) {
+                      final args = state.extra! as MapMealsArgs;
+                      return MapMealsScreen(args: args);
+                    },
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/src/routing/routes.g.dart
+++ b/lib/src/routing/routes.g.dart
@@ -6,7 +6,7 @@ part of 'routes.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'912de38e73f694207dd43a86f399b729d0ca443b';
+String _$goRouterHash() => r'4bae9e0da3b41f5b896dcf7524ab4d9d34701b69';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)


### PR DESCRIPTION
## Summary
New full-screen Map Meals Plan screen (NIB-95). Takes a list of picked recipes + a date range (handed in via `GoRouterState.extra` as a freezed `MapMealsArgs` payload from NIB-87's Browse Meal sheet), lets the user assign each picked recipe to a day in the range, and bulk-commits via `MealPlanService.appendMealsToRange` (APPEND only, per NIB-120). On success pops with `true`; on failure shows a blocking P1 retry dialog.

## Routes added
- `route_enums.dart`: `mealPlanMap` → `/home/meal/map` (name `meal-plan-map`).
- `routes.dart`: child `GoRoute(path: 'map')` under existing `mealPlan` route with `parentNavigatorKey: rootNavigatorKey` (full-screen push, no shell). Extracts `MapMealsArgs` from `state.extra`.

## Files added
- `lib/src/features/meal_plan/map/map_meals_screen.dart`
- `lib/src/features/meal_plan/map/map_meals_controller.dart` + `.g.dart`
- `lib/src/features/meal_plan/map/map_meals_state.dart` + `.freezed.dart` (includes `MapMealsArgs` route payload)
- `lib/src/features/meal_plan/map/widgets/day_chip_row.dart`
- `lib/src/features/meal_plan/map/widgets/picked_recipe_row.dart`
- `lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart`

## Design System consumed
- Colors: `AppColors.cream`, `greenDeep`, `greenTint`, `green`, `coralSoft`, `coralDeep`, `borderSoft`, `borderMuted`, `surface`, `surfaceVariant`, `fgDefault`, `fgMuted`, `fgFaint`, `onGreen`.
- Typography: `AppTypography.sectionTitle`, `bodyBold`, `caption`, `button`, `textTheme.titleLarge`, `textTheme.bodyMedium`.
- Sizes: `AppSizes` spacing / radii / icon / chip / button / page padding tokens.
- Zero hex / Nunito / withAlpha / `AllergenStatus.completed`.

## Handoff note
NIB-87's Browse Meal sheet should push to this route via `context.pushNamed(AppRoute.mealPlanMap.name, extra: MapMealsArgs(pickedRecipes: ..., startDate: ..., endDate: ...))`. The screen pops with `true` on a successful append commit; the caller should `invalidate` its meal plan provider on receipt.

## Figma
- Map Meals Plan: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8375
- Mapper variants: nodes 971-8334, 971-8409, 971-8441, 971-8476, 971-8511

## Acceptance criteria
- [x] New screen + controller + state + 1 route entry + matching GoRoute
- [x] `appendMealsToRange` called from controller `commit()`
- [x] Success pops with `true`; failure shows blocking AlertDialog ("Couldn't save your plan" + "Please try again") with Retry
- [x] APPEND-only semantics — no replace
- [x] `flutter analyze` 0 issues
- [x] `flutter test` 334/334 passing
- [x] `make gen` clean (idempotent — pre-existing `home_controller.g.dart` drift reverted)

## Gate results
- `make gen`: clean, ticket-only output (freezed + riverpod g + routes.g hash bump)
- `flutter analyze`: `No issues found!`
- `flutter test`: `00:23 +334: All tests passed!`