### PR TITLE
feat(recipe): add nutrition_tags + category to recipes, Recipe entity, service grouping helpers [NIB-129]

### DIFF
--- a/lib/src/common/data/repositories/recipe_repository.dart
+++ b/lib/src/common/data/repositories/recipe_repository.dart
@@ -156,6 +156,7 @@ class RecipeRepositoryImpl implements RecipeRepository {
   Recipe _recipeFromRow(Map<String, dynamic> row) {
     final rawIngredients = (row['ingredients'] as List<dynamic>)
         .cast<Map<String, dynamic>>();
+    final rawNutritionTags = row['nutrition_tags'] as List<dynamic>?;
     return Recipe(
       id: row['id'] as String,
       title: row['title'] as String,
@@ -166,6 +167,9 @@ class RecipeRepositoryImpl implements RecipeRepository {
       howToServe: row['serving_guidance'] as String,
       notes: row['notes'] as String?,
       thumbnailUrl: row['thumbnail_url'] as String?,
+      nutritionTags:
+          rawNutritionTags?.map((e) => e as String).toList() ?? <String>[],
+      category: row['category'] as String?,
     );
   }
 }

--- a/lib/src/common/domain/entities/recipe.dart
+++ b/lib/src/common/domain/entities/recipe.dart
@@ -16,6 +16,8 @@ class Recipe with _$Recipe {
     required String howToServe,
     String? notes,
     String? thumbnailUrl,
+    @Default(<String>[]) List<String> nutritionTags,
+    String? category,
   }) = _Recipe;
 
   factory Recipe.fromJson(Map<String, dynamic> json) => _$RecipeFromJson(json);

--- a/lib/src/common/domain/entities/recipe.freezed.dart
+++ b/lib/src/common/domain/entities/recipe.freezed.dart
@@ -30,6 +30,8 @@ mixin _$Recipe {
   String get howToServe => throw _privateConstructorUsedError;
   String? get notes => throw _privateConstructorUsedError;
   String? get thumbnailUrl => throw _privateConstructorUsedError;
+  List<String> get nutritionTags => throw _privateConstructorUsedError;
+  String? get category => throw _privateConstructorUsedError;
 
   /// Serializes this Recipe to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -55,6 +57,8 @@ abstract class $RecipeCopyWith<$Res> {
     String howToServe,
     String? notes,
     String? thumbnailUrl,
+    List<String> nutritionTags,
+    String? category,
   });
 }
 
@@ -82,6 +86,8 @@ class _$RecipeCopyWithImpl<$Res, $Val extends Recipe>
     Object? howToServe = null,
     Object? notes = freezed,
     Object? thumbnailUrl = freezed,
+    Object? nutritionTags = null,
+    Object? category = freezed,
   }) {
     return _then(
       _value.copyWith(
@@ -121,6 +127,14 @@ class _$RecipeCopyWithImpl<$Res, $Val extends Recipe>
                 ? _value.thumbnailUrl
                 : thumbnailUrl // ignore: cast_nullable_to_non_nullable
                       as String?,
+            nutritionTags: null == nutritionTags
+                ? _value.nutritionTags
+                : nutritionTags // ignore: cast_nullable_to_non_nullable
+                      as List<String>,
+            category: freezed == category
+                ? _value.category
+                : category // ignore: cast_nullable_to_non_nullable
+                      as String?,
           )
           as $Val,
     );
@@ -145,6 +159,8 @@ abstract class _$$RecipeImplCopyWith<$Res> implements $RecipeCopyWith<$Res> {
     String howToServe,
     String? notes,
     String? thumbnailUrl,
+    List<String> nutritionTags,
+    String? category,
   });
 }
 
@@ -171,6 +187,8 @@ class __$$RecipeImplCopyWithImpl<$Res>
     Object? howToServe = null,
     Object? notes = freezed,
     Object? thumbnailUrl = freezed,
+    Object? nutritionTags = null,
+    Object? category = freezed,
   }) {
     return _then(
       _$RecipeImpl(
@@ -210,6 +228,14 @@ class __$$RecipeImplCopyWithImpl<$Res>
             ? _value.thumbnailUrl
             : thumbnailUrl // ignore: cast_nullable_to_non_nullable
                   as String?,
+        nutritionTags: null == nutritionTags
+            ? _value._nutritionTags
+            : nutritionTags // ignore: cast_nullable_to_non_nullable
+                  as List<String>,
+        category: freezed == category
+            ? _value.category
+            : category // ignore: cast_nullable_to_non_nullable
+                  as String?,
       ),
     );
   }
@@ -228,9 +254,12 @@ class _$RecipeImpl implements _Recipe {
     required this.howToServe,
     this.notes,
     this.thumbnailUrl,
+    final List<String> nutritionTags = const <String>[],
+    this.category,
   }) : _allergenTags = allergenTags,
        _ingredients = ingredients,
