### PR TITLE
feat(recipe): re-skin detail screen — hero, banner, advisory, sections, sticky CTA [NIB-68]

### DIFF
--- a/lib/src/features/recipe/detail/recipe_detail_screen.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_screen.dart
@@ -1,16 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:nibbles/src/app/constants/allergen_emoji.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/ingredient.dart';
-import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/recipe/detail/recipe_detail_controller.dart';
 import 'package:nibbles/src/features/recipe/detail/recipe_detail_state.dart';
+import 'package:nibbles/src/features/recipe/detail/widgets/add_to_meal_plan_cta.dart';
 import 'package:nibbles/src/features/recipe/detail/widgets/add_to_meal_plan_sheet.dart';
-import 'package:nibbles/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart';
+import 'package:nibbles/src/features/recipe/detail/widgets/contains_allergens_card.dart';
+import 'package:nibbles/src/features/recipe/detail/widgets/icon_section.dart';
+import 'package:nibbles/src/features/recipe/detail/widgets/recipe_banner_card.dart';
+import 'package:nibbles/src/features/recipe/detail/widgets/recipe_hero.dart';
+import 'package:nibbles/src/features/recipe/detail/widgets/recipe_tip_card.dart';
+import 'package:nibbles/src/features/recipe/detail/widgets/storage_card_row.dart';
 
 class RecipeDetailScreen extends ConsumerWidget {
   const RecipeDetailScreen({required this.recipeId, super.key});
@@ -57,43 +62,53 @@ class _RecipeDetailBody extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.surface,
-        elevation: 0,
-        leading: const BackButton(),
-        title: const Text('Recipe Detail'),
-      ),
       body: detailAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, _) => Center(
-          child: Padding(
-            padding: const EdgeInsets.all(AppSizes.lg),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  "Couldn't load recipe.",
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: AppSizes.sm),
-                FilledButton(
-                  onPressed: () => ref.invalidate(
-                    recipeDetailControllerProvider(babyId, recipeId),
-                  ),
-                  child: const Text('Retry'),
-                ),
-              ],
-            ),
+        error: (error, _) => _ErrorView(
+          onRetry: () => ref.invalidate(
+            recipeDetailControllerProvider(babyId, recipeId),
           ),
         ),
-        data: (state) =>
-            _RecipeContent(babyId: babyId, recipeId: recipeId, state: state),
+        data: (state) => _RecipeContent(
+          babyId: babyId,
+          recipeId: recipeId,
+          state: state,
+        ),
       ),
     );
   }
 }
 
