### PR TITLE
feat(recipe): multi-day add-to-meal-plan accordion sheet [NIB-84]

### DIFF
--- a/lib/src/features/recipe/detail/recipe_detail_controller.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_controller.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/meal_plan_service.dart';
@@ -49,20 +49,41 @@ class RecipeDetailController extends _$RecipeDetailController {
     );
   }
 
-  /// Assigns this recipe to a meal plan date, with optional meal time.
-  /// Fires analytics on success.
-  Future<Result<void>> assignToMealPlan(
-    DateTime date, {
-    TimeOfDay? time,
-  }) async {
+  /// Bulk-assigns this recipe to every date in [dates] via a single
+  /// `appendMealsToRange` call.
+  ///
+  /// Builds a list of [RecipeAssignment] with `dayOffset` relative to the
+  /// earliest date in [dates] (the window's `startDate`). Fires analytics
+  /// once on success regardless of day count.
+  Future<Result<List<MealPlanEntry>>> assignToMealPlan(
+    Set<DateTime> dates,
+  ) async {
     final current = state.valueOrNull;
     if (current == null) return const Result.failure(UnknownException());
+    if (dates.isEmpty) return const Result.success(<MealPlanEntry>[]);
 
     state = AsyncData(current.copyWith(isAddingToMealPlan: true));
 
+    final normalized = dates.map(_dateOnly).toList()..sort();
+    final start = normalized.first;
+    final end = normalized.last;
+    final assignments = normalized
+        .map(
+          (d) => RecipeAssignment(
+            recipeId: recipeId,
+            dayOffset: d.difference(start).inDays,
+          ),
+        )
+        .toList();
+
     final result = await ref
         .read(mealPlanServiceProvider)
-        .assignRecipe(babyId, recipeId, date, mealTime: time);
+        .appendMealsToRange(
+          babyId: babyId,
+          startDate: start,
+          endDate: end,
+          assignments: assignments,
+        );
 
     state = AsyncData(current.copyWith(isAddingToMealPlan: false));
 
@@ -87,4 +108,6 @@ class RecipeDetailController extends _$RecipeDetailController {
     state = AsyncData(current.copyWith(isAddingToShoppingList: false));
     return result;
   }
+
+  static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
 }

--- a/lib/src/features/recipe/detail/recipe_detail_controller.g.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_controller.g.dart
@@ -7,7 +7,7 @@ part of 'recipe_detail_controller.dart';
 // **************************************************************************
 
 String _$recipeDetailControllerHash() =>
-    r'a923f19625fd19a4dec3d1decc0224460d006d49';
+    r'4176d7b257f546bc46421ae83d8d5ce228a2677c';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/recipe/detail/recipe_detail_screen.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_screen.dart
@@ -127,17 +127,17 @@ class _RecipeContentState extends ConsumerState<_RecipeContent> {
   bool _showSuccessBanner = false;
 
   Future<void> _handleAddToMealPlan() async {
-    final result = await showAddToMealPlanFlow(context);
-    if (result == null) return;
+    final dates = await showAddToMealPlanSheet(
+      context,
+      babyId: widget.babyId,
+    );
+    if (dates == null || dates.isEmpty) return;
     if (!mounted) return;
 
     final controller = ref.read(
       recipeDetailControllerProvider(widget.babyId, widget.recipeId).notifier,
     );
-    final addResult = await controller.assignToMealPlan(
-      result.date,
-      time: result.time,
-    );
+    final addResult = await controller.assignToMealPlan(dates);
 
     if (!mounted) return;
 

--- a/lib/src/features/recipe/detail/widgets/add_to_meal_plan_cta.dart
+++ b/lib/src/features/recipe/detail/widgets/add_to_meal_plan_cta.dart
@@ -4,7 +4,7 @@ import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 
 /// Sticky bottom CTA used on the recipe detail screen — a single full-width
-/// green pill button that opens the existing `AddToMealPlanSheet`.
+/// green pill button that opens the multi-day Add-to-Meal-Plan sheet.
 ///
 /// Wrapped in a white surface with a subtle top divider so it floats above
 /// the scrollable content. Bottom inset is added so the button clears the

--- a/lib/src/features/recipe/detail/widgets/add_to_meal_plan_sheet.dart
+++ b/lib/src/features/recipe/detail/widgets/add_to_meal_plan_sheet.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
-import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/controls/app_checkbox.dart';
 
 /// Shows the multi-day Add-to-Meal-Plan bottom sheet.
 ///
@@ -102,7 +102,10 @@ class _AddToMealPlanSheetState extends State<_AddToMealPlanSheet> {
               child: _SheetHeader(selectedCount: count),
             ),
             const SizedBox(height: AppSizes.sm),
-            const Divider(height: 1, color: AppColors.borderSoft),
+            const Divider(
+              height: AppSizes.dividerThickness,
+              color: AppColors.borderSoft,
+            ),
             Flexible(
               child: ListView.separated(
                 padding: const EdgeInsets.symmetric(
@@ -128,7 +131,10 @@ class _AddToMealPlanSheetState extends State<_AddToMealPlanSheet> {
                 },
               ),
             ),
-            const Divider(height: 1, color: AppColors.borderSoft),
+            const Divider(
+              height: AppSizes.dividerThickness,
+              color: AppColors.borderSoft,
+            ),
             Padding(
               padding: const EdgeInsets.fromLTRB(
                 AppSizes.pagePaddingH,
@@ -190,11 +196,10 @@ class _SheetHeader extends StatelessWidget {
               Text(
                 '$selectedCount ${selectedCount == 1 ? 'Day' : 'Days'} '
                 'Selected',
-                style: AppTypography.caption.copyWith(
+                style: theme.textTheme.labelMedium?.copyWith(
                   color: selectedCount == 0
                       ? AppColors.fgMuted
                       : AppColors.greenDeep,
-                  fontWeight: FontWeight.w600,
                 ),
               ),
             ],
@@ -284,18 +289,16 @@ class _WeekAccordion extends StatelessWidget {
                       children: [
                         Text(
                           _weekLabel,
-                          style: theme.textTheme.labelLarge?.copyWith(
+                          style: theme.textTheme.titleSmall?.copyWith(
                             color: AppColors.fgDefault,
-                            fontWeight: FontWeight.w700,
                           ),
                         ),
                         if (selectedCount > 0) ...[
                           const SizedBox(height: AppSizes.sp2),
                           Text(
                             '$selectedCount selected',
-                            style: AppTypography.caption.copyWith(
+                            style: theme.textTheme.labelMedium?.copyWith(
                               color: AppColors.greenDeep,
-                              fontWeight: FontWeight.w600,
                             ),
                           ),
                         ],
@@ -323,7 +326,7 @@ class _WeekAccordion extends StatelessWidget {
                 ? Column(
                     children: [
                       const Divider(
-                        height: 1,
+                        height: AppSizes.dividerThickness,
                         color: AppColors.borderSoft,
                       ),
                       for (var i = 0; i < 7; i++)
@@ -389,60 +392,22 @@ class _DayRow extends StatelessWidget {
         ),
         child: Row(
           children: [
-            _Checkbox(checked: isSelected, disabled: disabled),
+            AppCheckbox(
+              value: isSelected,
+              onChanged: disabled ? null : (_) => onTap(day),
+            ),
             const SizedBox(width: AppSizes.sm),
             Expanded(
               child: Text(
                 _label,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: labelColor,
-                  fontWeight: FontWeight.w600,
                 ),
               ),
             ),
           ],
         ),
       ),
-    );
-  }
-}
-
-class _Checkbox extends StatelessWidget {
-  const _Checkbox({required this.checked, required this.disabled});
-
-  final bool checked;
-  final bool disabled;
-
-  @override
-  Widget build(BuildContext context) {
-    final Color fill;
-    final Color border;
-    if (disabled) {
-      fill = AppColors.bgInput;
-      border = AppColors.borderMuted;
-    } else if (checked) {
-      fill = AppColors.greenDeep;
-      border = AppColors.greenDeep;
-    } else {
-      fill = AppColors.surface;
-      border = AppColors.borderMuted;
-    }
-
-    return Container(
-      width: AppSizes.checkbox,
-      height: AppSizes.checkbox,
-      decoration: BoxDecoration(
-        color: fill,
-        borderRadius: BorderRadius.circular(AppSizes.radiusSm),
-        border: Border.all(color: border, width: 1.5),
-      ),
-      child: checked
-          ? const Icon(
-              Icons.check,
-              size: AppSizes.iconSm,
-              color: AppColors.cream,
-            )
-          : null,
     );
   }
 }

--- a/lib/src/features/recipe/detail/widgets/add_to_meal_plan_sheet.dart
+++ b/lib/src/features/recipe/detail/widgets/add_to_meal_plan_sheet.dart
@@ -1,59 +1,448 @@
 import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 
-/// Runs the Add to Meal Plan flow:
-/// 1. Date picker
-/// 2. Optional time picker dialog
+/// Shows the multi-day Add-to-Meal-Plan bottom sheet.
 ///
-/// Returns `({DateTime date, TimeOfDay? time})` on confirm, or null on cancel.
-Future<({DateTime date, TimeOfDay? time})?> showAddToMealPlanFlow(
-  BuildContext context,
-) async {
-  // Step 1: Date picker.
-  final now = DateTime.now();
-  final picked = await showDatePicker(
+/// The sheet renders week-by-week accordions over the next 12 weeks (from
+/// today). Each day inside a week shows a checkbox row; tapping toggles
+/// selection. The header shows a live `X Days Selected` counter and the
+/// bottom CTA (`Add to Meal Plan`) stays disabled while no day is picked.
+///
+/// Returns the set of selected dates on confirm, or `null` on cancel.
+Future<Set<DateTime>?> showAddToMealPlanSheet(
+  BuildContext context, {
+  required String babyId,
+}) {
+  return showModalBottomSheet<Set<DateTime>>(
     context: context,
-    initialDate: now,
-    firstDate: now,
-    lastDate: now.add(const Duration(days: 365)),
-    helpText: 'Select a meal plan date',
-  );
-
-  if (picked == null) return null;
-  if (!context.mounted) return null;
-
-  // Step 2: Optional time picker.
-  final wantTime = await showDialog<bool>(
-    context: context,
-    builder: (ctx) => AlertDialog(
-      title: const Text('Add a time?'),
-      content: const Text(
-        'Would you like to add a specific meal time? (optional)',
+    isScrollControlled: true,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppSizes.radiusLg),
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(ctx).pop(false),
-          child: const Text('Skip'),
-        ),
-        TextButton(
-          onPressed: () => Navigator.of(ctx).pop(true),
-          child: const Text('Add Time'),
-        ),
-      ],
     ),
+    builder: (_) => const _AddToMealPlanSheet(),
   );
+}
 
-  if (!context.mounted) return null;
+DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
 
-  TimeOfDay? mealTime;
-  if (wantTime ?? false) {
-    mealTime = await showTimePicker(
-      context: context,
-      initialTime: TimeOfDay.now(),
-      helpText: 'Select meal time',
+/// First Monday on-or-before [date]. Weeks are Monday-anchored.
+DateTime _weekStart(DateTime date) {
+  final d = _dateOnly(date);
+  // DateTime.weekday: Monday == 1, Sunday == 7.
+  return d.subtract(Duration(days: d.weekday - 1));
+}
+
+/// Number of accordion weeks shown (12 weeks ≈ 3 months ahead).
+const int _kWeekCount = 12;
+
+class _AddToMealPlanSheet extends StatefulWidget {
+  const _AddToMealPlanSheet();
+
+  @override
+  State<_AddToMealPlanSheet> createState() => _AddToMealPlanSheetState();
+}
+
+class _AddToMealPlanSheetState extends State<_AddToMealPlanSheet> {
+  final Set<DateTime> _selected = <DateTime>{};
+  late final DateTime _today;
+  late final DateTime _firstWeekStart;
+  late final List<DateTime> _weekStarts;
+  late int _expandedWeekIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _today = _dateOnly(DateTime.now());
+    _firstWeekStart = _weekStart(_today);
+    _weekStarts = List<DateTime>.generate(
+      _kWeekCount,
+      (i) => _firstWeekStart.add(Duration(days: 7 * i)),
     );
+    // Default-expand the current week.
+    _expandedWeekIndex = 0;
   }
 
-  if (!context.mounted) return null;
+  void _toggleDay(DateTime day) {
+    final normalized = _dateOnly(day);
+    setState(() {
+      if (_selected.contains(normalized)) {
+        _selected.remove(normalized);
+      } else {
+        _selected.add(normalized);
+      }
+    });
+  }
 
-  return (date: picked, time: mealTime);
+  @override
+  Widget build(BuildContext context) {
+    final media = MediaQuery.of(context);
+    final count = _selected.length;
+
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: media.size.height * 0.82,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: AppSizes.sm),
+            _SheetGrabber(),
+            const SizedBox(height: AppSizes.md),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.pagePaddingH,
+              ),
+              child: _SheetHeader(selectedCount: count),
+            ),
+            const SizedBox(height: AppSizes.sm),
+            const Divider(height: 1, color: AppColors.borderSoft),
+            Flexible(
+              child: ListView.separated(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.pagePaddingH,
+                  vertical: AppSizes.sm,
+                ),
+                itemCount: _weekStarts.length,
+                separatorBuilder: (_, __) =>
+                    const SizedBox(height: AppSizes.sm),
+                itemBuilder: (context, weekIndex) {
+                  final weekStart = _weekStarts[weekIndex];
+                  return _WeekAccordion(
+                    weekStart: weekStart,
+                    today: _today,
+                    selected: _selected,
+                    expanded: _expandedWeekIndex == weekIndex,
+                    onHeaderTap: () => setState(() {
+                      _expandedWeekIndex =
+                          _expandedWeekIndex == weekIndex ? -1 : weekIndex;
+                    }),
+                    onDayTap: _toggleDay,
+                  );
+                },
+              ),
+            ),
+            const Divider(height: 1, color: AppColors.borderSoft),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.pagePaddingH,
+                AppSizes.sp12,
+                AppSizes.pagePaddingH,
+                AppSizes.sp12,
+              ),
+              child: AppPillButton(
+                label: 'Add to Meal Plan',
+                onPressed: count == 0
+                    ? null
+                    : () => Navigator.of(context).pop(_selected),
+                leading: const Icon(Icons.add),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SheetGrabber extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 4,
+      decoration: BoxDecoration(
+        color: AppColors.divider,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+    );
+  }
+}
+
+class _SheetHeader extends StatelessWidget {
+  const _SheetHeader({required this.selectedCount});
+
+  final int selectedCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Add to Meal Plan',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: AppColors.fgDefault,
+                ),
+              ),
+              const SizedBox(height: AppSizes.xs),
+              Text(
+                '$selectedCount ${selectedCount == 1 ? 'Day' : 'Days'} '
+                'Selected',
+                style: AppTypography.caption.copyWith(
+                  color: selectedCount == 0
+                      ? AppColors.fgMuted
+                      : AppColors.greenDeep,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.close, size: AppSizes.iconMd),
+          color: AppColors.fgMuted,
+          onPressed: () => Navigator.of(context).pop(),
+          tooltip: 'Close',
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(
+            minWidth: AppSizes.roundButtonSm,
+            minHeight: AppSizes.roundButtonSm,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _WeekAccordion extends StatelessWidget {
+  const _WeekAccordion({
+    required this.weekStart,
+    required this.today,
+    required this.selected,
+    required this.expanded,
+    required this.onHeaderTap,
+    required this.onDayTap,
+  });
+
+  final DateTime weekStart;
+  final DateTime today;
+  final Set<DateTime> selected;
+  final bool expanded;
+  final VoidCallback onHeaderTap;
+  final ValueChanged<DateTime> onDayTap;
+
+  static const List<String> _monthAbbr = <String>[
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+
+  static String _monthDay(DateTime d) =>
+      '${_monthAbbr[d.month - 1]} ${d.day}';
+
+  String get _weekLabel {
+    final end = weekStart.add(const Duration(days: 6));
+    return '${_monthDay(weekStart)} – ${_monthDay(end)}';
+  }
+
+  int get _selectedInWeek {
+    var n = 0;
+    for (var i = 0; i < 7; i++) {
+      final d = weekStart.add(Duration(days: i));
+      if (selected.contains(d)) n++;
+    }
+    return n;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final selectedCount = _selectedInWeek;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        border: Border.all(color: AppColors.borderSoft),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        children: [
+          InkWell(
+            onTap: onHeaderTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.md,
+                vertical: AppSizes.sp12,
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          _weekLabel,
+                          style: theme.textTheme.labelLarge?.copyWith(
+                            color: AppColors.fgDefault,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        if (selectedCount > 0) ...[
+                          const SizedBox(height: AppSizes.sp2),
+                          Text(
+                            '$selectedCount selected',
+                            style: AppTypography.caption.copyWith(
+                              color: AppColors.greenDeep,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  AnimatedRotation(
+                    turns: expanded ? 0.5 : 0,
+                    duration: const Duration(milliseconds: 180),
+                    child: const Icon(
+                      Icons.expand_more,
+                      color: AppColors.fgMuted,
+                      size: AppSizes.iconMd,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 180),
+            curve: Curves.easeOut,
+            alignment: Alignment.topCenter,
+            child: expanded
+                ? Column(
+                    children: [
+                      const Divider(
+                        height: 1,
+                        color: AppColors.borderSoft,
+                      ),
+                      for (var i = 0; i < 7; i++)
+                        _DayRow(
+                          day: weekStart.add(Duration(days: i)),
+                          isPast: weekStart
+                              .add(Duration(days: i))
+                              .isBefore(today),
+                          isSelected: selected.contains(
+                            weekStart.add(Duration(days: i)),
+                          ),
+                          onTap: onDayTap,
+                        ),
+                    ],
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DayRow extends StatelessWidget {
+  const _DayRow({
+    required this.day,
+    required this.isPast,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final DateTime day;
+  final bool isPast;
+  final bool isSelected;
+  final ValueChanged<DateTime> onTap;
+
+  static const List<String> _dowAbbr = <String>[
+    'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun',
+  ];
+
+  static const List<String> _monthAbbr = <String>[
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+
+  String get _label =>
+      '${_dowAbbr[day.weekday - 1]}, ${_monthAbbr[day.month - 1]} ${day.day}';
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final disabled = isPast;
+    final labelColor = disabled
+        ? AppColors.fgFaint
+        : AppColors.fgDefault;
+
+    return InkWell(
+      onTap: disabled ? null : () => onTap(day),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.md,
+          vertical: AppSizes.sm,
+        ),
+        child: Row(
+          children: [
+            _Checkbox(checked: isSelected, disabled: disabled),
+            const SizedBox(width: AppSizes.sm),
+            Expanded(
+              child: Text(
+                _label,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: labelColor,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Checkbox extends StatelessWidget {
+  const _Checkbox({required this.checked, required this.disabled});
+
+  final bool checked;
+  final bool disabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color fill;
+    final Color border;
+    if (disabled) {
+      fill = AppColors.bgInput;
+      border = AppColors.borderMuted;
+    } else if (checked) {
+      fill = AppColors.greenDeep;
+      border = AppColors.greenDeep;
+    } else {
+      fill = AppColors.surface;
+      border = AppColors.borderMuted;
+    }
+
+    return Container(
+      width: AppSizes.checkbox,
+      height: AppSizes.checkbox,
+      decoration: BoxDecoration(
+        color: fill,
+        borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+        border: Border.all(color: border, width: 1.5),
+      ),
+      child: checked
+          ? const Icon(
+              Icons.check,
+              size: AppSizes.iconSm,
+              color: AppColors.cream,
+            )
+          : null,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Replaces the native `showDatePicker` + `showTimePicker` flow on RC-02 with a multi-day accordion bottom sheet that lets the user assign a recipe to one or more days, then bulk-commits via `MealPlanService.appendMealsToRange` (single Supabase call).

## Figma

- Sheet: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-9346
- Counter state: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-9481

## DS components consumed

- `AppPillButton` (primary, full-width) — bottom CTA "Add to Meal Plan"
- `AppColors` (greenDeep, fgDefault, fgMuted, fgFaint, borderSoft, borderMuted, surface, bgInput, cream, divider) — tokens only
- `AppSizes` (radius / spacing / icon / checkbox) — tokens only
- `AppTypography` (titleMedium, labelLarge, bodyMedium, caption) — tokens only
- Existing sticky CTA + success banner from NIB-68 (`AddToMealPlanCta`, `AddToMealPlanSuccessBanner`) — consumed unchanged (only the doc comment on the CTA was updated).

## New controller method signature

```dart
Future<Result<List<MealPlanEntry>>> assignToMealPlan(Set<DateTime> dates)
```

Replaces the old `assignToMealPlan(DateTime date, {TimeOfDay? time})`. The only call site (`recipe_detail_screen.dart`) is updated in the same commit.

## Single Supabase-call commit pattern

1. Sheet returns `Set<DateTime>` on confirm.
2. Controller normalizes via `DateTime(y,m,d)`, sorts, takes `startDate = first`, `endDate = last`.
3. Builds a `List<RecipeAssignment>` where each entry's `dayOffset = (date - startDate).inDays`.
4. Single `MealPlanService.appendMealsToRange(babyId, startDate, endDate, assignments)` call — exactly the shape NIB-59 added; mirrors `MapMealsController.commit`.
5. Analytics (`logRecipeAddedToMealPlan`) fires once on success regardless of day count.

## Acceptance criteria

- [x] Sheet matches Figma 971:9346 (accordion + per-day checkbox + live counter + bottom CTA).
- [x] Native date/time picker flow REMOVED (no `showDatePicker` / `showTimePicker` calls in the new sheet).
- [x] Multi-day confirm calls `appendMealsToRange` — single Supabase call.
- [x] CTA disabled when 0 days selected.
- [x] `flutter analyze` 0 issues; existing tests still pass (one pre-existing failure on `recipe_to_shopping_list_integration_test` is NIB-75 territory and unaffected by this branch).
- [x] `make gen` clean + idempotent.
- [x] Zero hex / Nunito / withAlpha / `AllergenStatus.completed`.
- [x] No files outside the allowed list modified.

## Gate results

- `make gen`: clean (no extra diff on re-run; only `recipe_detail_controller.g.dart` riverpod-hash bump, expected).
- `flutter analyze`: `No issues found! (ran in 2.2s)`
- `flutter test`: `+384 -1` — same `-1` as baseline `origin/redesign` (NIB-75 expects an "Add to Shopping List" CTA on RC-02 that does not yet exist on this branch). No new failures introduced.

## Files touched (strict scope, parallel-safe with NIB-75)

- `lib/src/features/recipe/detail/widgets/add_to_meal_plan_sheet.dart` (rewrite)
- `lib/src/features/recipe/detail/recipe_detail_controller.dart` (`assignToMealPlan` replaced)
- `lib/src/features/recipe/detail/recipe_detail_controller.g.dart` (regen — riverpod hash)
- `lib/src/features/recipe/detail/recipe_detail_screen.dart` (call-site update)
- `lib/src/features/recipe/detail/widgets/add_to_meal_plan_cta.dart` (doc-comment only)

## Test plan

- [ ] On RC-02, tap "Add to Meal Plan" — sheet opens with current week expanded and counter `0 Days Selected`.
- [ ] Tap a day checkbox; header updates live to `1 Day Selected`; CTA becomes enabled.
- [ ] Tap days across two different weeks; counter sums correctly; expanding/collapsing weeks preserves selection.
- [ ] Tap "Add to Meal Plan" — sheet dismisses, success banner appears.
- [ ] Verify in Supabase: a single bulk insert lands; each selected day has a `meal_plan_entries` row for this recipe.
- [ ] Force-fail the network — confirm P2 SnackBar "Couldn't add to meal plan. Try again." surfaces.