### PR TITLE
chore(meal-plan): add controller/widget/integration test coverage [NIB-113]

### DIFF
--- a/test/features/meal_plan/map/map_meals_controller_test.dart
+++ b/test/features/meal_plan/map/map_meals_controller_test.dart
@@ -1,0 +1,302 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:nibbles/src/features/meal_plan/map/map_meals_controller.dart';
+import 'package:nibbles/src/features/meal_plan/map/map_meals_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class _MockBabyProfileService extends Mock implements BabyProfileService {}
+
+class _MockMealPlanService extends Mock implements MealPlanService {}
+
+const _babyId = 'baby-001';
+
+final _fakeBaby = Baby(
+  id: _babyId,
+  userId: 'user-001',
+  name: 'Lily',
+  dateOfBirth: DateTime(2025, 6),
+  gender: Gender.female,
+  onboardingCompleted: true,
+);
+
+const _recipeA = Recipe(
+  id: 'r-A',
+  title: 'Recipe A',
+  ageRange: '6m+',
+  allergenTags: [],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+const _recipeB = Recipe(
+  id: 'r-B',
+  title: 'Recipe B',
+  ageRange: '6m+',
+  allergenTags: [],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+void main() {
+  late _MockBabyProfileService mockBabyService;
+  late _MockMealPlanService mockMealPlanService;
+  late FakeAnalytics fakeAnalytics;
+  late List<_RecorderCall> recorderCalls;
+
+  setUpAll(() {
+    registerFallbackValue(DateTime(2026));
+    registerFallbackValue(StackTrace.empty);
+  });
+
+  setUp(() {
+    mockBabyService = _MockBabyProfileService();
+    mockMealPlanService = _MockMealPlanService();
+    fakeAnalytics = FakeAnalytics();
+    recorderCalls = <_RecorderCall>[];
+  });
+
+  Future<void> fakeRecorder(
+    Object error,
+    StackTrace stack, {
+    String? reason,
+    List<String>? information,
+  }) async {
+    recorderCalls.add(
+      _RecorderCall(
+        error: error,
+        stack: stack,
+        reason: reason,
+        information: information,
+      ),
+    );
+  }
+
+  ProviderContainer buildContainer() {
+    when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);
+    final container = ProviderContainer(
+      overrides: [
+        babyProfileServiceProvider.overrideWithValue(mockBabyService),
+        mealPlanServiceProvider.overrideWithValue(mockMealPlanService),
+        analyticsProvider.overrideWithValue(fakeAnalytics),
+        mealPrepCrashRecorderProvider.overrideWithValue(fakeRecorder),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  MapMealsArgs makeArgs({
+    List<Recipe> picked = const [_recipeA, _recipeB],
+    DateTime? start,
+    DateTime? end,
+  }) {
+    final s = start ?? DateTime(2026, 5, 30);
+    final e = end ?? s.add(const Duration(days: 6));
+    return MapMealsArgs(pickedRecipes: picked, startDate: s, endDate: e);
+  }
+
+  group('MapMealsController.build', () {
+    test(
+      'initializes selectedDay = startDate (date-only), '
+      'empty assignments, isCommitting=false',
+      () {
+        final container = buildContainer();
+        final args = makeArgs(
+          start: DateTime(2026, 5, 30, 14, 32),
+          end: DateTime(2026, 6, 5),
+        );
+
+        final state = container.read(mapMealsControllerProvider(args));
+
+        expect(state.selectedDay, DateTime(2026, 5, 30));
+        expect(state.startDate, DateTime(2026, 5, 30));
+        expect(state.endDate, DateTime(2026, 6, 5));
+        expect(state.assignments, isEmpty);
+        expect(state.isCommitting, isFalse);
+        expect(state.errorMessage, isNull);
+      },
+    );
+  });
+
+  group('MapMealsController.selectDay', () {
+    test('updates selectedDay (date-only normalized)', () {
+      final container = buildContainer();
+      final args = makeArgs();
+      container
+          .read(mapMealsControllerProvider(args).notifier)
+          .selectDay(DateTime(2026, 6, 2, 11, 22));
+
+      final state = container.read(mapMealsControllerProvider(args));
+      expect(state.selectedDay, DateTime(2026, 6, 2));
+    });
+  });
+
+  group('MapMealsController.assignToSelectedDay', () {
+    test('maps recipeId → selectedDay (overwrites on re-assign)', () {
+      final container = buildContainer();
+      final args = makeArgs();
+      final notifier = container.read(
+        mapMealsControllerProvider(args).notifier,
+      )
+        ..selectDay(DateTime(2026, 5, 31))
+        ..assignToSelectedDay('r-A');
+
+      var state = container.read(mapMealsControllerProvider(args));
+      expect(state.assignments['r-A'], DateTime(2026, 5, 31));
+
+      notifier
+        ..selectDay(DateTime(2026, 6, 3))
+        ..assignToSelectedDay('r-A');
+
+      state = container.read(mapMealsControllerProvider(args));
+      expect(
+        state.assignments['r-A'],
+        DateTime(2026, 6, 3),
+        reason: 'Re-assignment should overwrite the original day.',
+      );
+    });
+  });
+
+  group('MapMealsController.unassign', () {
+    test('removes the recipeId from assignments', () {
+      final container = buildContainer();
+      final args = makeArgs();
+      container
+          .read(mapMealsControllerProvider(args).notifier)
+        ..assignToSelectedDay('r-A')
+        ..unassign('r-A');
+
+      final state = container.read(mapMealsControllerProvider(args));
+      expect(state.assignments, isEmpty);
+    });
+  });
+
+  group('MapMealsController.commit', () {
+    test(
+      'success: maps assignments → RecipeAssignment(dayOffset) and '
+      'returns true',
+      () async {
+        final args = makeArgs();
+        when(
+          () => mockMealPlanService.appendMealsToRange(
+            babyId: any(named: 'babyId'),
+            startDate: any(named: 'startDate'),
+            endDate: any(named: 'endDate'),
+            assignments: any(named: 'assignments'),
+          ),
+        ).thenAnswer((_) async => const Result.success([]));
+
+        final container = buildContainer();
+        final notifier = container.read(
+          mapMealsControllerProvider(args).notifier,
+        )
+          // r-A → start (offset 0)
+          ..assignToSelectedDay('r-A')
+          // r-B → start + 3 days (offset 3)
+          ..selectDay(DateTime(2026, 6, 2))
+          ..assignToSelectedDay('r-B');
+
+        final ok = await notifier.commit();
+
+        expect(ok, isTrue);
+        final captured = verify(
+          () => mockMealPlanService.appendMealsToRange(
+            babyId: _babyId,
+            startDate: DateTime(2026, 5, 30),
+            endDate: DateTime(2026, 6, 5),
+            assignments: captureAny(named: 'assignments'),
+          ),
+        ).captured.single as List<RecipeAssignment>;
+        expect(captured, hasLength(2));
+        final byId = {for (final a in captured) a.recipeId: a.dayOffset};
+        expect(byId['r-A'], 0);
+        expect(byId['r-B'], 3);
+        expect(recorderCalls, isEmpty);
+      },
+    );
+
+    test(
+      'failure: sets errorMessage, returns false, records non-fatal via '
+      'injected MealPrepCrashRecorderFn',
+      () async {
+        final args = makeArgs();
+        when(
+          () => mockMealPlanService.appendMealsToRange(
+            babyId: any(named: 'babyId'),
+            startDate: any(named: 'startDate'),
+            endDate: any(named: 'endDate'),
+            assignments: any(named: 'assignments'),
+          ),
+        ).thenAnswer(
+          (_) async => const Result.failure(ServerException('boom')),
+        );
+
+        final container = buildContainer();
+        final notifier = container.read(
+          mapMealsControllerProvider(args).notifier,
+        )..assignToSelectedDay('r-A');
+
+        final ok = await notifier.commit();
+
+        expect(ok, isFalse);
+        final state = container.read(mapMealsControllerProvider(args));
+        expect(state.errorMessage, 'boom');
+        expect(state.isCommitting, isFalse);
+
+        expect(recorderCalls, hasLength(1));
+        expect(recorderCalls.single.reason, 'meal_prep_commit_failure');
+        expect(
+          recorderCalls.single.information,
+          containsAll(<String>['recipe_count=1', 'day_count=7']),
+        );
+      },
+    );
+
+    test('empty assignments short-circuits to false (no service call)',
+        () async {
+      final container = buildContainer();
+      final args = makeArgs();
+      final notifier = container.read(
+        mapMealsControllerProvider(args).notifier,
+      );
+
+      final ok = await notifier.commit();
+
+      expect(ok, isFalse);
+      verifyNever(
+        () => mockMealPlanService.appendMealsToRange(
+          babyId: any(named: 'babyId'),
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          assignments: any(named: 'assignments'),
+        ),
+      );
+    });
+  });
+}
+
+class _RecorderCall {
+  _RecorderCall({
+    required this.error,
+    required this.stack,
+    required this.reason,
+    required this.information,
+  });
+
+  final Object error;
+  final StackTrace stack;
+  final String? reason;
+  final List<String>? information;
+}

--- a/test/features/meal_plan/map/map_meals_screen_test.dart
+++ b/test/features/meal_plan/map/map_meals_screen_test.dart
@@ -1,0 +1,298 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:nibbles/src/features/meal_plan/map/map_meals_controller.dart';
+import 'package:nibbles/src/features/meal_plan/map/map_meals_screen.dart';
+import 'package:nibbles/src/features/meal_plan/map/map_meals_state.dart';
+import 'package:nibbles/src/features/meal_plan/map/widgets/day_chip_row.dart';
+import 'package:nibbles/src/features/meal_plan/map/widgets/picked_recipe_row.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class _MockBabyProfileService extends Mock implements BabyProfileService {}
+
+class _MockMealPlanService extends Mock implements MealPlanService {}
+
+const _babyId = 'baby-001';
+
+final _fakeBaby = Baby(
+  id: _babyId,
+  userId: 'user-001',
+  name: 'Lily',
+  dateOfBirth: DateTime(2025, 6),
+  gender: Gender.female,
+  onboardingCompleted: true,
+);
+
+const _recipeA = Recipe(
+  id: 'r-A',
+  title: 'Avocado Mash',
+  ageRange: '6m+',
+  allergenTags: [],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+const _recipeB = Recipe(
+  id: 'r-B',
+  title: 'Banana Porridge',
+  ageRange: '6m+',
+  allergenTags: [],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+MapMealsArgs _makeArgs() => MapMealsArgs(
+      pickedRecipes: const [_recipeA, _recipeB],
+      startDate: DateTime(2026, 5, 30),
+      endDate: DateTime(2026, 6, 5),
+    );
+
+void main() {
+  late _MockBabyProfileService mockBabyService;
+  late _MockMealPlanService mockMealPlanService;
+  late FakeAnalytics fakeAnalytics;
+  late List<_RecorderCall> recorderCalls;
+
+  setUpAll(() {
+    registerFallbackValue(DateTime(2026));
+    registerFallbackValue(StackTrace.empty);
+  });
+
+  setUp(() {
+    mockBabyService = _MockBabyProfileService();
+    mockMealPlanService = _MockMealPlanService();
+    fakeAnalytics = FakeAnalytics();
+    recorderCalls = <_RecorderCall>[];
+    when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);
+  });
+
+  Future<void> fakeRecorder(
+    Object error,
+    StackTrace stack, {
+    String? reason,
+    List<String>? information,
+  }) async {
+    recorderCalls.add(
+      _RecorderCall(
+        error: error,
+        stack: stack,
+        reason: reason,
+        information: information,
+      ),
+    );
+  }
+
+  Future<void> pumpMap(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final args = _makeArgs();
+    final router = GoRouter(
+      initialLocation: '/map',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, __) => const Scaffold(body: Text('Home')),
+        ),
+        GoRoute(
+          path: '/map',
+          builder: (_, __) => MapMealsScreen(args: args),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          babyProfileServiceProvider.overrideWithValue(mockBabyService),
+          mealPlanServiceProvider.overrideWithValue(mockMealPlanService),
+          analyticsProvider.overrideWithValue(fakeAnalytics),
+          mealPrepCrashRecorderProvider.overrideWithValue(fakeRecorder),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('MapMealsScreen', () {
+    testWidgets(
+      'renders day chips, picked recipe list and the "X of Y slots filled" '
+      'progress badge',
+      (tester) async {
+        await pumpMap(tester);
+
+        expect(find.byType(DayChipRow), findsOneWidget);
+        expect(find.byType(PickedRecipeRow), findsNWidgets(2));
+        expect(find.text('0 of 2 slots filled'), findsOneWidget);
+      },
+    );
+
+    testWidgets('tapping a picked recipe assigns it to the selected day',
+        (tester) async {
+      await pumpMap(tester);
+
+      // Tap the first picked recipe to assign it to the (currently) selected
+      // start day.
+      await tester.tap(find.text(_recipeA.title));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 of 2 slots filled'), findsOneWidget);
+    });
+
+    testWidgets(
+      '"Mapp Meal Plan" CTA is disabled until at least 1 assignment exists',
+      (tester) async {
+        await pumpMap(tester);
+
+        final cta = find.widgetWithText(FilledButton, 'Mapp Meal Plan');
+        expect(cta, findsOneWidget);
+        expect(tester.widget<FilledButton>(cta).onPressed, isNull);
+
+        await tester.tap(find.text(_recipeA.title));
+        await tester.pumpAndSettle();
+
+        expect(tester.widget<FilledButton>(cta).onPressed, isNotNull);
+      },
+    );
+
+    testWidgets('commit success pops the route with true', (tester) async {
+      when(
+        () => mockMealPlanService.appendMealsToRange(
+          babyId: any(named: 'babyId'),
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          assignments: any(named: 'assignments'),
+        ),
+      ).thenAnswer((_) async => const Result.success([]));
+
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      // GoRouter so the screen's `context.pop(true)` resolves the pushed
+      // future on the previous route.
+      final args = _makeArgs();
+      Object? popResult;
+      late GoRouter router;
+      router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, _) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () async {
+                    popResult =
+                        await router.push<dynamic>('/map');
+                  },
+                  child: const Text('Push'),
+                ),
+              ),
+            ),
+          ),
+          GoRoute(
+            path: '/map',
+            builder: (_, __) => MapMealsScreen(args: args),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            babyProfileServiceProvider.overrideWithValue(mockBabyService),
+            mealPlanServiceProvider.overrideWithValue(mockMealPlanService),
+            analyticsProvider.overrideWithValue(fakeAnalytics),
+            mealPrepCrashRecorderProvider.overrideWithValue(fakeRecorder),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+
+      await tester.tap(find.text('Push'));
+      await tester.pumpAndSettle();
+
+      // Assign one recipe + commit.
+      await tester.tap(find.text(_recipeA.title));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.widgetWithText(FilledButton, 'Mapp Meal Plan'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(popResult, isTrue);
+    });
+
+    testWidgets(
+      'commit failure shows a blocking AlertDialog with Retry that '
+      're-calls commit',
+      (tester) async {
+        var callCount = 0;
+        when(
+          () => mockMealPlanService.appendMealsToRange(
+            babyId: any(named: 'babyId'),
+            startDate: any(named: 'startDate'),
+            endDate: any(named: 'endDate'),
+            assignments: any(named: 'assignments'),
+          ),
+        ).thenAnswer((_) async {
+          callCount++;
+          return const Result.failure(ServerException('boom'));
+        });
+
+        await pumpMap(tester);
+
+        await tester.tap(find.text(_recipeA.title));
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.widgetWithText(FilledButton, 'Mapp Meal Plan'),
+        );
+        await tester.pumpAndSettle();
+
+        // Blocking AlertDialog with Retry button.
+        expect(find.byType(AlertDialog), findsOneWidget);
+        expect(find.text("Couldn't save your plan"), findsOneWidget);
+        expect(find.widgetWithText(FilledButton, 'Retry'), findsOneWidget);
+        expect(callCount, 1);
+
+        await tester.tap(find.widgetWithText(FilledButton, 'Retry'));
+        await tester.pumpAndSettle();
+
+        // Retry re-invokes commit (which fires the service again).
+        expect(callCount, 2);
+      },
+    );
+  });
+}
+
+class _RecorderCall {
+  _RecorderCall({
+    required this.error,
+    required this.stack,
+    required this.reason,
+    required this.information,
+  });
+
+  final Object error;
+  final StackTrace stack;
+  final String? reason;
+  final List<String>? information;
+}

--- a/test/features/meal_plan/meal_plan_controller_test.dart
+++ b/test/features/meal_plan/meal_plan_controller_test.dart
@@ -1,0 +1,374 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:nibbles/src/common/services/recipe_service.dart';
+import 'package:nibbles/src/features/meal_plan/meal_plan_controller.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../support/fake_analytics.dart';
+
+class _MockBabyProfileService extends Mock implements BabyProfileService {}
+
+class _MockMealPlanService extends Mock implements MealPlanService {}
+
+class _MockRecipeService extends Mock implements RecipeService {}
+
+class _MockAllergenService extends Mock implements AllergenService {}
+
+const _babyId = 'baby-001';
+
+final _fakeBaby = Baby(
+  id: _babyId,
+  userId: 'user-001',
+  name: 'Lily',
+  dateOfBirth: DateTime(2025, 6),
+  gender: Gender.female,
+  onboardingCompleted: true,
+);
+
+const _peanutAllergen = Allergen(
+  key: 'peanut',
+  name: 'Peanut',
+  sequenceOrder: 1,
+  emoji: '🥜',
+);
+
+const _fakeRecipe = Recipe(
+  id: 'recipe-001',
+  title: 'Peanut Butter Toast',
+  ageRange: '6m+',
+  allergenTags: ['peanut'],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve mashed.',
+);
+
+AllergenProgramState _makeProgramState({
+  AllergenProgramStatus status = AllergenProgramStatus.inProgress,
+  String currentKey = 'peanut',
+}) {
+  final now = DateTime(2026, 5, 30);
+  return AllergenProgramState(
+    id: 'ps-1',
+    babyId: _babyId,
+    currentAllergenKey: currentKey,
+    currentSequenceOrder: 1,
+    status: status,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+MealPlanEntry _makeEntry({
+  String id = 'mp-1',
+  String recipeId = 'recipe-001',
+  DateTime? planDate,
+}) => MealPlanEntry(
+  id: id,
+  babyId: _babyId,
+  recipeId: recipeId,
+  planDate: planDate ?? DateTime(2026, 5, 30),
+);
+
+void main() {
+  late _MockBabyProfileService mockBabyService;
+  late _MockMealPlanService mockMealPlanService;
+  late _MockRecipeService mockRecipeService;
+  late _MockAllergenService mockAllergenService;
+  late FakeAnalytics fakeAnalytics;
+
+  setUpAll(() {
+    registerFallbackValue(DateTime(2026));
+  });
+
+  setUp(() {
+    mockBabyService = _MockBabyProfileService();
+    mockMealPlanService = _MockMealPlanService();
+    mockRecipeService = _MockRecipeService();
+    mockAllergenService = _MockAllergenService();
+    fakeAnalytics = FakeAnalytics();
+  });
+
+  ProviderContainer buildContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        babyProfileServiceProvider.overrideWithValue(mockBabyService),
+        mealPlanServiceProvider.overrideWithValue(mockMealPlanService),
+        recipeServiceProvider.overrideWithValue(mockRecipeService),
+        allergenServiceProvider.overrideWithValue(mockAllergenService),
+        analyticsProvider.overrideWithValue(fakeAnalytics),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  void stubHappy({
+    List<MealPlanEntry> entries = const [],
+    AllergenProgramState? programState,
+  }) {
+    when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);
+    when(
+      () => mockMealPlanService.getRolling7(
+        any(),
+        today: any(named: 'today'),
+      ),
+    ).thenAnswer((_) async => Result.success(entries));
+    when(
+      () => mockRecipeService.getFlaggedAllergenKeys(any()),
+    ).thenAnswer((_) async => const Result.success(<String>{}));
+    when(
+      () => mockAllergenService.getProgramState(any()),
+    ).thenAnswer(
+      (_) async => Result.success(programState ?? _makeProgramState()),
+    );
+    when(
+      () => mockAllergenService.getAllergenBoardSummary(any()),
+    ).thenAnswer(
+      (_) async => const Result.success(<AllergenBoardItem>[
+        AllergenBoardItem(
+          allergen: _peanutAllergen,
+          logs: [],
+          status: AllergenStatus.inProgress,
+        ),
+      ]),
+    );
+    when(
+      () => mockRecipeService.getRecipeById(any()),
+    ).thenAnswer((_) async => const Result.success(_fakeRecipe));
+  }
+
+  group('MealPlanController.build', () {
+    test(
+      'sets windowStart to today (date-only), windowEnd to today+6, '
+      'populates entries + baby, expanded starts empty',
+      () async {
+        final entry = _makeEntry();
+        stubHappy(entries: [entry]);
+
+        final container = buildContainer();
+        final state = await container.read(
+          mealPlanControllerProvider(_babyId).future,
+        );
+
+        final today = DateTime.now();
+        final expectedStart = DateTime(today.year, today.month, today.day);
+        final expectedEnd = expectedStart.add(const Duration(days: 6));
+
+        expect(state.windowStart, expectedStart);
+        expect(state.windowEnd, expectedEnd);
+        expect(state.entries, hasLength(1));
+        expect(state.entries.single.id, 'mp-1');
+        expect(state.baby?.id, _babyId);
+        expect(state.expanded, isEmpty);
+        expect(state.recipes['recipe-001']?.title, 'Peanut Butter Toast');
+      },
+    );
+
+    test('build() with getRolling7 failure surfaces AsyncError', () async {
+      when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);
+      when(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).thenAnswer(
+        (_) async => const Result.failure(ServerException('db down')),
+      );
+      when(
+        () => mockRecipeService.getFlaggedAllergenKeys(any()),
+      ).thenAnswer((_) async => const Result.success(<String>{}));
+      when(
+        () => mockAllergenService.getProgramState(any()),
+      ).thenAnswer((_) async => Result.success(_makeProgramState()));
+
+      final container = buildContainer();
+      await expectLater(
+        container.read(mealPlanControllerProvider(_babyId).future),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('MealPlanController.toggleExpanded', () {
+    test('flips a day key WITHOUT re-fetching from the service', () async {
+      stubHappy();
+      final container = buildContainer();
+      // Initial build
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final notifier = container.read(
+        mealPlanControllerProvider(_babyId).notifier,
+      );
+
+      final day = DateTime(2026, 5, 30);
+      final key = DateTime.utc(2026, 5, 30);
+
+      notifier.toggleExpanded(day);
+      var state =
+          container.read(mealPlanControllerProvider(_babyId)).valueOrNull!;
+      expect(state.expanded[key], isTrue);
+
+      notifier.toggleExpanded(day);
+      state =
+          container.read(mealPlanControllerProvider(_babyId)).valueOrNull!;
+      expect(state.expanded[key], isFalse);
+
+      // Toggle does not refetch.
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(1);
+    });
+  });
+
+  group('MealPlanController.appendBulkPrep', () {
+    test('returns true on success and invalidates self (refetches)', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.appendMealsToRange(
+          babyId: any(named: 'babyId'),
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          assignments: any(named: 'assignments'),
+        ),
+      ).thenAnswer((_) async => const Result.success([]));
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final notifier = container.read(
+        mealPlanControllerProvider(_babyId).notifier,
+      );
+
+      final ok = await notifier.appendBulkPrep(
+        startDate: DateTime(2026, 5, 30),
+        endDate: DateTime(2026, 5, 30),
+        assignments: const [
+          RecipeAssignment(recipeId: 'recipe-001', dayOffset: 0),
+        ],
+      );
+
+      // Re-await the future so the invalidate-driven rebuild settles.
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      expect(ok, isTrue);
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(2);
+    });
+
+    test('returns false on failure and does NOT invalidate self', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.appendMealsToRange(
+          babyId: any(named: 'babyId'),
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          assignments: any(named: 'assignments'),
+        ),
+      ).thenAnswer(
+        (_) async => const Result.failure(ServerException('db down')),
+      );
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final notifier = container.read(
+        mealPlanControllerProvider(_babyId).notifier,
+      );
+      final ok = await notifier.appendBulkPrep(
+        startDate: DateTime(2026, 5, 30),
+        endDate: DateTime(2026, 5, 30),
+        assignments: const [
+          RecipeAssignment(recipeId: 'recipe-001', dayOffset: 0),
+        ],
+      );
+
+      expect(ok, isFalse);
+      // Only the initial build call — no invalidation.
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(1);
+    });
+  });
+
+  group('MealPlanController.clearRange', () {
+    test('returns true on success and invalidates self (refetches)', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.clearRange(any(), any(), any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final notifier = container.read(
+        mealPlanControllerProvider(_babyId).notifier,
+      );
+      final ok = await notifier.clearRange(
+        DateTime(2026, 5, 30),
+        DateTime(2026, 6, 5),
+      );
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      expect(ok, isTrue);
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(2);
+    });
+
+    test('returns false on failure and does NOT invalidate self', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.clearRange(any(), any(), any()),
+      ).thenAnswer(
+        (_) async => const Result.failure(ServerException('db down')),
+      );
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final notifier = container.read(
+        mealPlanControllerProvider(_babyId).notifier,
+      );
+      final ok = await notifier.clearRange(
+        DateTime(2026, 5, 30),
+        DateTime(2026, 6, 5),
+      );
+
+      expect(ok, isFalse);
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/test/features/meal_plan/meal_plan_screen_test.dart
+++ b/test/features/meal_plan/meal_plan_screen_test.dart
@@ -254,6 +254,106 @@ void main() {
     });
   });
 
+  group('MealPlanScreen single-day Add flow', () {
+    testWidgets(
+      'tapping a day-card + Add pill → BrowseMealSheet returns [recipe] → '
+      'appendMealsToRange called with startDate == endDate for that day',
+      (tester) async {
+        final start = DateTime.now();
+        final today = DateTime(start.year, start.month, start.day);
+        stubBoot(entries: [_entry(today)]);
+        // BrowseMealSheet needs these to load + render. Use a distinct
+        // sheet recipe so the master-list row tap doesn't collide with the
+        // expanded day-card row that renders `_fakeRecipe.title`.
+        const sheetRecipe = Recipe(
+          id: 'recipe-sheet',
+          title: 'Avocado Mash',
+          ageRange: '6m+',
+          allergenTags: [],
+          ingredients: [],
+          steps: [],
+          howToServe: 'Serve.',
+        );
+        when(
+          () => mockRecipeService.getAllRecipes(any()),
+        ).thenAnswer((_) async => const Result.success([sheetRecipe]));
+        when(
+          () => mockAllergenService.getAllergenStatuses(any()),
+        ).thenAnswer(
+          (_) async => const Result.success({
+            'peanut': AllergenStatus.safe,
+            'egg': AllergenStatus.safe,
+            'dairy': AllergenStatus.safe,
+            'tree_nuts': AllergenStatus.safe,
+            'sesame': AllergenStatus.safe,
+            'soy': AllergenStatus.safe,
+            'wheat': AllergenStatus.safe,
+            'fish': AllergenStatus.safe,
+            'shellfish': AllergenStatus.safe,
+          }),
+        );
+        when(
+          () => mockMealPlanService.appendMealsToRange(
+            babyId: any(named: 'babyId'),
+            startDate: any(named: 'startDate'),
+            endDate: any(named: 'endDate'),
+            assignments: any(named: 'assignments'),
+          ),
+        ).thenAnswer((_) async => const Result.success(<MealPlanEntry>[]));
+
+        await pumpScreen(tester);
+
+        // Expand the first day card so its '+ Add' pill is visible.
+        final firstCard = find.byType(DayAccordionCard).first;
+        final chevron = find
+            .descendant(of: firstCard, matching: find.byIcon(Icons.expand_more))
+            .first;
+        await tester.tap(chevron);
+        await tester.pumpAndSettle();
+
+        // Tap the '+ Add' pill inside the expanded card.
+        final addPill = find
+            .descendant(of: firstCard, matching: find.text('+ Add'))
+            .first;
+        await tester.tap(addPill);
+        // Drive the sheet entrance + _load() — pumpAndSettle would hang on
+        // the CircularProgressIndicator the sheet shows while loading.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+        await tester.pump();
+        await tester.pump();
+
+        // Pick the recipe in the sheet's master list.
+        await tester.tap(find.text(sheetRecipe.title).first);
+        await tester.pump();
+
+        // Confirm the picked count + tap the sticky CTA to pop with the list.
+        expect(find.text('Add (1)'), findsOneWidget);
+        await tester.tap(find.text('Add (1)'));
+        // Drive the sheet dismissal + appendBulkPrep future.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+        await tester.pump();
+
+        final captured = verify(
+          () => mockMealPlanService.appendMealsToRange(
+            babyId: _babyId,
+            startDate: captureAny(named: 'startDate'),
+            endDate: captureAny(named: 'endDate'),
+            assignments: captureAny(named: 'assignments'),
+          ),
+        ).captured;
+        expect(captured, hasLength(3));
+        final startDate = captured[0] as DateTime;
+        final endDate = captured[1] as DateTime;
+        expect(startDate, endDate, reason: 'single-day range');
+        expect(startDate, today);
+        final assignments = captured[2] as List<dynamic>;
+        expect(assignments, hasLength(1));
+      },
+    );
+  });
+
   group('MealPlanScreen clear-week flow', () {
     testWidgets(
       'tapping Delete in the real confirm dialog calls clearRange on the '

--- a/test/features/meal_plan/meal_plan_screen_test.dart
+++ b/test/features/meal_plan/meal_plan_screen_test.dart
@@ -1,0 +1,314 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:nibbles/src/common/services/recipe_service.dart';
+import 'package:nibbles/src/features/meal_plan/meal_plan_screen.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/add_date_pill.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/day_accordion_card.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_empty_state.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_header.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+import '../../support/fake_analytics.dart';
+
+class _MockBabyProfileService extends Mock implements BabyProfileService {}
+
+class _MockMealPlanService extends Mock implements MealPlanService {}
+
+class _MockRecipeService extends Mock implements RecipeService {}
+
+class _MockAllergenService extends Mock implements AllergenService {}
+
+const _babyId = 'baby-001';
+
+final _fakeBaby = Baby(
+  id: _babyId,
+  userId: 'user-001',
+  name: 'Lily',
+  dateOfBirth: DateTime(2025, 6),
+  gender: Gender.female,
+  onboardingCompleted: true,
+);
+
+const _peanutAllergen = Allergen(
+  key: 'peanut',
+  name: 'Peanut',
+  sequenceOrder: 1,
+  emoji: '🥜',
+);
+
+const _fakeRecipe = Recipe(
+  id: 'recipe-001',
+  title: 'Peanut Butter Toast',
+  ageRange: '6m+',
+  allergenTags: ['peanut'],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+AllergenProgramState _makeProgramState({
+  AllergenProgramStatus status = AllergenProgramStatus.inProgress,
+}) {
+  final now = DateTime(2026, 5, 30);
+  return AllergenProgramState(
+    id: 'ps-1',
+    babyId: _babyId,
+    currentAllergenKey: 'peanut',
+    currentSequenceOrder: 1,
+    status: status,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+MealPlanEntry _entry(DateTime planDate, {String id = 'mp-1'}) => MealPlanEntry(
+      id: id,
+      babyId: _babyId,
+      recipeId: 'recipe-001',
+      planDate: planDate,
+    );
+
+GoRouter _testRouter() => GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(path: '/', builder: (_, __) => const MealPlanScreen()),
+        GoRoute(
+          path: AppRoute.mealPlanMap.path,
+          name: AppRoute.mealPlanMap.name,
+          builder: (_, __) => const Scaffold(body: Text('Map Stub')),
+        ),
+        GoRoute(
+          path: AppRoute.recipeDetail.path,
+          name: AppRoute.recipeDetail.name,
+          builder: (_, __) => const Scaffold(body: Text('Recipe Detail Stub')),
+        ),
+      ],
+    );
+
+void main() {
+  late _MockBabyProfileService mockBabyService;
+  late _MockMealPlanService mockMealPlanService;
+  late _MockRecipeService mockRecipeService;
+  late _MockAllergenService mockAllergenService;
+  late FakeAnalytics fakeAnalytics;
+
+  setUpAll(() {
+    registerFallbackValue(DateTime(2026));
+  });
+
+  setUp(() {
+    mockBabyService = _MockBabyProfileService();
+    mockMealPlanService = _MockMealPlanService();
+    mockRecipeService = _MockRecipeService();
+    mockAllergenService = _MockAllergenService();
+    fakeAnalytics = FakeAnalytics();
+  });
+
+  void stubBoot({
+    List<MealPlanEntry> entries = const [],
+    AllergenProgramState? programState,
+  }) {
+    when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);
+    when(
+      () => mockMealPlanService.getRolling7(
+        any(),
+        today: any(named: 'today'),
+      ),
+    ).thenAnswer((_) async => Result.success(entries));
+    when(
+      () => mockRecipeService.getFlaggedAllergenKeys(any()),
+    ).thenAnswer((_) async => const Result.success(<String>{}));
+    when(
+      () => mockAllergenService.getProgramState(any()),
+    ).thenAnswer(
+      (_) async => Result.success(programState ?? _makeProgramState()),
+    );
+    when(
+      () => mockAllergenService.getAllergenBoardSummary(any()),
+    ).thenAnswer(
+      (_) async => const Result.success(<AllergenBoardItem>[
+        AllergenBoardItem(
+          allergen: _peanutAllergen,
+          logs: [],
+          status: AllergenStatus.inProgress,
+        ),
+      ]),
+    );
+    when(
+      () => mockRecipeService.getRecipeById(any()),
+    ).thenAnswer((_) async => const Result.success(_fakeRecipe));
+  }
+
+  Future<void> pumpScreen(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          babyProfileServiceProvider.overrideWithValue(mockBabyService),
+          mealPlanServiceProvider.overrideWithValue(mockMealPlanService),
+          recipeServiceProvider.overrideWithValue(mockRecipeService),
+          allergenServiceProvider.overrideWithValue(mockAllergenService),
+          analyticsProvider.overrideWithValue(fakeAnalytics),
+        ],
+        child: MaterialApp.router(routerConfig: _testRouter()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('MealPlanScreen empty branch', () {
+    testWidgets('renders MealPlanEmptyState when entries is empty',
+        (tester) async {
+      stubBoot();
+      await pumpScreen(tester);
+
+      expect(find.byType(MealPlanEmptyState), findsOneWidget);
+      expect(find.byType(DayAccordionCard), findsNothing);
+      expect(find.byType(MealPlanHeader), findsNothing);
+    });
+  });
+
+  group('MealPlanScreen populated branch', () {
+    testWidgets(
+      'renders MealPlanHeader + 7 DayAccordionCards + AddDatePill',
+      (tester) async {
+        final start = DateTime.now();
+        final today = DateTime(start.year, start.month, start.day);
+        stubBoot(entries: [_entry(today)]);
+        await pumpScreen(tester);
+
+        expect(find.byType(MealPlanHeader), findsOneWidget);
+        // Rolling-7 window.
+        expect(find.byType(DayAccordionCard), findsNWidgets(7));
+        expect(find.byType(AddDatePill), findsOneWidget);
+        expect(find.byType(MealPlanEmptyState), findsNothing);
+      },
+    );
+  });
+
+  group('MealPlanScreen overflow menu', () {
+    testWidgets('shows exactly 3 items in the screen-level menu',
+        (tester) async {
+      final start = DateTime.now();
+      final today = DateTime(start.year, start.month, start.day);
+      stubBoot(entries: [_entry(today)]);
+      await pumpScreen(tester);
+
+      await tester.tap(find.byType(MealPlanOverflowButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add to shop list'), findsOneWidget);
+      expect(find.text('Create new meal prep'), findsOneWidget);
+      expect(find.text('Clear current week'), findsOneWidget);
+      // PopupMenuItem<_ScreenMenuAction> is private — match by superclass.
+      expect(
+        find.byWidgetPredicate((w) => w is PopupMenuItem),
+        findsNWidgets(3),
+      );
+    });
+
+    testWidgets('per-card overflow menu shows exactly 2 items', (tester) async {
+      final start = DateTime.now();
+      final today = DateTime(start.year, start.month, start.day);
+      stubBoot(entries: [_entry(today)]);
+      await pumpScreen(tester);
+
+      // Tap the kebab INSIDE the first DayAccordionCard (avoid the
+      // header-level MealPlanOverflowButton which renders the same icon).
+      final cardKebab = find
+          .descendant(
+            of: find.byType(DayAccordionCard).first,
+            matching: find.byIcon(Icons.more_horiz),
+          )
+          .first;
+      await tester.tap(cardKebab);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add to shop list'), findsOneWidget);
+      expect(find.text('Clear current week'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate((w) => w is PopupMenuItem),
+        findsNWidgets(2),
+      );
+    });
+  });
+
+  group('MealPlanScreen clear-week flow', () {
+    testWidgets(
+      'tapping Delete in the real confirm dialog calls clearRange on the '
+      'service',
+      (tester) async {
+        final start = DateTime.now();
+        final today = DateTime(start.year, start.month, start.day);
+        stubBoot(entries: [_entry(today)]);
+        when(
+          () => mockMealPlanService.clearRange(any(), any(), any()),
+        ).thenAnswer((_) async => const Result.success(null));
+
+        await pumpScreen(tester);
+
+        // Open the screen-level menu, pick Clear current week.
+        await tester.tap(find.byType(MealPlanOverflowButton));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Clear current week'));
+        await tester.pumpAndSettle();
+
+        // Real confirm dialog rendered.
+        expect(find.text('Are you sure you want to delete?'), findsOneWidget);
+
+        await tester.tap(find.text('Delete'));
+        // clearRange triggers ref.invalidateSelf → re-fetches getRolling7.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        verify(
+          () => mockMealPlanService.clearRange(_babyId, any(), any()),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'tapping Cancel in the confirm dialog leaves clearRange unmocked-called',
+      (tester) async {
+        final start = DateTime.now();
+        final today = DateTime(start.year, start.month, start.day);
+        stubBoot(entries: [_entry(today)]);
+
+        await pumpScreen(tester);
+
+        await tester.tap(find.byType(MealPlanOverflowButton));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Clear current week'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        verifyNever(
+          () => mockMealPlanService.clearRange(any(), any(), any()),
+        );
+      },
+    );
+  });
+}

--- a/test/features/meal_plan/sheets/browse_meal_sheet_test.dart
+++ b/test/features/meal_plan/sheets/browse_meal_sheet_test.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/recipe_service.dart';
+import 'package:nibbles/src/features/meal_plan/sheets/browse_meal_sheet.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class _MockRecipeService extends Mock implements RecipeService {}
+
+class _MockAllergenService extends Mock implements AllergenService {}
+
+const _babyId = 'baby-001';
+
+const _safeA = Recipe(
+  id: 'safe-a',
+  title: 'Avocado Mash',
+  ageRange: '6m+',
+  allergenTags: [],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+const _safeB = Recipe(
+  id: 'safe-b',
+  title: 'Banana Porridge',
+  ageRange: '6m+',
+  allergenTags: [],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+const _flagged = Recipe(
+  id: 'flagged',
+  title: 'Peanut Butter Toast',
+  ageRange: '6m+',
+  allergenTags: ['peanut'],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+Map<String, AllergenStatus> _allSafeStatuses() => const {
+      'peanut': AllergenStatus.safe,
+      'egg': AllergenStatus.safe,
+      'dairy': AllergenStatus.safe,
+      'tree_nuts': AllergenStatus.safe,
+      'sesame': AllergenStatus.safe,
+      'soy': AllergenStatus.safe,
+      'wheat': AllergenStatus.safe,
+      'fish': AllergenStatus.safe,
+      'shellfish': AllergenStatus.safe,
+    };
+
+void main() {
+  late _MockRecipeService mockRecipeService;
+  late _MockAllergenService mockAllergenService;
+  late FakeAnalytics fakeAnalytics;
+
+  setUp(() {
+    mockRecipeService = _MockRecipeService();
+    mockAllergenService = _MockAllergenService();
+    fakeAnalytics = FakeAnalytics();
+  });
+
+  /// Reference holder so a test can await the eventual result of
+  /// `showBrowseMealSheet` AFTER it dismisses. Never returned through an
+  /// async function — that would force the test framework to await the
+  /// (intentionally) never-completing modal Future before the next step
+  /// runs, hanging the suite.
+  late Future<List<Recipe>?> pendingResult;
+
+  Future<void> openSheet(
+    WidgetTester tester, {
+    required List<Recipe> recipes,
+    required Set<String> flaggedKeys,
+    Map<String, AllergenStatus>? statuses,
+  }) async {
+    when(
+      () => mockRecipeService.getAllRecipes(any()),
+    ).thenAnswer((_) async => Result.success(recipes));
+    when(
+      () => mockRecipeService.getFlaggedAllergenKeys(any()),
+    ).thenAnswer((_) async => Result.success(flaggedKeys));
+    when(
+      () => mockAllergenService.getAllergenStatuses(any()),
+    ).thenAnswer((_) async => Result.success(statuses ?? _allSafeStatuses()));
+
+    // Larger viewport so the sheet, CTA and rows are all on-screen.
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          recipeServiceProvider.overrideWithValue(mockRecipeService),
+          allergenServiceProvider.overrideWithValue(mockAllergenService),
+          analyticsProvider.overrideWithValue(fakeAnalytics),
+        ],
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    pendingResult = showBrowseMealSheet(
+                      context,
+                      babyId: _babyId,
+                      startDate: DateTime(2026, 5, 30),
+                      endDate: DateTime(2026, 6, 5),
+                    );
+                  },
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    // Drive route + sheet entrance + _load() future. Avoid pumpAndSettle —
+    // CircularProgressIndicator animates forever and would block forever.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pump();
+    await tester.pump();
+  }
+
+  group('BrowseMealSheet', () {
+    testWidgets('multi-select toggles selected counter', (tester) async {
+      await openSheet(
+        tester,
+        recipes: const [_safeA, _safeB],
+        flaggedKeys: const {},
+      );
+
+      expect(find.text('0 selected'), findsOneWidget);
+
+      // Tap row for first recipe (the master list at the bottom).
+      await tester.tap(find.text(_safeA.title).first);
+      await tester.pump();
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await tester.tap(find.text(_safeB.title).first);
+      await tester.pump();
+      expect(find.text('2 selected'), findsOneWidget);
+
+      // Deselect.
+      await tester.tap(find.text(_safeA.title).first);
+      await tester.pump();
+      expect(find.text('1 selected'), findsOneWidget);
+    });
+
+    testWidgets(
+      'flagged recipes are rendered visually disabled and non-selectable',
+      (tester) async {
+        await openSheet(
+          tester,
+          recipes: const [_safeA, _flagged],
+          flaggedKeys: const {'peanut'},
+        );
+
+        expect(find.text('0 selected'), findsOneWidget);
+
+        // Tap the flagged recipe row — selected counter must NOT increment.
+        await tester.tap(find.text(_flagged.title).first);
+        await tester.pump();
+        expect(find.text('0 selected'), findsOneWidget);
+
+        // Tapping a safe recipe should still work.
+        await tester.tap(find.text(_safeA.title).first);
+        await tester.pump();
+        expect(find.text('1 selected'), findsOneWidget);
+      },
+    );
+
+    testWidgets('search filters by title (case-insensitive contains)', (
+      tester,
+    ) async {
+      await openSheet(
+        tester,
+        recipes: const [_safeA, _safeB],
+        flaggedKeys: const {},
+      );
+
+      await tester.enterText(find.byType(TextField), 'BANANA');
+      await tester.pump();
+
+      // Master-list row for Banana Porridge should still be visible.
+      expect(find.text(_safeB.title), findsWidgets);
+      // No-results placeholder should NOT show for the matching query.
+      expect(find.textContaining('No results'), findsNothing);
+
+      // Search for a string with no matches — placeholder should appear.
+      await tester.enterText(find.byType(TextField), 'zzz');
+      await tester.pump();
+      expect(find.textContaining('No results for "zzz"'), findsOneWidget);
+    });
+
+    testWidgets('"Add (N)" returns picked recipes on Navigator.pop',
+        (tester) async {
+      await openSheet(
+        tester,
+        recipes: const [_safeA, _safeB],
+        flaggedKeys: const {},
+      );
+
+      await tester.tap(find.text(_safeA.title).first);
+      await tester.pump();
+
+      // CTA reflects the count.
+      expect(find.text('Add (1)'), findsOneWidget);
+
+      await tester.tap(find.text('Add (1)'));
+      // Drive the sheet dismissal animation.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final result = await pendingResult;
+      expect(result, hasLength(1));
+      expect(result!.single.id, _safeA.id);
+    });
+
+    testWidgets(
+      'ongoing-allergen carousel is hidden when no inProgress status exists',
+      (tester) async {
+        await openSheet(
+          tester,
+          recipes: const [_safeA],
+          flaggedKeys: const {},
+          // All statuses safe → no ongoing allergen → no carousel header.
+        );
+
+        expect(find.textContaining('Recommendation for'), findsNothing);
+      },
+    );
+  });
+}

--- a/test/features/meal_plan/widgets/day_accordion_card_test.dart
+++ b/test/features/meal_plan/widgets/day_accordion_card_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/day_accordion_card.dart';
+
+const _babyId = 'baby-001';
+
+MealPlanEntry _entry({
+  String id = 'mp-1',
+  String recipeId = 'r-1',
+  DateTime? planDate,
+}) => MealPlanEntry(
+  id: id,
+  babyId: _babyId,
+  recipeId: recipeId,
+  planDate: planDate ?? DateTime(2026, 5, 30),
+);
+
+Recipe _recipe({
+  String id = 'r-1',
+  String title = 'Peanut Butter Toast',
+  List<String> tags = const ['peanut'],
+}) => Recipe(
+  id: id,
+  title: title,
+  ageRange: '6m+',
+  allergenTags: tags,
+  ingredients: const [],
+  steps: const [],
+  howToServe: 'Serve.',
+);
+
+Future<void> _pumpCard(
+  WidgetTester tester, {
+  required List<MealPlanEntry> entries,
+  required Map<String, Recipe> recipes,
+  required bool isExpanded,
+  VoidCallback? onToggle,
+  VoidCallback? onAdd,
+  Set<String> flaggedAllergenKeys = const {},
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: DayAccordionCard(
+          day: DateTime(2026, 5, 30),
+          entries: entries,
+          recipes: recipes,
+          flaggedAllergenKeys: flaggedAllergenKeys,
+          isExpanded: isExpanded,
+          onToggle: onToggle ?? () {},
+          onAdd: onAdd ?? () {},
+          onRecipeTap: (_) {},
+          onMenuSelected: (_) {},
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('DayAccordionCard', () {
+    testWidgets('collapsed: header visible, body hidden', (tester) async {
+      await _pumpCard(
+        tester,
+        entries: [_entry()],
+        recipes: {'r-1': _recipe()},
+        isExpanded: false,
+      );
+
+      // Header includes the date label e.g. "Sat 30 May".
+      expect(find.textContaining('30 May'), findsOneWidget);
+      // Body content (recipe title + Add pill) is hidden.
+      expect(find.text('Peanut Butter Toast'), findsNothing);
+      expect(find.text('+ Add'), findsNothing);
+      expect(find.text('No meal plan yet.'), findsNothing);
+    });
+
+    testWidgets(
+      'expanded + entries: recipe row renders with title + tag chips '
+      '+ Add pill',
+      (tester) async {
+        await _pumpCard(
+          tester,
+          entries: [_entry()],
+          recipes: {
+            'r-1': _recipe(tags: const ['peanut', 'egg']),
+          },
+          isExpanded: true,
+        );
+
+        expect(find.text('Peanut Butter Toast'), findsOneWidget);
+        expect(find.text('+ Add'), findsOneWidget);
+        // Tag chips render with replaced underscore labels.
+        expect(find.text('peanut'), findsOneWidget);
+        expect(find.text('egg'), findsOneWidget);
+        // No empty-state hint.
+        expect(find.text('No meal plan yet.'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'expanded + entries: 3+ tags renders +N overflow chip after first 2',
+      (tester) async {
+        await _pumpCard(
+          tester,
+          entries: [_entry()],
+          recipes: {
+            'r-1': _recipe(tags: const ['peanut', 'egg', 'dairy', 'soy']),
+          },
+          isExpanded: true,
+        );
+
+        // First 2 tags visible.
+        expect(find.text('peanut'), findsOneWidget);
+        expect(find.text('egg'), findsOneWidget);
+        // 4 - 2 = +2 overflow chip.
+        expect(find.text('+2'), findsOneWidget);
+        // Hidden tags should not render their labels.
+        expect(find.text('dairy'), findsNothing);
+        expect(find.text('soy'), findsNothing);
+      },
+    );
+
+    testWidgets('expanded + empty: shows empty hint and Add pill', (
+      tester,
+    ) async {
+      await _pumpCard(
+        tester,
+        entries: const [],
+        recipes: const {},
+        isExpanded: true,
+      );
+
+      expect(find.text('No meal plan yet.'), findsOneWidget);
+      expect(find.text('+ Add'), findsOneWidget);
+    });
+
+    testWidgets('header tap fires onToggle', (tester) async {
+      var toggled = 0;
+      await _pumpCard(
+        tester,
+        entries: const [],
+        recipes: const {},
+        isExpanded: false,
+        onToggle: () => toggled++,
+      );
+
+      // Tap on the header text — the GestureDetector wraps the row.
+      await tester.tap(find.textContaining('30 May'));
+      await tester.pumpAndSettle();
+
+      expect(toggled, 1);
+    });
+
+    testWidgets('"+ Add" pill tap fires onAdd', (tester) async {
+      var added = 0;
+      await _pumpCard(
+        tester,
+        entries: const [],
+        recipes: const {},
+        isExpanded: true,
+        onAdd: () => added++,
+      );
+
+      await tester.tap(find.text('+ Add'));
+      await tester.pumpAndSettle();
+
+      expect(added, 1);
+    });
+  });
+}

--- a/test/features/meal_plan/widgets/inline_calendar_test.dart
+++ b/test/features/meal_plan/widgets/inline_calendar_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required DateTime focusedMonth,
+  DateTime? selectedDate,
+  DateTime? minDate,
+  DateTime? maxDate,
+  ValueChanged<DateTime>? onDaySelected,
+  ValueChanged<DateTime>? onMonthChanged,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: InlineCalendar(
+          selectedDate: selectedDate,
+          focusedMonth: focusedMonth,
+          onDaySelected: onDaySelected ?? (_) {},
+          onMonthChanged: onMonthChanged ?? (_) {},
+          minDate: minDate,
+          maxDate: maxDate,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('InlineCalendar', () {
+    testWidgets('day tap fires onDaySelected with the correct date', (
+      tester,
+    ) async {
+      DateTime? selected;
+      await _pump(
+        tester,
+        focusedMonth: DateTime(2026, 5),
+        onDaySelected: (d) => selected = d,
+      );
+
+      // Tap day 15 of May 2026 — uses last text match for the digit.
+      await tester.tap(find.text('15'));
+      await tester.pump();
+
+      expect(selected, DateTime(2026, 5, 15));
+    });
+
+    testWidgets('chevron taps fire onMonthChanged with prev/next month', (
+      tester,
+    ) async {
+      DateTime? changedTo;
+      await _pump(
+        tester,
+        focusedMonth: DateTime(2026, 5),
+        onMonthChanged: (d) => changedTo = d,
+      );
+
+      await tester.tap(find.bySemanticsLabel('Next month'));
+      await tester.pump();
+      expect(changedTo, DateTime(2026, 6));
+
+      await tester.tap(find.bySemanticsLabel('Previous month'));
+      await tester.pump();
+      expect(changedTo, DateTime(2026, 4));
+    });
+
+    testWidgets('today cell is visually distinguished (border decoration)', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+      await _pump(tester, focusedMonth: DateTime(today.year, today.month));
+
+      final todayCells = find.descendant(
+        of: find.byType(InlineCalendar),
+        matching: find.text('${today.day}'),
+      );
+      expect(todayCells, findsWidgets);
+
+      // Walk up to the nearest Container with a circle BoxDecoration and
+      // assert the today border/background is the butterSoft + green-bordered
+      // styling. We check via at least one ancestor Container.
+      final containers = tester.widgetList<Container>(
+        find.ancestor(of: todayCells.first, matching: find.byType(Container)),
+      );
+      final hasTodayDeco = containers.any((c) {
+        final d = c.decoration;
+        if (d is! BoxDecoration) return false;
+        return d.color == AppColors.butterSoft && d.border != null;
+      });
+      expect(
+        hasTodayDeco,
+        isTrue,
+        reason: 'Today cell must use butterSoft fill + bordered styling.',
+      );
+    });
+
+    testWidgets('selected day is visually distinguished (greenDeep fill)', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        focusedMonth: DateTime(2026, 5),
+        selectedDate: DateTime(2026, 5, 15),
+      );
+
+      final cell = find.descendant(
+        of: find.byType(InlineCalendar),
+        matching: find.text('15'),
+      );
+      expect(cell, findsOneWidget);
+
+      final containers = tester.widgetList<Container>(
+        find.ancestor(of: cell, matching: find.byType(Container)),
+      );
+      final hasSelected = containers.any((c) {
+        final d = c.decoration;
+        if (d is! BoxDecoration) return false;
+        return d.color == AppColors.greenDeep && d.shape == BoxShape.circle;
+      });
+      expect(
+        hasSelected,
+        isTrue,
+        reason: 'Selected day must use greenDeep circular fill.',
+      );
+    });
+
+    testWidgets(
+      'days outside minDate/maxDate are visually disabled (untappable)',
+      (tester) async {
+        var tapped = 0;
+        await _pump(
+          tester,
+          focusedMonth: DateTime(2026, 5),
+          minDate: DateTime(2026, 5, 10),
+          maxDate: DateTime(2026, 5, 20),
+          onDaySelected: (_) => tapped++,
+        );
+
+        // 5 May is before minDate → tapping should be a no-op.
+        await tester.tap(find.text('5'));
+        await tester.pump();
+        // 25 May is after maxDate → tapping should be a no-op.
+        await tester.tap(find.text('25'));
+        await tester.pump();
+        expect(tapped, 0);
+
+        // Tap a day inside range to confirm the callback still fires.
+        await tester.tap(find.text('15'));
+        await tester.pump();
+        expect(tapped, 1);
+      },
+    );
+  });
+}

--- a/test/features/meal_plan/widgets/meal_plan_empty_state_test.dart
+++ b/test/features/meal_plan/widgets/meal_plan_empty_state_test.dart
@@ -58,6 +58,34 @@ void main() {
       expect(tester.widget<AppPillButton>(cta).onPressed, isNull);
     });
 
+    testWidgets('CTA stays disabled when end date is before start date', (
+      tester,
+    ) async {
+      await _pump(tester, babyName: 'Lily');
+
+      final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
+
+      // Pick start = 20.
+      await tester.tap(find.text('Select start date'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('20').first);
+      await tester.pumpAndSettle();
+
+      // Pick end = 10 (before start).
+      await tester.tap(find.text('Select end date'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('10').first);
+      await tester.pumpAndSettle();
+
+      // CTA must remain disabled: production code rejects end < start
+      // (either by auto-clearing the invalid end or by gating the validator).
+      expect(
+        tester.widget<AppPillButton>(cta).onPressed,
+        isNull,
+        reason: 'CTA must stay disabled when end < start.',
+      );
+    });
+
     testWidgets('tapping a date field opens the inline calendar', (
       tester,
     ) async {

--- a/test/features/meal_plan/widgets/meal_plan_empty_state_test.dart
+++ b/test/features/meal_plan/widgets/meal_plan_empty_state_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_empty_state.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required String babyName,
+  ValueChanged<DateTimeRange>? onCreate,
+}) async {
+  // Give the screen extra height so the CTA + calendars fit in the viewport
+  // without scrolling — keeps taps deterministic.
+  tester.view.physicalSize = const Size(1080, 2400);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: MealPlanEmptyState(
+          babyName: babyName,
+          onCreateMealPlan: onCreate ?? (_) {},
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('MealPlanEmptyState', () {
+    testWidgets('renders babyName in copy', (tester) async {
+      await _pump(tester, babyName: 'Lily');
+      expect(find.textContaining("Lily's meals"), findsOneWidget);
+      expect(find.text('Ready to start?'), findsOneWidget);
+    });
+
+    testWidgets('CTA is disabled until both start and end are set', (
+      tester,
+    ) async {
+      await _pump(tester, babyName: 'Lily');
+
+      final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
+      expect(cta, findsOneWidget);
+
+      // Initially disabled (no dates picked).
+      expect(tester.widget<AppPillButton>(cta).onPressed, isNull);
+
+      // Tap Start Date hint → inline calendar appears.
+      await tester.tap(find.text('Select start date'));
+      await tester.pumpAndSettle();
+      expect(find.byType(InlineCalendar), findsOneWidget);
+
+      // Pick day 10 → start date set, calendar closes.
+      await tester.tap(find.text('10').first);
+      await tester.pumpAndSettle();
+      // CTA still disabled (end not set).
+      expect(tester.widget<AppPillButton>(cta).onPressed, isNull);
+    });
+
+    testWidgets('tapping a date field opens the inline calendar', (
+      tester,
+    ) async {
+      await _pump(tester, babyName: 'Lily');
+
+      // No calendar at first.
+      expect(find.byType(InlineCalendar), findsNothing);
+
+      await tester.tap(find.text('Select start date'));
+      await tester.pumpAndSettle();
+      expect(find.byType(InlineCalendar), findsOneWidget);
+
+      // Toggle the same field — should close.
+      await tester.tap(find.text('Select start date'));
+      await tester.pumpAndSettle();
+      expect(find.byType(InlineCalendar), findsNothing);
+    });
+
+    testWidgets(
+      'tapping CTA fires onCreateMealPlan with the picked DateTimeRange',
+      (tester) async {
+        DateTimeRange? captured;
+        await _pump(
+          tester,
+          babyName: 'Lily',
+          onCreate: (r) => captured = r,
+        );
+
+        // Pick start date.
+        await tester.tap(find.text('Select start date'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('10').first);
+        await tester.pumpAndSettle();
+
+        // Pick end date — once start is picked the hint is no longer shown.
+        // The picked-start row now reads its formatted date; the end-date row
+        // still shows the placeholder.
+        await tester.tap(find.text('Select end date'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('20').first);
+        await tester.pumpAndSettle();
+
+        // CTA should now be enabled.
+        final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
+        expect(
+          tester.widget<AppPillButton>(cta).onPressed,
+          isNotNull,
+          reason: 'CTA should enable once both dates are picked.',
+        );
+
+        await tester.tap(cta);
+        await tester.pumpAndSettle();
+
+        expect(captured, isNotNull);
+        expect(captured!.start.day, 10);
+        expect(captured!.end.day, 20);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes the Meal Plan milestone with **45 net-new tests** across 8 files. Brings the suite from 334 → 379 passing.

No `lib/**` changes. Reuses existing mocktail + `FakeAnalytics` infrastructure — no new test dependencies.

## Coverage by file

| File | New tests | Coverage |
|---|---:|---|
| `test/features/meal_plan/meal_plan_controller_test.dart` | 7 | build window (today, today+6) + entries + baby + expanded; `toggleExpanded` doesn't refetch (`verify(...).called(1)`); `appendBulkPrep`/`clearRange` return true on success and invalidate self (refetches: `.called(2)`), false on failure (no invalidate); build with `getRolling7` failure surfaces `AsyncError`. |
| `test/features/meal_plan/map/map_meals_controller_test.dart` | 7 | build initializes `selectedDay = startDate` (date-only), empty assignments, `isCommitting=false`; `selectDay` normalizes to date-only; `assignToSelectedDay` overwrites on re-assign; `unassign` removes; `commit` success maps `RecipeId → dayOffset` (asserted with `verify(captureAny)`); `commit` failure sets `errorMessage` + records non-fatal via injected `MealPrepCrashRecorderFn` (captured by override); empty-assignment short-circuit. |
| `test/features/meal_plan/widgets/day_accordion_card_test.dart` | 6 | collapsed: header visible, body hidden; expanded + entries: title + tags + Add pill; 3+ tags: `+N` overflow chip; expanded + empty: hint + Add pill; chevron tap fires `onToggle`; `+ Add` tap fires `onAdd`. |
| `test/features/meal_plan/widgets/inline_calendar_test.dart` | 5 | day tap → correct date; chevron taps → prev/next month; today cell distinguished (butterSoft fill + green border); selected day distinguished (greenDeep fill); out-of-range days are untappable. |
| `test/features/meal_plan/widgets/meal_plan_empty_state_test.dart` | 4 | babyName rendered; CTA disabled until both dates picked; tapping a date field opens `InlineCalendar`; tapping CTA fires `onCreateMealPlan(DateTimeRange)`. |
| `test/features/meal_plan/sheets/browse_meal_sheet_test.dart` | 5 | multi-select toggles selected counter; flagged recipes are non-selectable; search filters case-insensitively (and shows `No results for "..."`); `Add (N)` returns picked list on `Navigator.pop`; ongoing-allergen carousel hidden when no `inProgress` status. |
| `test/features/meal_plan/meal_plan_screen_test.dart` | 6 | empty branch → `MealPlanEmptyState`; populated branch → `MealPlanHeader` + 7 `DayAccordionCard`s + `AddDatePill`; screen overflow menu shows exactly 3 items ("Add to shop list" / "Create new meal prep" / "Clear current week"); per-card overflow menu shows exactly 2 items; tapping Delete in the real `showClearMealPlanConfirm` dialog calls `clearRange`; tapping Cancel leaves it un-called. |
| `test/features/meal_plan/map/map_meals_screen_test.dart` | 5 | day chips + picked recipe list + `X of Y slots filled` badge render; tapping a picked recipe assigns; `Mapp Meal Plan` CTA disabled until ≥ 1 assignment; commit success pops the route with `true` (driven through a real `GoRouter` push to satisfy `context.pop`); commit failure shows blocking `AlertDialog` + Retry re-calls commit. |

## Gates

- [x] `make gen` — clean (idempotent — second run produces 0 outputs)
- [x] `flutter analyze` — `No issues found!`
- [x] `flutter test` — `All tests passed!` (379 tests, up from 334)
- [x] No `lib/**` modifications
- [x] Final total flutter test count > 334

## Acceptance criteria

- [x] meal-plan controller: window + `toggleExpanded` + `appendBulkPrep` + `clearRange`
- [x] map-meals controller: build + selectDay + assignToSelectedDay + unassign + commit success/failure + Crashlytics recorder injection
- [x] day accordion: expand/collapse + populated/empty + chevron + Add tap
- [x] browse-meal sheet: multi-select + flagged-disabled + search + ongoing-allergen carousel hidden
- [x] inline-calendar: day + month + today/selected styling + min/max
- [x] empty-state: CTA validation + babyName + open calendar + emits DateTimeRange
- [x] screen-level: empty + populated + overflow menus + clear-week wiring
- [x] map-screen: day chips + assign + commit/retry

## Known seams / non-mockable functions

The ticket asked for "mock `showBrowseMealSheet` returning [recipe]" for the single-day Add wiring on `meal_plan_screen`. `showBrowseMealSheet` and `showClearMealPlanConfirm` are top-level functions imported and called directly — no injection seam exists. Per build-rule #2 (no `lib/**` changes), I:

- **Drove the real `showClearMealPlanConfirm` dialog** end-to-end (open overflow → tap Clear current week → tap Delete in real dialog → assert `clearRange` called).
- **Skipped the deep-modal "Single-day Add via browse sheet" assertion** on the screen test. The Browse sheet itself is independently covered by `browse_meal_sheet_test.dart` (5 tests including `Add (N)` → `Navigator.pop`), and the screen's wiring for that flow is the same pattern as the clear-week confirm (which is fully covered). Re-mocking `showBrowseMealSheet` at the screen level would require a `lib/` injection point — out of scope.

This is the only deliberate gap from the ticket spec; everything else is covered.