### PR TITLE
feat(recipe): library search collapses to results + new empty state [NIB-58]

### DIFF
--- a/lib/src/features/recipe/library/recipe_library_controller.dart
+++ b/lib/src/features/recipe/library/recipe_library_controller.dart
@@ -69,4 +69,16 @@ class RecipeLibraryController extends _$RecipeLibraryController {
     state = AsyncData(current.copyWith(isStartingGuideSeen: true));
     await ref.read(localFlagServiceProvider).markStartingGuideSeen();
   }
+
+  /// Updates the active search query. The query is trimmed; a non-empty
+  /// query collapses the screen into the search-results view, an empty one
+  /// restores the category-rows layout. Filtering itself lives on
+  /// [RecipeLibraryState.filteredRecipes].
+  void setSearchQuery(String query) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    final trimmed = query.trim();
+    if (trimmed == current.searchQuery) return;
+    state = AsyncData(current.copyWith(searchQuery: trimmed));
+  }
 }

--- a/lib/src/features/recipe/library/recipe_library_controller.g.dart
+++ b/lib/src/features/recipe/library/recipe_library_controller.g.dart
@@ -7,7 +7,7 @@ part of 'recipe_library_controller.dart';
 // **************************************************************************
 
 String _$recipeLibraryControllerHash() =>
-    r'f1d4e66df0fe4a1d0f08daa4e7bf0d382402ca99';
+    r'40f19a72ba8e5d33fa117b06a02df66b35b86b20';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/recipe/library/recipe_library_screen.dart
+++ b/lib/src/features/recipe/library/recipe_library_screen.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/constants/allergen_emoji.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
@@ -14,10 +13,10 @@ import 'package:nibbles/src/features/recipe/library/recipe_library_state.dart';
 import 'package:nibbles/src/features/recipe/library/widgets/library_header.dart';
 import 'package:nibbles/src/features/recipe/library/widgets/read_guide_banner.dart';
 import 'package:nibbles/src/features/recipe/library/widgets/recipe_category_row.dart';
-import 'package:nibbles/src/features/recipe/library/widgets/recipe_grid_card.dart';
-import 'package:nibbles/src/routing/route_enums.dart';
+import 'package:nibbles/src/features/recipe/library/widgets/recipe_search_empty.dart';
+import 'package:nibbles/src/features/recipe/library/widgets/recipe_search_results.dart';
 
-/// Recipe Library screen (RC-01, NIB-53 reskin).
+/// Recipe Library screen (RC-01, NIB-53 reskin + NIB-58 search rewire).
 ///
 /// Reskins the previous SliverGrid layout to a butter-wash [LibraryHeader] +
 /// vertical stack of horizontal [RecipeCategoryRow]s, driven by
@@ -28,8 +27,14 @@ import 'package:nibbles/src/routing/route_enums.dart';
 ///      any category whose `allergenTags` contain the in-progress allergen.
 ///   2. One row per category in the order returned by the service.
 ///
