### PR TITLE
feat(meal-plan): analytics events + crashlytics non-fatal on commit failure [NIB-109]

### DIFF
--- a/lib/src/features/meal_plan/map/map_meals_controller.dart
+++ b/lib/src/features/meal_plan/map/map_meals_controller.dart
@@ -1,10 +1,51 @@
+import 'dart:async';
+
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/common/services/meal_plan_service.dart';
 import 'package:nibbles/src/features/meal_plan/map/map_meals_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'map_meals_controller.g.dart';
+
+/// Injectable Crashlytics recorder so unit tests can assert the non-fatal
+/// payload without touching real Firebase. Mirrors the
+/// `AllergenCrashRecorderFn` pattern from NIB-125.
+typedef MealPrepCrashRecorderFn =
+    Future<void> Function(
+      Object error,
+      StackTrace stack, {
+      String? reason,
+      List<String>? information,
+    });
+
+Future<void> _defaultMealPrepCrashRecorder(
+  Object error,
+  StackTrace stack, {
+  String? reason,
+  List<String>? information,
+}) {
+  return FirebaseCrashlytics.instance.recordError(
+    error,
+    stack,
+    reason: reason,
+    information: information ?? const <Object>[],
+    // Non-fatal: meal-prep commit failures still surface a P1 retry dialog.
+    // ignore: avoid_redundant_argument_values
+    fatal: false,
+  );
+}
+
+/// Provider for the [MealPrepCrashRecorderFn]. Tests override this to capture
+/// the recorded payload without hitting Crashlytics.
+@Riverpod(keepAlive: true)
+MealPrepCrashRecorderFn mealPrepCrashRecorder(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  MealPrepCrashRecorderRef ref,
+) => _defaultMealPrepCrashRecorder;
 
 /// Drives the NIB-95 Map Meals Plan screen.
 ///
@@ -39,6 +80,14 @@ class MapMealsController extends _$MapMealsController {
     final next = Map<String, DateTime>.from(state.assignments);
     next[recipeId] = state.selectedDay;
     state = state.copyWith(assignments: next, errorMessage: null);
+    unawaited(
+      ref
+          .read(analyticsProvider)
+          .logMealPrepMappingAssigned(
+            recipeId: recipeId,
+            dayOffsetIso: _isoDate(state.selectedDay),
+          ),
+    );
   }
 
   /// Removes [recipeId] from the assignments map.
@@ -83,6 +132,16 @@ class MapMealsController extends _$MapMealsController {
         );
 
     if (result.isFailure) {
+      final dayCount = state.endDate.difference(state.startDate).inDays + 1;
+      await ref.read(mealPrepCrashRecorderProvider)(
+        'meal_prep_commit_failure: ${result.errorOrNull?.message}',
+        StackTrace.current,
+        reason: 'meal_prep_commit_failure',
+        information: <String>[
+          'recipe_count=${assignments.length}',
+          'day_count=$dayCount',
+        ],
+      );
       state = state.copyWith(
         isCommitting: false,
         errorMessage: result.errorOrNull?.message ?? 'Failed to save plan.',
@@ -91,6 +150,21 @@ class MapMealsController extends _$MapMealsController {
     }
 
     state = state.copyWith(isCommitting: false);
+    unawaited(
+      ref
+          .read(analyticsProvider)
+          .logMealPrepCommitted(
+            recipeCount: assignments.length,
+            dayCount: state.endDate.difference(state.startDate).inDays + 1,
+          ),
+    );
     return true;
+  }
+
+  /// `yyyy-MM-dd` for analytics. Locale-stable, no PII.
+  static String _isoDate(DateTime dt) {
+    final m = dt.month.toString().padLeft(2, '0');
+    final d = dt.day.toString().padLeft(2, '0');
+    return '${dt.year}-$m-$d';
   }
 }