-class _RecipeContent extends ConsumerWidget {
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSizes.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              "Couldn't load recipe.",
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: AppSizes.sm),
+            FilledButton(
+              onPressed: onRetry,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RecipeContent extends ConsumerStatefulWidget {
   const _RecipeContent({
     required this.babyId,
     required this.recipeId,
@@ -104,292 +119,185 @@ class _RecipeContent extends ConsumerWidget {
   final String recipeId;
   final RecipeDetailState state;
 
-  Future<void> _handleAddToMealPlan(BuildContext context, WidgetRef ref) async {
+  @override
+  ConsumerState<_RecipeContent> createState() => _RecipeContentState();
+}
+
+class _RecipeContentState extends ConsumerState<_RecipeContent> {
+  bool _showSuccessBanner = false;
+
+  Future<void> _handleAddToMealPlan() async {
     final result = await showAddToMealPlanFlow(context);
     if (result == null) return;
-    if (!context.mounted) return;
+    if (!mounted) return;
 
     final controller = ref.read(
-      recipeDetailControllerProvider(babyId, recipeId).notifier,
+      recipeDetailControllerProvider(widget.babyId, widget.recipeId).notifier,
     );
     final addResult = await controller.assignToMealPlan(
       result.date,
       time: result.time,
     );
 
-    if (!context.mounted) return;
+    if (!mounted) return;
 
     if (addResult.isSuccess) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Added to meal plan')));
+      setState(() => _showSuccessBanner = true);
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Couldn't add to meal plan. Try again.")),
-      );
-    }
-  }
-
-  Future<void> _handleAddToShoppingList(
-    BuildContext context,
-    WidgetRef ref,
-  ) async {
-    final selectedNames = await showAddToShoppingListSheet(
-      context,
-      state.recipe.ingredients,
-    );
-    if (selectedNames == null || selectedNames.isEmpty) return;
-    if (!context.mounted) return;
-
-    final controller = ref.read(
-      recipeDetailControllerProvider(babyId, recipeId).notifier,
-    );
-    final addResult = await controller.addToShoppingList(selectedNames);
-
-    if (!context.mounted) return;
-
-    if (addResult.isSuccess) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Added to shopping list')));
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Couldn't add items. Try again.")),
+        const SnackBar(
+          content: Text("Couldn't add to meal plan. Try again."),
+        ),
       );
     }
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
+    final state = widget.state;
     final recipe = state.recipe;
 
-    return Column(
+    return Stack(
       children: [
-        Expanded(
-          child: SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Thumbnail hero
-                if (recipe.thumbnailUrl != null)
-                  AspectRatio(
-                    aspectRatio: 16 / 9,
-                    child: Image.network(
-                      recipe.thumbnailUrl!,
-                      fit: BoxFit.cover,
-                      errorBuilder: (_, __, ___) => const ColoredBox(
-                        color: AppColors.surfaceVariant,
-                        child: Center(
-                          child: Icon(
-                            Icons.restaurant,
-                            size: AppSizes.iconXl,
-                            color: AppColors.subtext,
-                          ),
-                        ),
-                      ),
-                    ),
-                  )
-                else
-                  Container(
-                    height: 180,
-                    color: AppColors.surfaceVariant,
-                    child: const Center(
-                      child: Icon(
-                        Icons.restaurant,
-                        size: AppSizes.iconXl,
-                        color: AppColors.subtext,
-                      ),
-                    ),
+        Positioned.fill(
+          child: CustomScrollView(
+            slivers: [
+              SliverAppBar(
+                backgroundColor: Colors.transparent,
+                elevation: 0,
+                leadingWidth: AppSizes.roundButton + AppSizes.sm,
+                leading: Padding(
+                  padding: const EdgeInsets.only(left: AppSizes.sm),
+                  child: AppRoundButton(
+                    icon: const Icon(Icons.arrow_back),
+                    onPressed: () => Navigator.of(context).maybePop(),
+                    semanticLabel: 'Back',
                   ),
-
-                Padding(
-                  padding: const EdgeInsets.all(AppSizes.pagePaddingH),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // Title
-                      Text(
-                        recipe.title,
-                        style: Theme.of(context).textTheme.headlineSmall
-                            ?.copyWith(
-                              fontWeight: FontWeight.w700,
-                              color: AppColors.text,
-                            ),
+                ),
+                expandedHeight: MediaQuery.of(context).size.width * 9 / 16,
+                flexibleSpace: FlexibleSpaceBar(
+                  background: RecipeHero(imageUrl: recipe.thumbnailUrl),
+                ),
+              ),
+              SliverPadding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSizes.pagePaddingH,
+                  AppSizes.sm,
+                  AppSizes.pagePaddingH,
+                  AppSizes.buttonHeight + AppSizes.xxl,
+                ),
+                sliver: SliverList(
+                  delegate: SliverChildListDelegate.fixed([
+                    RecipeBannerCard(
+                      title: recipe.title,
+                      ageRange: recipe.ageRange,
+                      nutritionTags: recipe.nutritionTags,
+                      category: recipe.category,
+                    ),
+                    if (recipe.allergenTags.isNotEmpty) ...[
+                      const SizedBox(height: AppSizes.md),
+                      ContainsAllergensCard(
+                        allergenTags: recipe.allergenTags,
+                        statuses: state.allergenStatuses,
                       ),
-                      const SizedBox(height: AppSizes.sm),
-
-                      // Age range chip
-                      _AgeRangeChip(ageRange: recipe.ageRange),
-                      const SizedBox(height: AppSizes.sm),
-
-                      // Allergen chips
-                      if (recipe.allergenTags.isNotEmpty) ...[
-                        _AllergenChipsRow(
-                          tags: recipe.allergenTags,
-                          currentKey: state.currentAllergenKey,
-                          statuses: state.allergenStatuses,
-                        ),
-                        const SizedBox(height: AppSizes.md),
-                      ],
-
-                      // Ingredients
-                      const _SectionHeader(title: 'Ingredients'),
-                      const SizedBox(height: AppSizes.sm),
-                      _IngredientsList(ingredients: recipe.ingredients),
+                    ],
+                    const SizedBox(height: AppSizes.md),
+                    IconSection(
+                      icon: Icons.shopping_basket_outlined,
+                      title: 'Ingredients',
+                      child: _IngredientsList(ingredients: recipe.ingredients),
+                    ),
+                    const SizedBox(height: AppSizes.lg),
+                    IconSection(
+                      icon: Icons.format_list_numbered,
+                      title: 'Method',
+                      child: _StepsList(steps: recipe.steps),
+                    ),
+                    if (state.utensils != null &&
+                        state.utensils!.isNotEmpty) ...[
                       const SizedBox(height: AppSizes.lg),
-
-                      // Steps
-                      const _SectionHeader(title: 'Steps'),
-                      const SizedBox(height: AppSizes.sm),
-                      _StepsList(steps: recipe.steps),
-                      const SizedBox(height: AppSizes.lg),
-
-                      // How to Serve
-                      const _SectionHeader(title: 'How to Serve'),
-                      const SizedBox(height: AppSizes.sm),
-                      Text(
+                      IconSection(
+                        icon: Icons.kitchen_outlined,
+                        title: 'Utensils',
+                        child: _UtensilsList(utensils: state.utensils!),
+                      ),
+                    ],
+                    const SizedBox(height: AppSizes.lg),
+                    IconSection(
+                      icon: Icons.room_service_outlined,
+                      title: 'How to Serve',
+                      child: Text(
                         recipe.howToServe,
                         style: Theme.of(
                           context,
-                        ).textTheme.bodyMedium?.copyWith(color: AppColors.text),
-                      ),
-
-                      // Notes (optional)
-                      if (recipe.notes != null && recipe.notes!.isNotEmpty) ...[
-                        const SizedBox(height: AppSizes.lg),
-                        const _SectionHeader(title: 'Notes'),
-                        const SizedBox(height: AppSizes.sm),
-                        Text(
-                          recipe.notes!,
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(color: AppColors.subtext),
+                        ).textTheme.bodyMedium?.copyWith(
+                          color: AppColors.fgDefault,
                         ),
-                      ],
-
-                      const SizedBox(height: AppSizes.xl),
+                      ),
+                    ),
+                    if (state.storageNote != null ||
+                        state.freezerNote != null) ...[
+                      const SizedBox(height: AppSizes.lg),
+                      StorageCardRow(
+                        storageNote: state.storageNote,
+                        freezerNote: state.freezerNote,
+                      ),
                     ],
-                  ),
+                    if (state.textureTip != null) ...[
+                      const SizedBox(height: AppSizes.md),
+                      RecipeTipCard(
+                        kind: RecipeTipKind.textureTip,
+                        body: state.textureTip,
+                      ),
+                    ],
+                    if (state.whyThisMeal != null) ...[
+                      const SizedBox(height: AppSizes.md),
+                      RecipeTipCard(
+                        kind: RecipeTipKind.whyThisMeal,
+                        body: state.whyThisMeal,
+                      ),
+                    ],
+                    if (recipe.notes != null && recipe.notes!.isNotEmpty) ...[
+                      const SizedBox(height: AppSizes.lg),
+                      IconSection(
+                        icon: Icons.sticky_note_2_outlined,
+                        title: 'Notes',
+                        child: Text(
+                          recipe.notes!,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.bodyMedium?.copyWith(
+                            color: AppColors.fgDefault,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ]),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
-
-        // Sticky CTA bar
-        _CtaBar(
-          isAddingToMealPlan: state.isAddingToMealPlan,
-          isAddingToShoppingList: state.isAddingToShoppingList,
-          onAddToMealPlan: () => _handleAddToMealPlan(context, ref),
-          onAddToShoppingList: () => _handleAddToShoppingList(context, ref),
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: AddToMealPlanCta(
+            isAdding: state.isAddingToMealPlan,
+            onPressed: _handleAddToMealPlan,
+          ),
         ),
+        if (_showSuccessBanner)
+          Positioned(
+            top: MediaQuery.of(context).padding.top,
+            left: 0,
+            right: 0,
+            child: AddToMealPlanSuccessBanner(
+              message: 'Added to meal plan.',
+              onDismiss: () => setState(() => _showSuccessBanner = false),
+            ),
+          ),
       ],
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Section widgets
-// ---------------------------------------------------------------------------
-
-class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({required this.title});
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      title,
-      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-        fontWeight: FontWeight.w700,
-        color: AppColors.text,
-      ),
-    );
-  }
-}
-
-class _AgeRangeChip extends StatelessWidget {
-  const _AgeRangeChip({required this.ageRange});
-
-  final String ageRange;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.sm + AppSizes.xs,
-        vertical: AppSizes.xs,
-      ),
-      decoration: BoxDecoration(
-        color: AppColors.primaryLight.withValues(alpha: 0.2),
-        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-      ),
-      child: Text(
-        'Fit for $ageRange',
-        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-          color: AppColors.primaryDark,
-          fontWeight: FontWeight.w500,
-        ),
-      ),
-    );
-  }
-}
-
-class _AllergenChipsRow extends StatelessWidget {
-  const _AllergenChipsRow({
-    required this.tags,
-    required this.currentKey,
-    required this.statuses,
-  });
-
-  final List<String> tags;
-  final String currentKey;
-  final Map<String, AllergenStatus> statuses;
-
-  Color _chipColor(String tag) {
-    if (tag == currentKey) return const Color(0xFF2196F3);
-    return switch (statuses[tag] ?? AllergenStatus.notStarted) {
-      AllergenStatus.safe => AppColors.allergenSafe,
-      AllergenStatus.flagged => AppColors.allergenFlagged,
-      AllergenStatus.inProgress => AppColors.allergenInProgress,
-      AllergenStatus.notStarted => AppColors.allergenNotStarted,
-    };
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Wrap(
-      spacing: AppSizes.xs,
-      runSpacing: AppSizes.xs,
-      children: tags.map((tag) {
-        final emoji = AllergenEmoji.get(tag);
-        final name = tag
-            .split('_')
-            .map(
-              (w) => w.isEmpty ? '' : '${w[0].toUpperCase()}${w.substring(1)}',
-            )
-            .join(' ');
-        final color = _chipColor(tag);
-
-        return Container(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.sm,
-            vertical: AppSizes.xs,
-          ),
-          decoration: BoxDecoration(
-            color: color.withValues(alpha: 0.12),
-            borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-            border: Border.all(color: color.withValues(alpha: 0.4)),
-          ),
-          child: Text(
-            '$emoji $name',
-            style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: color,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        );
-      }).toList(),
     );
   }
 }
@@ -401,7 +309,10 @@ class _IngredientsList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         for (final ingredient in ingredients)
           Padding(
@@ -409,13 +320,16 @@ class _IngredientsList extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Text('• ', style: TextStyle(color: AppColors.primary)),
+                const Text(
+                  '• ',
+                  style: TextStyle(color: AppColors.coralDeep),
+                ),
                 Expanded(
                   child: Text(
                     '${ingredient.quantity}  ${ingredient.name}',
-                    style: Theme.of(
-                      context,
-                    ).textTheme.bodyMedium?.copyWith(color: AppColors.text),
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: AppColors.fgDefault,
+                    ),
                   ),
                 ),
               ],
@@ -433,6 +347,8 @@ class _StepsList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Column(
       children: [
         for (int i = 0; i < steps.length; i++)
@@ -442,17 +358,17 @@ class _StepsList extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Container(
-                  width: 24,
-                  height: 24,
+                  width: AppSizes.tipGlyph,
+                  height: AppSizes.tipGlyph,
                   alignment: Alignment.center,
                   decoration: const BoxDecoration(
-                    color: AppColors.primary,
+                    color: AppColors.greenDeep,
                     shape: BoxShape.circle,
                   ),
                   child: Text(
                     '${i + 1}',
-                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                      color: AppColors.onPrimary,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: AppColors.cream,
                       fontWeight: FontWeight.w700,
                     ),
                   ),
@@ -460,12 +376,12 @@ class _StepsList extends StatelessWidget {
                 const SizedBox(width: AppSizes.sm),
                 Expanded(
                   child: Padding(
-                    padding: const EdgeInsets.only(top: 2),
+                    padding: const EdgeInsets.only(top: AppSizes.xs),
                     child: Text(
                       steps[i],
-                      style: Theme.of(
-                        context,
-                      ).textTheme.bodyMedium?.copyWith(color: AppColors.text),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: AppColors.fgDefault,
+                      ),
                     ),
                   ),
                 ),
@@ -477,86 +393,41 @@ class _StepsList extends StatelessWidget {
   }
 }
 
-class _CtaBar extends StatelessWidget {
-  const _CtaBar({
-    required this.isAddingToMealPlan,
-    required this.isAddingToShoppingList,
-    required this.onAddToMealPlan,
-    required this.onAddToShoppingList,
-  });
+class _UtensilsList extends StatelessWidget {
+  const _UtensilsList({required this.utensils});
 
-  final bool isAddingToMealPlan;
-  final bool isAddingToShoppingList;
-  final VoidCallback onAddToMealPlan;
-  final VoidCallback onAddToShoppingList;
+  final List<String> utensils;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.08),
-            blurRadius: 12,
-            offset: const Offset(0, -2),
-          ),
-        ],
-      ),
-      padding: EdgeInsets.fromLTRB(
-        AppSizes.pagePaddingH,
-        AppSizes.sm,
-        AppSizes.pagePaddingH,
-        AppSizes.sm + MediaQuery.of(context).padding.bottom,
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: OutlinedButton(
-              onPressed: isAddingToShoppingList ? null : onAddToShoppingList,
-              style: OutlinedButton.styleFrom(
-                minimumSize: const Size(0, AppSizes.buttonHeight),
-                foregroundColor: AppColors.primary,
-                side: const BorderSide(color: AppColors.primary),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final utensil in utensils)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: AppSizes.xs),
+            child: Row(
+              children: [
+                const Icon(
+                  Icons.check,
+                  size: AppSizes.iconSm,
+                  color: AppColors.greenDeep,
                 ),
-              ),
-              child: isAddingToShoppingList
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Text('Add to Shopping List'),
+                const SizedBox(width: AppSizes.sm),
+                Expanded(
+                  child: Text(
+                    utensil,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: AppColors.fgDefault,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
-          const SizedBox(width: AppSizes.sm),
-          Expanded(
-            child: FilledButton(
-              onPressed: isAddingToMealPlan ? null : onAddToMealPlan,
-              style: FilledButton.styleFrom(
-                minimumSize: const Size(0, AppSizes.buttonHeight),
-                backgroundColor: AppColors.primary,
-                foregroundColor: AppColors.onPrimary,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-                ),
-              ),
-              child: isAddingToMealPlan
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: AppColors.onPrimary,
-                      ),
-                    )
-                  : const Text('Add to Meal Plan'),
-            ),
-          ),
-        ],
-      ),
+      ],
     );
   }
 }

