### PR TITLE
refactor(home): controller/state rework + screen scaffold w/ placeholders [NIB-86]

### DIFF
--- a/lib/src/features/home/home_controller.dart
+++ b/lib/src/features/home/home_controller.dart
@@ -1,115 +1,60 @@
-import 'dart:math';
-
-import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
-import 'package:nibbles/src/common/domain/entities/recipe.dart';
-import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/common/services/meal_plan_service.dart';
-import 'package:nibbles/src/common/services/recipe_service.dart';
 import 'package:nibbles/src/features/home/home_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'home_controller.g.dart';
 
+/// NIB-86: Redesigned Home dashboard controller.
+///
+/// Parallel-fetches:
+///  1. The current baby profile (NIB-65 header + greeting).
+///  2. Per-allergen derived statuses (NIB-126).
+///  3. Rolling-7 meal plan entries (NIB-59), filtered to today.
+///
+/// A missing baby is NOT an error — the screen renders the full empty-state
+/// placeholder. Allergen or meal-plan fetch failures throw via the existing
+/// pattern and surface as `AsyncValue.error`.
 @riverpod
 class HomeController extends _$HomeController {
   @override
   Future<HomeState> build(String babyId) async {
-    final baby = await ref.read(babyProfileServiceProvider).getBaby();
-    if (baby == null) throw const UnknownException('Baby profile not found.');
-
-    final recipeService = ref.read(recipeServiceProvider);
-
-    final programResult = await ref
+    final babyFut = ref.read(babyProfileServiceProvider).getBaby();
+    final statusesFut = ref
         .read(allergenServiceProvider)
-        .getProgramState(babyId);
-    if (programResult.isFailure) throw programResult.errorOrNull!;
-    final programState = programResult.dataOrNull!;
+        .getAllergenStatuses(babyId);
+    final mealsFut = ref.read(mealPlanServiceProvider).getRolling7(babyId);
 
-    final flaggedResult = await recipeService.getFlaggedAllergenKeys(babyId);
-    final flaggedKeys = flaggedResult.dataOrNull ?? <String>{};
+    final baby = await babyFut;
+    final statusesResult = await statusesFut;
+    final mealsResult = await mealsFut;
 
-    // Get today's meals from this week's plan
+    if (baby == null) {
+      // Empty-state path: no baby yet — surface a successful, empty state so
+      // the screen can render the empty-state placeholder rather than an error.
+      return const HomeState();
+    }
+
+    if (statusesResult.isFailure) throw statusesResult.errorOrNull!;
+    if (mealsResult.isFailure) throw mealsResult.errorOrNull!;
+
+    final statuses =
+        statusesResult.dataOrNull ?? const <String, AllergenStatus>{};
+    final rolling = mealsResult.dataOrNull ?? const <MealPlanEntry>[];
+
     final today = DateTime.now();
-    final weekStart = today.subtract(Duration(days: today.weekday % 7));
-    var todayMeals = <MealPlanEntry>[];
-    final todayRecipes = <Recipe>[];
-    final weekMealsResult = await ref
-        .read(mealPlanServiceProvider)
-        .getWeekMeals(babyId, weekStart);
-    if (weekMealsResult.isSuccess) {
-      todayMeals = weekMealsResult.dataOrNull!
-          .where((MealPlanEntry e) => _isSameDay(e.planDate, today))
-          .toList();
-      for (final meal in todayMeals) {
-        final recipeResult = await recipeService.getRecipeById(meal.recipeId);
-        if (recipeResult.dataOrNull != null) {
-          todayRecipes.add(recipeResult.dataOrNull!);
-        }
-      }
-    }
-
-    AllergenBoardItem? currentBoardItem;
-    var recommendations = <Recipe>[];
-    var generalRecommendations = <Recipe>[];
-
-    if (programState.status != AllergenProgramStatus.completed) {
-      final boardResult = await ref
-          .read(allergenServiceProvider)
-          .getAllergenBoardSummary(babyId);
-      if (boardResult.isSuccess) {
-        currentBoardItem = boardResult.dataOrNull!
-            .where(
-              (AllergenBoardItem item) =>
-                  item.allergen.key == programState.currentAllergenKey,
-            )
-            .firstOrNull;
-      }
-
-      final isAllergenDone =
-          currentBoardItem?.status == AllergenStatus.safe ||
-          currentBoardItem?.status == AllergenStatus.flagged;
-
-      if (isAllergenDone) {
-        final recsResult = await recipeService.getGeneralRecommendations(
-          babyId,
-        );
-        generalRecommendations = recsResult.dataOrNull ?? [];
-      } else {
-        final recsResult = await recipeService.getRecommendationsForAllergen(
-          programState.currentAllergenKey,
-          babyId,
-        );
-        recommendations = recsResult.dataOrNull ?? [];
-
-        // Also fetch randomised general recommendations shown below the
-        // allergen-specific strip when the allergen is still in progress.
-        final allResult = await recipeService.getAllRecipes(babyId);
-        if (allResult.isSuccess) {
-          final all = List<Recipe>.from(allResult.dataOrNull!)
-            ..shuffle(Random());
-          generalRecommendations = all.take(10).toList();
-        }
-      }
-    }
+    final todaysMeals = rolling
+        .where((e) => _isSameDay(e.planDate, today))
+        .toList(growable: false);
 
     return HomeState(
       baby: baby,
-      programState: programState,
-      currentAllergenBoardItem: currentBoardItem,
-      todayMeals: todayMeals,
-      todayRecipes: todayRecipes,
-      recommendations: recommendations,
-      isGeneralRecommendations:
-          currentBoardItem?.status == AllergenStatus.safe ||
-          currentBoardItem?.status == AllergenStatus.flagged,
-      generalRecommendations: generalRecommendations,
-      flaggedAllergenKeys: flaggedKeys,
+      allergenStatuses: statuses,
+      todaysMeals: todaysMeals,
     );
   }
 }

--- a/lib/src/features/home/home_controller.g.dart
+++ b/lib/src/features/home/home_controller.g.dart
@@ -6,7 +6,7 @@ part of 'home_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$homeControllerHash() => r'ba048ff8c2dfa7e39ee80675c53fbdcc1c3cc69e';
+String _$homeControllerHash() => r'3e6824097b5ab3b84f6affc4d44f66de76cffeb8';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -36,16 +36,60 @@ abstract class _$HomeController
   FutureOr<HomeState> build(String babyId);
 }
 
-/// See also [HomeController].
+/// NIB-86: Redesigned Home dashboard controller.
+///
+/// Parallel-fetches:
+///  1. The current baby profile (NIB-65 header + greeting).
+///  2. Per-allergen derived statuses (NIB-126).
+///  3. Rolling-7 meal plan entries (NIB-59), filtered to today.
+///
+/// A missing baby is NOT an error — the screen renders the full empty-state
+/// placeholder. Allergen or meal-plan fetch failures throw via the existing
+/// pattern and surface as `AsyncValue.error`.
+///
+/// Copied from [HomeController].
 @ProviderFor(HomeController)
 const homeControllerProvider = HomeControllerFamily();
 
