### PR TITLE
feat(recipe): analytics + starting-guide events [NIB-101]

### DIFF
--- a/lib/src/features/recipe/detail/recipe_detail_controller.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
@@ -88,7 +90,12 @@ class RecipeDetailController extends _$RecipeDetailController {
     state = AsyncData(current.copyWith(isAddingToMealPlan: false));
 
     if (result.isSuccess) {
-      await Analytics.instance.logRecipeAddedToMealPlan(recipeId: recipeId);
+      unawaited(
+        Analytics.instance.logRecipeAddedToMealPlan(
+          recipeId: recipeId,
+          dayCount: normalized.length,
+        ),
+      );
     }
 
     return result;
@@ -106,6 +113,16 @@ class RecipeDetailController extends _$RecipeDetailController {
         .addFromRecipe(babyId, recipeId, selectedNames);
 
     state = AsyncData(current.copyWith(isAddingToShoppingList: false));
+
+    if (result.isSuccess) {
+      unawaited(
+        Analytics.instance.logRecipeAddedToShoppingList(
+          recipeId: recipeId,
+          itemCount: selectedNames.length,
+        ),
+      );
+    }
+
     return result;
   }
 

--- a/lib/src/features/recipe/detail/recipe_detail_controller.g.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_controller.g.dart
@@ -7,7 +7,7 @@ part of 'recipe_detail_controller.dart';
 // **************************************************************************
 
 String _$recipeDetailControllerHash() =>
-    r'4176d7b257f546bc46421ae83d8d5ce228a2677c';
+    r'524892489215c79adb0542319d64215ac3a00f43';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/recipe/detail/recipe_detail_screen.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
@@ -16,14 +18,31 @@ import 'package:nibbles/src/features/recipe/detail/widgets/recipe_banner_card.da
 import 'package:nibbles/src/features/recipe/detail/widgets/recipe_hero.dart';
 import 'package:nibbles/src/features/recipe/detail/widgets/recipe_tip_card.dart';
 import 'package:nibbles/src/features/recipe/detail/widgets/storage_card_row.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 
-class RecipeDetailScreen extends ConsumerWidget {
+class RecipeDetailScreen extends ConsumerStatefulWidget {
   const RecipeDetailScreen({required this.recipeId, super.key});
 
   final String recipeId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<RecipeDetailScreen> createState() => _RecipeDetailScreenState();
+}
+
+class _RecipeDetailScreenState extends ConsumerState<RecipeDetailScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(
+        Analytics.instance.logRecipeViewed(recipeId: widget.recipeId),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final babyIdAsync = ref.watch(currentBabyIdProvider);
 
     return babyIdAsync.when(
@@ -42,7 +61,7 @@ class RecipeDetailScreen extends ConsumerWidget {
             body: Center(child: Text('No baby profile found.')),
           );
         }
-        return _RecipeDetailBody(babyId: babyId, recipeId: recipeId);
+        return _RecipeDetailBody(babyId: babyId, recipeId: widget.recipeId);
       },
     );
   }

--- a/lib/src/features/recipe/library/recipe_library_controller.dart
+++ b/lib/src/features/recipe/library/recipe_library_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
@@ -5,6 +7,7 @@ import 'package:nibbles/src/common/services/helpers/derive_allergen_status.dart'
 import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/common/services/recipe_service.dart';
 import 'package:nibbles/src/features/recipe/library/recipe_library_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'recipe_library_controller.g.dart';
@@ -79,6 +82,12 @@ class RecipeLibraryController extends _$RecipeLibraryController {
     if (current == null) return;
     final trimmed = query.trim();
     if (trimmed == current.searchQuery) return;
+    final wasEmpty = current.searchQuery.isEmpty;
     state = AsyncData(current.copyWith(searchQuery: trimmed));
+    if (wasEmpty && trimmed.isNotEmpty) {
+      unawaited(
+        Analytics.instance.logRecipeSearch(queryLength: trimmed.length),
+      );
+    }
   }
 }

--- a/lib/src/features/recipe/library/recipe_library_controller.g.dart
+++ b/lib/src/features/recipe/library/recipe_library_controller.g.dart
@@ -7,7 +7,7 @@ part of 'recipe_library_controller.dart';
 // **************************************************************************
 
 String _$recipeLibraryControllerHash() =>
-    r'40f19a72ba8e5d33fa117b06a02df66b35b86b20';
+    r'0924bca0fc73d5402be8bf6455ca646c764637fb';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/starting_guide/starting_guide_article_screen.dart
+++ b/lib/src/features/starting_guide/starting_guide_article_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -10,6 +12,7 @@ import 'package:nibbles/src/features/starting_guide/widgets/guide_back_button.da
 import 'package:nibbles/src/features/starting_guide/widgets/guide_cta_pill.dart';
 import 'package:nibbles/src/features/starting_guide/widgets/guide_hero_card.dart';
 import 'package:nibbles/src/features/starting_guide/widgets/numbered_step.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
 /// Single Starting Guide article screen.