-       _steps = steps;
+       _steps = steps,
+       _nutritionTags = nutritionTags;
 
   factory _$RecipeImpl.fromJson(Map<String, dynamic> json) =>
       _$$RecipeImplFromJson(json);
@@ -271,10 +300,21 @@ class _$RecipeImpl implements _Recipe {
   final String? notes;
   @override
   final String? thumbnailUrl;
+  final List<String> _nutritionTags;
+  @override
+  @JsonKey()
+  List<String> get nutritionTags {
+    if (_nutritionTags is EqualUnmodifiableListView) return _nutritionTags;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_nutritionTags);
+  }
+
+  @override
+  final String? category;
 
   @override
   String toString() {
-    return 'Recipe(id: $id, title: $title, ageRange: $ageRange, allergenTags: $allergenTags, ingredients: $ingredients, steps: $steps, howToServe: $howToServe, notes: $notes, thumbnailUrl: $thumbnailUrl)';
+    return 'Recipe(id: $id, title: $title, ageRange: $ageRange, allergenTags: $allergenTags, ingredients: $ingredients, steps: $steps, howToServe: $howToServe, notes: $notes, thumbnailUrl: $thumbnailUrl, nutritionTags: $nutritionTags, category: $category)';
   }
 
   @override
@@ -299,7 +339,13 @@ class _$RecipeImpl implements _Recipe {
                 other.howToServe == howToServe) &&
             (identical(other.notes, notes) || other.notes == notes) &&
             (identical(other.thumbnailUrl, thumbnailUrl) ||
-                other.thumbnailUrl == thumbnailUrl));
+                other.thumbnailUrl == thumbnailUrl) &&
+            const DeepCollectionEquality().equals(
+              other._nutritionTags,
+              _nutritionTags,
+            ) &&
+            (identical(other.category, category) ||
+                other.category == category));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -315,6 +361,8 @@ class _$RecipeImpl implements _Recipe {
     howToServe,
     notes,
     thumbnailUrl,
+    const DeepCollectionEquality().hash(_nutritionTags),
+    category,
   );
 
   /// Create a copy of Recipe
@@ -342,6 +390,8 @@ abstract class _Recipe implements Recipe {
     required final String howToServe,
     final String? notes,
     final String? thumbnailUrl,
+    final List<String> nutritionTags,
+    final String? category,
   }) = _$RecipeImpl;
 
   factory _Recipe.fromJson(Map<String, dynamic> json) = _$RecipeImpl.fromJson;
