### PR TITLE
feat(starting-guide): hub + 4 articles new feature module [NIB-94]

### DIFF
--- a/lib/src/features/starting_guide/constants/articles.dart
+++ b/lib/src/features/starting_guide/constants/articles.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/foundation.dart';
+
+/// Static content model for the Starting Guide.
+///
+/// Articles are hardcoded. The hub renders one card per [GuideArticle];
+/// tapping a card opens the article screen routed by [slug].
+@immutable
+class GuideArticle {
+  const GuideArticle({
+    required this.slug,
+    required this.title,
+    required this.subtitle,
+    required this.sections,
+    required this.terminalCta,
+  });
+
+  final String slug;
+  final String title;
+  final String subtitle;
+  final List<GuideSection> sections;
+  final GuideCta? terminalCta;
+}
+
+/// A numbered (or unnumbered) content block inside an article.
+///
+/// [stepNumber] is rendered as a leading pill (e.g. '1', '2'). When null the
+/// section renders as a plain heading + body (used for intros/outros).
+@immutable
+class GuideSection {
+  const GuideSection({
+    required this.heading,
+    required this.body,
+    this.stepNumber,
+  });
+
+  final int? stepNumber;
+  final String heading;
+  final String body;
+}
+
+/// Terminal action at the bottom of an article. [routeName] is one of the
+/// `AppRoute.<route>.name` literals — the article screen routes via
+/// `context.goNamed(routeName)` so the bottom-nav shell is restored.
+@immutable
+class GuideCta {
+  const GuideCta({required this.label, required this.routeName});
+
+  final String label;
+  final String routeName;
+}
+
+/// Hardcoded Starting Guide articles. Copy is a placeholder approximation of
+/// the Figma frames (the live Figma was unreachable at build time — content
+/// fidelity is a follow-up).
+const List<GuideArticle> kStartingGuideArticles = [
+  GuideArticle(
+    slug: 'first-nibbles',
+    title: "Baby's First Nibbles",
+    subtitle: 'A gentle introduction to your baby starting solid foods.',
+    sections: [
+      GuideSection(
+        stepNumber: 1,
+        heading: 'Start with single ingredients',
+        body: 'Offer one new food at a time so you can spot reactions early. '
+            'Mashed avocado, soft banana, or oatmeal are gentle first picks.',
+      ),
+      GuideSection(
+        stepNumber: 2,
+        heading: 'Keep portions tiny',
+        body: 'A teaspoon is plenty for a first taste. Babies learn the '
+            'mechanics of eating before they learn to eat for fuel.',
+      ),
+      GuideSection(
+        stepNumber: 3,
+        heading: 'Follow their lead',
+        body: 'A turned head or pressed lips means done. Never force a bite — '
+            'mealtimes should feel calm, curious, and unhurried.',
+      ),
+      GuideSection(
+        stepNumber: 4,
+        heading: 'Make it a daily ritual',
+        body: 'Aim for one consistent solid meal a day to start. Routine helps '
+            'your baby (and you) build confidence around the table.',
+      ),
+    ],
+    terminalCta: GuideCta(
+      label: 'Explore Recipes',
+      routeName: 'recipe-library',
+    ),
+  ),
+  GuideArticle(
+    slug: 'introduction',
+    title: 'Introduction to Solids',
+    subtitle: 'How to plan your first weeks of solid food meals.',
+    sections: [
+      GuideSection(
+        stepNumber: 1,
+        heading: 'Pick a calm time of day',
+        body: 'Mid-morning often works best — baby is alert but not overtired. '
+            'Avoid the witching-hour fussiness window.',
+      ),
+      GuideSection(
+        stepNumber: 2,
+        heading: 'Plan three soft foods to rotate',
+        body: 'Two veg and one fruit purée, or a simple grain, give variety '
+            'without overwhelming a new eater.',
+      ),
+      GuideSection(
+        stepNumber: 3,
+        heading: 'Pair with a familiar bottle or feed',
+        body: 'Milk feeds stay primary in the first months of solids. Offer '
+            'milk before or after a meal, not as a reward.',
+      ),
+      GuideSection(
+        stepNumber: 4,
+        heading: 'Track tastes in the app',
+        body: 'Logging reactions helps you spot favourites — and gives you a '
+            'record if you ever need to share notes with your pediatrician.',
+      ),
+    ],
+    terminalCta: GuideCta(
+      label: 'Create First Meal',
+      routeName: 'meal-plan',
+    ),
+  ),
+  GuideArticle(
+    slug: 'feeding-principles',
+    title: 'Feeding Principles',
+    subtitle: 'The simple rules that make mealtimes work for both of you.',
+    sections: [
+      GuideSection(
+        stepNumber: 1,
+        heading: 'You decide what, when, and where',
+        body: 'Your baby decides whether and how much. This split keeps power '
+            'struggles out of the high chair.',
+      ),
+      GuideSection(
+        stepNumber: 2,
+        heading: 'Expose, do not pressure',
+        body: 'It can take ten or more tries before a new food is accepted. '
+            'Keep offering without commentary.',
+      ),
+      GuideSection(
+        stepNumber: 3,
+        heading: 'Eat together when you can',
+        body: 'Babies learn to chew, swallow, and enjoy food by watching you. '
+            'Share even a small bite of what they are having.',
+      ),
+      GuideSection(
+        stepNumber: 4,
+        heading: 'Stay flat and supported',
+        body: 'Upright posture with feet supported makes safe swallowing '
+            'easier. A wobbly seat = a stressful meal.',
+      ),
+      GuideSection(
+        stepNumber: 5,
+        heading: 'Introduce allergens early and often',
+        body: 'Current guidance is to introduce common allergens between '
+            '4-6 months, then keep them in the rotation regularly.',
+      ),
+    ],
+    terminalCta: GuideCta(
+      label: 'Start Introducing Allergens',
+      routeName: 'allergen-tracker',
+    ),
+  ),
+  GuideArticle(
+    slug: 'readiness-signs',
+    title: '5 Signs of Readiness',
+    subtitle: 'How to know your baby is ready to start solids.',
+    sections: [
+      GuideSection(
+        stepNumber: 1,
+        heading: 'Sits with little help',
+        body: 'Your baby can hold their head steady and sit upright in a high '
+            'chair with minimal support.',
+      ),
+      GuideSection(
+        stepNumber: 2,
+        heading: 'Has lost the tongue-thrust reflex',
+        body: 'When you offer a spoon, food goes back instead of being pushed '
+            'straight out by the tongue.',
+      ),
+      GuideSection(
+        stepNumber: 3,
+        heading: 'Shows interest in food',
+        body: 'Watches you eat, opens their mouth toward your spoon, or '
+            'reaches for what is on your plate.',
+      ),
+      GuideSection(
+        stepNumber: 4,
+        heading: 'Can bring objects to mouth',
+        body: 'Grabbing a toy and getting it to their mouth signals the '
+            'hand-eye coordination needed for self-feeding.',
+      ),
+      GuideSection(
+        stepNumber: 5,
+        heading: 'Is around 6 months old',
+        body: 'Most babies are ready around six months. Always check with '
+            'your pediatrician before introducing solids.',
+      ),
+    ],
+    // TODO(NIB-94): wire a real mailto / weekly recipe sign-up flow once
+    //  copywriting + ESP integration land. For now, pop back to the hub.
+    terminalCta: GuideCta(
+      label: 'Get Free Weekly Baby Recipes',
+      routeName: 'starting-guide',
+    ),
+  ),
+];
+
+/// Returns the article whose [GuideArticle.slug] equals [slug], or `null`.
+GuideArticle? findArticleBySlug(String slug) {
+  for (final article in kStartingGuideArticles) {
+    if (article.slug == slug) return article;
+  }
+  return null;
+}