-/// See also [HomeController].
+/// NIB-86: Redesigned Home dashboard controller.
+///
+/// Parallel-fetches:
+///  1. The current baby profile (NIB-65 header + greeting).
+///  2. Per-allergen derived statuses (NIB-126).
+///  3. Rolling-7 meal plan entries (NIB-59), filtered to today.
+///
+/// A missing baby is NOT an error — the screen renders the full empty-state
+/// placeholder. Allergen or meal-plan fetch failures throw via the existing
+/// pattern and surface as `AsyncValue.error`.
+///
+/// Copied from [HomeController].
 class HomeControllerFamily extends Family<AsyncValue<HomeState>> {
-  /// See also [HomeController].
+  /// NIB-86: Redesigned Home dashboard controller.
+  ///
+  /// Parallel-fetches:
+  ///  1. The current baby profile (NIB-65 header + greeting).
+  ///  2. Per-allergen derived statuses (NIB-126).
+  ///  3. Rolling-7 meal plan entries (NIB-59), filtered to today.
+  ///
+  /// A missing baby is NOT an error — the screen renders the full empty-state
+  /// placeholder. Allergen or meal-plan fetch failures throw via the existing
+  /// pattern and surface as `AsyncValue.error`.
+  ///
+  /// Copied from [HomeController].
   const HomeControllerFamily();
 
-  /// See also [HomeController].
+  /// NIB-86: Redesigned Home dashboard controller.
+  ///
+  /// Parallel-fetches:
+  ///  1. The current baby profile (NIB-65 header + greeting).
+  ///  2. Per-allergen derived statuses (NIB-126).
+  ///  3. Rolling-7 meal plan entries (NIB-59), filtered to today.
+  ///
+  /// A missing baby is NOT an error — the screen renders the full empty-state
+  /// placeholder. Allergen or meal-plan fetch failures throw via the existing
+  /// pattern and surface as `AsyncValue.error`.
+  ///
+  /// Copied from [HomeController].
   HomeControllerProvider call(String babyId) {
     return HomeControllerProvider(babyId);
   }
@@ -72,10 +116,32 @@ class HomeControllerFamily extends Family<AsyncValue<HomeState>> {
   String? get name => r'homeControllerProvider';
 }
 
-/// See also [HomeController].
+/// NIB-86: Redesigned Home dashboard controller.
+///
+/// Parallel-fetches:
+///  1. The current baby profile (NIB-65 header + greeting).
+///  2. Per-allergen derived statuses (NIB-126).
+///  3. Rolling-7 meal plan entries (NIB-59), filtered to today.
+///
+/// A missing baby is NOT an error — the screen renders the full empty-state
+/// placeholder. Allergen or meal-plan fetch failures throw via the existing
+/// pattern and surface as `AsyncValue.error`.
+///
+/// Copied from [HomeController].
 class HomeControllerProvider
     extends AutoDisposeAsyncNotifierProviderImpl<HomeController, HomeState> {
-  /// See also [HomeController].
+  /// NIB-86: Redesigned Home dashboard controller.
+  ///
+  /// Parallel-fetches:
+  ///  1. The current baby profile (NIB-65 header + greeting).
+  ///  2. Per-allergen derived statuses (NIB-126).
+  ///  3. Rolling-7 meal plan entries (NIB-59), filtered to today.
+  ///
+  /// A missing baby is NOT an error — the screen renders the full empty-state
+  /// placeholder. Allergen or meal-plan fetch failures throw via the existing
+  /// pattern and surface as `AsyncValue.error`.
+  ///
+  /// Copied from [HomeController].
   HomeControllerProvider(String babyId)
     : this._internal(
         () => HomeController()..babyId = babyId,

--- a/lib/src/features/home/home_screen.dart
+++ b/lib/src/features/home/home_screen.dart
@@ -1,27 +1,27 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-import 'package:nibbles/src/app/constants/allergen_emoji.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
-import 'package:nibbles/src/common/domain/entities/baby.dart';
-import 'package:nibbles/src/common/domain/entities/recipe.dart';
-import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
-import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
-import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
-import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
-import 'package:nibbles/src/features/allergen/log/allergen_log_controller.dart';
 import 'package:nibbles/src/features/home/home_controller.dart';
 import 'package:nibbles/src/features/home/home_state.dart';
-import 'package:nibbles/src/features/recipe/library/widgets/recipe_grid_card.dart';
-import 'package:nibbles/src/routing/route_enums.dart';
+import 'package:nibbles/src/features/home/widgets/day_chip_row.dart';
+import 'package:nibbles/src/features/home/widgets/greeting_card.dart';
+import 'package:nibbles/src/features/home/widgets/helpful_guidance_card.dart';
+import 'package:nibbles/src/features/home/widgets/home_empty_state_full.dart';
+import 'package:nibbles/src/features/home/widgets/home_header.dart';
+import 'package:nibbles/src/features/home/widgets/ongoing_introduced_card.dart';
+import 'package:nibbles/src/features/home/widgets/stat_ring_card.dart';
+import 'package:nibbles/src/features/home/widgets/todays_meals_card.dart';
 
+/// NIB-86 scaffold.
+///
+/// The screen is intentionally thin: it watches the controller and routes the
+/// resulting [HomeState] into placeholder widgets under `widgets/`. The leaf
+/// implementations land in NIB-65 (header + greeting + stat ring), NIB-77
+/// (ongoing card + day chips + today's meals + guidance) and NIB-96
+/// (empty-state variants).
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
@@ -30,15 +30,15 @@ class HomeScreen extends ConsumerWidget {
     final babyIdAsync = ref.watch(currentBabyIdProvider);
 
     return babyIdAsync.when(
-      loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (_, __) => const Scaffold(
-        body: Center(child: Text('Could not load baby profile.')),
+      loading: () => const _HomeLoadingScaffold(),
+      error: (_, __) => const _HomeErrorScaffold(
+        message: 'Could not load baby profile.',
       ),
       data: (babyId) {
         if (babyId == null) {
           return const Scaffold(
-            body: Center(child: Text('No baby profile found.')),
+            backgroundColor: AppColors.background,
+            body: SafeArea(child: HomeEmptyStateFull()),
           );
         }
         return _HomeBody(babyId: babyId);
@@ -57,11 +57,112 @@ class _HomeBody extends ConsumerWidget {
     final asyncState = ref.watch(homeControllerProvider(babyId));
 
     return asyncState.when(
-      loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (err, _) => Scaffold(
+      loading: () => const _HomeLoadingScaffold(),
+      error: (err, _) => _HomeErrorScaffold(
+        message: err is AppException ? err.message : 'Something went wrong.',
+        onRetry: () => ref.invalidate(homeControllerProvider(babyId)),
+      ),
+      data: (state) => _HomeContent(state: state),
+    );
+  }
+}
+
+class _HomeContent extends StatelessWidget {
+  const _HomeContent({required this.state});
+
+  final HomeState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final baby = state.baby;
+
+    // Full empty-state — no baby OR no logged activity yet.
+    if (baby == null || state.hasNoActivity) {
+      return Scaffold(
         backgroundColor: AppColors.background,
-        body: Center(
+        body: SafeArea(
+          child: HomeEmptyStateFull(babyName: baby?.name),
+        ),
+      );
+    }
+
+    final ageMonths = _monthsBetween(baby.dateOfBirth, DateTime.now());
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+            vertical: AppSizes.pagePaddingV,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              HomeHeader(
+                babyName: baby.name,
+                ageMonths: ageMonths,
+              ),
+              const SizedBox(height: AppSizes.md),
+              GreetingCard(
+                babyName: baby.name,
+                ageMonths: ageMonths,
+              ),
+              const SizedBox(height: AppSizes.md),
+              StatRingCard(
+                safeCount: state.safeCount,
+                flaggedCount: state.flaggedCount,
+                notStartedCount: state.notStartedCount,
+                inProgressCount: state.inProgressCount,
+              ),
+              const SizedBox(height: AppSizes.md),
+              OngoingIntroducedCard(
+                allergenStatuses: state.allergenStatuses,
+              ),
+              const SizedBox(height: AppSizes.md),
+              const DayChipRow(),
+              const SizedBox(height: AppSizes.md),
+              TodaysMealsCard(todaysMeals: state.todaysMeals),
+              const SizedBox(height: AppSizes.md),
+              const HelpfulGuidanceCard(),
+              const SizedBox(height: AppSizes.xl),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  int _monthsBetween(DateTime from, DateTime to) {
+    final raw = (to.year - from.year) * 12 + (to.month - from.month);
+    final adjusted = to.day < from.day ? raw - 1 : raw;
+    return adjusted < 0 ? 0 : adjusted;
+  }
+}
+
+class _HomeLoadingScaffold extends StatelessWidget {
+  const _HomeLoadingScaffold();
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(
+    backgroundColor: AppColors.background,
+    body: Center(child: CircularProgressIndicator()),
+  );
+}
+
+class _HomeErrorScaffold extends StatelessWidget {
+  const _HomeErrorScaffold({required this.message, this.onRetry});
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Center(
           child: Padding(
             padding: const EdgeInsets.all(AppSizes.pagePaddingH),
             child: Column(
@@ -74,872 +175,24 @@ class _HomeBody extends ConsumerWidget {
                 ),
                 const SizedBox(height: AppSizes.md),
                 Text(
-                  err is AppException ? err.message : 'Something went wrong.',
+                  message,
                   textAlign: TextAlign.center,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
+                  style: textTheme.bodyLarge?.copyWith(
+                    color: AppColors.subtext,
+                  ),
                 ),
-                const SizedBox(height: AppSizes.lg),
-                FilledButton(
-                  onPressed: () =>
-                      ref.invalidate(homeControllerProvider(babyId)),
-                  child: const Text('Try Again'),
-                ),
+                if (onRetry != null) ...[
+                  const SizedBox(height: AppSizes.lg),
+                  FilledButton(
+                    onPressed: onRetry,
+                    child: const Text('Try Again'),
+                  ),
+                ],
               ],
             ),
           ),
         ),
       ),
-      data: (state) => _HomeContent(babyId: babyId, state: state),
-    );
-  }
-}
-
-class _HomeContent extends ConsumerWidget {
-  const _HomeContent({required this.babyId, required this.state});
-
-  final String babyId;
-  final HomeState state;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      body: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  AppSizes.pagePaddingH,
-                  AppSizes.pagePaddingV,
-                  AppSizes.pagePaddingH,
-                  0,
-                ),
-                child: _Header(baby: state.baby),
-              ),
-            ),
-            const SliverToBoxAdapter(child: SizedBox(height: AppSizes.md)),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.pagePaddingH,
-                ),
-                child: _AllergenWidget(
-                  babyId: babyId,
-                  state: state,
-                  onLogFood: () => _openLogSheet(context, ref, state),
-                  onProceedToNext: () => _proceedToNext(context, ref),
-                ),
-              ),
-            ),
-            const SliverToBoxAdapter(child: SizedBox(height: AppSizes.md)),
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.pagePaddingH,
-                ),
-                child: _TodayMealCard(
-                  babyId: babyId,
-                  state: state,
-                  flaggedAllergenKeys: state.flaggedAllergenKeys,
-                ),
-              ),
-            ),
-            if (_showRecommendations(state)) ...[
-              const SliverToBoxAdapter(child: SizedBox(height: AppSizes.md)),
-              SliverToBoxAdapter(
-                child: _RecommendationsStrip(
-                  state: state,
-                  flaggedAllergenKeys: state.flaggedAllergenKeys,
-                ),
-              ),
-            ],
-            if (_showGeneralGrid(state)) ...[
-              const SliverToBoxAdapter(child: SizedBox(height: AppSizes.md)),
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSizes.pagePaddingH,
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                        state.isGeneralRecommendations
-                            ? 'Recipes for You 🍽️'
-                            : 'General Recommendations 🍽️',
-                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                      TextButton(
-                        onPressed: () =>
-                            context.goNamed(AppRoute.recipeLibrary.name),
-                        style: TextButton.styleFrom(
-                          padding: EdgeInsets.zero,
-                          minimumSize: Size.zero,
-                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        ),
-                        child: const Text('See All'),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              const SliverToBoxAdapter(child: SizedBox(height: AppSizes.sm)),
-              SliverPadding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.pagePaddingH,
-                ),
-                sliver: SliverGrid(
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    crossAxisSpacing: AppSizes.sm,
-                    mainAxisSpacing: AppSizes.sm,
-                    childAspectRatio: 0.72,
-                  ),
-                  delegate: SliverChildBuilderDelegate((context, index) {
-                    final recipe = state.generalRecommendations[index];
-                    return RecipeGridCard(
-                      recipe: recipe,
-                      flaggedAllergenKeys: state.flaggedAllergenKeys,
-                      onTap: () => context.pushNamed(
-                        AppRoute.recipeDetail.name,
-                        pathParameters: {'recipeId': recipe.id},
-                      ),
-                    );
-                  }, childCount: state.generalRecommendations.length),
-                ),
-              ),
-            ],
-            const SliverToBoxAdapter(child: SizedBox(height: AppSizes.xl)),
-          ],
-        ),
-      ),
-    );
-  }
-
-  bool _showRecommendations(HomeState state) {
-    return state.programState.status != AllergenProgramStatus.completed &&
-        !state.isGeneralRecommendations &&
-        state.recommendations.isNotEmpty;
-  }
-
-  bool _showGeneralGrid(HomeState state) {
-    return state.programState.status != AllergenProgramStatus.completed &&
-        state.generalRecommendations.isNotEmpty;
-  }
-
-  Future<void> _proceedToNext(BuildContext context, WidgetRef ref) async {
-    final result = await ref
-        .read(allergenServiceProvider)
-        .advanceToNextAllergen(babyId);
-    result.when(
-      success: (_) => ref.invalidate(homeControllerProvider(babyId)),
-      failure: (_) {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text("Couldn't advance. Please try again."),
-            ),
-          );
-        }
-      },
-    );
-  }
-
-  Future<void> _openLogSheet(
-    BuildContext context,
-    WidgetRef ref,
-    HomeState state,
-  ) async {
-    final boardItem = state.currentAllergenBoardItem;
-    if (boardItem == null) return;
-
-    final logged = await context.pushNamed<bool>(
-      AppRoute.allergenLogCreate.name,
-      pathParameters: {'allergenKey': boardItem.allergen.key},
-    );
-
-    if (logged ?? false) {
-      ref.invalidate(homeControllerProvider(babyId));
-
-      // If a reaction was logged, show GP referral dialog. The capture
-      // controller is keepAlive so its last state survives the route pop.
-      final logState = ref.read(allergenLogControllerProvider);
-      if (logState.hadReaction == true && context.mounted) {
-        await showDialog<void>(
-          context: context,
-          builder: (_) => const _GpReferralDialog(),
-        );
-      }
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Header
-// ---------------------------------------------------------------------------
-
-class _Header extends StatelessWidget {
-  const _Header({required this.baby});
-
-  final Baby baby;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return Row(
-      children: [
-        // Left: greeting
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              "Hi, ${baby.name}'s Parents 👋",
-              style: textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            Text(
-              _ageStageLabel(baby.dateOfBirth),
-              style: textTheme.bodySmall?.copyWith(color: AppColors.subtext),
-            ),
-          ],
-        ),
-        const Spacer(),
-        // Right: profile avatar
-        Builder(
-          builder: (context) => GestureDetector(
-            onTap: () => context.pushNamed(AppRoute.profile.name),
-            child: Container(
-              width: AppSizes.avatarSm,
-              height: AppSizes.avatarSm,
-              decoration: const BoxDecoration(
-                color: AppColors.primaryLight,
-                shape: BoxShape.circle,
-              ),
-              child: Center(
-                child: Text(
-                  baby.name.isNotEmpty ? baby.name[0].toUpperCase() : '?',
-                  style: const TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.bold,
-                    color: AppColors.primaryDark,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  String _ageStageLabel(DateTime dob) {
-    final months =
-        (DateTime.now().year - dob.year) * 12 +
-        DateTime.now().month -
-        dob.month;
-    if (months < 6) return 'Under 6 months';
-    if (months < 9) return '6–9 months';
-    if (months < 12) return '9–12 months';
-    if (months < 18) return '12–18 months';
-    if (months < 24) return '18–24 months';
-    return '2+ years';
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Allergen Widget — 3 states
-// ---------------------------------------------------------------------------
-
-class _AllergenWidget extends StatelessWidget {
-  const _AllergenWidget({
-    required this.babyId,
-    required this.state,
-    required this.onLogFood,
-    required this.onProceedToNext,
-  });
-
-  final String babyId;
-  final HomeState state;
-  final VoidCallback onLogFood;
-  final VoidCallback onProceedToNext;
-
-  @override
-  Widget build(BuildContext context) {
-    // State C — program complete
-    if (state.programState.status == AllergenProgramStatus.completed) {
-      return _CompletionBanner(babyName: state.baby.name);
-    }
-
-    final boardItem = state.currentAllergenBoardItem;
-    if (boardItem == null) return const SizedBox.shrink();
-
-    return GestureDetector(
-      onTap: () => context.pushNamed(AppRoute.allergenTracker.name),
-      child: _ActiveAllergenCard(
-        boardItem: boardItem,
-        onLogFood: onLogFood,
-        onProceedToNext: onProceedToNext,
-      ),
-    );
-  }
-}
-
-class _CompletionBanner extends StatelessWidget {
-  const _CompletionBanner({required this.babyName});
-
-  final String babyName;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return GestureDetector(
-      onTap: () => context.pushNamed(AppRoute.profile.name),
-      child: Container(
-        padding: const EdgeInsets.all(AppSizes.cardPadding),
-        decoration: BoxDecoration(
-          color: AppColors.primary.withValues(alpha: 0.1),
-          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-          border: Border.all(color: AppColors.primary, width: 1.5),
-        ),
-        child: Row(
-          children: [
-            const Text('🎉', style: TextStyle(fontSize: 28)),
-            const SizedBox(width: AppSizes.sm),
-            Expanded(
-              child: Text(
-                '$babyName has completed the allergen program! '
-                'All discovered safe allergens are in your Profile.',
-                style: textTheme.bodyMedium?.copyWith(
-                  color: AppColors.primaryDark,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-            ),
-            const Icon(
-              Icons.chevron_right,
-              color: AppColors.primary,
-              size: AppSizes.iconMd,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _ActiveAllergenCard extends StatelessWidget {
-  const _ActiveAllergenCard({
-    required this.boardItem,
-    required this.onLogFood,
-    required this.onProceedToNext,
-  });
-
-  final AllergenBoardItem boardItem;
-  final VoidCallback onLogFood;
-  final VoidCallback onProceedToNext;
-
-  String _progressCopy(int logCount, bool isSafe, bool isFlagged) {
-    if (isSafe) return 'All 3 exposures done — no reaction! 🎉';
-    if (isFlagged) return 'Reaction detected — you can skip to the next one.';
-    if (logCount == 0) return 'Feed 3 times over a few days to confirm safe.';
-    if (logCount == 1) return '2 more exposures needed — keep going!';
-    return '1 more exposure to go — almost there!';
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final logs = boardItem.logs;
-    final allergen = boardItem.allergen;
-    final logCount = min(logs.length, 3);
-    final isSafe = boardItem.status == AllergenStatus.safe;
-    final isFlagged = boardItem.status == AllergenStatus.flagged;
-    final lastLog = logs.isEmpty
-        ? null
-        : (List<AllergenLog>.from(
-            logs,
-          )..sort((a, b) => b.logDate.compareTo(a.logDate))).first;
-
-    return Container(
-      padding: const EdgeInsets.all(AppSizes.cardPadding),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.06),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Eyebrow label
-          Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSizes.sm,
-              vertical: 3,
-            ),
-            decoration: BoxDecoration(
-              color: isFlagged
-                  ? AppColors.warning.withValues(alpha: 0.15)
-                  : isSafe
-                  ? AppColors.success.withValues(alpha: 0.15)
-                  : AppColors.primary.withValues(alpha: 0.12),
-              borderRadius: BorderRadius.circular(AppSizes.radiusSm),
-            ),
-            child: Text(
-              isFlagged
-                  ? '⚠️ Reaction flagged'
-                  : isSafe
-                  ? '✅ Allergen safe'
-                  : '🧪 Now introducing',
-              style: textTheme.labelSmall?.copyWith(
-                color: isFlagged
-                    ? AppColors.warning
-                    : isSafe
-                    ? AppColors.success
-                    : AppColors.primary,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0.3,
-              ),
-            ),
-          ),
-          const SizedBox(height: AppSizes.sm),
-          // Allergen header
-          Row(
-            children: [
-              Text(allergen.emoji, style: const TextStyle(fontSize: 32)),
-              const SizedBox(width: AppSizes.sm),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      allergen.name,
-                      style: textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    Text(
-                      '$logCount of 3 exposures logged',
-                      style: textTheme.bodySmall?.copyWith(
-                        color: AppColors.subtext,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              // Tap hint
-              const Icon(
-                Icons.chevron_right,
-                color: AppColors.subtext,
-                size: AppSizes.iconSm,
-              ),
-            ],
-          ),
-          const SizedBox(height: AppSizes.md),
-          // Introduction dots (3 required logs)
-          _IntroductionDots(logs: logs),
-          const SizedBox(height: AppSizes.sm),
-          // Progress copy
-          Text(
-            _progressCopy(logCount, isSafe, isFlagged),
-            style: textTheme.bodySmall?.copyWith(color: AppColors.subtext),
-          ),
-          // Last log summary
-          if (lastLog != null) ...[
-            const SizedBox(height: AppSizes.xs),
-            Text(
-              lastLog.hadReaction
-                  ? 'Last log: Had Reaction ⚠️'
-                  : 'Last log: No Reaction ✅',
-              style: textTheme.bodySmall?.copyWith(
-                color: AppColors.subtext,
-                fontStyle: FontStyle.italic,
-              ),
-            ),
-          ],
-          const SizedBox(height: AppSizes.md),
-          SizedBox(
-            width: double.infinity,
-            child: isSafe
-                ? FilledButton(
-                    key: const Key('proceed_next_button'),
-                    onPressed: onProceedToNext,
-                    child: const Text('Proceed to Next Allergen'),
-                  )
-                : isFlagged
-                ? FilledButton(
-                    key: const Key('skip_next_button'),
-                    onPressed: onProceedToNext,
-                    style: FilledButton.styleFrom(
-                      backgroundColor: AppColors.warning,
-                    ),
-                    child: const Text('Skip to Next Allergen'),
-                  )
-                : FilledButton(
-                    key: const Key('log_food_button'),
-                    onPressed: onLogFood,
-                    child: const Text('Log Food Today'),
-                  ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _IntroductionDots extends StatelessWidget {
-  const _IntroductionDots({required this.logs});
-
-  final List<AllergenLog> logs;
-
-  String _tasteEmoji(EmojiTaste taste) => switch (taste) {
-    EmojiTaste.love => '😍',
-    EmojiTaste.neutral => '😐',
-    EmojiTaste.dislike => '😣',
-  };
-
-  @override
-  Widget build(BuildContext context) {
-    final sorted = List<AllergenLog>.from(logs)
-      ..sort((a, b) => a.logDate.compareTo(b.logDate));
-    final capped = sorted.length > 3 ? sorted.sublist(0, 3) : sorted;
-    return Row(
-      children: List.generate(3, (i) {
-        final log = i < capped.length ? capped[i] : null;
-        final filled = log != null;
-        final isReaction = log?.hadReaction ?? false;
-        final dotColor = !filled
-            ? AppColors.surfaceVariant
-            : isReaction
-            ? AppColors.allergenFlagged
-            : AppColors.allergenSafe;
-        final borderColor = !filled ? AppColors.divider : dotColor;
-
-        return Padding(
-          padding: const EdgeInsets.only(right: AppSizes.sm),
-          child: Container(
-            width: 28,
-            height: 28,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: dotColor,
-              border: Border.all(color: borderColor, width: 1.5),
-            ),
-            child: filled
-                ? Center(
-                    child: Text(
-                      isReaction
-                          ? '⚠️'
-                          : _tasteEmoji(log.emojiTaste ?? EmojiTaste.neutral),
-                      style: const TextStyle(fontSize: 14),
-                    ),
-                  )
-                : null,
-          ),
-        );
-      }),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// GP Referral Dialog — shown after a reaction is logged
-// ---------------------------------------------------------------------------
-
-class _GpReferralDialog extends StatelessWidget {
-  const _GpReferralDialog();
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return AlertDialog(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-      ),
-      icon: const Icon(
-        Icons.local_hospital_outlined,
-        color: AppColors.warning,
-        size: AppSizes.iconXl,
-      ),
-      title: Text(
-        'Reaction Recorded',
-        style: textTheme.titleLarge,
-        textAlign: TextAlign.center,
-      ),
-      content: Text(
-        'A reaction has been logged for this allergen. '
-        'We recommend consulting your GP or paediatrician '
-        'before continuing exposure.',
-        style: textTheme.bodyMedium?.copyWith(color: AppColors.subtext),
-        textAlign: TextAlign.center,
-      ),
-      actions: [
-        SizedBox(
-          width: double.infinity,
-          child: FilledButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Understood'),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Today's Meal Card
-// ---------------------------------------------------------------------------
-
-class _TodayMealCard extends StatelessWidget {
-  const _TodayMealCard({
-    required this.babyId,
-    required this.state,
-    this.flaggedAllergenKeys = const {},
-  });
-
-  final String babyId;
-  final HomeState state;
-  final Set<String> flaggedAllergenKeys;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return Container(
-      padding: const EdgeInsets.all(AppSizes.cardPadding),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.06),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            "Today's Meal",
-            style: textTheme.titleSmall?.copyWith(
-              fontWeight: FontWeight.w700,
-              color: AppColors.subtext,
-            ),
-          ),
-          const SizedBox(height: AppSizes.sm),
-          if (state.todayRecipes.isNotEmpty)
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children:
-                  state.todayRecipes
-                      .expand(
-                        (r) => [
-                          _FilledMealCard(
-                            recipe: r,
-                            flaggedAllergenKeys: flaggedAllergenKeys,
-                          ),
-                          const SizedBox(height: AppSizes.sm),
-                        ],
-                      )
-                      .toList()
-                    ..removeLast(),
-            )
-          else
-            _EmptyMealCard(),
-        ],
-      ),
-    );
-  }
-}
-
-class _FilledMealCard extends StatelessWidget {
-  const _FilledMealCard({
-    required this.recipe,
-    this.flaggedAllergenKeys = const {},
-  });
-
-  final Recipe recipe;
-  final Set<String> flaggedAllergenKeys;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final flaggedTags = recipe.allergenTags
-        .where(flaggedAllergenKeys.contains)
-        .toList();
-    final isUnsafe = flaggedTags.isNotEmpty;
-
-    return GestureDetector(
-      onTap: () => context.pushNamed(
-        AppRoute.recipeDetail.name,
-        pathParameters: {'recipeId': recipe.id},
-      ),
-      behavior: HitTestBehavior.opaque,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            recipe.title,
-            style: textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600),
-          ),
-          if (recipe.allergenTags.isNotEmpty) ...[
-            const SizedBox(height: AppSizes.xs),
-            Wrap(
-              spacing: AppSizes.xs,
-              children: recipe.allergenTags.map((tag) {
-                final emoji = AllergenEmoji.get(tag);
-                final isFlagged = flaggedAllergenKeys.contains(tag);
-                return Chip(
-                  label: Text('$emoji $tag'),
-                  labelStyle: textTheme.labelSmall?.copyWith(
-                    color: isFlagged ? AppColors.allergenFlagged : null,
-                    fontWeight: isFlagged ? FontWeight.w700 : null,
-                  ),
-                  padding: EdgeInsets.zero,
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  backgroundColor: isFlagged
-                      ? AppColors.allergenFlagged.withValues(alpha: 0.1)
-                      : AppColors.surfaceVariant,
-                  side: isFlagged
-                      ? BorderSide(
-                          color: AppColors.allergenFlagged.withValues(
-                            alpha: 0.4,
-                          ),
-                        )
-                      : BorderSide.none,
-                );
-              }).toList(),
-            ),
-          ],
-          if (isUnsafe) ...[
-            const SizedBox(height: AppSizes.xs),
-            Row(
-              children: [
-                const Icon(
-                  Icons.warning_amber_rounded,
-                  size: 14,
-                  color: AppColors.allergenFlagged,
-                ),
-                const SizedBox(width: AppSizes.xs),
-                Text(
-                  'Contains flagged allergen',
-                  style: textTheme.labelSmall?.copyWith(
-                    color: AppColors.allergenFlagged,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _EmptyMealCard extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'No meal planned for today. Add one to get started.',
-          style: textTheme.bodyMedium?.copyWith(color: AppColors.subtext),
-        ),
-        const SizedBox(height: AppSizes.sm),
-        TextButton(
-          onPressed: () => context.goNamed(AppRoute.mealPlan.name),
-          child: const Text('Plan a Meal'),
-        ),
-      ],
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Recommendations Strip
-// ---------------------------------------------------------------------------
-
-class _RecommendationsStrip extends StatelessWidget {
-  const _RecommendationsStrip({
-    required this.state,
-    this.flaggedAllergenKeys = const {},
-  });
-
-  final HomeState state;
-  final Set<String> flaggedAllergenKeys;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final allergenKey = state.programState.currentAllergenKey;
-    final allergenEmoji = AllergenEmoji.get(allergenKey);
-    final allergenName =
-        state.currentAllergenBoardItem?.allergen.name ??
-        allergenKey.replaceAll('_', ' ');
-    final title = state.isGeneralRecommendations
-        ? 'Recipes for You 🍽️'
-        : 'Recommended for $allergenName $allergenEmoji';
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
-          ),
-          child: Text(
-            title,
-            style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
-          ),
-        ),
-        const SizedBox(height: AppSizes.sm),
-        SizedBox(
-          height: 226,
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSizes.pagePaddingH,
-              vertical: AppSizes.xs,
-            ),
-            itemCount: state.recommendations.length,
-            separatorBuilder: (_, __) => const SizedBox(width: AppSizes.sm),
-            itemBuilder: (context, index) {
-              final recipe = state.recommendations[index];
-              return SizedBox(
-                width: 140,
-                child: RecipeGridCard(
-                  recipe: recipe,
-                  flaggedAllergenKeys: flaggedAllergenKeys,
-                  onTap: () => context.pushNamed(
-                    AppRoute.recipeDetail.name,
-                    pathParameters: {'recipeId': recipe.id},
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/src/features/home/home_state.dart
+++ b/lib/src/features/home/home_state.dart
@@ -1,23 +1,59 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
-import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 
 part 'home_state.freezed.dart';
 
+/// Reshaped per NIB-86 (NIB-120 Home redesign):
+///
+/// - `baby`: nullable so empty-state can render without throwing.
+/// - `allergenStatuses`: derived per-allergen statuses (NIB-126). Always
+///   contains all 9 canonical keys.
+/// - `todaysMeals`: rolling-7 entries (NIB-59) filtered to today.
+///
+/// Legacy fields (`programState`, `recommendations`, `todayRecipes`,
+/// `currentAllergenBoardItem`, `isGeneralRecommendations`,
+/// `generalRecommendations`, `flaggedAllergenKeys`) are dropped — no remaining
+/// consumers exist after the `home_screen` rewrite.
 @freezed
 class HomeState with _$HomeState {
   const factory HomeState({
-    required Baby baby,
-    required AllergenProgramState programState,
-    required List<Recipe> recommendations,
-    AllergenBoardItem? currentAllergenBoardItem,
-    @Default([]) List<MealPlanEntry> todayMeals,
-    @Default([]) List<Recipe> todayRecipes,
-    @Default(false) bool isGeneralRecommendations,
-    @Default([]) List<Recipe> generalRecommendations,
-    @Default(<String>{}) Set<String> flaggedAllergenKeys,
+    Baby? baby,
+    @Default(<String, AllergenStatus>{})
+    Map<String, AllergenStatus> allergenStatuses,
+    @Default(<MealPlanEntry>[]) List<MealPlanEntry> todaysMeals,
   }) = _HomeState;
+
+  const HomeState._();
+
+  /// Count of allergens in [AllergenStatus.safe].
+  int get safeCount =>
+      allergenStatuses.values.where((s) => s == AllergenStatus.safe).length;
+
+  /// Count of allergens in [AllergenStatus.flagged].
+  int get flaggedCount =>
+      allergenStatuses.values.where((s) => s == AllergenStatus.flagged).length;
+
+  /// Count of allergens in [AllergenStatus.notStarted].
+  int get notStartedCount => allergenStatuses.values
+      .where((s) => s == AllergenStatus.notStarted)
+      .length;
+
+  /// Count of allergens currently being introduced.
+  int get inProgressCount => allergenStatuses.values
+      .where((s) => s == AllergenStatus.inProgress)
+      .length;
+
+  /// Today's meal count.
+  int get todayMealCount => todaysMeals.length;
+
+  /// True when the baby exists but has zero allergen logs (everything still
+  /// [AllergenStatus.notStarted]) and no meals planned. Drives the full
+  /// empty-state placeholder.
+  bool get hasNoActivity =>
+      todayMealCount == 0 &&
+      safeCount == 0 &&
+      flaggedCount == 0 &&
+      inProgressCount == 0;
 }

--- a/lib/src/features/home/home_state.freezed.dart
+++ b/lib/src/features/home/home_state.freezed.dart
@@ -17,16 +17,10 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$HomeState {
-  Baby get baby => throw _privateConstructorUsedError;
-  AllergenProgramState get programState => throw _privateConstructorUsedError;
-  List<Recipe> get recommendations => throw _privateConstructorUsedError;
-  AllergenBoardItem? get currentAllergenBoardItem =>
+  Baby? get baby => throw _privateConstructorUsedError;
+  Map<String, AllergenStatus> get allergenStatuses =>
       throw _privateConstructorUsedError;
-  List<MealPlanEntry> get todayMeals => throw _privateConstructorUsedError;
-  List<Recipe> get todayRecipes => throw _privateConstructorUsedError;
-  bool get isGeneralRecommendations => throw _privateConstructorUsedError;
-  List<Recipe> get generalRecommendations => throw _privateConstructorUsedError;
-  Set<String> get flaggedAllergenKeys => throw _privateConstructorUsedError;
+  List<MealPlanEntry> get todaysMeals => throw _privateConstructorUsedError;
 
   /// Create a copy of HomeState
   /// with the given fields replaced by the non-null parameter values.
@@ -41,20 +35,12 @@ abstract class $HomeStateCopyWith<$Res> {
       _$HomeStateCopyWithImpl<$Res, HomeState>;
   @useResult
   $Res call({
-    Baby baby,
-    AllergenProgramState programState,
-    List<Recipe> recommendations,
-    AllergenBoardItem? currentAllergenBoardItem,
-    List<MealPlanEntry> todayMeals,
-    List<Recipe> todayRecipes,
-    bool isGeneralRecommendations,
-    List<Recipe> generalRecommendations,
-    Set<String> flaggedAllergenKeys,
+    Baby? baby,
+    Map<String, AllergenStatus> allergenStatuses,
+    List<MealPlanEntry> todaysMeals,
   });
 
-  $BabyCopyWith<$Res> get baby;
-  $AllergenProgramStateCopyWith<$Res> get programState;
-  $AllergenBoardItemCopyWith<$Res>? get currentAllergenBoardItem;
+  $BabyCopyWith<$Res>? get baby;
 }
 
 /// @nodoc
@@ -72,54 +58,24 @@ class _$HomeStateCopyWithImpl<$Res, $Val extends HomeState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? baby = null,
-    Object? programState = null,
-    Object? recommendations = null,
-    Object? currentAllergenBoardItem = freezed,
-    Object? todayMeals = null,
-    Object? todayRecipes = null,
-    Object? isGeneralRecommendations = null,
-    Object? generalRecommendations = null,
-    Object? flaggedAllergenKeys = null,
+    Object? baby = freezed,
+    Object? allergenStatuses = null,
+    Object? todaysMeals = null,
   }) {
     return _then(
       _value.copyWith(
-            baby: null == baby
+            baby: freezed == baby
                 ? _value.baby
                 : baby // ignore: cast_nullable_to_non_nullable
-                      as Baby,
-            programState: null == programState
-                ? _value.programState
-                : programState // ignore: cast_nullable_to_non_nullable
-                      as AllergenProgramState,
-            recommendations: null == recommendations
-                ? _value.recommendations
-                : recommendations // ignore: cast_nullable_to_non_nullable
-                      as List<Recipe>,
-            currentAllergenBoardItem: freezed == currentAllergenBoardItem
-                ? _value.currentAllergenBoardItem
-                : currentAllergenBoardItem // ignore: cast_nullable_to_non_nullable
-                      as AllergenBoardItem?,
-            todayMeals: null == todayMeals
-                ? _value.todayMeals
-                : todayMeals // ignore: cast_nullable_to_non_nullable
+                      as Baby?,
+            allergenStatuses: null == allergenStatuses
+                ? _value.allergenStatuses
+                : allergenStatuses // ignore: cast_nullable_to_non_nullable
+                      as Map<String, AllergenStatus>,
+            todaysMeals: null == todaysMeals
+                ? _value.todaysMeals
+                : todaysMeals // ignore: cast_nullable_to_non_nullable
                       as List<MealPlanEntry>,
-            todayRecipes: null == todayRecipes
-                ? _value.todayRecipes
-                : todayRecipes // ignore: cast_nullable_to_non_nullable
-                      as List<Recipe>,
-            isGeneralRecommendations: null == isGeneralRecommendations
-                ? _value.isGeneralRecommendations
-                : isGeneralRecommendations // ignore: cast_nullable_to_non_nullable
-                      as bool,
-            generalRecommendations: null == generalRecommendations
-                ? _value.generalRecommendations
-                : generalRecommendations // ignore: cast_nullable_to_non_nullable
-                      as List<Recipe>,
-            flaggedAllergenKeys: null == flaggedAllergenKeys
-                ? _value.flaggedAllergenKeys
-                : flaggedAllergenKeys // ignore: cast_nullable_to_non_nullable
-                      as Set<String>,
           )
           as $Val,
     );
@@ -129,35 +85,13 @@ class _$HomeStateCopyWithImpl<$Res, $Val extends HomeState>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  $BabyCopyWith<$Res> get baby {
-    return $BabyCopyWith<$Res>(_value.baby, (value) {
-      return _then(_value.copyWith(baby: value) as $Val);
-    });
-  }
-
-  /// Create a copy of HomeState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $AllergenProgramStateCopyWith<$Res> get programState {
-    return $AllergenProgramStateCopyWith<$Res>(_value.programState, (value) {
-      return _then(_value.copyWith(programState: value) as $Val);
-    });
-  }
-
-  /// Create a copy of HomeState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $AllergenBoardItemCopyWith<$Res>? get currentAllergenBoardItem {
-    if (_value.currentAllergenBoardItem == null) {
+  $BabyCopyWith<$Res>? get baby {
+    if (_value.baby == null) {
       return null;
     }
 
-    return $AllergenBoardItemCopyWith<$Res>(_value.currentAllergenBoardItem!, (
-      value,
-    ) {
-      return _then(_value.copyWith(currentAllergenBoardItem: value) as $Val);
+    return $BabyCopyWith<$Res>(_value.baby!, (value) {
+      return _then(_value.copyWith(baby: value) as $Val);
     });
   }
 }
@@ -172,23 +106,13 @@ abstract class _$$HomeStateImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    Baby baby,
-    AllergenProgramState programState,
-    List<Recipe> recommendations,
-    AllergenBoardItem? currentAllergenBoardItem,
-    List<MealPlanEntry> todayMeals,
-    List<Recipe> todayRecipes,
-    bool isGeneralRecommendations,
-    List<Recipe> generalRecommendations,
-    Set<String> flaggedAllergenKeys,
+    Baby? baby,
+    Map<String, AllergenStatus> allergenStatuses,
+    List<MealPlanEntry> todaysMeals,
   });
 
   @override
-  $BabyCopyWith<$Res> get baby;
-  @override
-  $AllergenProgramStateCopyWith<$Res> get programState;
-  @override
-  $AllergenBoardItemCopyWith<$Res>? get currentAllergenBoardItem;
+  $BabyCopyWith<$Res>? get baby;
 }
 
 /// @nodoc
@@ -205,54 +129,24 @@ class __$$HomeStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? baby = null,
-    Object? programState = null,
-    Object? recommendations = null,
-    Object? currentAllergenBoardItem = freezed,
-    Object? todayMeals = null,
-    Object? todayRecipes = null,
-    Object? isGeneralRecommendations = null,
-    Object? generalRecommendations = null,
-    Object? flaggedAllergenKeys = null,
+    Object? baby = freezed,
+    Object? allergenStatuses = null,
+    Object? todaysMeals = null,
   }) {
     return _then(
       _$HomeStateImpl(
-        baby: null == baby
+        baby: freezed == baby
             ? _value.baby
             : baby // ignore: cast_nullable_to_non_nullable
-                  as Baby,
-        programState: null == programState
-            ? _value.programState
-            : programState // ignore: cast_nullable_to_non_nullable
-                  as AllergenProgramState,
-        recommendations: null == recommendations
-            ? _value._recommendations
-            : recommendations // ignore: cast_nullable_to_non_nullable
-                  as List<Recipe>,
-        currentAllergenBoardItem: freezed == currentAllergenBoardItem
-            ? _value.currentAllergenBoardItem
-            : currentAllergenBoardItem // ignore: cast_nullable_to_non_nullable
-                  as AllergenBoardItem?,
-        todayMeals: null == todayMeals
-            ? _value._todayMeals
-            : todayMeals // ignore: cast_nullable_to_non_nullable
+                  as Baby?,
+        allergenStatuses: null == allergenStatuses
+            ? _value._allergenStatuses
+            : allergenStatuses // ignore: cast_nullable_to_non_nullable
+                  as Map<String, AllergenStatus>,
+        todaysMeals: null == todaysMeals
+            ? _value._todaysMeals
+            : todaysMeals // ignore: cast_nullable_to_non_nullable
                   as List<MealPlanEntry>,
-        todayRecipes: null == todayRecipes
-            ? _value._todayRecipes
-            : todayRecipes // ignore: cast_nullable_to_non_nullable
-                  as List<Recipe>,
-        isGeneralRecommendations: null == isGeneralRecommendations
-            ? _value.isGeneralRecommendations
-            : isGeneralRecommendations // ignore: cast_nullable_to_non_nullable
-                  as bool,
-        generalRecommendations: null == generalRecommendations
-            ? _value._generalRecommendations
-            : generalRecommendations // ignore: cast_nullable_to_non_nullable
-                  as List<Recipe>,
-        flaggedAllergenKeys: null == flaggedAllergenKeys
-            ? _value._flaggedAllergenKeys
-            : flaggedAllergenKeys // ignore: cast_nullable_to_non_nullable
-                  as Set<String>,
       ),
     );
   }
@@ -260,81 +154,39 @@ class __$$HomeStateImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$HomeStateImpl implements _HomeState {
+class _$HomeStateImpl extends _HomeState {
   const _$HomeStateImpl({
-    required this.baby,
-    required this.programState,
-    required final List<Recipe> recommendations,
-    this.currentAllergenBoardItem,
-    final List<MealPlanEntry> todayMeals = const [],
-    final List<Recipe> todayRecipes = const [],
-    this.isGeneralRecommendations = false,
-    final List<Recipe> generalRecommendations = const [],
-    final Set<String> flaggedAllergenKeys = const <String>{},
-  }) : _recommendations = recommendations,
-       _todayMeals = todayMeals,
-       _todayRecipes = todayRecipes,
-       _generalRecommendations = generalRecommendations,
-       _flaggedAllergenKeys = flaggedAllergenKeys;
+    this.baby,
+    final Map<String, AllergenStatus> allergenStatuses =
+        const <String, AllergenStatus>{},
+    final List<MealPlanEntry> todaysMeals = const <MealPlanEntry>[],
+  }) : _allergenStatuses = allergenStatuses,
+       _todaysMeals = todaysMeals,
+       super._();
 
   @override
-  final Baby baby;
+  final Baby? baby;
+  final Map<String, AllergenStatus> _allergenStatuses;
   @override
-  final AllergenProgramState programState;
-  final List<Recipe> _recommendations;
-  @override
-  List<Recipe> get recommendations {
-    if (_recommendations is EqualUnmodifiableListView) return _recommendations;
+  @JsonKey()
+  Map<String, AllergenStatus> get allergenStatuses {
+    if (_allergenStatuses is EqualUnmodifiableMapView) return _allergenStatuses;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_recommendations);
+    return EqualUnmodifiableMapView(_allergenStatuses);
   }
 
-  @override
-  final AllergenBoardItem? currentAllergenBoardItem;
-  final List<MealPlanEntry> _todayMeals;
+  final List<MealPlanEntry> _todaysMeals;
   @override
   @JsonKey()
-  List<MealPlanEntry> get todayMeals {
-    if (_todayMeals is EqualUnmodifiableListView) return _todayMeals;
+  List<MealPlanEntry> get todaysMeals {
+    if (_todaysMeals is EqualUnmodifiableListView) return _todaysMeals;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_todayMeals);
-  }
-
-  final List<Recipe> _todayRecipes;
-  @override
-  @JsonKey()
-  List<Recipe> get todayRecipes {
-    if (_todayRecipes is EqualUnmodifiableListView) return _todayRecipes;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_todayRecipes);
-  }
-
-  @override
-  @JsonKey()
-  final bool isGeneralRecommendations;
-  final List<Recipe> _generalRecommendations;
-  @override
-  @JsonKey()
-  List<Recipe> get generalRecommendations {
-    if (_generalRecommendations is EqualUnmodifiableListView)
-      return _generalRecommendations;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_generalRecommendations);
-  }
-
-  final Set<String> _flaggedAllergenKeys;
-  @override
-  @JsonKey()
-  Set<String> get flaggedAllergenKeys {
-    if (_flaggedAllergenKeys is EqualUnmodifiableSetView)
-      return _flaggedAllergenKeys;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableSetView(_flaggedAllergenKeys);
+    return EqualUnmodifiableListView(_todaysMeals);
   }
 
   @override
   String toString() {
-    return 'HomeState(baby: $baby, programState: $programState, recommendations: $recommendations, currentAllergenBoardItem: $currentAllergenBoardItem, todayMeals: $todayMeals, todayRecipes: $todayRecipes, isGeneralRecommendations: $isGeneralRecommendations, generalRecommendations: $generalRecommendations, flaggedAllergenKeys: $flaggedAllergenKeys)';
+    return 'HomeState(baby: $baby, allergenStatuses: $allergenStatuses, todaysMeals: $todaysMeals)';
   }
 
   @override
@@ -343,37 +195,13 @@ class _$HomeStateImpl implements _HomeState {
         (other.runtimeType == runtimeType &&
             other is _$HomeStateImpl &&
             (identical(other.baby, baby) || other.baby == baby) &&
-            (identical(other.programState, programState) ||
-                other.programState == programState) &&
             const DeepCollectionEquality().equals(
-              other._recommendations,
-              _recommendations,
-            ) &&
-            (identical(
-                  other.currentAllergenBoardItem,
-                  currentAllergenBoardItem,
-                ) ||
-                other.currentAllergenBoardItem == currentAllergenBoardItem) &&
-            const DeepCollectionEquality().equals(
-              other._todayMeals,
-              _todayMeals,
+              other._allergenStatuses,
+              _allergenStatuses,
             ) &&
             const DeepCollectionEquality().equals(
-              other._todayRecipes,
-              _todayRecipes,
-            ) &&
-            (identical(
-                  other.isGeneralRecommendations,
-                  isGeneralRecommendations,
-                ) ||
-                other.isGeneralRecommendations == isGeneralRecommendations) &&
-            const DeepCollectionEquality().equals(
-              other._generalRecommendations,
-              _generalRecommendations,
-            ) &&
-            const DeepCollectionEquality().equals(
-              other._flaggedAllergenKeys,
-              _flaggedAllergenKeys,
+              other._todaysMeals,
+              _todaysMeals,
             ));
   }
 
@@ -381,14 +209,8 @@ class _$HomeStateImpl implements _HomeState {
   int get hashCode => Object.hash(
     runtimeType,
     baby,
-    programState,
-    const DeepCollectionEquality().hash(_recommendations),
-    currentAllergenBoardItem,
-    const DeepCollectionEquality().hash(_todayMeals),
-    const DeepCollectionEquality().hash(_todayRecipes),
-    isGeneralRecommendations,
-    const DeepCollectionEquality().hash(_generalRecommendations),
-    const DeepCollectionEquality().hash(_flaggedAllergenKeys),
+    const DeepCollectionEquality().hash(_allergenStatuses),
+    const DeepCollectionEquality().hash(_todaysMeals),
   );
 
   /// Create a copy of HomeState
@@ -400,37 +222,20 @@ class _$HomeStateImpl implements _HomeState {
       __$$HomeStateImplCopyWithImpl<_$HomeStateImpl>(this, _$identity);
 }
 
-abstract class _HomeState implements HomeState {
+abstract class _HomeState extends HomeState {
   const factory _HomeState({
-    required final Baby baby,
-    required final AllergenProgramState programState,
-    required final List<Recipe> recommendations,
-    final AllergenBoardItem? currentAllergenBoardItem,
-    final List<MealPlanEntry> todayMeals,
-    final List<Recipe> todayRecipes,
-    final bool isGeneralRecommendations,
-    final List<Recipe> generalRecommendations,
-    final Set<String> flaggedAllergenKeys,
+    final Baby? baby,
+    final Map<String, AllergenStatus> allergenStatuses,
+    final List<MealPlanEntry> todaysMeals,
   }) = _$HomeStateImpl;
+  const _HomeState._() : super._();
 
   @override
-  Baby get baby;
+  Baby? get baby;
   @override
-  AllergenProgramState get programState;
+  Map<String, AllergenStatus> get allergenStatuses;
   @override
-  List<Recipe> get recommendations;
-  @override
-  AllergenBoardItem? get currentAllergenBoardItem;
-  @override
-  List<MealPlanEntry> get todayMeals;
-  @override
-  List<Recipe> get todayRecipes;
-  @override
-  bool get isGeneralRecommendations;
-  @override
-  List<Recipe> get generalRecommendations;
-  @override
-  Set<String> get flaggedAllergenKeys;
+  List<MealPlanEntry> get todaysMeals;
 
   /// Create a copy of HomeState
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/src/features/home/widgets/day_chip_row.dart
+++ b/lib/src/features/home/widgets/day_chip_row.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder for NIB-77 (rolling-7 day chips). Wave 2 will replace.
+class DayChipRow extends StatelessWidget {
+  const DayChipRow({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(NIB-77): implement day-chip row per redesign.
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/src/features/home/widgets/greeting_card.dart
+++ b/lib/src/features/home/widgets/greeting_card.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder for NIB-65 (greeting card). Wave 2 will replace.
+class GreetingCard extends StatelessWidget {
+  const GreetingCard({
+    required this.babyName,
+    required this.ageMonths,
+    super.key,
+  });
+
+  final String babyName;
+  final int ageMonths;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(NIB-65): implement greeting card per redesign.
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/src/features/home/widgets/helpful_guidance_card.dart
+++ b/lib/src/features/home/widgets/helpful_guidance_card.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder for NIB-77 (helpful guidance card). Wave 2 will replace.
+class HelpfulGuidanceCard extends StatelessWidget {
+  const HelpfulGuidanceCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(NIB-77): implement helpful-guidance card per redesign.
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/src/features/home/widgets/home_empty_state_full.dart
+++ b/lib/src/features/home/widgets/home_empty_state_full.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder for NIB-96 (full empty state — no baby OR zero activity).
+/// Wave 2 will replace.
+class HomeEmptyStateFull extends StatelessWidget {
+  const HomeEmptyStateFull({this.babyName, super.key});
+
+  final String? babyName;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(NIB-96): implement full empty state per redesign.
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/src/features/home/widgets/home_empty_state_short.dart
+++ b/lib/src/features/home/widgets/home_empty_state_short.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder for NIB-96 (short empty-state variant — some logs but no meals
+/// today, etc.). Wave 2 will replace.
+class HomeEmptyStateShort extends StatelessWidget {
+  const HomeEmptyStateShort({this.babyName, super.key});
+
+  final String? babyName;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(NIB-96): implement short empty state per redesign.
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/src/features/home/widgets/home_header.dart
+++ b/lib/src/features/home/widgets/home_header.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder for NIB-65 (header + avatar). Wave 2 will replace the
+/// implementation; this file fixes the call-site contract so `home_screen`
+/// does not need to change.
+class HomeHeader extends StatelessWidget {
+  const HomeHeader({
+    required this.babyName,
+    required this.ageMonths,
+    this.onAvatarTap,
+    super.key,
+  });
+
+  final String babyName;
+  final int ageMonths;
+  final VoidCallback? onAvatarTap;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(NIB-65): implement header + greeting + avatar per redesign.
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/src/features/home/widgets/home_no_meals_state.dart
+++ b/lib/src/features/home/widgets/home_no_meals_state.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder for NIB-96 (no-meals-today empty-state variant). Wave 2 will
+/// replace.
+class HomeNoMealsState extends StatelessWidget {
+  const HomeNoMealsState({this.babyName, super.key});
+
+  final String? babyName;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(NIB-96): implement no-meals state per redesign.
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/src/features/home/widgets/ongoing_introduced_card.dart
+++ b/lib/src/features/home/widgets/ongoing_introduced_card.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+
+/// Placeholder for NIB-77 (ongoing-introduced card). Wave 2 will replace.
+class OngoingIntroducedCard extends StatelessWidget {
+  const OngoingIntroducedCard({
+    required this.allergenStatuses,
+    super.key,
+  });
+
+  final Map<String, AllergenStatus> allergenStatuses;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(NIB-77): implement ongoing-introduced card per redesign.
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/src/features/home/widgets/stat_ring_card.dart
+++ b/lib/src/features/home/widgets/stat_ring_card.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder for NIB-65 (allergen progress stat ring). Wave 2 will replace.
+class StatRingCard extends StatelessWidget {
+  const StatRingCard({
+    required this.safeCount,
+    required this.flaggedCount,
+    required this.notStartedCount,
+    required this.inProgressCount,
+    super.key,
+  });
+
+  final int safeCount;
+  final int flaggedCount;
+  final int notStartedCount;
+  final int inProgressCount;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(NIB-65): implement stat ring card per redesign.
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/src/features/home/widgets/todays_meals_card.dart
+++ b/lib/src/features/home/widgets/todays_meals_card.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
+
+/// Placeholder for NIB-77 (today's meals card). Wave 2 will replace.
+class TodaysMealsCard extends StatelessWidget {
+  const TodaysMealsCard({
+    required this.todaysMeals,
+    super.key,
+  });
+
+  final List<MealPlanEntry> todaysMeals;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(NIB-77): implement today's meals card per redesign.
+    return const SizedBox.shrink();
+  }
+}

--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -4,37 +4,26 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
-import 'package:nibbles/src/common/domain/entities/allergen.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
-import 'package:nibbles/src/common/domain/entities/recipe.dart';
-import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/common/services/meal_plan_service.dart';
-import 'package:nibbles/src/common/services/recipe_service.dart';
 import 'package:nibbles/src/features/home/home_screen.dart';
-import 'package:nibbles/src/routing/route_enums.dart';
 
 // ---------------------------------------------------------------------------
-// Mocks
+// NIB-86: render-smoke tests only. The home screen now delegates to placeholder
+// widgets (NIB-65 / NIB-77 / NIB-96 will implement). NIB-111 owns the full
+// widget test suite once the leaf widgets land.
 // ---------------------------------------------------------------------------
 
-class MockBabyProfileService extends Mock implements BabyProfileService {}
+class _MockBabyProfileService extends Mock implements BabyProfileService {}
 
-class MockAllergenService extends Mock implements AllergenService {}
+class _MockAllergenService extends Mock implements AllergenService {}
 
-class MockMealPlanService extends Mock implements MealPlanService {}
-
-class MockRecipeService extends Mock implements RecipeService {}
-
-// ---------------------------------------------------------------------------
-// Fixtures
-// ---------------------------------------------------------------------------
+class _MockMealPlanService extends Mock implements MealPlanService {}
 
 const _babyId = 'baby-001';
 
@@ -47,288 +36,58 @@ final _fakeBaby = Baby(
   onboardingCompleted: true,
 );
 
-const _peanutAllergen = Allergen(
-  key: 'peanut',
-  name: 'Peanut',
-  sequenceOrder: 1,
-  emoji: '🥜',
-);
-
-AllergenBoardItem _makeBoardItem({
-  AllergenStatus status = AllergenStatus.inProgress,
-}) => AllergenBoardItem(
-  allergen: _peanutAllergen,
-  logs: const [],
-  status: status,
-);
-
-AllergenProgramState _makeProgramState({
-  AllergenProgramStatus status = AllergenProgramStatus.inProgress,
-  String currentKey = 'peanut',
-  int currentOrder = 1,
-}) {
-  final now = DateTime.now();
-  return AllergenProgramState(
-    id: 'ps-1',
-    babyId: _babyId,
-    currentAllergenKey: currentKey,
-    currentSequenceOrder: currentOrder,
-    status: status,
-    createdAt: now,
-    updatedAt: now,
-  );
-}
-
-const _fakeRecipe = Recipe(
-  id: 'recipe-001',
-  title: 'Peanut Butter Toast',
-  ageRange: '6m+',
-  allergenTags: ['peanut'],
-  ingredients: [],
-  steps: [],
-  howToServe: 'Serve mashed.',
-);
-
-MealPlanEntry get _todayMeal => MealPlanEntry(
-  id: 'mp-001',
-  babyId: _babyId,
-  recipeId: 'recipe-001',
-  planDate: DateTime.now(),
-);
-
-// ---------------------------------------------------------------------------
-// Router + widget helper
-// ---------------------------------------------------------------------------
-
-GoRouter _routerFor(Widget screen) => GoRouter(
-  initialLocation: '/',
-  routes: [
-    GoRoute(path: '/', builder: (_, __) => screen),
-    GoRoute(
-      path: AppRoute.profile.path,
-      name: AppRoute.profile.name,
-      builder: (_, __) => const Scaffold(body: Text('Profile')),
-    ),
-    GoRoute(
-      path: AppRoute.recipeLibrary.path,
-      name: AppRoute.recipeLibrary.name,
-      builder: (_, __) => const Scaffold(body: Text('Recipes')),
-    ),
-    GoRoute(
-      path: '/home/recipes/:recipeId',
-      name: AppRoute.recipeDetail.name,
-      builder: (_, __) => const Scaffold(body: Text('Recipe Detail')),
-    ),
-    GoRoute(
-      path: AppRoute.shoppingList.path,
-      name: AppRoute.shoppingList.name,
-      builder: (_, __) => const Scaffold(body: Text('Shopping List')),
-    ),
-  ],
-);
-
-Widget _wrap(Widget screen, List<Override> overrides) => ProviderScope(
+Widget _wrap(List<Override> overrides) => ProviderScope(
   overrides: overrides,
-  child: MaterialApp.router(routerConfig: _routerFor(screen)),
+  child: MaterialApp.router(
+    routerConfig: GoRouter(
+      initialLocation: '/',
+      routes: [GoRoute(path: '/', builder: (_, __) => const HomeScreen())],
+    ),
+  ),
 );
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 void main() {
-  late MockBabyProfileService mockBabyService;
-  late MockAllergenService mockAllergenService;
-  late MockMealPlanService mockMealPlanService;
-  late MockRecipeService mockRecipeService;
+  late _MockBabyProfileService mockBabyService;
+  late _MockAllergenService mockAllergenService;
+  late _MockMealPlanService mockMealPlanService;
 
   setUp(() {
-    mockBabyService = MockBabyProfileService();
-    mockAllergenService = MockAllergenService();
-    mockMealPlanService = MockMealPlanService();
-    mockRecipeService = MockRecipeService();
+    mockBabyService = _MockBabyProfileService();
+    mockAllergenService = _MockAllergenService();
+    mockMealPlanService = _MockMealPlanService();
   });
 
   List<Override> buildOverrides() => [
     babyProfileServiceProvider.overrideWithValue(mockBabyService),
     allergenServiceProvider.overrideWithValue(mockAllergenService),
     mealPlanServiceProvider.overrideWithValue(mockMealPlanService),
-    recipeServiceProvider.overrideWithValue(mockRecipeService),
   ];
 
-  /// Stubs the minimum service calls required for the home controller to build.
-  void stubCommon({
-    required AllergenProgramState programState,
-    List<Recipe> recommendations = const [],
-    List<MealPlanEntry> weekMeals = const [],
-    Recipe? recipeForMeal,
-    AllergenBoardItem? boardItem,
-  }) {
+  testWidgets('renders without errors when baby + services resolve', (
+    tester,
+  ) async {
     when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);
-    when(
-      () => mockAllergenService.getProgramState(_babyId),
-    ).thenAnswer((_) async => Result.success(programState));
-    when(
-      () => mockMealPlanService.getWeekMeals(_babyId, any()),
-    ).thenAnswer((_) async => Result.success(weekMeals));
-    when(
-      () => mockRecipeService.getFlaggedAllergenKeys(any()),
-    ).thenAnswer((_) async => const Result.success(<String>{}));
-    if (recipeForMeal != null) {
-      when(
-        () => mockRecipeService.getRecipeById(any()),
-      ).thenAnswer((_) async => Result.success(recipeForMeal));
-    }
-    if (programState.status != AllergenProgramStatus.completed) {
-      when(
-        () => mockAllergenService.getAllergenBoardSummary(_babyId),
-      ).thenAnswer(
-        (_) async => Result.success([boardItem ?? _makeBoardItem()]),
-      );
-      when(
-        () => mockRecipeService.getRecommendationsForAllergen(any(), _babyId),
-      ).thenAnswer((_) async => Result.success(recommendations));
-      when(
-        () => mockRecipeService.getAllRecipes(any()),
-      ).thenAnswer((_) async => Result.success(recommendations));
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // State A: active, not logged today
-  // -------------------------------------------------------------------------
-
-  testWidgets(
-    'State A — allergen emoji, name, Day X/3 and Log Food button shown',
-    (tester) async {
-      stubCommon(programState: _makeProgramState());
-
-      await tester.pumpWidget(_wrap(const HomeScreen(), buildOverrides()));
-      await tester.pumpAndSettle();
-
-      expect(find.text('🥜'), findsWidgets);
-      expect(find.text('Peanut'), findsOneWidget);
-      expect(find.textContaining('of 3 exposures logged'), findsOneWidget);
-      expect(find.byKey(const Key('log_food_button')), findsOneWidget);
-    },
-  );
-
-  // -------------------------------------------------------------------------
-  // State B: program complete
-  // -------------------------------------------------------------------------
-
-  testWidgets(
-    'State C — completion banner shown, allergen widget and strip absent',
-    (tester) async {
-      stubCommon(
-        programState: _makeProgramState(
-          status: AllergenProgramStatus.completed,
-        ),
-      );
-
-      await tester.pumpWidget(_wrap(const HomeScreen(), buildOverrides()));
-      await tester.pumpAndSettle();
-
-      expect(
-        find.textContaining('has completed the allergen program'),
-        findsOneWidget,
-      );
-      expect(find.byKey(const Key('log_food_button')), findsNothing);
-      expect(find.textContaining('Recommended for'), findsNothing);
-    },
-  );
-
-  // -------------------------------------------------------------------------
-  // No meal today
-  // -------------------------------------------------------------------------
-
-  testWidgets('No meal today — empty state copy and Plan a Meal CTA shown', (
-    tester,
-  ) async {
-    stubCommon(programState: _makeProgramState());
-
-    await tester.pumpWidget(_wrap(const HomeScreen(), buildOverrides()));
-    await tester.pumpAndSettle();
-
-    expect(
-      find.text('No meal planned for today. Add one to get started.'),
-      findsOneWidget,
+    when(() => mockAllergenService.getAllergenStatuses(_babyId)).thenAnswer(
+      (_) async => const Result.success(<String, AllergenStatus>{}),
     );
-    expect(find.text('Plan a Meal'), findsOneWidget);
-  });
-
-  // -------------------------------------------------------------------------
-  // With meal today
-  // -------------------------------------------------------------------------
-
-  testWidgets('With meal today — recipe name and allergen badge shown', (
-    tester,
-  ) async {
-    stubCommon(
-      programState: _makeProgramState(),
-      weekMeals: [_todayMeal],
-      recipeForMeal: _fakeRecipe,
+    when(() => mockMealPlanService.getRolling7(_babyId)).thenAnswer(
+      (_) async => const Result.success(<MealPlanEntry>[]),
     );
 
-    await tester.pumpWidget(_wrap(const HomeScreen(), buildOverrides()));
+    await tester.pumpWidget(_wrap(buildOverrides()));
     await tester.pumpAndSettle();
 
-    expect(find.text('Peanut Butter Toast'), findsOneWidget);
-    expect(find.textContaining('peanut'), findsWidgets);
+    expect(find.byType(HomeScreen), findsOneWidget);
   });
 
-  // -------------------------------------------------------------------------
-  // Recommendations strip visible
-  // -------------------------------------------------------------------------
+  testWidgets('renders empty state scaffold when no baby exists', (
+    tester,
+  ) async {
+    when(() => mockBabyService.getBaby()).thenAnswer((_) async => null);
 
-  testWidgets(
-    'Recommendations strip visible when program in progress and recipes exist',
-    (tester) async {
-      stubCommon(
-        programState: _makeProgramState(),
-        recommendations: [_fakeRecipe],
-      );
+    await tester.pumpWidget(_wrap(buildOverrides()));
+    await tester.pumpAndSettle();
 
-      await tester.pumpWidget(_wrap(const HomeScreen(), buildOverrides()));
-      await tester.pumpAndSettle();
-
-      expect(find.textContaining('Recommended for'), findsOneWidget);
-    },
-  );
-
-  // -------------------------------------------------------------------------
-  // Recommendations hidden — program complete
-  // -------------------------------------------------------------------------
-
-  testWidgets(
-    'Recommendations strip absent when allergen program is completed',
-    (tester) async {
-      stubCommon(
-        programState: _makeProgramState(
-          status: AllergenProgramStatus.completed,
-        ),
-      );
-
-      await tester.pumpWidget(_wrap(const HomeScreen(), buildOverrides()));
-      await tester.pumpAndSettle();
-
-      expect(find.textContaining('Recommended for'), findsNothing);
-    },
-  );
-
-  // -------------------------------------------------------------------------
-  // Recommendations hidden — no matching recipes
-  // -------------------------------------------------------------------------
-
-  testWidgets(
-    'Recommendations strip absent when no recipes match current allergen',
-    (tester) async {
-      stubCommon(programState: _makeProgramState());
-
-      await tester.pumpWidget(_wrap(const HomeScreen(), buildOverrides()));
-      await tester.pumpAndSettle();
-
-      expect(find.textContaining('Recommended for'), findsNothing);
-    },
-  );
+    expect(find.byType(HomeScreen), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary

Wave 1 of the Home milestone. Reshapes `HomeState` / `HomeController` for the
redesigned dashboard (NIB-120) and rewrites `home_screen.dart` as a thin
scaffold delegating to 9 placeholder widgets under `widgets/`. NIB-65, NIB-77
and NIB-96 land the leaf implementations without touching the call sites here.

## New `HomeState` shape

```
HomeState({
  Baby? baby,
  Map<String, AllergenStatus> allergenStatuses,
  List<MealPlanEntry> todaysMeals,
})
```

Derived getters: `safeCount`, `flaggedCount`, `notStartedCount`,
`inProgressCount`, `todayMealCount`, `hasNoActivity`.

### Dropped fields (no remaining consumers — no shims needed)
- `programState`
- `recommendations`
- `currentAllergenBoardItem`
- `todayRecipes`
- `isGeneralRecommendations`
- `generalRecommendations`
- `flaggedAllergenKeys`

## `HomeController.build()` behaviour
- Fires `getBaby` + `getAllergenStatuses(babyId)` + `getRolling7(babyId)` in
  parallel; awaits all three.
- Null baby returns a successful empty `HomeState` so the screen renders the
  full empty-state placeholder (no error path).
- Allergen / meal-plan `Result.failure` re-throws via the existing pattern →
  `AsyncValue.error`.
- Filters the rolling-7 entries to today (date-only equality).
- No more `getWeekMeals` / `getRecipeById` loop / recipe recommendations.

## Placeholder widget API contracts (for NIB-65 / NIB-77 / NIB-96)

| Widget | File | Ticket | Constructor |
|---|---|---|---|
| `HomeHeader` | `widgets/home_header.dart` | NIB-65 | `{required String babyName, required int ageMonths, VoidCallback? onAvatarTap}` |
| `GreetingCard` | `widgets/greeting_card.dart` | NIB-65 | `{required String babyName, required int ageMonths}` |
| `StatRingCard` | `widgets/stat_ring_card.dart` | NIB-65 | `{required int safeCount, required int flaggedCount, required int notStartedCount, required int inProgressCount}` |
| `OngoingIntroducedCard` | `widgets/ongoing_introduced_card.dart` | NIB-77 | `{required Map<String, AllergenStatus> allergenStatuses}` |
| `DayChipRow` | `widgets/day_chip_row.dart` | NIB-77 | `{}` (extends to take rolling-7 in NIB-77) |
| `TodaysMealsCard` | `widgets/todays_meals_card.dart` | NIB-77 | `{required List<MealPlanEntry> todaysMeals}` |
| `HelpfulGuidanceCard` | `widgets/helpful_guidance_card.dart` | NIB-77 | `{}` |
| `HomeEmptyStateFull` | `widgets/home_empty_state_full.dart` | NIB-96 | `{String? babyName}` |
| `HomeEmptyStateShort` | `widgets/home_empty_state_short.dart` | NIB-96 | `{String? babyName}` |
| `HomeNoMealsState` | `widgets/home_no_meals_state.dart` | NIB-96 | `{String? babyName}` |

`ageMonths` is computed in `home_screen.dart` from `baby.dateOfBirth` — not
carried in state.

## Acceptance criteria
- [x] `HomeState` carries `baby` / `allergenStatuses` / `todaysMeals` + derived counts
- [x] Legacy fields dropped (no external consumers found)
- [x] `HomeController.build()` parallel-fetches Baby + statuses + rolling-7
- [x] `home_screen.dart` renders a Column of placeholder widgets
- [x] Empty-state full placeholder rendered when no baby OR `hasNoActivity`
- [x] `getWeekMeals` has no consumers in `lib/src/features/home/`
- [x] `recipe_service.getRecommendations*` has no consumers in `lib/src/features/home/`
- [x] No files outside the allowlist modified
- [x] Zero hex / Nunito / `withAlpha` / `AllergenStatus.completed` introduced
- [x] `make gen` clean + idempotent (second run = 0 outputs)
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — All tests passed (423 tests)

## Gate results
- `make gen`: success (idempotent, 0 outputs on second run)
- `flutter analyze`: 0 issues
- `flutter test`: All 423 tests passed

## Out of scope
- Leaf widget implementations (NIB-65 / NIB-77 / NIB-96)
- Bottom-nav shell changes (NIB-104)
- Analytics events (NIB-106)
- Full widget test rebuild (NIB-111)