@@ -364,6 +414,10 @@ abstract class _Recipe implements Recipe {
   String? get notes;
   @override
   String? get thumbnailUrl;
+  @override
+  List<String> get nutritionTags;
+  @override
+  String? get category;
 
   /// Create a copy of Recipe
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/src/common/domain/entities/recipe.g.dart
+++ b/lib/src/common/domain/entities/recipe.g.dart
@@ -20,6 +20,12 @@ _$RecipeImpl _$$RecipeImplFromJson(Map<String, dynamic> json) => _$RecipeImpl(
   howToServe: json['howToServe'] as String,
   notes: json['notes'] as String?,
   thumbnailUrl: json['thumbnailUrl'] as String?,
+  nutritionTags:
+      (json['nutritionTags'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ??
+      const <String>[],
+  category: json['category'] as String?,
 );
 
 Map<String, dynamic> _$$RecipeImplToJson(_$RecipeImpl instance) =>
@@ -33,4 +39,6 @@ Map<String, dynamic> _$$RecipeImplToJson(_$RecipeImpl instance) =>
       'howToServe': instance.howToServe,
       'notes': instance.notes,
       'thumbnailUrl': instance.thumbnailUrl,
+      'nutritionTags': instance.nutritionTags,
+      'category': instance.category,
     };

--- a/lib/src/common/services/recipe_service.dart
+++ b/lib/src/common/services/recipe_service.dart
@@ -89,6 +89,42 @@ class RecipeService {
   Future<Result<Recipe>> getRecipeById(String recipeId) =>
       _recipeRepo.getRecipeById(recipeId);
 
+  /// Groups recipes by category. Recipes with null/empty category land in the
+  /// 'Other' bucket. Failures from [getAllRecipes] propagate unchanged.
+  Future<Result<Map<String, List<Recipe>>>> getRecipesByCategory(
+    String babyId,
+  ) async {
+    final result = await getAllRecipes(babyId);
+    if (result.isFailure) {
+      return Result.failure(result.errorOrNull!);
+    }
+
+    final grouped = <String, List<Recipe>>{};
+    for (final recipe in result.dataOrNull!) {
+      final key = (recipe.category == null || recipe.category!.isEmpty)
+          ? 'Other'
+          : recipe.category!;
+      grouped.putIfAbsent(key, () => <Recipe>[]).add(recipe);
+    }
+    return Result.success(grouped);
+  }
+
+  /// Returns recipes whose [Recipe.nutritionTags] contain [tag] (case-sensitive
+  /// exact match). Failures from [getAllRecipes] propagate unchanged.
+  Future<Result<List<Recipe>>> getRecipesByNutritionTag(
+    String babyId,
+    String tag,
+  ) async {
+    final result = await getAllRecipes(babyId);
+    if (result.isFailure) {
+      return Result.failure(result.errorOrNull!);
+    }
+    final filtered = result.dataOrNull!
+        .where((r) => r.nutritionTags.contains(tag))
+        .toList();
+    return Result.success(filtered);
+  }
+
   /// Returns the set of allergen keys for which [babyId] has had a reaction.
   Future<Result<Set<String>>> getFlaggedAllergenKeys(String babyId) async {
     final logsResult = await _allergenRepo.getLogs(babyId);

--- a/supabase/migrations/20240101000016_recipe_nutrition_tags_category.sql
+++ b/supabase/migrations/20240101000016_recipe_nutrition_tags_category.sql
@@ -1,0 +1,16 @@
+-- NIB-129: Extend recipes with nutrition_tags + category (per NIB-120 locked decisions).
+--
+-- nutrition_tags: ad-hoc tag groups consumed by NIB-87 Browse Meal sheet and
+-- Starting Guide-style sections (e.g. 'Iron-rich Purees', 'Quick weekday meals').
+-- Distinct from allergen_tags, which lists allergens a recipe contains.
+--
+-- category: single top-level grouping for NIB-53 horizontal category rows
+-- (e.g. 'Purees', 'Finger Foods', 'Toddler Meals', 'Soups', 'Snacks').
+-- Nullable for back-compat — legacy rows have null and fall into the 'Other'
+-- bucket on the client.
+
+ALTER TABLE recipes
+  ADD COLUMN IF NOT EXISTS nutrition_tags TEXT[] NOT NULL DEFAULT '{}';
+
+ALTER TABLE recipes
+  ADD COLUMN IF NOT EXISTS category TEXT;

--- a/test/common/services/recipe_service_test.dart
+++ b/test/common/services/recipe_service_test.dart
@@ -29,16 +29,22 @@ AllergenLog _makeLog({
   createdAt: _now,
 );
 
-Recipe _makeRecipe({String id = 'r1', List<String> allergenTags = const []}) =>
-    Recipe(
-      id: id,
-      title: 'Test Recipe $id',
-      ageRange: '6m+',
-      allergenTags: allergenTags,
-      ingredients: const [],
-      steps: const ['Step 1'],
-      howToServe: 'Serve warm.',
-    );
+Recipe _makeRecipe({
+  String id = 'r1',
+  List<String> allergenTags = const [],
+  List<String> nutritionTags = const [],
+  String? category,
+}) => Recipe(
+  id: id,
+  title: 'Test Recipe $id',
+  ageRange: '6m+',
+  allergenTags: allergenTags,
+  ingredients: const [],
+  steps: const ['Step 1'],
+  howToServe: 'Serve warm.',
+  nutritionTags: nutritionTags,
+  category: category,
+);
 
 void main() {
   late MockRecipeRepository mockRecipeRepo;
@@ -272,6 +278,91 @@ void main() {
       );
 
       final result = await sut.getRecipeById('r-missing');
+
+      expect(result.isFailure, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getRecipesByCategory
+  // ---------------------------------------------------------------------------
+
+  group('RecipeService.getRecipesByCategory', () {
+    test('buckets recipes by category; null/empty land in Other', () async {
+      when(
+        () => mockAllergenRepo.getLogs(_babyId),
+      ).thenAnswer((_) async => const Result.success([]));
+      when(() => mockRecipeRepo.getAllRecipes()).thenAnswer(
+        (_) async => Result.success([
+          _makeRecipe(category: 'Purees'),
+          _makeRecipe(id: 'r2', category: 'Purees'),
+          _makeRecipe(id: 'r3', category: 'Finger Foods'),
+          _makeRecipe(id: 'r4'),
+          _makeRecipe(id: 'r5', category: ''),
+        ]),
+      );
+
+      final result = await sut.getRecipesByCategory(_babyId);
+
+      expect(result.isSuccess, isTrue);
+      final grouped = result.dataOrNull!;
+      expect(
+        grouped.keys,
+        containsAll(<String>['Purees', 'Finger Foods', 'Other']),
+      );
+      expect(grouped['Purees'], hasLength(2));
+      expect(grouped['Finger Foods'], hasLength(1));
+      expect(grouped['Other'], hasLength(2));
+    });
+
+    test('repo failure → propagates', () async {
+      when(
+        () => mockAllergenRepo.getLogs(_babyId),
+      ).thenAnswer((_) async => const Result.success([]));
+      when(() => mockRecipeRepo.getAllRecipes()).thenAnswer(
+        (_) async => const Result.failure(ServerException('DB error')),
+      );
+
+      final result = await sut.getRecipesByCategory(_babyId);
+
+      expect(result.isFailure, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getRecipesByNutritionTag
+  // ---------------------------------------------------------------------------
+
+  group('RecipeService.getRecipesByNutritionTag', () {
+    test('returns only recipes whose nutrition_tags contain the tag', () async {
+      when(
+        () => mockAllergenRepo.getLogs(_babyId),
+      ).thenAnswer((_) async => const Result.success([]));
+      when(() => mockRecipeRepo.getAllRecipes()).thenAnswer(
+        (_) async => Result.success([
+          _makeRecipe(nutritionTags: ['Iron-rich', 'Quick']),
+          _makeRecipe(id: 'r2', nutritionTags: ['Quick']),
+          _makeRecipe(id: 'r3'),
+        ]),
+      );
+
+      final result = await sut.getRecipesByNutritionTag(_babyId, 'Iron-rich');
+
+      expect(result.isSuccess, isTrue);
+      final recipes = result.dataOrNull!;
+      expect(recipes, hasLength(1));
+      expect(recipes.first.id, 'r1');
+    });
+
+    test('repo failure → propagates', () async {
+      when(
+        () => mockAllergenRepo.getLogs(_babyId),
+      ).thenAnswer((_) async => const Result.success([]));
+      when(() => mockRecipeRepo.getAllRecipes()).thenAnswer(
+        (_) async => const Result.failure(ServerException('DB error')),
+      );
+
+      final result = await sut.getRecipesByNutritionTag(_babyId, 'Iron-rich');
 
       expect(result.isFailure, isTrue);
     });


### PR DESCRIPTION
## Summary

Per NIB-120 locked decisions, extends the `recipes` table with two new columns and exposes grouping/filtering helpers on `RecipeService`. Wave 1 of the Recipe Library milestone — unblocks NIB-53 (category rows), NIB-58 (search), and NIB-68 (detail).

## SQL migration

`supabase/migrations/20240101000016_recipe_nutrition_tags_category.sql`:

```sql
ALTER TABLE recipes
  ADD COLUMN IF NOT EXISTS nutrition_tags TEXT[] NOT NULL DEFAULT '{}';

ALTER TABLE recipes
  ADD COLUMN IF NOT EXISTS category TEXT;
```

**ACTION REQUIRED:** apply this migration on Supabase dev AND prod before runtime can read the new columns. The existing `allergen_tags` column is untouched.

## Entity additions

`Recipe`:
- `List<String> nutritionTags` — defaults to `<String>[]` (back-compat for legacy rows)
- `String? category` — nullable (legacy rows have null; surfaced as 'Other' on the client)

## New service methods

```dart
/// Group recipes by category. null/empty category -> 'Other' bucket.
Future<Result<Map<String, List<Recipe>>>> getRecipesByCategory(String babyId);

/// Filter recipes whose nutrition_tags contain `tag` (case-sensitive exact match).
Future<Result<List<Recipe>>> getRecipesByNutritionTag(String babyId, String tag);
```

Both call the existing `getAllRecipes(babyId)` under the hood and process in memory — no new Supabase queries. Result.failure propagates unchanged.

## Back-compat

- Legacy recipe rows without the new columns: `nutrition_tags` reads as empty list, `category` reads as null.
- `getRecipesByCategory` places null/empty category recipes into the `'Other'` bucket so they still surface.
- `allergen_tags` column and existing repo/service methods are untouched.

## Acceptance criteria

- [x] SQL migration file committed under `supabase/migrations/`.
- [x] `Recipe` entity carries `nutritionTags` (defaults to empty list) + `category` (nullable).
- [x] Repository reads new columns null-safe.
- [x] `RecipeService.getRecipesByCategory` + `getRecipesByNutritionTag` exposed with `Result<T>` returns.
- [x] `flutter analyze` — 0 issues.
- [x] `flutter test` — All 385 tests passed (was 381; added 4 new).
- [x] `make gen` clean + idempotent (re-run produced no diff).
- [x] No files outside the allowlist modified.

## Gate results

- `make gen`: clean (281 outputs, 14.2s); re-run idempotent.
- `flutter analyze`: No issues found.
- `flutter test`: All 385 tests passed.