--- a/lib/src/features/recipe/detail/recipe_detail_state.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_state.dart
@@ -14,4 +14,25 @@ class RecipeDetailState with _$RecipeDetailState {
     @Default(false) bool isAddingToMealPlan,
     @Default(false) bool isAddingToShoppingList,
   }) = _RecipeDetailState;
+
+  const RecipeDetailState._();
+
+  /// Optional list of utensils for this recipe. Returns null until the
+  /// `Recipe` entity surfaces a utensils field (NIB-129 only added
+  /// `nutritionTags` + `category`; the rest is pending). Routed through a
+  /// getter so callers stay compile-clean and the UI conditionally hides
+  /// the section.
+  List<String>? get utensils => null;
+
+  /// Optional fridge storage note. Null until backed by the entity.
+  String? get storageNote => null;
+
+  /// Optional freezer storage note. Null until backed by the entity.
+  String? get freezerNote => null;
+
+  /// Optional "Texture Tip" body copy. Null until backed by the entity.
+  String? get textureTip => null;
+
+  /// Optional "Why this meal" body copy. Null until backed by the entity.
+  String? get whyThisMeal => null;
 }

--- a/lib/src/features/recipe/detail/recipe_detail_state.freezed.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_state.freezed.dart
@@ -178,7 +178,7 @@ class __$$RecipeDetailStateImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$RecipeDetailStateImpl implements _RecipeDetailState {
+class _$RecipeDetailStateImpl extends _RecipeDetailState {
   const _$RecipeDetailStateImpl({
     required this.recipe,
     required this.currentAllergenKey,
@@ -186,7 +186,8 @@ class _$RecipeDetailStateImpl implements _RecipeDetailState {
         const <String, AllergenStatus>{},
     this.isAddingToMealPlan = false,
     this.isAddingToShoppingList = false,
-  }) : _allergenStatuses = allergenStatuses;
+  }) : _allergenStatuses = allergenStatuses,
+       super._();
 
   @override
   final Recipe recipe;
@@ -253,7 +254,7 @@ class _$RecipeDetailStateImpl implements _RecipeDetailState {
       );
 }
 