-/// Allergen-level recipe flagging is preserved via [RecipeGridCard]'s
-/// `flaggedAllergenKeys` prop.
+/// Search (NIB-58): the header's search input dispatches the query to
+/// [RecipeLibraryController.setSearchQuery]. A non-empty
+/// `state.searchQuery` collapses the body into [RecipeSearchResults]; an
+/// empty result inside that branch renders [RecipeSearchEmpty]. Clearing
+/// the field reverts to the category-rows layout.
+///
+/// Allergen-level recipe flagging is preserved via the
+/// `flaggedAllergenKeys` prop on every card-rendering widget.
 class RecipeLibraryScreen extends ConsumerWidget {
   const RecipeLibraryScreen({super.key});
 
@@ -70,7 +75,6 @@ class _RecipeLibraryBody extends ConsumerStatefulWidget {
 
 class _RecipeLibraryBodyState extends ConsumerState<_RecipeLibraryBody> {
   final _searchController = TextEditingController();
-  String _searchQuery = '';
 
   @override
   void dispose() {
@@ -109,6 +113,12 @@ class _RecipeLibraryBodyState extends ConsumerState<_RecipeLibraryBody> {
     _openStartingGuide();
   }
 
+  void _onSearchChanged(String query) {
+    ref
+        .read(recipeLibraryControllerProvider(widget.babyId).notifier)
+        .setSearchQuery(query);
+  }
+
   Future<void> _refresh() => ref
       .read(recipeLibraryControllerProvider(widget.babyId).notifier)
       .refresh();
@@ -119,15 +129,16 @@ class _RecipeLibraryBodyState extends ConsumerState<_RecipeLibraryBody> {
       recipeLibraryControllerProvider(widget.babyId),
     );
 
+    final searchValue = libraryAsync.valueOrNull?.searchQuery ?? '';
+
     return Scaffold(
       backgroundColor: AppColors.cream,
       body: Column(
         children: [
           LibraryHeader(
             searchController: _searchController,
-            searchValue: _searchQuery,
-            onSearchChanged: (q) =>
-                setState(() => _searchQuery = q.trim()),
+            searchValue: searchValue,
+            onSearchChanged: _onSearchChanged,
             onBookmarkTap: _onBookmarkTap,
           ),
           Expanded(
@@ -137,7 +148,6 @@ class _RecipeLibraryBodyState extends ConsumerState<_RecipeLibraryBody> {
               error: (_, __) => _ErrorView(onRetry: _refresh),
               data: (state) => _RecipeContent(
                 state: state,
-                searchQuery: _searchQuery,
                 onReadGuideTap: _onReadGuideTap,
                 onRefresh: _refresh,
               ),
@@ -152,13 +162,11 @@ class _RecipeLibraryBodyState extends ConsumerState<_RecipeLibraryBody> {
 class _RecipeContent extends StatelessWidget {
   const _RecipeContent({
     required this.state,
-    required this.searchQuery,
     required this.onReadGuideTap,
     required this.onRefresh,
   });
 
   final RecipeLibraryState state;
-  final String searchQuery;
   final VoidCallback onReadGuideTap;
   final Future<void> Function() onRefresh;
 
@@ -166,18 +174,6 @@ class _RecipeContent extends StatelessWidget {
       .expand((rs) => rs)
       .toSet()
       .toList();
-
-  List<Recipe> get _filteredRecipes {
-    final q = searchQuery.toLowerCase();
-    return _allRecipes
-        .where(
-          (r) =>
-              r.title.toLowerCase().contains(q) ||
-              r.allergenTags.any((t) => t.toLowerCase().contains(q)) ||
-              r.nutritionTags.any((t) => t.toLowerCase().contains(q)),
-        )
-        .toList();
-  }
 
   List<Recipe> get _recommendations {
     final key = state.ongoingAllergenKey;
@@ -187,10 +183,13 @@ class _RecipeContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (searchQuery.isNotEmpty) {
-      return _SearchResults(
-        recipes: _filteredRecipes,
-        query: searchQuery,
+    if (state.searchQuery.isNotEmpty) {
+      final results = state.filteredRecipes;
+      if (results.isEmpty) {
+        return const RecipeSearchEmpty();
+      }
+      return RecipeSearchResults(
+        recipes: results,
         flaggedAllergenKeys: state.flaggedAllergenKeys,
       );
     }
@@ -322,63 +321,6 @@ class _EmptyView extends StatelessWidget {
           ),
         ),
       ],
-    );
-  }
-}
-
-class _SearchResults extends StatelessWidget {
-  const _SearchResults({
-    required this.recipes,
-    required this.query,
-    this.flaggedAllergenKeys = const {},
-  });
-
-  final List<Recipe> recipes;
-  final String query;
-  final Set<String> flaggedAllergenKeys;
-
-  @override
-  Widget build(BuildContext context) {
-    if (recipes.isEmpty) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(AppSizes.lg),
-          child: Text(
-            'No recipes found for "$query".',
-            textAlign: TextAlign.center,
-            style: AppTypography.caption.copyWith(
-              color: AppColors.fgFaint,
-            ),
-          ),
-        ),
-      );
-    }
-
-    return GridView.builder(
-      padding: const EdgeInsets.fromLTRB(
-        AppSizes.pagePaddingH,
-        AppSizes.md,
-        AppSizes.pagePaddingH,
-        AppSizes.xl,
-      ),
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 2,
-        crossAxisSpacing: AppSizes.sp12,
-        mainAxisSpacing: AppSizes.sp12,
-        childAspectRatio: 158 / 220,
-      ),
-      itemCount: recipes.length,
-      itemBuilder: (context, index) {
-        final recipe = recipes[index];
-        return RecipeGridCard(
-          recipe: recipe,
-          flaggedAllergenKeys: flaggedAllergenKeys,
-          onTap: () => context.pushNamed(
-            AppRoute.recipeDetail.name,
-            pathParameters: {'recipeId': recipe.id},
-          ),
-        );
-      },
     );
   }
 }

--- a/lib/src/features/recipe/library/recipe_library_state.dart
+++ b/lib/src/features/recipe/library/recipe_library_state.dart
@@ -18,6 +18,11 @@ part 'recipe_library_state.freezed.dart';
 /// whose `allergenTags` intersect with a baby's flagged-allergen set.
 ///
 /// [isStartingGuideSeen] gates the first-launch 'Read Guide' banner.
+///
+/// [searchQuery] is the trimmed search input from the header pill. When
+/// non-empty the screen collapses category rows into a flat
+/// `RecipeSearchResults` list driven by [filteredRecipes]; when empty
+/// the category-rows layout is restored.
 @freezed
 class RecipeLibraryState with _$RecipeLibraryState {
   const factory RecipeLibraryState({
@@ -25,5 +30,28 @@ class RecipeLibraryState with _$RecipeLibraryState {
     String? ongoingAllergenKey,
     @Default(<String>{}) Set<String> flaggedAllergenKeys,
     @Default(false) bool isStartingGuideSeen,
+    @Default('') String searchQuery,
   }) = _RecipeLibraryState;
+
+  const RecipeLibraryState._();
+
+  /// Flat, deduped list of recipes across every category. Iteration order
+  /// follows the insertion order of [recipesByCategory].
+  List<Recipe> get _allRecipes =>
+      recipesByCategory.values.expand((rs) => rs).toSet().toList();
+
+  /// Recipes matching [searchQuery] (case-insensitive contains) against
+  /// the recipe title or any `nutritionTags` entry. Returns an empty list
+  /// when [searchQuery] is empty.
+  List<Recipe> get filteredRecipes {
+    final q = searchQuery.toLowerCase();
+    if (q.isEmpty) return const [];
+    return _allRecipes
+        .where(
+          (r) =>
+              r.title.toLowerCase().contains(q) ||
+              r.nutritionTags.any((t) => t.toLowerCase().contains(q)),
+        )
+        .toList();
+  }
 }

--- a/lib/src/features/recipe/library/recipe_library_state.freezed.dart
+++ b/lib/src/features/recipe/library/recipe_library_state.freezed.dart
@@ -22,6 +22,7 @@ mixin _$RecipeLibraryState {
   String? get ongoingAllergenKey => throw _privateConstructorUsedError;
   Set<String> get flaggedAllergenKeys => throw _privateConstructorUsedError;
   bool get isStartingGuideSeen => throw _privateConstructorUsedError;
+  String get searchQuery => throw _privateConstructorUsedError;
 
   /// Create a copy of RecipeLibraryState
   /// with the given fields replaced by the non-null parameter values.
@@ -42,6 +43,7 @@ abstract class $RecipeLibraryStateCopyWith<$Res> {
     String? ongoingAllergenKey,
     Set<String> flaggedAllergenKeys,
     bool isStartingGuideSeen,
+    String searchQuery,
   });
 }
 
@@ -64,6 +66,7 @@ class _$RecipeLibraryStateCopyWithImpl<$Res, $Val extends RecipeLibraryState>
     Object? ongoingAllergenKey = freezed,
     Object? flaggedAllergenKeys = null,
     Object? isStartingGuideSeen = null,
+    Object? searchQuery = null,
   }) {
     return _then(
       _value.copyWith(
@@ -83,6 +86,10 @@ class _$RecipeLibraryStateCopyWithImpl<$Res, $Val extends RecipeLibraryState>
                 ? _value.isStartingGuideSeen
                 : isStartingGuideSeen // ignore: cast_nullable_to_non_nullable
                       as bool,
+            searchQuery: null == searchQuery
+                ? _value.searchQuery
+                : searchQuery // ignore: cast_nullable_to_non_nullable
+                      as String,
           )
           as $Val,
     );
@@ -103,6 +110,7 @@ abstract class _$$RecipeLibraryStateImplCopyWith<$Res>
     String? ongoingAllergenKey,
     Set<String> flaggedAllergenKeys,
     bool isStartingGuideSeen,
+    String searchQuery,
   });
 }
 
@@ -124,6 +132,7 @@ class __$$RecipeLibraryStateImplCopyWithImpl<$Res>
     Object? ongoingAllergenKey = freezed,
     Object? flaggedAllergenKeys = null,
     Object? isStartingGuideSeen = null,
+    Object? searchQuery = null,
   }) {
     return _then(
       _$RecipeLibraryStateImpl(
@@ -143,6 +152,10 @@ class __$$RecipeLibraryStateImplCopyWithImpl<$Res>
             ? _value.isStartingGuideSeen
             : isStartingGuideSeen // ignore: cast_nullable_to_non_nullable
                   as bool,
+        searchQuery: null == searchQuery
+            ? _value.searchQuery
+            : searchQuery // ignore: cast_nullable_to_non_nullable
+                  as String,
       ),
     );
   }