@@ -21,10 +24,31 @@ import 'package:nibbles/src/routing/route_enums.dart';
 ///
 /// If the slug doesn't match any article we fall back to a tiny not-found
 /// scaffold rather than crashing — protects against a malformed deeplink.
-class StartingGuideArticleScreen extends ConsumerWidget {
+class StartingGuideArticleScreen extends ConsumerStatefulWidget {
   const StartingGuideArticleScreen({required this.slug, super.key});
 
   final String slug;
+
+  @override
+  ConsumerState<StartingGuideArticleScreen> createState() =>
+      _StartingGuideArticleScreenState();
+}
+
+class _StartingGuideArticleScreenState
+    extends ConsumerState<StartingGuideArticleScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(
+        Analytics.instance.logStartingGuideArticleViewed(slug: widget.slug),
+      );
+      unawaited(
+        Analytics.instance.logScreenView(screenName: 'starting_guide_article'),
+      );
+    });
+  }
 
   void _onBack(BuildContext context) {
     if (context.canPop()) {
@@ -49,7 +73,7 @@ class StartingGuideArticleScreen extends ConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final guideAsync = ref.watch(startingGuideControllerProvider);
 
     return Scaffold(
@@ -60,7 +84,7 @@ class StartingGuideArticleScreen extends ConsumerWidget {
         data: (state) {
           GuideArticle? article;
           for (final a in state.articles) {
-            if (a.slug == slug) {
+            if (a.slug == widget.slug) {
               article = a;
               break;
             }

--- a/lib/src/features/starting_guide/starting_guide_hub_screen.dart
+++ b/lib/src/features/starting_guide/starting_guide_hub_screen.dart
@@ -11,6 +11,7 @@ import 'package:nibbles/src/features/starting_guide/constants/articles.dart';
 import 'package:nibbles/src/features/starting_guide/starting_guide_controller.dart';
 import 'package:nibbles/src/features/starting_guide/widgets/article_card.dart';
 import 'package:nibbles/src/features/starting_guide/widgets/guide_back_button.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
 /// Starting Guide hub — the content index reachable from the Recipe Library
@@ -39,6 +40,12 @@ class _StartingGuideHubScreenState
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       unawaited(ref.read(localFlagServiceProvider).markStartingGuideSeen());
+      // TODO(NIB-53): pass `source` via GoRouter `extra` so we can distinguish
+      // hub vs article entry points instead of always firing 'unknown'.
+      unawaited(Analytics.instance.logStartingGuideOpened(source: 'unknown'));
+      unawaited(
+        Analytics.instance.logScreenView(screenName: 'starting_guide_hub'),
+      );
     });
   }
 

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -260,10 +260,57 @@ class Analytics {
     await _logEvent('recipe_viewed', parameters: {'recipe_id': recipeId});
   }
 
-  Future<void> logRecipeAddedToMealPlan({required String recipeId}) async {
+  Future<void> logRecipeAddedToMealPlan({
+    required String recipeId,
+    int dayCount = 1,
+  }) async {
     await _logEvent(
       'recipe_added_to_meal_plan',
-      parameters: {'recipe_id': recipeId},
+      parameters: {'recipe_id': recipeId, 'day_count': dayCount},
+    );
+  }
+
+  Future<void> logRecipeAddedToShoppingList({
+    required String recipeId,
+    required int itemCount,
+  }) async {
+    await _logEvent(
+      'recipe_added_to_shopping_list',
+      parameters: {'recipe_id': recipeId, 'item_count': itemCount},
+    );
+  }
+
+  /// Fires when the recipe library search query transitions from empty to
+  /// non-empty. NO `query` param (PII). [queryLength] is optional and bucketed
+  /// only by character count.
+  Future<void> logRecipeSearch({int? queryLength}) async {
+    await _logEvent(
+      'recipe_search',
+      parameters: {
+        if (queryLength != null) 'query_length': queryLength,
+      },
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Starting Guide
+  // ---------------------------------------------------------------------------
+
+  /// Fires when the Starting Guide hub mounts. [source] is one of
+  /// 'hub' / 'article' / 'unknown'.
+  // TODO(NIB-53): callers should pass `source` via GoRouter `extra` so we can
+  // distinguish hub vs article entry points.
+  Future<void> logStartingGuideOpened({required String source}) async {
+    await _logEvent(
+      'starting_guide_opened',
+      parameters: {'source': source},
+    );
+  }
+
+  Future<void> logStartingGuideArticleViewed({required String slug}) async {
+    await _logEvent(
+      'starting_guide_article_viewed',
+      parameters: {'slug': slug},
     );
   }
 

--- a/test/support/fake_analytics.dart
+++ b/test/support/fake_analytics.dart
@@ -151,8 +151,36 @@ class FakeAnalytics implements Analytics {
       _record('recipe_viewed', {'recipe_id': recipeId});
 
   @override
-  Future<void> logRecipeAddedToMealPlan({required String recipeId}) async =>
-      _record('recipe_added_to_meal_plan', {'recipe_id': recipeId});
+  Future<void> logRecipeAddedToMealPlan({
+    required String recipeId,
+    int dayCount = 1,
+  }) async => _record('recipe_added_to_meal_plan', {
+    'recipe_id': recipeId,
+    'day_count': dayCount,
+  });
+
+  @override
+  Future<void> logRecipeAddedToShoppingList({
+    required String recipeId,
+    required int itemCount,
+  }) async => _record('recipe_added_to_shopping_list', {
+    'recipe_id': recipeId,
+    'item_count': itemCount,
+  });
+
+  @override
+  Future<void> logRecipeSearch({int? queryLength}) async => _record(
+    'recipe_search',
+    {if (queryLength != null) 'query_length': queryLength},
+  );
+
+  @override
+  Future<void> logStartingGuideOpened({required String source}) async =>
+      _record('starting_guide_opened', {'source': source});
+
+  @override
+  Future<void> logStartingGuideArticleViewed({required String slug}) async =>
+      _record('starting_guide_article_viewed', {'slug': slug});
 
   @override
   Future<void> logMealPlanViewed({required int dayCount}) async =>


### PR DESCRIPTION
## Summary

Instruments redesigned Recipe library, detail, and Starting Guide flows for success/intent analytics. PII-free: parameters are recipe IDs, article slugs, source strings, and small primitives only.

## New / extended events

- `logRecipeSearch({int? queryLength})` — fires on empty→non-empty query transition (no `query` param).
- `logStartingGuideOpened({required String source})` — fires on hub mount; `source='unknown'` for now (TODO NIB-53 to pass source via GoRouter extra).
- `logStartingGuideArticleViewed({required String slug})` — fires on article mount.
- `logRecipeAddedToShoppingList({required String recipeId, required int itemCount})` — fires after `addToShoppingList` returns `Result.success`.
- `logRecipeAddedToMealPlan({required String recipeId, int dayCount = 1})` — extended with `dayCount`; fires after `assignToMealPlan` returns `Result.success`.
- `logRecipeViewed({required String recipeId})` — pre-existing, now wired from `recipe_detail_screen` initState postFrameCallback.
- `logScreenView({required String screenName})` — pre-existing, fired for `starting_guide_hub` and `starting_guide_article`.

## Fire sites

- `lib/src/logging/analytics.dart:259-318` — method definitions.
- `lib/src/features/recipe/library/recipe_library_controller.dart:84-95` — `logRecipeSearch` inside `setSearchQuery` (gated on `wasEmpty && trimmed.isNotEmpty`).
- `lib/src/features/recipe/detail/recipe_detail_screen.dart:30-40` — `logRecipeViewed` in initState postFrameCallback.
- `lib/src/features/recipe/detail/recipe_detail_controller.dart:92-99` — `logRecipeAddedToMealPlan(dayCount: normalized.length)` after `Result.success`.
- `lib/src/features/recipe/detail/recipe_detail_controller.dart:117-124` — `logRecipeAddedToShoppingList(itemCount: selectedNames.length)` after `Result.success`.
- `lib/src/features/starting_guide/starting_guide_hub_screen.dart:40-48` — `logStartingGuideOpened(source: 'unknown')` + `logScreenView(screenName: 'starting_guide_hub')`.
- `lib/src/features/starting_guide/starting_guide_article_screen.dart:43-50` — `logStartingGuideArticleViewed(slug: widget.slug)` + `logScreenView(screenName: 'starting_guide_article')`.

All fire sites use `unawaited(...)` to keep analytics fire-and-forget.

## PII confirmation

Params shipped: `recipe_id` (UUID), `slug` (kebab-case), `item_count`/`day_count`/`query_length` (int), `source`/`screen_name` (stable enums). No `query`, `title`, `baby_id`, or free text anywhere.

## Crashlytics non-fatals — deferred

Per spec: NIB-129's `_recipeFromRow` already wraps PostgrestException → ServerException via `Result.failure`, so the existing Result chain covers recipe-mapper failures. Category-mapper handles nulls defensively. Guide content is hardcoded (no remote load). No additional Crashlytics work needed at the repo level.

## Acceptance criteria

- [x] `analytics.dart` exposes 4 new methods + extended `logRecipeAddedToMealPlan({dayCount})`.
- [x] Fire sites for shop-list / meal-plan placed AFTER `Result.success`; intent events on user action / mount.
- [x] PII gate clean.
- [x] `flutter analyze`: 0 issues.
- [x] `flutter test`: 384 passed, 1 pre-existing failure (`recipe_to_shopping_list_integration_test` — NIB-108 owns).
- [x] `make gen`: clean + idempotent (second run = 0 outputs).
- [x] No files outside the allowed list modified (reverted unrelated `home_controller.g.dart` hash drift).

## Gate results

- `make gen` — clean (`Succeeded after 13.5s with 284 outputs`); idempotent (`0 outputs` on rerun).
- `flutter analyze` — `No issues found!`.
- `flutter test` — 384 passed, 1 known pre-existing failure (NIB-108 scope).