--- a/lib/src/features/meal_plan/map/map_meals_controller.g.dart
+++ b/lib/src/features/meal_plan/map/map_meals_controller.g.dart
@@ -6,8 +6,30 @@ part of 'map_meals_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$mealPrepCrashRecorderHash() =>
+    r'61917b9a106232580c8e34736777bb7e03961138';
+
+/// Provider for the [MealPrepCrashRecorderFn]. Tests override this to capture
+/// the recorded payload without hitting Crashlytics.
+///
+/// Copied from [mealPrepCrashRecorder].
+@ProviderFor(mealPrepCrashRecorder)
+final mealPrepCrashRecorderProvider =
+    Provider<MealPrepCrashRecorderFn>.internal(
+      mealPrepCrashRecorder,
+      name: r'mealPrepCrashRecorderProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$mealPrepCrashRecorderHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef MealPrepCrashRecorderRef = ProviderRef<MealPrepCrashRecorderFn>;
 String _$mapMealsControllerHash() =>
-    r'e4d7781e7268d1aa30b0fcce773b320022803c30';
+    r'3bd04cb23a21215baf69a349c8514a2adea03309';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/meal_plan/meal_plan_screen.dart
+++ b/lib/src/features/meal_plan/meal_plan_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -19,8 +21,16 @@ import 'package:nibbles/src/features/meal_plan/widgets/clear_confirm_dialog.dart
 import 'package:nibbles/src/features/meal_plan/widgets/day_accordion_card.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_empty_state.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_header.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 import 'package:nibbles/src/utils/age_in_months.dart';
+
+/// `yyyy-MM-dd` for analytics. Locale-stable, no PII.
+String _isoDate(DateTime dt) {
+  final m = dt.month.toString().padLeft(2, '0');
+  final d = dt.day.toString().padLeft(2, '0');
+  return '${dt.year}-$m-$d';
+}
 
 /// Screen-level overflow menu actions (Figma 971:7999).
 enum _ScreenMenuAction { addToShopList, createMealPrep, clearCurrentWeek }
@@ -74,6 +84,10 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
   /// controller state changes window (e.g. invalidate on the day rollover).
   DateTime? _extraEnd;
 
+  /// Guard so `meal_plan_viewed` only fires once per mount, after the
+  /// controller resolves with success.
+  bool _viewedFired = false;
+
   @override
   Widget build(BuildContext context) {
     final controllerAsync = ref.watch(
@@ -98,6 +112,7 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
     if (baby == null) {
       return const Center(child: Text('No baby profile found.'));
     }
+    _fireViewedOnce(state);
     if (state.entries.isEmpty) {
       return MealPlanEmptyState(
         babyName: baby.name,
@@ -113,11 +128,48 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
       onScreenMenuSelected: _onScreenMenuSelected,
       onDayAdd: _onDayAdd,
       onDayMenuSelected: _onDayMenuSelected,
-      onToggleExpanded: (day) => ref
-          .read(mealPlanControllerProvider(widget.babyId).notifier)
-          .toggleExpanded(day),
+      onToggleExpanded: _onToggleExpanded,
       onRecipeTap: _onRecipeTap,
     );
+  }
+
+  void _fireViewedOnce(MealPlanState state) {
+    if (_viewedFired) return;
+    _viewedFired = true;
+    final start = DateTime(
+      state.windowStart.year,
+      state.windowStart.month,
+      state.windowStart.day,
+    );
+    final end = _effectiveWindowEnd(state);
+    final dayCount = DateTime(end.year, end.month, end.day)
+            .difference(start)
+            .inDays +
+        1;
+    unawaited(
+      ref.read(analyticsProvider).logMealPlanViewed(dayCount: dayCount),
+    );
+  }
+
+  void _onToggleExpanded(DateTime day) {
+    final notifier = ref.read(
+      mealPlanControllerProvider(widget.babyId).notifier,
+    );
+    // Read current expanded state BEFORE toggling so we can fire the correct
+    // expanded/collapsed event for the resulting state.
+    final current = ref
+        .read(mealPlanControllerProvider(widget.babyId))
+        .valueOrNull;
+    final key = DateTime.utc(day.year, day.month, day.day);
+    final wasExpanded = current?.expanded[key] ?? false;
+    notifier.toggleExpanded(day);
+    final analytics = ref.read(analyticsProvider);
+    final iso = _isoDate(day);
+    if (wasExpanded) {
+      unawaited(analytics.logMealPlanDayCollapsed(dayOffsetIso: iso));
+    } else {
+      unawaited(analytics.logMealPlanDayExpanded(dayOffsetIso: iso));
+    }
   }
 
   DateTime _effectiveWindowEnd(MealPlanState state) {
@@ -135,9 +187,14 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
       final current = _effectiveWindowEnd(state);
       _extraEnd = current.add(const Duration(days: 1));
     });
+    unawaited(ref.read(analyticsProvider).logMealPlanAddDateTapped());
   }
 
   Future<void> _onCreateMealPlanFromEmpty(DateTimeRange range) async {
+    final days = range.end.difference(range.start).inDays + 1;
+    unawaited(
+      ref.read(analyticsProvider).logMealPrepRangeSelected(days: days),
+    );
     final picked = await showBrowseMealSheet(
       context,
       babyId: widget.babyId,
@@ -170,9 +227,21 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
           endDate: day,
           assignments: assignments,
         );
-    if (!ok && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Couldn't add to meal plan. Try again.")),
+    if (!ok) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text("Couldn't add to meal plan. Try again."),
+          ),
+        );
+      }
+      return;
+    }
+    final analytics = ref.read(analyticsProvider);
+    final iso = _isoDate(day);
+    for (final r in picked) {
+      unawaited(
+        analytics.logMealPlanRecipeAssigned(recipeId: r.id, dayOffsetIso: iso),
       );
     }
   }
