### PR TITLE
feat(recipe): add-to-shopping-list sheet reskin [NIB-75]

### DIFF
--- a/lib/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart
+++ b/lib/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart
@@ -1,10 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/controls/app_checkbox.dart';
 import 'package:nibbles/src/common/domain/entities/ingredient.dart';
 
-/// Shows a bottom sheet for selecting ingredients to add to the shopping list.
-/// Ingredient names only — no quantities. All pre-checked by default.
+/// Shows the Add-to-Shopping-List bottom sheet.
+///
+/// Per Figma node 971:9042 — each row has a leading [AppCheckbox] and a
+/// trailing `X` that permanently removes the ingredient from this add's
+/// candidate list. A bottom toggle flips between Select All / Unselect All
+/// over the remaining (non-removed) rows. The `Add (N)` CTA returns the
+/// selected ingredient names, or `null` on dismiss / cancel.
+///
+/// Names-only contract — reuses the existing
+/// `ShoppingListService.addFromRecipe` path. No data layer changes.
 Future<List<String>?> showAddToShoppingListSheet(
   BuildContext context,
   List<Ingredient> ingredients,
@@ -15,7 +25,7 @@ Future<List<String>?> showAddToShoppingListSheet(
     backgroundColor: AppColors.surface,
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(
-        top: Radius.circular(AppSizes.radiusLg),
+        top: Radius.circular(AppSizes.radiusXl),
       ),
     ),
     builder: (context) => _ShoppingListSheet(ingredients: ingredients),
@@ -32,19 +42,83 @@ class _ShoppingListSheet extends StatefulWidget {
 }
 
 class _ShoppingListSheetState extends State<_ShoppingListSheet> {
+  /// Indices (in the original ingredients order) currently selected.
   late Set<int> _selected;
+
+  /// Indices removed via the per-row `X`. Cannot be re-added in this session.
+  final Set<int> _removed = <int>{};
 
   @override
   void initState() {
     super.initState();
-    _selected = Set.from(Iterable.generate(widget.ingredients.length));
+    // Default: every row pre-selected.
+    _selected = <int>{
+      for (var i = 0; i < widget.ingredients.length; i++) i,
+    };
+  }
+
+  int get _remainingCount => widget.ingredients.length - _removed.length;
+
+  bool get _allSelected =>
+      _remainingCount > 0 && _selected.length == _remainingCount;
+
+  void _toggleRow(int index) {
+    setState(() {
+      if (_selected.contains(index)) {
+        _selected.remove(index);
+      } else {
+        _selected.add(index);
+      }
+    });
+  }
+
+  void _removeRow(int index) {
+    setState(() {
+      _removed.add(index);
+      _selected.remove(index);
+    });
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        const SnackBar(
+          content: Text('Removed.'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+  }
+
+  void _toggleSelectAll() {
+    setState(() {
+      if (_allSelected) {
+        _selected.clear();
+      } else {
+        _selected = <int>{
+          for (var i = 0; i < widget.ingredients.length; i++)
+            if (!_removed.contains(i)) i,
+        };
+      }
+    });
+  }
+
+  void _confirm() {
+    final picked = <String>[
+      for (var i = 0; i < widget.ingredients.length; i++)
+        if (_selected.contains(i)) widget.ingredients[i].name,
+    ];
+    Navigator.of(context).pop(picked);
   }
 
   @override
   Widget build(BuildContext context) {
-    final count = _selected.length;
+    final theme = Theme.of(context);
+    final selectedCount = _selected.length;
+    final visibleIndices = <int>[
+      for (var i = 0; i < widget.ingredients.length; i++)
+        if (!_removed.contains(i)) i,
+    ];
 
     return SafeArea(
+      top: false,
       child: Padding(
         padding: EdgeInsets.only(
           bottom: MediaQuery.of(context).viewInsets.bottom,
@@ -52,13 +126,13 @@ class _ShoppingListSheetState extends State<_ShoppingListSheet> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            // Handle
             const SizedBox(height: AppSizes.sm),
+            // Grab handle.
             Container(
-              width: 40,
-              height: 4,
+              width: AppSizes.sp40,
+              height: AppSizes.xs,
               decoration: BoxDecoration(
-                color: AppColors.divider,
+                color: AppColors.borderSoft,
                 borderRadius: BorderRadius.circular(AppSizes.radiusFull),
               ),
             ),
@@ -67,83 +141,227 @@ class _ShoppingListSheetState extends State<_ShoppingListSheet> {
               padding: const EdgeInsets.symmetric(
                 horizontal: AppSizes.pagePaddingH,
               ),
-              child: Text(
-                'Add to Shopping List',
-                style: Theme.of(
-                  context,
-                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
-              ),
-            ),
-            const SizedBox(height: AppSizes.sm),
-            const Divider(height: 1),
-            ConstrainedBox(
-              constraints: BoxConstraints(
-                maxHeight: MediaQuery.of(context).size.height * 0.45,
-              ),
-              child: ListView.builder(
-                shrinkWrap: true,
-                itemCount: widget.ingredients.length,
-                itemBuilder: (context, index) {
-                  final name = widget.ingredients[index].name;
-                  return CheckboxListTile(
-                    value: _selected.contains(index),
-                    onChanged: (checked) {
-                      setState(() {
-                        if (checked ?? false) {
-                          _selected.add(index);
-                        } else {
-                          _selected.remove(index);
-                        }
-                      });
-                    },
-                    title: Text(
-                      name,
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                    activeColor: AppColors.primary,
-                    controlAffinity: ListTileControlAffinity.leading,
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: AppSizes.pagePaddingH,
-                    ),
-                  );
-                },
-              ),
-            ),
-            const Divider(height: 1),
-            Padding(
-              padding: const EdgeInsets.all(AppSizes.md),
-              child: SizedBox(
-                width: double.infinity,
-                height: AppSizes.buttonHeight,
-                child: FilledButton(
-                  onPressed: count == 0
-                      ? null
-                      : () {
-                          final names = _selected
-                              .map((i) => widget.ingredients[i].name)
-                              .toList();
-                          Navigator.of(context).pop(names);
-                        },
-                  style: FilledButton.styleFrom(
-                    backgroundColor: AppColors.primary,
-                    foregroundColor: AppColors.onPrimary,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-                    ),
-                  ),
-                  child: Text(
-                    count == 0
-                        ? 'Select items'
-                        : 'Add $count ${count == 1 ? 'item' : 'items'}',
-                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                      color: AppColors.onPrimary,
-                      fontWeight: FontWeight.w600,
-                    ),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Add to Shopping List',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: AppColors.fgStrong,
                   ),
                 ),
               ),
             ),
+            const SizedBox(height: AppSizes.sm),
+            const Divider(
+              height: AppSizes.dividerThickness,
+              thickness: AppSizes.dividerThickness,
+              color: AppColors.borderSoft,
+            ),
+            Flexible(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.of(context).size.height * 0.5,
+                ),
+                child: visibleIndices.isEmpty
+                    ? _EmptyState(theme: theme)
+                    : ListView.separated(
+                        shrinkWrap: true,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AppSizes.pagePaddingH,
+                          vertical: AppSizes.sp12,
+                        ),
+                        itemCount: visibleIndices.length,
+                        separatorBuilder: (_, __) =>
+                            const SizedBox(height: AppSizes.sm),
+                        itemBuilder: (context, i) {
+                          final index = visibleIndices[i];
+                          return _IngredientRow(
+                            name: widget.ingredients[index].name,
+                            selected: _selected.contains(index),
+                            onToggle: () => _toggleRow(index),
+                            onRemove: () => _removeRow(index),
+                          );
+                        },
+                      ),
+              ),
+            ),
+            const Divider(
+              height: AppSizes.dividerThickness,
+              thickness: AppSizes.dividerThickness,
+              color: AppColors.borderSoft,
+            ),
+            Padding(
+              padding: EdgeInsets.fromLTRB(
+                AppSizes.pagePaddingH,
+                AppSizes.sp12,
+                AppSizes.pagePaddingH,
+                AppSizes.sp12 + MediaQuery.of(context).padding.bottom,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: _SelectAllToggle(
+                      label: _allSelected ? 'Unselect All' : 'Select All',
+                      onPressed: _remainingCount == 0 ? null : _toggleSelectAll,
+                    ),
+                  ),
+                  const SizedBox(height: AppSizes.sm),
+                  AppPillButton(
+                    label: 'Add ($selectedCount)',
+                    onPressed: selectedCount == 0 ? null : _confirm,
+                  ),
+                ],
+              ),
+            ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IngredientRow extends StatelessWidget {
+  const _IngredientRow({
+    required this.name,
+    required this.selected,
+    required this.onToggle,
+    required this.onRemove,
+  });
+
+  final String name;
+  final bool selected;
+  final VoidCallback onToggle;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Material(
+      color: AppColors.surface,
+      borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      child: InkWell(
+        onTap: onToggle,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.sp12,
+            vertical: AppSizes.sp12,
+          ),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            border: Border.all(color: AppColors.borderSoft),
+          ),
+          child: Row(
+            children: [
+              AppCheckbox(
+                value: selected,
+                onChanged: (_) => onToggle(),
+              ),
+              const SizedBox(width: AppSizes.sp12),
+              Expanded(
+                child: Text(
+                  name,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: AppColors.fgDefault,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSizes.sm),
+              _RemoveButton(onPressed: onRemove),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RemoveButton extends StatelessWidget {
+  const _RemoveButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: 'Remove',
+      child: InkResponse(
+        onTap: onPressed,
+        radius: AppSizes.checkbox,
+        child: Container(
+          width: AppSizes.checkbox,
+          height: AppSizes.checkbox,
+          alignment: Alignment.center,
+          decoration: const BoxDecoration(
+            color: AppColors.destructiveSoft,
+            shape: BoxShape.circle,
+          ),
+          child: const Icon(
+            Icons.close_rounded,
+            size: AppSizes.iconSm,
+            color: AppColors.destructive,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectAllToggle extends StatelessWidget {
+  const _SelectAllToggle({required this.label, required this.onPressed});
+
+  final String label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final disabled = onPressed == null;
+    final color = disabled ? AppColors.fgFaint : AppColors.greenDeep;
+
+    return InkWell(
+      onTap: onPressed,
+      borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.xs,
+          vertical: AppSizes.xs,
+        ),
+        child: Text(
+          label,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: color,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.xl,
+      ),
+      child: Center(
+        child: Text(
+          'No ingredients left.',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: AppColors.fgFaint,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary

Re-skins the Add-to-Shopping-List bottom sheet per Figma node `971:9042`. Each row gets a leading `AppCheckbox` and a trailing X that permanently removes the ingredient from this add's candidate list. A bottom Select All / Unselect All toggle operates over remaining (non-removed) rows, and the primary CTA shows `Add (N)` with the live count.

Names-only contract is preserved — reuses `ShoppingListService.addFromRecipe` via the existing `recipe_detail_controller.addToShoppingList(List<String>)` path. No data layer change.

## Figma

- Sheet: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-9042
- States: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-9204

Figma MCP was unreachable during the build, so the implementation is grounded in `design/preview/components-controls.html`, `design/ui_kits/nibbles_mobile/ShoppingListScreen.jsx`, and `design/ui_kits/nibbles_mobile/kit.css` (.shop-row tokens) plus the existing `AppCheckbox` + `AppPillButton` DS components.

## Preserved public API

```dart
Future<List<String>?> showAddToShoppingListSheet(
  BuildContext context,
  List<Ingredient> ingredients,
);
```

Positional `List<Ingredient>` is unchanged — no call-site touched. The spec's docblock referenced a named `List<String> ingredientNames` form; we kept the existing live signature per the spec's explicit \"keep the existing function signature\" rule (and there is no caller to migrate today).

## DS components consumed (no DS edits)

- `AppCheckbox` — 24px greenDeep / cream check, leading per row
- `AppPillButton` — primary `Add (N)` CTA, disabled when `N == 0`
- Tokens only: `AppColors` (greenDeep, surface, borderSoft, fgDefault, fgFaint, destructive, destructiveSoft) and `AppSizes` (radius, spacing, dividerThickness, checkbox)

Note: the kit's `.shop-row__cb` is 22px; the sanctioned `AppCheckbox` is 24px. Used the DS component for token purity — the 2px size delta is the only visual deviation from the kit reference.

## UI state shape

- `Set<int> _selected` — indices (in the original `ingredients` order) currently checked. Defaults to all rows selected.
- `Set<int> _removed` — indices removed via per-row X. Cannot be re-added in this session.
- Per-row X: `_removed.add(i); _selected.remove(i);` — N updates immediately.
- Select All: `_selected = {0..n-1}\\_removed`. Unselect All: `_selected.clear()`.
- Toggle label flips to \"Unselect All\" when `_selected.length == n - _removed.length` and at least one row remains; else \"Select All\".
- CTA disabled when `_selected.length == 0`.
- Empty-state line shown when every row is removed.

## Acceptance criteria

- [x] Sheet matches Figma 971:9042 — leading checkbox + trailing X + Select All / Unselect All + Add (N).
- [x] Per-row X removes the ingredient; the running count updates.
- [x] Select All / Unselect All toggles work.
- [x] Confirm returns the picked names; cancel returns null.
- [x] `flutter analyze`: 0 issues.
- [x] `make gen` clean + idempotent (drift on `home_controller.g.dart` reverted before commit).
- [x] No hex / Nunito / `withAlpha` / `AllergenStatus.completed`.
- [x] Only one file touched: `lib/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart`.

## Gate results

- `make gen` — clean (idempotent on second run).
- `flutter analyze` — `No issues found!`.
- `flutter test` — `+384 -1`. The single failing test is the pre-existing `test/features/recipe_to_shopping_list_integration_test.dart` regression flagged by NIB-68 (no in-screen wiring of `showAddToShoppingListSheet` yet, so the integration test cannot open the sheet) — out of scope for this ticket.