### PR TITLE
feat(home): restyle bottom nav with DS theme + new labels/icons [NIB-104]

### DIFF
--- a/lib/src/features/home/home_shell_screen.dart
+++ b/lib/src/features/home/home_shell_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/home/home_controller.dart';
 import 'package:nibbles/src/features/meal_plan/meal_plan_controller.dart';
@@ -45,27 +46,54 @@ class _HomeShellScreenState extends ConsumerState<HomeShellScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: widget.navigationShell,
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: widget.navigationShell.currentIndex,
-        onDestinationSelected: (index) => widget.navigationShell.goBranch(
-          index,
-          initialLocation: index == widget.navigationShell.currentIndex,
+      bottomNavigationBar: NavigationBarTheme(
+        data: NavigationBarThemeData(
+          indicatorColor: AppColors.butter,
+          backgroundColor: AppColors.surface,
+          surfaceTintColor: AppColors.surface,
+          iconTheme: WidgetStateProperty.resolveWith((states) {
+            final selected = states.contains(WidgetState.selected);
+            return IconThemeData(
+              color: selected ? AppColors.greenDeep : AppColors.fgFaint,
+            );
+          }),
+          labelTextStyle: WidgetStateProperty.resolveWith((states) {
+            final selected = states.contains(WidgetState.selected);
+            return TextStyle(
+              color: selected ? AppColors.greenDeep : AppColors.fgFaint,
+              fontWeight: FontWeight.w700,
+            );
+          }),
         ),
-        destinations: const [
-          NavigationDestination(icon: Icon(Icons.home_outlined), label: 'Home'),
-          NavigationDestination(
-            icon: Icon(Icons.calendar_today_outlined),
-            label: 'Meal Plan',
+        child: NavigationBar(
+          selectedIndex: widget.navigationShell.currentIndex,
+          onDestinationSelected: (index) => widget.navigationShell.goBranch(
+            index,
+            initialLocation: index == widget.navigationShell.currentIndex,
           ),
-          NavigationDestination(
-            icon: Icon(Icons.shopping_cart_outlined),
-            label: 'Shopping',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.menu_book_outlined),
-            label: 'Recipes',
-          ),
-        ],
+          destinations: const [
+            NavigationDestination(
+              icon: Icon(Icons.home_outlined),
+              selectedIcon: Icon(Icons.home),
+              label: 'Home',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.restaurant_menu_outlined),
+              selectedIcon: Icon(Icons.restaurant_menu),
+              label: 'Meals',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.shopping_cart_outlined),
+              selectedIcon: Icon(Icons.shopping_cart),
+              label: 'Grocery',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.menu_book_outlined),
+              selectedIcon: Icon(Icons.menu_book),
+              label: 'Recipes',
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/features/home/home_shell_screen.dart
+++ b/lib/src/features/home/home_shell_screen.dart
@@ -60,8 +60,11 @@ class _HomeShellScreenState extends ConsumerState<HomeShellScreen> {
           labelTextStyle: WidgetStateProperty.resolveWith((states) {
             final selected = states.contains(WidgetState.selected);
             return TextStyle(
-              color: selected ? AppColors.greenDeep : AppColors.fgFaint,
+              fontFamily: 'Parkinsans',
+              fontSize: 10,
+              height: 1,
               fontWeight: FontWeight.w700,
+              color: selected ? AppColors.greenDeep : AppColors.fgFaint,
             );
           }),
         ),

--- a/lib/src/features/home/home_shell_screen.dart
+++ b/lib/src/features/home/home_shell_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/home/home_controller.dart';
@@ -60,7 +61,7 @@ class _HomeShellScreenState extends ConsumerState<HomeShellScreen> {
           labelTextStyle: WidgetStateProperty.resolveWith((states) {
             final selected = states.contains(WidgetState.selected);
             return TextStyle(
-              fontFamily: 'Parkinsans',
+              fontFamily: FontFamily.parkinsans,
               fontSize: 10,
               height: 1,
               fontWeight: FontWeight.w700,


### PR DESCRIPTION
## Summary

Restyle the bottom `NavigationBar` in `home_shell_screen.dart` per the new DS. Labels renamed (Meal Plan -> Meals, Shopping -> Grocery), Material icons updated per spec, and active state themed via a local `NavigationBarTheme` wrap (butter pill + greenDeep selected fg + fgFaint inactive fg). The `didUpdateWidget` branch-invalidation block and `selectedIndex` / `onDestinationSelected` wiring are byte-identical to before.

## Figma

- Navbar frame: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1290-10371
- Reference: `design/preview/components-bottom-nav.html`, `design/ui_kits/nibbles_mobile/Primitives.jsx` (TabBar lines 19-40)

## DS theming approach

- Wrapped `NavigationBar` in `NavigationBarTheme(data: NavigationBarThemeData(...))` LOCALLY — no global theme tokens added, no edits to `lib/src/app/themes/**`.
- `indicatorColor`: `AppColors.butter`
- `iconTheme` (WidgetStateProperty): selected -> `AppColors.greenDeep`, unselected -> `AppColors.fgFaint`
- `labelTextStyle` (WidgetStateProperty): selected -> `AppColors.greenDeep`, unselected -> `AppColors.fgFaint`, weight `w700`
- Icons: per spec (`home_outlined`/`home`, `restaurant_menu_outlined`/`restaurant_menu`, `shopping_cart_outlined`/`shopping_cart`, `menu_book_outlined`/`menu_book`).

## Behavioral integrity

`didUpdateWidget` branch-invalidation block (lines 22-42) is byte-identical to prior. The `NavigationBar`'s `selectedIndex: widget.navigationShell.currentIndex` and `onDestinationSelected: (index) => widget.navigationShell.goBranch(index, initialLocation: index == widget.navigationShell.currentIndex)` are unchanged (now nested one level deeper inside the `NavigationBarTheme.child:`).

## Acceptance criteria

- [x] Labels exactly 'Home' / 'Meals' / 'Grocery' / 'Recipes'.
- [x] Icons + selected variants per spec.
- [x] Active indicator = butter; selected fg = greenDeep; inactive fg = fgFaint.
- [x] `didUpdateWidget` branch-invalidation block UNCHANGED.
- [x] `flutter analyze` 0 issues.
- [x] Existing tests still pass (423 / 423).
- [x] `make gen` clean and idempotent (no diff on rerun).
- [x] Zero hex / Nunito / withAlpha / AllergenStatus.completed.
- [x] Only `home_shell_screen.dart` modified.

## Gate results

- `make gen` -> clean, 0 unintended diffs on second run.
- `flutter analyze` -> `No issues found! (ran in 3.6s)`
- `flutter test` -> `All tests passed!` (423 tests)