@@ -150,14 +163,16 @@ class __$$RecipeLibraryStateImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$RecipeLibraryStateImpl implements _RecipeLibraryState {
+class _$RecipeLibraryStateImpl extends _RecipeLibraryState {
   const _$RecipeLibraryStateImpl({
     required final Map<String, List<Recipe>> recipesByCategory,
     this.ongoingAllergenKey,
     final Set<String> flaggedAllergenKeys = const <String>{},
     this.isStartingGuideSeen = false,
+    this.searchQuery = '',
   }) : _recipesByCategory = recipesByCategory,
-       _flaggedAllergenKeys = flaggedAllergenKeys;
+       _flaggedAllergenKeys = flaggedAllergenKeys,
+       super._();
 
   final Map<String, List<Recipe>> _recipesByCategory;
   @override
@@ -183,10 +198,13 @@ class _$RecipeLibraryStateImpl implements _RecipeLibraryState {
   @override
   @JsonKey()
   final bool isStartingGuideSeen;
+  @override
+  @JsonKey()
+  final String searchQuery;
 
   @override
   String toString() {
-    return 'RecipeLibraryState(recipesByCategory: $recipesByCategory, ongoingAllergenKey: $ongoingAllergenKey, flaggedAllergenKeys: $flaggedAllergenKeys, isStartingGuideSeen: $isStartingGuideSeen)';
+    return 'RecipeLibraryState(recipesByCategory: $recipesByCategory, ongoingAllergenKey: $ongoingAllergenKey, flaggedAllergenKeys: $flaggedAllergenKeys, isStartingGuideSeen: $isStartingGuideSeen, searchQuery: $searchQuery)';
   }
 
   @override
@@ -205,7 +223,9 @@ class _$RecipeLibraryStateImpl implements _RecipeLibraryState {
               _flaggedAllergenKeys,
             ) &&
             (identical(other.isStartingGuideSeen, isStartingGuideSeen) ||
-                other.isStartingGuideSeen == isStartingGuideSeen));
+                other.isStartingGuideSeen == isStartingGuideSeen) &&
+            (identical(other.searchQuery, searchQuery) ||
+                other.searchQuery == searchQuery));
   }
 
   @override