@@ -182,10 +251,23 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
         .read(mealPlanControllerProvider(widget.babyId))
         .valueOrNull;
     if (state == null) return;
+    final analytics = ref.read(analyticsProvider);
     switch (action) {
       case _ScreenMenuAction.addToShopList:
+        final start = DateTime(
+          state.windowStart.year,
+          state.windowStart.month,
+          state.windowStart.day,
+        );
+        final end = _effectiveWindowEnd(state);
+        final dayCount = DateTime(end.year, end.month, end.day)
+                .difference(start)
+                .inDays +
+            1;
+        unawaited(analytics.logMealPlanAddToShopList(dayCount: dayCount));
         await _openAddToShoppingList(state.windowStart);
       case _ScreenMenuAction.createMealPrep:
+        unawaited(analytics.logMealPrepCreateStarted());
         await _onCreateMealPrep(state);
       case _ScreenMenuAction.clearCurrentWeek:
         await _onClearWindow(state);
@@ -202,6 +284,9 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
     if (state == null) return;
     switch (action) {
       case DayCardMenuAction.addToShopList:
+        // Per NIB-109 spec, `meal_plan_add_to_shop_list` only fires from the
+        // SCREEN-LEVEL overflow menu (see [_onScreenMenuSelected]). The
+        // day-card menu intentionally does not fire it.
         await _openAddToShoppingList(day);
       case DayCardMenuAction.clearCurrentWeek:
         await _onClearWindow(state);
@@ -209,29 +294,44 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
   }
 
   Future<void> _onCreateMealPrep(MealPlanState state) async {
+    final endDate = _effectiveWindowEnd(state);
+    final days = endDate.difference(state.windowStart).inDays + 1;
+    unawaited(
+      ref.read(analyticsProvider).logMealPrepRangeSelected(days: days),
+    );
     final picked = await showBrowseMealSheet(
       context,
       babyId: widget.babyId,
       startDate: state.windowStart,
-      endDate: _effectiveWindowEnd(state),
+      endDate: endDate,
     );
     if (picked == null || picked.isEmpty) return;
     if (!mounted) return;
-    await _pushMapMeals(picked, state.windowStart, _effectiveWindowEnd(state));
+    await _pushMapMeals(picked, state.windowStart, endDate);
   }
 
   Future<void> _onClearWindow(MealPlanState state) async {
     final confirmed = await showClearMealPlanConfirm(context);
     if (confirmed != true) return;
     if (!mounted) return;
+    final endDate = _effectiveWindowEnd(state);
     final ok = await ref
         .read(mealPlanControllerProvider(widget.babyId).notifier)
-        .clearRange(state.windowStart, _effectiveWindowEnd(state));
-    if (!ok && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Couldn't clear meals. Try again.")),
-      );
+        .clearRange(state.windowStart, endDate);
+    if (!ok) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text("Couldn't clear meals. Try again.")),
+        );
+      }
+      return;
     }