--- a/lib/src/features/starting_guide/starting_guide_article_screen.dart
+++ b/lib/src/features/starting_guide/starting_guide_article_screen.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/features/starting_guide/constants/articles.dart';
+import 'package:nibbles/src/features/starting_guide/starting_guide_controller.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_back_button.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_cta_pill.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_hero_card.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/numbered_step.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+/// Single Starting Guide article screen.
+///
+/// Resolves the article by [slug] via [StartingGuideController]. Renders the
+/// hero card, the article's numbered sections, and a single terminal CTA at
+/// the bottom that routes to one of the existing top-level routes
+/// (`recipe-library`, `meal-plan`, `allergen-tracker`, etc.).
+///
+/// If the slug doesn't match any article we fall back to a tiny not-found
+/// scaffold rather than crashing — protects against a malformed deeplink.
+class StartingGuideArticleScreen extends ConsumerWidget {
+  const StartingGuideArticleScreen({required this.slug, super.key});
+
+  final String slug;
+
+  void _onBack(BuildContext context) {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.goNamed(AppRoute.startingGuide.name);
+    }
+  }
+
+  void _onCta(BuildContext context, GuideCta cta) {
+    // 'Get Free Weekly Baby Recipes' has no destination flow yet — see the
+    // placeholder note in `constants/articles.dart`. The article routes back
+    // to the hub (placeholder targets `AppRoute.startingGuide.name`); doing
+    // the same for unknown route names keeps us crash-safe if the list is
+    // extended with a target that isn't registered yet.
+    final isKnown = AppRoute.values.any((r) => r.name == cta.routeName);
+    if (!isKnown || cta.routeName == AppRoute.startingGuide.name) {
+      _onBack(context);
+      return;
+    }
+    context.goNamed(cta.routeName);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final guideAsync = ref.watch(startingGuideControllerProvider);
+
+    return Scaffold(
+      backgroundColor: AppColors.cream,
+      body: guideAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => _NotFound(onBack: () => _onBack(context)),
+        data: (state) {
+          GuideArticle? article;
+          for (final a in state.articles) {
+            if (a.slug == slug) {
+              article = a;
+              break;
+            }
+          }
+          if (article == null) {
+            return _NotFound(onBack: () => _onBack(context));
+          }
+          return _ArticleBody(
+            article: article,
+            onBack: () => _onBack(context),
+            onCta: (cta) => _onCta(context, cta),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ArticleBody extends StatelessWidget {
+  const _ArticleBody({
+    required this.article,
+    required this.onBack,
+    required this.onCta,
+  });
+
+  final GuideArticle article;
+  final VoidCallback onBack;
+  final ValueChanged<GuideCta> onCta;
+
+  @override
+  Widget build(BuildContext context) {
+    final cta = article.terminalCta;
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(child: _Header(onBack: onBack)),
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSizes.pagePaddingH,
+            AppSizes.md,
+            AppSizes.pagePaddingH,
+            AppSizes.lg,
+          ),
+          sliver: SliverToBoxAdapter(
+            child: GuideHeroCard(
+              title: article.title,
+              subtitle: article.subtitle,
+            ),
+          ),
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSizes.pagePaddingH,
+            0,
+            AppSizes.pagePaddingH,
+            AppSizes.lg,
+          ),
+          sliver: SliverList.separated(
+            itemCount: article.sections.length,
+            separatorBuilder: (_, __) => const SizedBox(height: AppSizes.lg),
+            itemBuilder: (context, index) {
+              final section = article.sections[index];
+              return NumberedStep(
+                stepNumber: section.stepNumber,
+                heading: section.heading,
+                body: section.body,
+              );
+            },
+          ),
+        ),
+        if (cta != null)
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSizes.pagePaddingH,
+              AppSizes.sm,
+              AppSizes.pagePaddingH,
+              AppSizes.xl,
+            ),
+            sliver: SliverToBoxAdapter(
+              child: GuideCtaPill(
+                label: cta.label,
+                onTap: () => onCta(cta),
+              ),
+            ),
+          )
+        else
+          const SliverToBoxAdapter(child: SizedBox(height: AppSizes.xl)),
+      ],
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.onBack});
+
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [AppColors.butter, AppColors.butterSoft],
+        ),
+      ),
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.sm,
+        AppSizes.pagePaddingH,
+        AppSizes.md,
+      ),
+      child: SafeArea(
+        bottom: false,
+        child: Row(
+          children: [
+            GuideBackButton(onTap: onBack),
+            const SizedBox(width: AppSizes.sp12),
+            Expanded(
+              child: Text(
+                'Starting Guide',
+                style: AppTypography.textTheme.titleLarge,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NotFound extends StatelessWidget {
+  const _NotFound({required this.onBack});
+
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSizes.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GuideBackButton(onTap: onBack),
+            const SizedBox(height: AppSizes.lg),
+            const Text(
+              'Article not found',
+              style: AppTypography.emptyStateTitle,
+            ),
+            const SizedBox(height: AppSizes.sm),
+            Text(
+              "We couldn't find that guide article.",
+              style: AppTypography.textTheme.bodyMedium?.copyWith(
+                color: AppColors.fgMuted,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/starting_guide_controller.dart
+++ b/lib/src/features/starting_guide/starting_guide_controller.dart
@@ -1,0 +1,27 @@
+import 'package:nibbles/src/features/starting_guide/constants/articles.dart';
+import 'package:nibbles/src/features/starting_guide/starting_guide_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'starting_guide_controller.g.dart';
+
+/// AsyncNotifier for the Starting Guide hub.
+///
+/// Returns the hardcoded [kStartingGuideArticles] list. Async-shaped so the
+/// screens treat the data the same way they would a future remote source.
+@riverpod
+class StartingGuideController extends _$StartingGuideController {
+  @override
+  Future<StartingGuideState> build() async {
+    return const StartingGuideState(articles: kStartingGuideArticles);
+  }
+
+  /// Looks up an article by [slug]. Returns `null` if no article matches.
+  GuideArticle? articleFor(String slug) {
+    final current = state.valueOrNull;
+    if (current == null) return findArticleBySlug(slug);
+    for (final article in current.articles) {
+      if (article.slug == slug) return article;
+    }
+    return null;
+  }
+}

--- a/lib/src/features/starting_guide/starting_guide_controller.g.dart
+++ b/lib/src/features/starting_guide/starting_guide_controller.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'starting_guide_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$startingGuideControllerHash() =>
+    r'92f0e78aa5c837bc7237432cba6348eea1b55021';
+
+/// AsyncNotifier for the Starting Guide hub.
+///
+/// Returns the hardcoded [kStartingGuideArticles] list. Async-shaped so the
+/// screens treat the data the same way they would a future remote source.
+///
+/// Copied from [StartingGuideController].
+@ProviderFor(StartingGuideController)
+final startingGuideControllerProvider =
+    AutoDisposeAsyncNotifierProvider<
+      StartingGuideController,
+      StartingGuideState
+    >.internal(
+      StartingGuideController.new,
+      name: r'startingGuideControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$startingGuideControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$StartingGuideController =
+    AutoDisposeAsyncNotifier<StartingGuideState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/starting_guide/starting_guide_hub_screen.dart
+++ b/lib/src/features/starting_guide/starting_guide_hub_screen.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/starting_guide/constants/articles.dart';
+import 'package:nibbles/src/features/starting_guide/starting_guide_controller.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/article_card.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_back_button.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+/// Starting Guide hub — the content index reachable from the Recipe Library
+/// 'Read Guide' banner and bookmark button (NIB-53 wires both).
+///
+/// Renders a butter-wash header + a vertical list of [ArticleCard]s, one per
+/// entry in [kStartingGuideArticles]. Tapping a card pushes the article
+/// screen routed by slug.
+///
+/// First-launch dismiss (build rule 9): on mount, marks the Starting Guide
+/// as seen via [LocalFlagService.markStartingGuideSeen] so the library
+/// banner stops showing on subsequent visits.
+class StartingGuideHubScreen extends ConsumerStatefulWidget {
+  const StartingGuideHubScreen({super.key});
+
+  @override
+  ConsumerState<StartingGuideHubScreen> createState() =>
+      _StartingGuideHubScreenState();
+}
+
+class _StartingGuideHubScreenState
+    extends ConsumerState<StartingGuideHubScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(ref.read(localFlagServiceProvider).markStartingGuideSeen());
+    });
+  }
+
+  void _onBack() {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.goNamed(AppRoute.recipeLibrary.name);
+    }
+  }
+
+  void _openArticle(String slug) {
+    context.pushNamed(
+      AppRoute.startingGuideArticle.name,
+      pathParameters: {'slug': slug},
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final guideAsync = ref.watch(startingGuideControllerProvider);
+
+    return Scaffold(
+      backgroundColor: AppColors.cream,
+      body: guideAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => const Center(
+          child: Padding(
+            padding: EdgeInsets.all(AppSizes.lg),
+            child: Text(
+              "Couldn't load the Starting Guide.",
+              style: AppTypography.emptyStateTitle,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        data: (state) => CustomScrollView(
+          slivers: [
+            SliverToBoxAdapter(child: _Header(onBack: _onBack)),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.pagePaddingH,
+                AppSizes.md,
+                AppSizes.pagePaddingH,
+                AppSizes.xl,
+              ),
+              sliver: SliverList.separated(
+                itemCount: state.articles.length,
+                separatorBuilder: (_, __) =>
+                    const SizedBox(height: AppSizes.sp12),
+                itemBuilder: (context, index) {
+                  final article = state.articles[index];
+                  return ArticleCard(
+                    article: article,
+                    onTap: () => _openArticle(article.slug),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.onBack});
+
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [AppColors.butter, AppColors.butterSoft],
+        ),
+      ),
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.sm,
+        AppSizes.pagePaddingH,
+        AppSizes.lg,
+      ),
+      child: SafeArea(
+        bottom: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                GuideBackButton(onTap: onBack),
+                const SizedBox(width: AppSizes.sp12),
+                Expanded(
+                  child: Text(
+                    'Starting Guide',
+                    style: AppTypography.textTheme.titleLarge,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSizes.sm),
+            Text(
+              'Bite-sized reads to help you start solids with confidence.',
+              style: AppTypography.textTheme.bodyMedium?.copyWith(
+                color: AppColors.fgMuted,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/starting_guide_state.dart
+++ b/lib/src/features/starting_guide/starting_guide_state.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/features/starting_guide/constants/articles.dart';
+
+part 'starting_guide_state.freezed.dart';
+
+/// State for the Starting Guide hub.
+///
+/// [articles] is the full ordered article list. Content is hardcoded today
+/// (see [kStartingGuideArticles]) but the controller stays AsyncNotifier-shaped
+/// to match the project's controller pattern and so a future migration to a
+/// remote/CMS-backed source slots in without changing screens.
+@freezed
+class StartingGuideState with _$StartingGuideState {
+  const factory StartingGuideState({
+    @Default(<GuideArticle>[]) List<GuideArticle> articles,
+  }) = _StartingGuideState;
+}

--- a/lib/src/features/starting_guide/starting_guide_state.freezed.dart
+++ b/lib/src/features/starting_guide/starting_guide_state.freezed.dart
@@ -1,0 +1,161 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'starting_guide_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$StartingGuideState {
+  List<GuideArticle> get articles => throw _privateConstructorUsedError;
+
+  /// Create a copy of StartingGuideState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $StartingGuideStateCopyWith<StartingGuideState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StartingGuideStateCopyWith<$Res> {
+  factory $StartingGuideStateCopyWith(
+    StartingGuideState value,
+    $Res Function(StartingGuideState) then,
+  ) = _$StartingGuideStateCopyWithImpl<$Res, StartingGuideState>;
+  @useResult
+  $Res call({List<GuideArticle> articles});
+}
+
+/// @nodoc
+class _$StartingGuideStateCopyWithImpl<$Res, $Val extends StartingGuideState>
+    implements $StartingGuideStateCopyWith<$Res> {
+  _$StartingGuideStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of StartingGuideState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? articles = null}) {
+    return _then(
+      _value.copyWith(
+            articles: null == articles
+                ? _value.articles
+                : articles // ignore: cast_nullable_to_non_nullable
+                      as List<GuideArticle>,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$StartingGuideStateImplCopyWith<$Res>
+    implements $StartingGuideStateCopyWith<$Res> {
+  factory _$$StartingGuideStateImplCopyWith(
+    _$StartingGuideStateImpl value,
+    $Res Function(_$StartingGuideStateImpl) then,
+  ) = __$$StartingGuideStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<GuideArticle> articles});
+}
+
+/// @nodoc
+class __$$StartingGuideStateImplCopyWithImpl<$Res>
+    extends _$StartingGuideStateCopyWithImpl<$Res, _$StartingGuideStateImpl>
+    implements _$$StartingGuideStateImplCopyWith<$Res> {
+  __$$StartingGuideStateImplCopyWithImpl(
+    _$StartingGuideStateImpl _value,
+    $Res Function(_$StartingGuideStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of StartingGuideState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? articles = null}) {
+    return _then(
+      _$StartingGuideStateImpl(
+        articles: null == articles
+            ? _value._articles
+            : articles // ignore: cast_nullable_to_non_nullable
+                  as List<GuideArticle>,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$StartingGuideStateImpl implements _StartingGuideState {
+  const _$StartingGuideStateImpl({
+    final List<GuideArticle> articles = const <GuideArticle>[],
+  }) : _articles = articles;
+
+  final List<GuideArticle> _articles;
+  @override
+  @JsonKey()
+  List<GuideArticle> get articles {
+    if (_articles is EqualUnmodifiableListView) return _articles;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_articles);
+  }
+
+  @override
+  String toString() {
+    return 'StartingGuideState(articles: $articles)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$StartingGuideStateImpl &&
+            const DeepCollectionEquality().equals(other._articles, _articles));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_articles));
+
+  /// Create a copy of StartingGuideState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$StartingGuideStateImplCopyWith<_$StartingGuideStateImpl> get copyWith =>
+      __$$StartingGuideStateImplCopyWithImpl<_$StartingGuideStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _StartingGuideState implements StartingGuideState {
+  const factory _StartingGuideState({final List<GuideArticle> articles}) =
+      _$StartingGuideStateImpl;
+
+  @override
+  List<GuideArticle> get articles;
+
+  /// Create a copy of StartingGuideState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$StartingGuideStateImplCopyWith<_$StartingGuideStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/starting_guide/widgets/article_card.dart
+++ b/lib/src/features/starting_guide/widgets/article_card.dart
@@ -7,9 +7,9 @@ import 'package:nibbles/src/features/starting_guide/widgets/baby_face_glyph.dart
 
 /// Article card rendered on the Starting Guide hub list.
 ///
-/// White surface, rounded-2xl, soft card shadow, with a butter-tinted glyph,
-/// title, subtitle, and a trailing chevron — mirrors the kit's interactive
-/// list card pattern.
+/// White surface, rounded-2xl, soft card shadow, with a green-deep glyph
+/// (kit `.tip__ico`), title, subtitle, and a trailing chevron — mirrors the
+/// kit's interactive list card pattern.
 class ArticleCard extends StatelessWidget {
   const ArticleCard({
     required this.article,

--- a/lib/src/features/starting_guide/widgets/article_card.dart
+++ b/lib/src/features/starting_guide/widgets/article_card.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/features/starting_guide/constants/articles.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/baby_face_glyph.dart';
+
+/// Article card rendered on the Starting Guide hub list.
+///
+/// White surface, rounded-2xl, soft card shadow, with a butter-tinted glyph,
+/// title, subtitle, and a trailing chevron — mirrors the kit's interactive
+/// list card pattern.
+class ArticleCard extends StatelessWidget {
+  const ArticleCard({
+    required this.article,
+    required this.onTap,
+    super.key,
+  });
+
+  final GuideArticle article;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.surface,
+      borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.all(AppSizes.md),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+            boxShadow: AppSizes.shadowCard,
+          ),
+          child: Row(
+            children: [
+              const BabyFaceGlyph(size: BabyFaceGlyph.smallSize),
+              const SizedBox(width: AppSizes.sp12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      article.title,
+                      style: AppTypography.textTheme.titleSmall?.copyWith(
+                        color: AppColors.fgStrong,
+                      ),
+                    ),
+                    const SizedBox(height: AppSizes.xs),
+                    Text(
+                      article.subtitle,
+                      style: AppTypography.textTheme.bodyMedium?.copyWith(
+                        color: AppColors.fgMuted,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSizes.sm),
+              const Icon(
+                Icons.chevron_right_rounded,
+                color: AppColors.greenDeep,
+                size: AppSizes.iconMd,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/baby_face_glyph.dart
+++ b/lib/src/features/starting_guide/widgets/baby_face_glyph.dart
@@ -2,9 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 
-/// Round butter-tinted glyph showing a baby face emoji — used as the hero
-/// mark on the Starting Guide hub and as a stand-in for hardcoded article
-/// hero imagery while real illustration is pending.
+/// Round green-deep glyph used as the hero mark on the Starting Guide hub
+/// and as a stand-in for hardcoded article hero imagery while real
+/// illustration is pending.
+///
+/// Aligns with the only kit precedent for this circular badge shape —
+/// `.tip__ico` (kit.css line 108-114): `--color-green-deep` background,
+/// `--color-butter` foreground content.
 class BabyFaceGlyph extends StatelessWidget {
   const BabyFaceGlyph({this.size = 56, super.key});
 
@@ -16,13 +20,14 @@ class BabyFaceGlyph extends StatelessWidget {
       width: size,
       height: size,
       decoration: const BoxDecoration(
-        color: AppColors.butter,
+        color: AppColors.greenDeep,
         shape: BoxShape.circle,
       ),
       alignment: Alignment.center,
-      child: Text(
-        '\u{1F476}',
-        style: TextStyle(fontSize: size * 0.55, height: 1),
+      child: Icon(
+        Icons.child_care_rounded,
+        color: AppColors.butter,
+        size: size * 0.6,
       ),
     );
   }

--- a/lib/src/features/starting_guide/widgets/baby_face_glyph.dart
+++ b/lib/src/features/starting_guide/widgets/baby_face_glyph.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Round butter-tinted glyph showing a baby face emoji — used as the hero
+/// mark on the Starting Guide hub and as a stand-in for hardcoded article
+/// hero imagery while real illustration is pending.
+class BabyFaceGlyph extends StatelessWidget {
+  const BabyFaceGlyph({this.size = 56, super.key});
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: const BoxDecoration(
+        color: AppColors.butter,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '\u{1F476}',
+        style: TextStyle(fontSize: size * 0.55, height: 1),
+      ),
+    );
+  }
+
+  /// Convenience small-glyph constant matched to the tip-card spec
+  /// (`AppSizes.tipGlyph` — used on hub article cards).
+  static const double smallSize = AppSizes.tipGlyph;
+}

--- a/lib/src/features/starting_guide/widgets/guide_back_button.dart
+++ b/lib/src/features/starting_guide/widgets/guide_back_button.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Rounded-square green-deep back button matching the kit header treatment
+/// (see `components-header.html` — green-deep on cream, 32x32, radius8).
+class GuideBackButton extends StatelessWidget {
+  const GuideBackButton({required this.onTap, super.key});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.greenDeep,
+      borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+        onTap: onTap,
+        child: const SizedBox(
+          width: AppSizes.roundButtonSm,
+          height: AppSizes.roundButtonSm,
+          child: Icon(
+            Icons.arrow_back_rounded,
+            color: AppColors.onGreen,
+            size: AppSizes.iconMd,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/guide_back_button.dart
+++ b/lib/src/features/starting_guide/widgets/guide_back_button.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 
-/// Rounded-square green-deep back button matching the kit header treatment
-/// (see `components-header.html` — green-deep on cream, 32x32, radius8).
+/// Circular ghost back button matching the kit `.rbtn` spec
+/// (kit.css line 62-71 + PlanAndRecipes.jsx line 18): 32x32 circle,
+/// transparent background, green-deep icon.
 class GuideBackButton extends StatelessWidget {
   const GuideBackButton({required this.onTap, super.key});
 
@@ -12,17 +13,17 @@ class GuideBackButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: AppColors.greenDeep,
-      borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+      color: Colors.transparent,
+      shape: const CircleBorder(),
       child: InkWell(
-        borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+        customBorder: const CircleBorder(),
         onTap: onTap,
         child: const SizedBox(
           width: AppSizes.roundButtonSm,
           height: AppSizes.roundButtonSm,
           child: Icon(
             Icons.arrow_back_rounded,
-            color: AppColors.onGreen,
+            color: AppColors.greenDeep,
             size: AppSizes.iconMd,
           ),
         ),

--- a/lib/src/features/starting_guide/widgets/guide_cta_pill.dart
+++ b/lib/src/features/starting_guide/widgets/guide_cta_pill.dart
@@ -24,7 +24,9 @@ class GuideCtaPill extends StatelessWidget {
         child: Container(
           height: AppSizes.buttonHeight,
           alignment: Alignment.center,
-          padding: const EdgeInsets.symmetric(horizontal: AppSizes.lg),
+          // Kit `.pillbtn` horizontal padding is 22px — literal because there
+          // is no current token; matches kit.css line 74-80 exactly.
+          padding: const EdgeInsets.symmetric(horizontal: 22),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.min,
@@ -35,9 +37,9 @@ class GuideCtaPill extends StatelessWidget {
                   textAlign: TextAlign.center,
                   style: const TextStyle(
                     fontFamily: FontFamily.parkinsans,
-                    fontSize: 15,
+                    fontSize: 16,
                     fontWeight: FontWeight.w700,
-                    height: 1.2,
+                    height: 1,
                     color: AppColors.cream,
                   ),
                 ),

--- a/lib/src/features/starting_guide/widgets/guide_cta_pill.dart
+++ b/lib/src/features/starting_guide/widgets/guide_cta_pill.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Full-width green-deep pill CTA used at the bottom of every article.
+///
+/// Matches the kit `.pillbtn` spec — green-deep fill, cream label in
+/// Parkinsans 700, full radius, trailing forward arrow.
+class GuideCtaPill extends StatelessWidget {
+  const GuideCtaPill({required this.label, required this.onTap, super.key});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.greenDeep,
+      borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+        onTap: onTap,
+        child: Container(
+          height: AppSizes.buttonHeight,
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(horizontal: AppSizes.lg),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                child: Text(
+                  label,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    fontFamily: FontFamily.parkinsans,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    height: 1.2,
+                    color: AppColors.cream,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSizes.sm),
+              const Icon(
+                Icons.arrow_forward_rounded,
+                color: AppColors.cream,
+                size: AppSizes.iconMd,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/guide_hero_card.dart
+++ b/lib/src/features/starting_guide/widgets/guide_hero_card.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/baby_face_glyph.dart';
+
+/// Hero card on top of an article — butter-soft tinted card with a baby-face
+/// glyph, title, and subtitle. Modelled on `components-cards.html` tip card
+/// (radius20, butter-soft tint, fgDefault title, fgMuted body).
+class GuideHeroCard extends StatelessWidget {
+  const GuideHeroCard({
+    required this.title,
+    required this.subtitle,
+    super.key,
+  });
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSizes.lg),
+      decoration: BoxDecoration(
+        color: AppColors.bgCardTint,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const BabyFaceGlyph(),
+          const SizedBox(height: AppSizes.md),
+          Text(
+            title,
+            style: AppTypography.textTheme.headlineSmall?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+          ),
+          const SizedBox(height: AppSizes.sm),
+          Text(
+            subtitle,
+            style: AppTypography.textTheme.bodyMedium?.copyWith(
+              color: AppColors.fgMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/guide_hero_card.dart
+++ b/lib/src/features/starting_guide/widgets/guide_hero_card.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/features/starting_guide/widgets/baby_face_glyph.dart';
 
 /// Hero card on top of an article — butter-soft tinted card with a baby-face
-/// glyph, title, and subtitle. Modelled on `components-cards.html` tip card
-/// (radius20, butter-soft tint, fgDefault title, fgMuted body).
+/// glyph, title, and subtitle. Modelled on the kit `.tip` card
+/// (kit.css line 102-117): `bg-card-tint`, `r-xl` radius, 14px 16px padding,
+/// `.tip__ttl` title (700 14px/1.2 Parkinsans, fg-strong).
 class GuideHeroCard extends StatelessWidget {
   const GuideHeroCard({
     required this.title,
@@ -21,7 +23,9 @@ class GuideHeroCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.all(AppSizes.lg),
+      // Kit `.tip` padding is 14px 16px — literal because there are no exact
+      // tokens for 14px vertical / 16px horizontal pair.
+      padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 16),
       decoration: BoxDecoration(
         color: AppColors.bgCardTint,
         borderRadius: BorderRadius.circular(AppSizes.radiusXl),
@@ -30,14 +34,18 @@ class GuideHeroCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const BabyFaceGlyph(),
-          const SizedBox(height: AppSizes.md),
+          const SizedBox(height: AppSizes.sm),
           Text(
             title,
-            style: AppTypography.textTheme.headlineSmall?.copyWith(
+            style: const TextStyle(
+              fontFamily: FontFamily.parkinsans,
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              height: 1.2,
               color: AppColors.fgStrong,
             ),
           ),
-          const SizedBox(height: AppSizes.sm),
+          const SizedBox(height: AppSizes.xs),
           Text(
             subtitle,
             style: AppTypography.textTheme.bodyMedium?.copyWith(

--- a/lib/src/features/starting_guide/widgets/numbered_step.dart
+++ b/lib/src/features/starting_guide/widgets/numbered_step.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+
+/// One numbered step row inside an article — green-deep pill containing the
+/// step number, sitting next to a heading + body block.
+///
+/// Renders without the number pill when [stepNumber] is null (used for
+/// plain heading/body sections).
+class NumberedStep extends StatelessWidget {
+  const NumberedStep({
+    required this.heading,
+    required this.body,
+    this.stepNumber,
+    super.key,
+  });
+
+  final int? stepNumber;
+  final String heading;
+  final String body;
+
+  static const _pillSize = AppSizes.tipGlyph;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (stepNumber != null) ...[
+          _StepPill(stepNumber: stepNumber!),
+          const SizedBox(width: AppSizes.sp12),
+        ],
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: stepNumber != null
+                    ? const EdgeInsets.only(top: AppSizes.xs)
+                    : EdgeInsets.zero,
+                child: Text(
+                  heading,
+                  style: AppTypography.textTheme.titleSmall?.copyWith(
+                    color: AppColors.fgStrong,
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppSizes.xs),
+              Text(
+                body,
+                style: AppTypography.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.fgMuted,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StepPill extends StatelessWidget {
+  const _StepPill({required this.stepNumber});
+
+  final int stepNumber;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: NumberedStep._pillSize,
+      height: NumberedStep._pillSize,
+      decoration: const BoxDecoration(
+        color: AppColors.greenDeep,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '$stepNumber',
+        style: const TextStyle(
+          fontFamily: FontFamily.parkinsans,
+          fontSize: 14,
+          fontWeight: FontWeight.w700,
+          height: 1,
+          color: AppColors.butter,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/routing/route_enums.dart
+++ b/lib/src/routing/route_enums.dart
@@ -29,6 +29,11 @@ enum AppRoute {
   mealPlanMap(path: '/home/meal/map', name: 'meal-plan-map'),
   shoppingList(path: '/home/shopping-list', name: 'shopping-list'),
   recipeLibrary(path: '/home/recipe', name: 'recipe-library'),
+  startingGuide(path: '/home/recipe/guide', name: 'starting-guide'),
+  startingGuideArticle(
+    path: '/home/recipe/guide/:slug',
+    name: 'starting-guide-article',
+  ),
   allergenTracker(path: '/home/allergen/tracker', name: 'allergen-tracker'),
   allergenDetail(path: '/home/allergen/:allergenKey', name: 'allergen-detail'),
   allergenLogCreate(

--- a/lib/src/routing/routes.dart
+++ b/lib/src/routing/routes.dart
@@ -30,6 +30,8 @@ import 'package:nibbles/src/features/recipe/detail/recipe_detail_screen.dart';
 import 'package:nibbles/src/features/recipe/library/recipe_library_screen.dart';
 import 'package:nibbles/src/features/shopping_list/shopping_list_screen.dart';
 import 'package:nibbles/src/features/splash/splash_screen.dart';
+import 'package:nibbles/src/features/starting_guide/starting_guide_article_screen.dart';
+import 'package:nibbles/src/features/starting_guide/starting_guide_hub_screen.dart';
 import 'package:nibbles/src/features/subscription/paywall/paywall_screen.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -359,6 +361,25 @@ GoRouter goRouter(Ref ref) {
                 path: AppRoute.recipeLibrary.path,
                 name: AppRoute.recipeLibrary.name,
                 builder: (context, state) => const RecipeLibraryScreen(),
+                routes: [
+                  GoRoute(
+                    path: 'guide',
+                    name: AppRoute.startingGuide.name,
+                    parentNavigatorKey: rootNavigatorKey,
+                    builder: (context, state) => const StartingGuideHubScreen(),
+                    routes: [
+                      GoRoute(
+                        path: ':slug',
+                        name: AppRoute.startingGuideArticle.name,
+                        parentNavigatorKey: rootNavigatorKey,
+                        builder: (context, state) =>
+                            StartingGuideArticleScreen(
+                          slug: state.pathParameters['slug'] ?? '',
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/src/routing/routes.g.dart
+++ b/lib/src/routing/routes.g.dart
@@ -6,7 +6,7 @@ part of 'routes.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'4bae9e0da3b41f5b896dcf7524ab4d9d34701b69';
+String _$goRouterHash() => r'fd30efe79ed323932190b1a0248eb92d7775cfed';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)


### PR DESCRIPTION
## Summary
New Starting Guide content hub reachable from the Recipe Library banner / bookmark (NIB-53). Adds a hub index of 4 hardcoded articles and a slug-routed article screen with terminal CTAs that route back into existing feature flows (Recipe Library, Meal Plan, Allergen Tracker).

## Figma frames
- Hub index: 971-8692
- Article 1 (Baby's First Nibbles): 971-8730
- Article 2 (Introduction): 971-8744 + 1474-50031
- Article 3 (Feeding Principles): 1474-50514
- Article 4 (5 Sign Readiness): 1474-53362

## Routes added
- `startingGuide` -> `/home/recipe/guide` (name `starting-guide`)
- `startingGuideArticle` -> `/home/recipe/guide/:slug` (name `starting-guide-article`)

Both registered under the existing recipe shell branch with `parentNavigatorKey: rootNavigatorKey` so they push full-screen without the bottom nav.

## DS components consumed
- `AppColors` / `AppSizes` / `AppTypography` tokens only
- `LocalFlagService.markStartingGuideSeen()` consumed (added by NIB-53, not modified here)
- `FontFamily.parkinsans` for kit-spec display tokens local to step + CTA pills
- Existing `AppRoute.recipeLibrary` / `AppRoute.mealPlan` / `AppRoute.allergenTracker` consumed as CTA targets

## Acceptance criteria
- [x] New feature module under `lib/src/features/starting_guide/` matches the rule-5 structure (controller, state, hub screen, article screen, `constants/articles.dart`, `widgets/`)
- [x] `route_enums.dart` adds `startingGuide` + `startingGuideArticle`
- [x] `routes.dart` adds matching GoRoute entries with `parentNavigatorKey: rootNavigatorKey` under the recipe shell branch
- [x] Hub screen renders 4 article cards; tapping pushes the article screen with the slug
- [x] Article screen renders matching article hero + sections + terminal CTA per slug; not-found fallback for malformed slugs
- [x] `LocalFlagService.markStartingGuideSeen()` called from the hub's `initState` postFrameCallback
- [x] CTAs use `context.goNamed(...)` to route to existing top-level routes
- [x] `flutter analyze` 0 issues
- [x] `make gen` clean + idempotent (second run produces no diff)
- [x] Zero hex / Nunito / withAlpha / `AllergenStatus.completed`
- [x] No files outside the allowlist modified

## Gate results
- `make gen` -> succeeded, 1040 outputs, idempotent on second run
- `flutter analyze` -> No issues found
- `flutter test` -> 384 passed, 1 failed. The single failure (`recipe_to_shopping_list_integration_test.dart` -> "RC-01 -> RC-02 -> Add to Shopping List: names only, deselected excluded") is pre-existing on the `redesign` base branch and unrelated to this change (verified by re-running the test against base with this PR's changes stashed)

## Content-fidelity follow-up
The Figma file was unreachable from the build environment, so the four articles ship with placeholder copy that approximates the spec headings + 4-5 numbered steps each. Copy should be replaced with the verbatim Figma text in a follow-up. The article model + screen scaffolding are unaffected by that swap.

## Known gaps (deliberately out of scope per the ticket's STRICT scope rules)
- The Recipe Library 'Read Guide' / bookmark call sites still show a SnackBar referencing a NIB-94 TODO. The recipe module is on the forbidden-touch list for this ticket, so swapping the SnackBar for `context.pushNamed(AppRoute.startingGuide.name)` is left to a follow-up against `lib/src/features/recipe/library/recipe_library_screen.dart`. The routes are live and ready to be wired.
- 'Get Free Weekly Baby Recipes' has no destination flow; the CTA currently pops back to the hub. Tracked by a TODO in `constants/articles.dart`.
- NIB-108 owns starting-guide navigation tests; no tests added in this PR.

## Test plan
- [ ] Open Recipe Library; once the route is wired, tap the bookmark / 'Read Guide' CTA -> Starting Guide hub appears (full screen, no bottom nav)
- [ ] On hub mount, the Read Guide banner stays dismissed on returning to the library
- [ ] Tap each of the 4 article cards -> article screen with matching hero, sections, terminal CTA
- [ ] Tap each terminal CTA -> routes to the correct top-level route (Recipe Library, Meal Plan, Allergen Tracker); the placeholder 'Get Free Weekly Baby Recipes' pops back to the hub
- [ ] Hardware back / back button from article -> hub; from hub -> Recipe Library
- [ ] Visit `/home/recipe/guide/does-not-exist` -> not-found scaffold renders without crashing