-abstract class _RecipeDetailState implements RecipeDetailState {
+abstract class _RecipeDetailState extends RecipeDetailState {
   const factory _RecipeDetailState({
     required final Recipe recipe,
     required final String currentAllergenKey,
@@ -261,6 +262,7 @@ abstract class _RecipeDetailState implements RecipeDetailState {
     final bool isAddingToMealPlan,
     final bool isAddingToShoppingList,
   }) = _$RecipeDetailStateImpl;
+  const _RecipeDetailState._() : super._();
 
   @override
   Recipe get recipe;

--- a/lib/src/features/recipe/detail/widgets/add_to_meal_plan_cta.dart
+++ b/lib/src/features/recipe/detail/widgets/add_to_meal_plan_cta.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+
+/// Sticky bottom CTA used on the recipe detail screen — a single full-width
+/// green pill button that opens the existing `AddToMealPlanSheet`.
+///
+/// Wrapped in a white surface with a subtle top divider so it floats above
+/// the scrollable content. Bottom inset is added so the button clears the
+/// home indicator.
+class AddToMealPlanCta extends StatelessWidget {
+  const AddToMealPlanCta({
+    required this.isAdding,
+    required this.onPressed,
+    super.key,
+  });
+
+  final bool isAdding;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: AppColors.surface,
+        boxShadow: AppSizes.shadowCard,
+      ),
+      padding: EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.sp12,
+        AppSizes.pagePaddingH,
+        AppSizes.sp12 + MediaQuery.of(context).padding.bottom,
+      ),
+      child: AppPillButton(
+        label: isAdding ? 'Adding…' : 'Add to Meal Plan',
+        onPressed: isAdding ? null : onPressed,
+        leading: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+/// Inline success banner — DS-styled, top-anchored inside the scroll view.
+/// Mirrors Figma node 1474:53362. The screen owns dismiss state.
+class AddToMealPlanSuccessBanner extends StatelessWidget {
+  const AddToMealPlanSuccessBanner({
+    required this.message,
+    required this.onDismiss,
+    super.key,
+  });
+
+  final String message;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.sm,
+        AppSizes.pagePaddingH,
+        0,
+      ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.md,
+          vertical: AppSizes.sp12,
+        ),
+        decoration: BoxDecoration(
+          color: AppColors.greenTint,
+          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+          border: Border.all(color: AppColors.green, width: 1.5),
+        ),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.check_circle_outline,
+              size: AppSizes.iconMd,
+              color: AppColors.greenDeep,
+            ),
+            const SizedBox(width: AppSizes.sm),
+            Expanded(
+              child: Text(
+                message,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.greenDeep,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            IconButton(
+              onPressed: onDismiss,
+              icon: const Icon(
+                Icons.close,
+                size: AppSizes.iconSm,
+                color: AppColors.greenDeep,
+              ),
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(
+                minHeight: AppSizes.iconLg,
+                minWidth: AppSizes.iconLg,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/recipe/detail/widgets/contains_allergens_card.dart
+++ b/lib/src/features/recipe/detail/widgets/contains_allergens_card.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/constants/allergen_emoji.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/cards/app_card.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+
+/// "Contains allergens" section — renders a chip per allergen tag plus a
+/// salmon-ghost advisory box telling parents to consult a pediatrician.
+///
+/// Chip tone uses the canonical status semantics: safe → safe chip,
+/// flagged → flag chip; everything else stays neutral. `.completed` is
+/// never used — see CLAUDE.md.
+class ContainsAllergensCard extends StatelessWidget {
+  const ContainsAllergensCard({
+    required this.allergenTags,
+    required this.statuses,
+    super.key,
+  });
+
+  final List<String> allergenTags;
+  final Map<String, AllergenStatus> statuses;
+
+  String _humanize(String raw) {
+    return raw
+        .split('_')
+        .where((w) => w.isNotEmpty)
+        .map((w) => '${w[0].toUpperCase()}${w.substring(1)}')
+        .join(' ');
+  }
+
+  AppChipTone _toneFor(String tag) {
+    final status = statuses[tag] ?? AllergenStatus.notStarted;
+    return switch (status) {
+      AllergenStatus.safe => AppChipTone.safe,
+      AllergenStatus.flagged => AppChipTone.flag,
+      AllergenStatus.inProgress => AppChipTone.warn,
+      AllergenStatus.notStarted => AppChipTone.mute,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AppCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.shield_outlined,
+                size: AppSizes.iconSm,
+                color: AppColors.coralDeep,
+              ),
+              const SizedBox(width: AppSizes.xs),
+              Text(
+                'Contains allergens',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: AppColors.fgStrong,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSizes.sm),
+          Wrap(
+            spacing: AppSizes.xs,
+            runSpacing: AppSizes.xs,
+            children: [
+              for (final tag in allergenTags)
+                AppChip(
+                  label: _humanize(tag),
+                  tone: _toneFor(tag),
+                  emoji: AllergenEmoji.get(tag),
+                ),
+            ],
+          ),
+          const SizedBox(height: AppSizes.sm),
+          _AdvisoryBox(theme: theme),
+        ],
+      ),
+    );
+  }
+}
+
+class _AdvisoryBox extends StatelessWidget {
+  const _AdvisoryBox({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.sp12,
+        vertical: AppSizes.sp12,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.coralSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(
+            Icons.menu_book_outlined,
+            size: AppSizes.iconMd,
+            color: AppColors.coralDeep,
+          ),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: Text(
+              'Always consult your pediatrician before introducing '
+              'new allergens.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: AppColors.fgDefault,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/recipe/detail/widgets/icon_section.dart
+++ b/lib/src/features/recipe/detail/widgets/icon_section.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Section header with a leading butter-circle icon and a Parkinsans
+/// title. Used by Ingredients, Method, and Utensils on the recipe detail
+/// screen.
+///
+/// Layout: 28px circle (butter background, greenDeep icon) + title text.
+class IconSectionHeader extends StatelessWidget {
+  const IconSectionHeader({
+    required this.icon,
+    required this.title,
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Row(
+      children: [
+        Container(
+          width: AppSizes.tipGlyph,
+          height: AppSizes.tipGlyph,
+          decoration: const BoxDecoration(
+            color: AppColors.butter,
+            shape: BoxShape.circle,
+          ),
+          alignment: Alignment.center,
+          child: Icon(
+            icon,
+            size: AppSizes.iconSm,
+            color: AppColors.greenDeep,
+          ),
+        ),
+        const SizedBox(width: AppSizes.sm),
+        Expanded(
+          child: Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Composed section block — `IconSectionHeader` plus arbitrary [child] body.
+/// Wraps the body in 12px vertical spacing and keeps the section left-aligned.
+class IconSection extends StatelessWidget {
+  const IconSection({
+    required this.icon,
+    required this.title,
+    required this.child,
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        IconSectionHeader(icon: icon, title: title),
+        const SizedBox(height: AppSizes.sp12),
+        child,
+      ],
+    );
+  }
+}

--- a/lib/src/features/recipe/detail/widgets/recipe_banner_card.dart
+++ b/lib/src/features/recipe/detail/widgets/recipe_banner_card.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/cards/app_card.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+
+/// Recipe banner card — sits just under the hero image. Shows the title,
+/// the age range, an optional category chip, and the diet (nutrition) chips.
+///
+/// Mirrors Figma node 1129:13972.
+class RecipeBannerCard extends StatelessWidget {
+  const RecipeBannerCard({
+    required this.title,
+    required this.ageRange,
+    required this.nutritionTags,
+    this.category,
+    super.key,
+  });
+
+  final String title;
+  final String ageRange;
+  final List<String> nutritionTags;
+  final String? category;
+
+  String _humanize(String raw) {
+    return raw
+        .split(RegExp(r'[_\s]+'))
+        .where((w) => w.isNotEmpty)
+        .map((w) => '${w[0].toUpperCase()}${w.substring(1)}')
+        .join(' ');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final categoryLabel = category;
+    final hasSubheader = categoryLabel != null && categoryLabel.isNotEmpty;
+    final hasDietChips = nutritionTags.isNotEmpty;
+
+    return AppCard(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md,
+        vertical: AppSizes.md,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+          ),
+          const SizedBox(height: AppSizes.sm),
+          Row(
+            children: [
+              AppChip(
+                label: 'Fit for $ageRange',
+                tone: AppChipTone.butter,
+                icon: const Icon(Icons.child_care_outlined),
+              ),
+              if (hasSubheader) ...[
+                const SizedBox(width: AppSizes.xs),
+                AppChip(
+                  label: _humanize(categoryLabel),
+                  tone: AppChipTone.mute,
+                ),
+              ],
+            ],
+          ),
+          if (hasDietChips) ...[
+            const SizedBox(height: AppSizes.sm),
+            Wrap(
+              spacing: AppSizes.xs,
+              runSpacing: AppSizes.xs,
+              children: [
+                for (final tag in nutritionTags)
+                  AppChip(label: _humanize(tag)),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/recipe/detail/widgets/recipe_hero.dart
+++ b/lib/src/features/recipe/detail/widgets/recipe_hero.dart
@@ -1,0 +1,48 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Full-bleed hero image used at the top of the recipe detail screen.
+///
+/// Renders [imageUrl] edge-to-edge with a 16:9 ratio and a soft butter-tint
+/// fallback when the image is null or fails to load. The recipe banner card
+/// sits below this in the parent layout.
+class RecipeHero extends StatelessWidget {
+  const RecipeHero({required this.imageUrl, super.key});
+
+  final String? imageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 16 / 9,
+      child: imageUrl == null || imageUrl!.isEmpty
+          ? const _Fallback()
+          : CachedNetworkImage(
+              imageUrl: imageUrl!,
+              fit: BoxFit.cover,
+              placeholder: (_, __) => const _Fallback(),
+              errorWidget: (_, __, ___) => const _Fallback(),
+            ),
+    );
+  }
+}
+
+class _Fallback extends StatelessWidget {
+  const _Fallback();
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      color: AppColors.butterSoft,
+      child: Center(
+        child: Icon(
+          Icons.restaurant_outlined,
+          size: AppSizes.iconXl,
+          color: AppColors.coralDeep,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/recipe/detail/widgets/recipe_tip_card.dart
+++ b/lib/src/features/recipe/detail/widgets/recipe_tip_card.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/cards/tip_card.dart';
+
+/// Tip card variant used on the recipe detail screen for "Texture Tip" and
+/// "Why this meal".
+///
+/// Thin wrapper around the design-system [TipCard] that fixes a feature-
+/// specific icon per tip kind. Hides itself when the body is null or empty so
+/// callers can drop a single line per slot without ad-hoc null checks.
+enum RecipeTipKind { textureTip, whyThisMeal }
+
+class RecipeTipCard extends StatelessWidget {
+  const RecipeTipCard({required this.kind, required this.body, super.key});
+
+  final RecipeTipKind kind;
+  final String? body;
+
+  String get _title => switch (kind) {
+    RecipeTipKind.textureTip => 'Texture Tip',
+    RecipeTipKind.whyThisMeal => 'Why this meal',
+  };
+
+  String get _glyph => switch (kind) {
+    RecipeTipKind.textureTip => 'T',
+    RecipeTipKind.whyThisMeal => '?',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final text = body;
+    if (text == null || text.isEmpty) return const SizedBox.shrink();
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.butterSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+      ),
+      child: TipCard(title: _title, body: text, glyph: _glyph),
+    );
+  }
+}

--- a/lib/src/features/recipe/detail/widgets/storage_card_row.dart
+++ b/lib/src/features/recipe/detail/widgets/storage_card_row.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Row of two salmon "Storage" / "Freezer" cards. If both notes are null the
+/// row is suppressed entirely — caller should hide via the same null-check.
+///
+/// Either side can be null independently; this widget handles that by laying
+/// out only the non-null sides side-by-side. When both are null an empty
+/// [SizedBox] is returned (defence-in-depth — caller is expected to hide
+/// the whole section).
+class StorageCardRow extends StatelessWidget {
+  const StorageCardRow({
+    this.storageNote,
+    this.freezerNote,
+    super.key,
+  });
+
+  final String? storageNote;
+  final String? freezerNote;
+
+  @override
+  Widget build(BuildContext context) {
+    final storage = storageNote;
+    final freezer = freezerNote;
+    if (storage == null && freezer == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (storage != null)
+          Expanded(
+            child: _StorageCard(
+              icon: Icons.kitchen_outlined,
+              title: 'Storage',
+              body: storage,
+            ),
+          ),
+        if (storage != null && freezer != null)
+          const SizedBox(width: AppSizes.sm),
+        if (freezer != null)
+          Expanded(
+            child: _StorageCard(
+              icon: Icons.ac_unit_outlined,
+              title: 'Freezer',
+              body: freezer,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _StorageCard extends StatelessWidget {
+  const _StorageCard({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+
+  final IconData icon;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.sp12,
+        vertical: AppSizes.sp12,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.coralSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, size: AppSizes.iconSm, color: AppColors.coralDeep),
+              const SizedBox(width: AppSizes.xs),
+              Text(
+                title,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: AppColors.fgStrong,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSizes.xs),
+          Text(
+            body,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: AppColors.fgDefault,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Rewrites the recipe detail screen per the Figma redesign. Replaces the legacy dual-CTA layout with a full-bleed hero, recipe banner card, allergen advisory, icon-led sections, storage/freezer cards, tip cards, and a single sticky Add to Meal Plan CTA. Success surfaces as a DS-styled green banner; failure falls back to the existing P2 SnackBar.

## Figma frames

- Detail screen: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-9616
- Success banner: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1474-53362
- Recipe banner card: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1129-13972

## DS components consumed

- `AppCard` (plain + soft variants)
- `AppChip` (butter, mute, neutral, safe, warn, flag tones)
- `AppPillButton` (primary)
- `AppRoundButton` (white)
- `TipCard` (re-skinned via `RecipeTipCard`)
- Tokens: `AppColors` (sage/butter/coral/cream/safeFg/flagFg/coralSoft/etc.), `AppSizes`, `AppTypography` (via theme), `AllergenEmoji`

## New widget files (under `detail/widgets/`)

- `recipe_hero.dart` — full-bleed 16:9 hero with butter-tint fallback
- `recipe_banner_card.dart` — title + age + category + diet chips
- `contains_allergens_card.dart` — allergen chips + salmon-ghost advisory box
- `icon_section.dart` — reusable section header w/ butter glyph circle
- `storage_card_row.dart` — salmon Storage + Freezer cards (each renders only when its note is present)
- `recipe_tip_card.dart` — butter Texture Tip / Why this meal wrapper
- `add_to_meal_plan_cta.dart` — sticky pill CTA + green success banner

## Spec carve-outs

- **Recipe entity scope:** NIB-129 only landed `nutritionTags` and `category` on `Recipe`. `utensils`, `storageNote`, `freezerNote`, `textureTip`, `whyThisMeal` are not on the entity yet. Per the allowlist, `recipe.dart` is consume-only, so those widgets are built and wired through nullable getters on `RecipeDetailState` that return null until the entity surfaces them. The conditional `if (state.foo != null)` blocks satisfy rules 9/10 ("hide when null") today and become fully data-driven once those fields land — no UI rework needed.
- **`addToShoppingList` controller path preserved** (open question 4) — controller method, state flag, and analytics-ready hook are all intact even though the screen no longer offers the dual CTA.
- **Sheets untouched:** `add_to_meal_plan_sheet.dart` (NIB-84) and `add_to_shopping_list_sheet.dart` (NIB-75) are not modified.
- **Allergen semantics:** `AllergenStatus.safe`/`flagged` only — `.completed` never used.
- **Tokens only:** zero hex / Nunito / withAlpha / `AllergenStatus.completed`. The only `Colors.*` reference is `Colors.transparent` on the `SliverAppBar` (no DS token for transparency).

## Gate results

- `make gen`: clean and idempotent (verified twice).
- `flutter analyze`: **0 issues**.
- `flutter test`: **384 passed, 1 failed** — `recipe_to_shopping_list_integration_test.dart` taps the now-removed "Add to Shopping List" button at line 192. Removing the button is required by rules 11 and 12 ("single full-width green sticky 'Add to Meal Plan'", "delete legacy `_CtaBar`"). Test maintenance is owned by NIB-108 per rule 13; `test/` is outside this ticket's allowlist.

## Acceptance criteria checklist

- [x] `recipe_detail_screen.dart` fully rewritten — no `_CtaBar` legacy widget
- [x] New widget modules under `detail/widgets/`: recipe_hero, recipe_banner_card, contains_allergens_card, icon_section, storage_card_row, recipe_tip_card, add_to_meal_plan_cta
- [x] Diet chips render from `Recipe.nutritionTags`; category chip from `Recipe.category`
- [x] Allergen advisory uses `AllergenStatus.safe`/`flagged` semantics; never `.completed`
- [x] Storage/Freezer + Tip cards conditionally render based on null checks
- [x] Sticky CTA is a single "Add to Meal Plan" — success shows DS banner, failure shows P2 toast
- [x] `add_to_meal_plan_sheet.dart` + `add_to_shopping_list_sheet.dart` UNTOUCHED
- [x] `flutter analyze` 0 issues
- [x] `make gen` clean + idempotent
- [x] Zero hex / Nunito / withAlpha / `AllergenStatus.completed`
- [x] No files outside allowlist modified

## Test plan

- [ ] Open a recipe with `thumbnailUrl` set — hero renders full-bleed, banner card sits below
- [ ] Open a recipe without `thumbnailUrl` — butter fallback shows the food glyph
- [ ] Banner card renders age range, optional category chip, and diet chips from `nutritionTags`
- [ ] Allergen advisory card lists each allergen as a chip; safe/flagged statuses use canonical tones; advisory text reads "Always consult your pediatrician before introducing new allergens."
- [ ] Ingredients, Method, How to Serve sections render with butter-circle icon headers
- [ ] Sticky "Add to Meal Plan" CTA stays pinned at the bottom over scroll content
- [ ] Tap CTA → date picker → optional time → success → green banner appears at top, dismiss via X
- [ ] Force failure → P2 SnackBar "Couldn't add to meal plan. Try again."
- [ ] Back arrow round button returns to the recipe library