+    final dayCount = endDate.difference(state.windowStart).inDays + 1;
+    unawaited(
+      ref
+          .read(analyticsProvider)
+          .logMealPlanClearWeekConfirmed(dayCount: dayCount),
+    );
   }
 
   Future<void> _openAddToShoppingList(DateTime date) async {

--- a/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
+++ b/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nibbles/src/app/constants/allergen_emoji.dart';
@@ -12,6 +14,7 @@ import 'package:nibbles/src/common/services/helpers/derive_allergen_status.dart'
 import 'package:nibbles/src/common/services/recipe_service.dart';
 import 'package:nibbles/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart';
 import 'package:nibbles/src/features/meal_plan/sheets/widgets/recommendation_carousel_section.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 
 /// Bottom sheet shown via [showModalBottomSheet]. Returns the picked recipes
 /// or null on cancel. Multi-select Browse Meal sheet for the meal-plan
@@ -143,11 +146,14 @@ class _BrowseMealSheetState extends ConsumerState<_BrowseMealSheet> {
 
   void _toggleRecipe(Recipe r) {
     if (_isUnsafe(r)) return;
+    final analytics = ref.read(analyticsProvider);
     setState(() {
       if (_selectedRecipeIds.contains(r.id)) {
         _selectedRecipeIds.remove(r.id);
+        unawaited(analytics.logMealPrepBrowseDeselected(recipeId: r.id));
       } else {
         _selectedRecipeIds.add(r.id);
+        unawaited(analytics.logMealPrepBrowseSelected(recipeId: r.id));
       }
     });
   }

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -268,6 +268,105 @@ class Analytics {
   }
 
   // ---------------------------------------------------------------------------
+  // Meal Plan (NIB-109) — non-PII only: recipe IDs, ISO date strings, counts.
+  // ---------------------------------------------------------------------------
+
+  Future<void> logMealPlanViewed({required int dayCount}) async {
+    await _logEvent('meal_plan_viewed', parameters: {'day_count': dayCount});
+  }
+
+  Future<void> logMealPlanDayExpanded({required String dayOffsetIso}) async {
+    await _logEvent(
+      'meal_plan_day_expanded',
+      parameters: {'day_offset_iso': dayOffsetIso},
+    );
+  }
+
+  Future<void> logMealPlanDayCollapsed({required String dayOffsetIso}) async {
+    await _logEvent(
+      'meal_plan_day_collapsed',
+      parameters: {'day_offset_iso': dayOffsetIso},
+    );
+  }
+
+  Future<void> logMealPlanAddDateTapped() async {
+    await _logEvent('meal_plan_add_date_tapped');
+  }
+
+  Future<void> logMealPlanRecipeAssigned({
+    required String recipeId,
+    required String dayOffsetIso,
+  }) async {
+    await _logEvent(
+      'meal_plan_recipe_assigned',
+      parameters: {'recipe_id': recipeId, 'day_offset_iso': dayOffsetIso},
+    );
+  }
+
+  Future<void> logMealPlanRecipeRemoved({required String recipeId}) async {
+    await _logEvent(
+      'meal_plan_recipe_removed',
+      parameters: {'recipe_id': recipeId},
+    );
+  }
+
+  Future<void> logMealPrepCreateStarted() async {
+    await _logEvent('meal_prep_create_started');
+  }
+
+  Future<void> logMealPrepRangeSelected({required int days}) async {
+    await _logEvent('meal_prep_range_selected', parameters: {'days': days});
+  }
+
+  Future<void> logMealPrepBrowseSelected({required String recipeId}) async {
+    await _logEvent(
+      'meal_prep_browse_selected',
+      parameters: {'recipe_id': recipeId},
+    );
+  }
+
+  Future<void> logMealPrepBrowseDeselected({required String recipeId}) async {
+    await _logEvent(
+      'meal_prep_browse_deselected',
+      parameters: {'recipe_id': recipeId},
+    );
+  }
+
+  Future<void> logMealPrepMappingAssigned({
+    required String recipeId,
+    required String dayOffsetIso,
+  }) async {
+    await _logEvent(
+      'meal_prep_mapping_assigned',
+      parameters: {'recipe_id': recipeId, 'day_offset_iso': dayOffsetIso},
+    );
+  }
+
+  Future<void> logMealPrepCommitted({
+    required int recipeCount,
+    required int dayCount,
+  }) async {
+    await _logEvent(
+      'meal_prep_committed',
+      parameters: {'recipe_count': recipeCount, 'day_count': dayCount},
+    );
+  }
+
+  Future<void> logMealPlanClearWeekConfirmed({required int dayCount}) async {
+    await _logEvent(
+      'meal_plan_clear_week_confirmed',
+      parameters: {'day_count': dayCount},
+    );
+  }
+
+  Future<void> logMealPlanAddToShopList({required int dayCount}) async {
+    await _logEvent(
+      'meal_plan_add_to_shop_list',
+      parameters: {'day_count': dayCount},
+    );
+  }
+
+  // ---------------------------------------------------------------------------
   // Screen tracking
   // ---------------------------------------------------------------------------
 

--- a/test/support/fake_analytics.dart
+++ b/test/support/fake_analytics.dart
@@ -155,6 +155,77 @@ class FakeAnalytics implements Analytics {
       _record('recipe_added_to_meal_plan', {'recipe_id': recipeId});
 
   @override
+  Future<void> logMealPlanViewed({required int dayCount}) async =>
+      _record('meal_plan_viewed', {'day_count': dayCount});
+
+  @override
+  Future<void> logMealPlanDayExpanded({required String dayOffsetIso}) async =>
+      _record('meal_plan_day_expanded', {'day_offset_iso': dayOffsetIso});
+
+  @override
+  Future<void> logMealPlanDayCollapsed({required String dayOffsetIso}) async =>
+      _record('meal_plan_day_collapsed', {'day_offset_iso': dayOffsetIso});
+
+  @override
+  Future<void> logMealPlanAddDateTapped() async =>
+      _record('meal_plan_add_date_tapped');
+
+  @override
+  Future<void> logMealPlanRecipeAssigned({
+    required String recipeId,
+    required String dayOffsetIso,
+  }) async => _record('meal_plan_recipe_assigned', {
+    'recipe_id': recipeId,
+    'day_offset_iso': dayOffsetIso,
+  });
+
+  @override
+  Future<void> logMealPlanRecipeRemoved({required String recipeId}) async =>
+      _record('meal_plan_recipe_removed', {'recipe_id': recipeId});
+
+  @override
+  Future<void> logMealPrepCreateStarted() async =>
+      _record('meal_prep_create_started');
+
+  @override
+  Future<void> logMealPrepRangeSelected({required int days}) async =>
+      _record('meal_prep_range_selected', {'days': days});
+
+  @override
+  Future<void> logMealPrepBrowseSelected({required String recipeId}) async =>
+      _record('meal_prep_browse_selected', {'recipe_id': recipeId});
+
+  @override
+  Future<void> logMealPrepBrowseDeselected({required String recipeId}) async =>
+      _record('meal_prep_browse_deselected', {'recipe_id': recipeId});
+
+  @override
+  Future<void> logMealPrepMappingAssigned({
+    required String recipeId,
+    required String dayOffsetIso,
+  }) async => _record('meal_prep_mapping_assigned', {
+    'recipe_id': recipeId,
+    'day_offset_iso': dayOffsetIso,
+  });
+
+  @override
+  Future<void> logMealPrepCommitted({
+    required int recipeCount,
+    required int dayCount,
+  }) async => _record('meal_prep_committed', {
+    'recipe_count': recipeCount,
+    'day_count': dayCount,
+  });
+
+  @override
+  Future<void> logMealPlanClearWeekConfirmed({required int dayCount}) async =>
+      _record('meal_plan_clear_week_confirmed', {'day_count': dayCount});
+
+  @override
+  Future<void> logMealPlanAddToShopList({required int dayCount}) async =>
+      _record('meal_plan_add_to_shop_list', {'day_count': dayCount});
+
+  @override
   Future<void> logScreenView({required String screenName}) async =>
       _record('screen_view', {'screen_name': screenName});
 }


### PR DESCRIPTION
## Summary

Instrument the redesigned Meal Plan flows with 14 success-only analytics events (no PII) and record a non-fatal Crashlytics report on bulk-prep commit failure. Recorder is injected via a `MealPrepCrashRecorderFn` typedef + Riverpod provider so NIB-113 tests can override without touching Firebase.

(Note: the ticket prose says "13 new methods" but the enumerated bullet list has 14 events — the enumerated list wins; all 14 are implemented.)

## Events added (`lib/src/logging/analytics.dart`)

| Event name | Parameters |
| --- | --- |
| `meal_plan_viewed` | `day_count: int` |
| `meal_plan_day_expanded` | `day_offset_iso: String` (`yyyy-MM-dd`) |
| `meal_plan_day_collapsed` | `day_offset_iso: String` |
| `meal_plan_add_date_tapped` | — |
| `meal_plan_recipe_assigned` | `recipe_id: String`, `day_offset_iso: String` |
| `meal_plan_recipe_removed` | `recipe_id: String` (defined; no fire site yet) |
| `meal_prep_create_started` | — |
| `meal_prep_range_selected` | `days: int` |
| `meal_prep_browse_selected` | `recipe_id: String` |
| `meal_prep_browse_deselected` | `recipe_id: String` |
| `meal_prep_mapping_assigned` | `recipe_id: String`, `day_offset_iso: String` |
| `meal_prep_committed` | `recipe_count: int`, `day_count: int` |
| `meal_plan_clear_week_confirmed` | `day_count: int` |
| `meal_plan_add_to_shop_list` | `day_count: int` |

## Fire sites (exact `file:line` of the call)

- `meal_plan_viewed` — `lib/src/features/meal_plan/meal_plan_screen.dart:150` (fired once per mount via `_fireViewedOnce` after the controller resolves with success)
- `meal_plan_day_collapsed` — `meal_plan_screen.dart:169` (in `_onToggleExpanded`, branched on pre-toggle state)
- `meal_plan_day_expanded` — `meal_plan_screen.dart:171`
- `meal_plan_add_date_tapped` — `meal_plan_screen.dart:190` (in `_onAddDate`)
- `meal_prep_range_selected` (empty-state range pick) — `meal_plan_screen.dart:196` (in `_onCreateMealPlanFromEmpty`, fired before `showBrowseMealSheet`)
- `meal_plan_recipe_assigned` — `meal_plan_screen.dart:244` (in `_onDayAdd`, ONLY after `appendBulkPrep` returns `true`; one event per picked recipe)
- `meal_plan_add_to_shop_list` — `meal_plan_screen.dart:267` (in `_onScreenMenuSelected`, screen-level overflow only; the day-card overflow intentionally does NOT fire this per the spec's exact wording)
- `meal_prep_create_started` — `meal_plan_screen.dart:270` (in `_onScreenMenuSelected`)
- `meal_prep_range_selected` (Create-Meal-Prep flow) — `meal_plan_screen.dart:300` (in `_onCreateMealPrep`)
- `meal_plan_clear_week_confirmed` — `meal_plan_screen.dart:333` (in `_onClearWindow`, ONLY after `clearRange` returns `true`)
- `meal_prep_browse_selected` — `lib/src/features/meal_plan/sheets/browse_meal_sheet.dart:156` (in `_toggleRecipe`, SELECT branch)
- `meal_prep_browse_deselected` — `browse_meal_sheet.dart:153` (in `_toggleRecipe`, DESELECT branch)
- `meal_prep_mapping_assigned` — `lib/src/features/meal_plan/map/map_meals_controller.dart:86` (in `assignToSelectedDay`, post-mutation)
- `meal_prep_committed` — `map_meals_controller.dart:156` (in `commit()`, ONLY after `Result.success`)
- `meal_plan_recipe_removed` — defined in `analytics.dart`, no fire site yet (per spec; other tickets may wire it).

All analytics calls are wrapped with `unawaited(...)` (`dart:async`) for fire-and-forget semantics.

## Crashlytics non-fatal

- Recorded in `lib/src/features/meal_plan/map/map_meals_controller.dart:136`, inside `commit()` BEFORE `state.errorMessage` is set / the P1 dialog surfaces, only when `result.isFailure`.
- Recorder dispatched via `mealPrepCrashRecorderProvider` (`map_meals_controller.dart:44`) which returns the default `_defaultMealPrepCrashRecorder` (`map_meals_controller.dart:24`) calling `FirebaseCrashlytics.instance.recordError(...)`.
- Typedef: `MealPrepCrashRecorderFn` at `map_meals_controller.dart:16` (mirrors the `AllergenCrashRecorderFn` pattern from NIB-125).
- Payload shape:
  - `error` — `String`: `'meal_prep_commit_failure: <Result.errorOrNull?.message>'`
  - `stack` — `StackTrace.current`
  - `reason` — `'meal_prep_commit_failure'`
  - `information` — `['recipe_count=<assignments.length>', 'day_count=<endDate.difference(startDate).inDays + 1>']`
  - `fatal` — `false`

## PII gate

All event parameters are primitives: stable recipe UUIDs, `yyyy-MM-dd` ISO date strings, integer counts. No `baby_id`, no baby names, no notes, no photo paths, no free text. Crashlytics payload is identical (counts + a stable failure reason string — no per-baby identifiers, no message content beyond the Result error string surfaced from the data layer).

## Allowed-file scope check

Touched only the files in the allowed list:
- `lib/src/logging/analytics.dart`
- `lib/src/features/meal_plan/meal_plan_screen.dart`
- `lib/src/features/meal_plan/sheets/browse_meal_sheet.dart`
- `lib/src/features/meal_plan/map/map_meals_controller.dart` (+ regenerated `.g.dart`)
- `test/support/fake_analytics.dart`

Forbidden files (`meal_plan_controller.dart`, `meal_plan_service.dart`, `widgets/**`, routing, common components, other features) — untouched.

A stale base-drift edit to `lib/src/features/home/home_controller.g.dart` (regenerated riverpod hash) was reverted as instructed in the orchestrator notes.

## Acceptance checklist

- [x] `analytics.dart` exposes 14 new `logMealPlan*` / `logMealPrep*` methods following the existing pattern.
- [x] Each fire site is AFTER `Result.success` only (controller-mediated mutations); intent events fire on user action.
- [x] Crashlytics non-fatal recorded on bulk-prep commit failure with `recipe_count` + `day_count`.
- [x] PII gate clean — no `baby_id` / notes / free-text params.
- [x] `flutter analyze` — 0 issues.
- [x] Existing tests pass (`flutter test` — 334 passed, 0 failed).
- [x] `make gen` clean + idempotent (re-running produces no working-tree diff beyond the ticket's files).
- [x] No files outside the allowed list are modified.

## Gate results

- `make gen` — clean, idempotent.
- `flutter analyze` — `No issues found! (ran in 2.7s)`.
- `flutter test` — `All tests passed! (00:24 +334)`.