@@ -215,6 +235,7 @@ class _$RecipeLibraryStateImpl implements _RecipeLibraryState {
     ongoingAllergenKey,
     const DeepCollectionEquality().hash(_flaggedAllergenKeys),
     isStartingGuideSeen,
+    searchQuery,
   );
 
   /// Create a copy of RecipeLibraryState
@@ -229,13 +250,15 @@ class _$RecipeLibraryStateImpl implements _RecipeLibraryState {
       );
 }
 
-abstract class _RecipeLibraryState implements RecipeLibraryState {
+abstract class _RecipeLibraryState extends RecipeLibraryState {
   const factory _RecipeLibraryState({
     required final Map<String, List<Recipe>> recipesByCategory,
     final String? ongoingAllergenKey,
     final Set<String> flaggedAllergenKeys,
     final bool isStartingGuideSeen,
+    final String searchQuery,
   }) = _$RecipeLibraryStateImpl;
+  const _RecipeLibraryState._() : super._();
 
   @override
   Map<String, List<Recipe>> get recipesByCategory;
@@ -245,6 +268,8 @@ abstract class _RecipeLibraryState implements RecipeLibraryState {
   Set<String> get flaggedAllergenKeys;
   @override
   bool get isStartingGuideSeen;
+  @override
+  String get searchQuery;
 
   /// Create a copy of RecipeLibraryState
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/src/features/recipe/library/widgets/recipe_search_empty.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_search_empty.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+
+/// Generic 'no results' empty state for the Recipe Library search
+/// (Figma 971:8813 / 971:8828).
+///
+/// Centered butter-flower-glyph ([Quatrefoil]) + 16/700 title + caption
+/// subtitle. Copy is intentionally generic — the search query is NOT
+/// interpolated into the message.
+class RecipeSearchEmpty extends StatelessWidget {
+  const RecipeSearchEmpty({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.pagePaddingH,
+          vertical: AppSizes.xl,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Quatrefoil(),
+            const SizedBox(height: AppSizes.sm + 2),
+            const Text(
+              "We couldn't find any recipes",
+              textAlign: TextAlign.center,
+              style: AppTypography.emptyStateTitle,
+            ),
+            const SizedBox(height: AppSizes.xs),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 240),
+              child: Text(
+                'Try a different keyword or clear the search to browse '
+                'every category.',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: AppColors.fgFaint,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/recipe/library/widgets/recipe_search_results.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_search_results.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/features/recipe/library/widgets/recipe_grid_card.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+/// Search-results view for the Recipe Library (Figma 971:8803).
+///
+/// Renders a flat vertical list of [RecipeGridCard]s — one card per result.
+/// The category-rows layout (NIB-53) is suppressed by the parent screen
+/// whenever `RecipeLibraryState.searchQuery` is non-empty; this widget owns
+/// only the list rendering.
+class RecipeSearchResults extends StatelessWidget {
+  const RecipeSearchResults({
+    required this.recipes,
+    this.flaggedAllergenKeys = const {},
+    super.key,
+  });
+
+  final List<Recipe> recipes;
+  final Set<String> flaggedAllergenKeys;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.md,
+        AppSizes.pagePaddingH,
+        AppSizes.xl,
+      ),
+      itemCount: recipes.length,
+      separatorBuilder: (_, __) => const SizedBox(height: AppSizes.sp12),
+      itemBuilder: (context, index) {
+        final recipe = recipes[index];
+        return RecipeGridCard(
+          recipe: recipe,
+          flaggedAllergenKeys: flaggedAllergenKeys,
+          onTap: () => context.pushNamed(
+            AppRoute.recipeDetail.name,
+            pathParameters: {'recipeId': recipe.id},
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Updates the Recipe Library search so a non-empty query collapses the category rows into a flat results list, and an empty result shows a new centered butter-flower-glyph empty state.

## Figma

- Single result list: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8803
- Empty state: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8813
- Empty state variant: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-8828

## DS components consumed

- `RecipeGridCard` (NIB-53) — one per result in the new vertical list.
- `Quatrefoil` brand glyph — centered illustration in the empty state.
- `AppColors` / `AppTypography` (`emptyStateTitle`) / `AppSizes` tokens — zero hex / Nunito / withAlpha.

## Screen-state shape change

- `RecipeLibraryState` gains `String searchQuery` (default `''`) and a derived `List<Recipe> filteredRecipes` getter (`recipesByCategory.values.expand().toSet()` then case-insensitive contains over `recipe.title` + `recipe.nutritionTags`).
- `RecipeLibraryController.setSearchQuery(String)` trims the input and writes to state; the screen now drives header search through the controller instead of local widget state.

## Clear-search behavior

- The header's existing clear (X) button is untouched. It calls the field's `onChanged('')` which routes through `setSearchQuery` → empty `state.searchQuery` → screen reverts to the category-rows layout (Read Guide banner + optional recommendation row + per-category rows).

## Acceptance criteria

- [x] Typing in the header search field collapses the body into `RecipeSearchResults` (vertical list).
- [x] No matches shows `RecipeSearchEmpty` with butter-flower glyph + generic 'We couldn't find any recipes' copy (no query string in the message).
- [x] Clearing the search restores the category-rows layout.
- [x] `flutter analyze`: 0 issues.
- [x] Existing tests still pass (test count unchanged from baseline — the one pre-existing failure in `recipe_to_shopping_list_integration_test.dart` reproduces on `redesign` without this PR).
- [x] `make gen` clean + idempotent (second run produces 0 outputs, no surprise diff).
- [x] Zero hex / Nunito / withAlpha / `AllergenStatus.completed`.
- [x] No files outside the allowlist modified.

## Gate results

- `make gen`: succeeded, 0 outputs on second run (idempotent).
- `flutter analyze`: `No issues found! (ran in 2.6s)`.
- `flutter test`: 384 passed, 1 failed — the failure is pre-existing on `redesign` (`recipe_to_shopping_list_integration_test.dart` — `Add to Shopping List` finder); reproduced on the base commit without this PR.

## Files touched

- `lib/src/features/recipe/library/recipe_library_state.dart` (+ `.freezed.dart`)
- `lib/src/features/recipe/library/recipe_library_controller.dart` (+ `.g.dart`)
- `lib/src/features/recipe/library/recipe_library_screen.dart`
- `lib/src/features/recipe/library/widgets/recipe_search_results.dart` (new)
- `lib/src/features/recipe/library/widgets/recipe_search_empty.dart` (new)