### PR TITLE
feat(home): implement ongoing-introduced, day-chip row, today's meals, helpful guidance cards [NIB-77]

### DIFF
--- a/lib/src/features/home/widgets/day_chip_row.dart
+++ b/lib/src/features/home/widgets/day_chip_row.dart
@@ -1,12 +1,100 @@
 import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
 
-/// Placeholder for NIB-77 (rolling-7 day chips). Wave 2 will replace.
+/// Home — rolling-7 day-chip row (NIB-77, Figma 1242:10628).
+///
+/// Decorative-only pill chips for today + the previous 6 days. The 'Today'
+/// chip is highlighted (butter background, green-deep text); the rest use a
+/// muted surface (surfaceVariant background, fgMuted text). No day selection
+/// callback — selection is owned by the meal-plan screen, not Home.
 class DayChipRow extends StatelessWidget {
   const DayChipRow({super.key});
 
+  static const List<String> _shortMonths = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+
+  static const List<String> _shortWeekdays = [
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat',
+    'Sun',
+  ];
+
+  String _label(DateTime date) {
+    final weekday = _shortWeekdays[date.weekday - 1];
+    final month = _shortMonths[date.month - 1];
+    return '$weekday, $month ${date.day}';
+  }
+
   @override
   Widget build(BuildContext context) {
-    // TODO(NIB-77): implement day-chip row per redesign.
-    return const SizedBox.shrink();
+    final today = DateTime.now();
+    final dates = List<DateTime>.generate(
+      7,
+      (i) => DateTime(today.year, today.month, today.day - i),
+    );
+
+    return SizedBox(
+      height: AppSizes.chipHeight,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: dates.length,
+        separatorBuilder: (_, __) => const SizedBox(width: AppSizes.sm),
+        itemBuilder: (context, i) {
+          final isToday = i == 0;
+          return _PillChip(
+            label: isToday ? 'Today' : _label(dates[i]),
+            isActive: isToday,
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PillChip extends StatelessWidget {
+  const _PillChip({required this.label, required this.isActive});
+
+  final String label;
+  final bool isActive;
+
+  @override
+  Widget build(BuildContext context) {
+    final background = isActive ? AppColors.butter : AppColors.surfaceVariant;
+    final foreground = isActive ? AppColors.greenDeep : AppColors.fgMuted;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.md - 2),
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      child: Text(
+        label,
+        style: AppTypography.textTheme.labelMedium?.copyWith(
+          color: foreground,
+          fontWeight: FontWeight.w700,
+          height: 1,
+        ),
+      ),
+    );
   }
 }

--- a/lib/src/features/home/widgets/helpful_guidance_card.dart
+++ b/lib/src/features/home/widgets/helpful_guidance_card.dart
@@ -1,12 +1,131 @@
 import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/cards/tip_card.dart';
 
-/// Placeholder for NIB-77 (helpful guidance card). Wave 2 will replace.
+/// Home — Helpful Guidance section (NIB-77, Figma 1242:10648).
+///
+/// Renders a 'Helpful Guidance' title3 + three white tip cards (butter glyph
+/// circle, display 14/700 title, callout body) + a final 'Important Health
+/// Disclaimer' [TipCard] (butter-soft surface). Static content for MVP.
 class HelpfulGuidanceCard extends StatelessWidget {
   const HelpfulGuidanceCard({super.key});
 
+  static const List<_TipContent> _tips = [
+    _TipContent(
+      emoji: '🥄',
+      title: 'Try one new food at a time',
+      body: 'Wait 3-5 days between new foods so reactions are easy to trace.',
+    ),
+    _TipContent(
+      emoji: '⏱️',
+      title: 'Watch for reactions for 24 hours',
+      body: 'Most reactions surface within the first day after a new food.',
+    ),
+    _TipContent(
+      emoji: '👩‍⚕️',
+      title: 'Consult your pediatrician for concerns',
+      body: 'Reach out before introducing high-risk foods or for any reaction.',
+    ),
+  ];
+
   @override
   Widget build(BuildContext context) {
-    // TODO(NIB-77): implement helpful-guidance card per redesign.
-    return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Helpful Guidance', style: AppTypography.sectionTitle),
+        const SizedBox(height: AppSizes.sm + 2),
+        ...List<Widget>.generate(_tips.length, (i) {
+          return Padding(
+            padding: EdgeInsets.only(top: i == 0 ? 0 : AppSizes.sm + 2),
+            child: _GuidanceTipCard(content: _tips[i]),
+          );
+        }),
+        const SizedBox(height: AppSizes.sm + 2),
+        const TipCard(
+          title: 'Important Health Disclaimer',
+          body: 'Our recommendations are intended for educational purposes '
+              'only and should not be considered medical advice.',
+        ),
+      ],
+    );
+  }
+}
+
+class _TipContent {
+  const _TipContent({
+    required this.emoji,
+    required this.title,
+    required this.body,
+  });
+
+  final String emoji;
+  final String title;
+  final String body;
+}
+
+class _GuidanceTipCard extends StatelessWidget {
+  const _GuidanceTipCard({required this.content});
+
+  final _TipContent content;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+        boxShadow: AppSizes.shadowCard,
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md - 2,
+        vertical: AppSizes.sp12,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 36,
+            height: 36,
+            decoration: const BoxDecoration(
+              color: AppColors.butter,
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              content.emoji,
+              style: const TextStyle(fontSize: 16, height: 1),
+            ),
+          ),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  content.title,
+                  style: AppTypography.textTheme.bodyMedium?.copyWith(
+                    fontFamily: AppTypography.sectionTitle.fontFamily,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    height: 1.2,
+                    color: AppColors.fgStrong,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.sp2),
+                Text(
+                  content.body,
+                  style: AppTypography.textTheme.bodyMedium?.copyWith(
+                    color: AppColors.fgDefault,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/src/features/home/widgets/ongoing_introduced_card.dart
+++ b/lib/src/features/home/widgets/ongoing_introduced_card.dart
@@ -51,7 +51,7 @@ class OngoingIntroducedCard extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Ongoing introduced',
+          'ONGOING INTRODUCED',
           style: AppTypography.textTheme.labelSmall?.copyWith(
             color: AppColors.fgFaint,
           ),

--- a/lib/src/features/home/widgets/ongoing_introduced_card.dart
+++ b/lib/src/features/home/widgets/ongoing_introduced_card.dart
@@ -1,7 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/constants/allergen_emoji.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/services/helpers/derive_allergen_status.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Placeholder for NIB-77 (ongoing-introduced card). Wave 2 will replace.
+/// Home — Ongoing-introduced card (NIB-77, Figma 1242:10616).
+///
+/// Shows the first allergen in [kAllergenKeys] order whose status is
+/// [AllergenStatus.inProgress]. Whole card taps push the allergen tracker.
+/// When no allergen is in-progress the card renders [SizedBox.shrink] so the
+/// home layout collapses naturally.
+///
+/// Note: log counts ('X/3 times' subhead) are intentionally omitted — the home
+/// state only carries derived statuses, not per-allergen log counts. The
+/// 3-segment progress bar therefore renders all 3 empty.
 class OngoingIntroducedCard extends StatelessWidget {
   const OngoingIntroducedCard({
     required this.allergenStatuses,
@@ -10,9 +26,142 @@ class OngoingIntroducedCard extends StatelessWidget {
 
   final Map<String, AllergenStatus> allergenStatuses;
 
+  String? get _ongoingKey {
+    for (final key in kAllergenKeys) {
+      if (allergenStatuses[key] == AllergenStatus.inProgress) return key;
+    }
+    return null;
+  }
+
+  String _displayName(String key) =>
+      key.replaceAll('_', ' ').split(' ').map(_capitalize).join(' ');
+
+  String _capitalize(String word) =>
+      word.isEmpty ? word : '${word[0].toUpperCase()}${word.substring(1)}';
+
   @override
   Widget build(BuildContext context) {
-    // TODO(NIB-77): implement ongoing-introduced card per redesign.
-    return const SizedBox.shrink();
+    final key = _ongoingKey;
+    if (key == null) return const SizedBox.shrink();
+
+    final emoji = AllergenEmoji.get(key);
+    final name = _displayName(key);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Ongoing introduced',
+          style: AppTypography.textTheme.labelSmall?.copyWith(
+            color: AppColors.fgFaint,
+          ),
+        ),
+        const SizedBox(height: AppSizes.sm),
+        Material(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+            onTap: () =>
+                context.pushNamed(AppRoute.allergenTracker.name),
+            child: Ink(
+              decoration: BoxDecoration(
+                color: AppColors.surface,
+                borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+                boxShadow: AppSizes.shadowCard,
+              ),
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.md - 2,
+                vertical: AppSizes.sp12,
+              ),
+              child: Row(
+                children: [
+                  _CoralThumb(emoji: emoji),
+                  const SizedBox(width: AppSizes.sp12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          name,
+                          style: AppTypography.emptyStateTitle,
+                        ),
+                        const SizedBox(height: AppSizes.sp2),
+                        Text(
+                          'Currently introducing',
+                          style: AppTypography.caption.copyWith(
+                            color: AppColors.fgFaint,
+                          ),
+                        ),
+                        const SizedBox(height: AppSizes.sm),
+                        const _ProgressSegments(),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: AppSizes.sm),
+                  const Icon(
+                    Icons.chevron_right,
+                    size: AppSizes.iconMd,
+                    color: AppColors.fgFaint,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CoralThumb extends StatelessWidget {
+  const _CoralThumb({required this.emoji});
+
+  final String emoji;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 62,
+      height: 62,
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [AppColors.coral, AppColors.orange50],
+        ),
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        emoji,
+        style: const TextStyle(fontSize: 28, height: 1),
+      ),
+    );
+  }
+}
+
+class _ProgressSegments extends StatelessWidget {
+  const _ProgressSegments();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: List<Widget>.generate(3, (i) {
+        return Expanded(
+          child: Padding(
+            padding: EdgeInsets.only(left: i == 0 ? 0 : AppSizes.xs),
+            child: Container(
+              height: 6,
+              decoration: BoxDecoration(
+                color: AppColors.coralSoft,
+                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              ),
+            ),
+          ),
+        );
+      }),
+    );
   }
 }

--- a/lib/src/features/home/widgets/todays_meals_card.dart
+++ b/lib/src/features/home/widgets/todays_meals_card.dart
@@ -1,7 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Placeholder for NIB-77 (today's meals card). Wave 2 will replace.
+/// Home — Today's meals card (NIB-77, Figma 1242:10630).
+///
+/// 'Today, {Month Day}' title rendered outside the white card. The card
+/// contains a butter coverage banner, a 'TODAY'S MEALS' overline + n/2 meta
+/// counter, then meal rows. Each row taps to `recipeDetail` with the entry's
+/// `recipeId`. When `todaysMeals` is empty, an inline 'No meals today'
+/// placeholder is rendered inside the card (the full-screen empty state lives
+/// in NIB-96).
+///
+/// Note: `MealPlanEntry` only carries `recipeId` (no recipe title or allergen
+/// tags). Until home_controller hydrates recipes, each row shows a generic
+/// thumb + the meal-time label (when present, falling back to 'Meal'). Tag
+/// chips are intentionally omitted.
 class TodaysMealsCard extends StatelessWidget {
   const TodaysMealsCard({
     required this.todaysMeals,
@@ -10,9 +27,228 @@ class TodaysMealsCard extends StatelessWidget {
 
   final List<MealPlanEntry> todaysMeals;
 
+  static const List<String> _shortMonths = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+
+  static const int _dailyTarget = 2;
+
   @override
   Widget build(BuildContext context) {
-    // TODO(NIB-77): implement today's meals card per redesign.
-    return const SizedBox.shrink();
+    final today = DateTime.now();
+    final headerTitle =
+        'Today, ${_shortMonths[today.month - 1]} ${today.day}';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(headerTitle, style: AppTypography.sectionTitle),
+        const SizedBox(height: AppSizes.sm),
+        Container(
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+            boxShadow: AppSizes.shadowCard,
+          ),
+          padding: const EdgeInsets.all(AppSizes.sp12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _MealsOverlineRow(count: todaysMeals.length),
+              const SizedBox(height: AppSizes.sm),
+              const _CoverageBanner(),
+              const SizedBox(height: AppSizes.sm + 2),
+              if (todaysMeals.isEmpty)
+                const _NoMealsInline()
+              else
+                ...List<Widget>.generate(todaysMeals.length, (i) {
+                  final entry = todaysMeals[i];
+                  return Padding(
+                    padding: EdgeInsets.only(top: i == 0 ? 0 : AppSizes.sm),
+                    child: _MealRow(entry: entry),
+                  );
+                }),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MealsOverlineRow extends StatelessWidget {
+  const _MealsOverlineRow({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.baseline,
+        textBaseline: TextBaseline.alphabetic,
+        children: [
+          Expanded(
+            child: Text(
+              "TODAY'S MEALS",
+              style: AppTypography.textTheme.labelSmall?.copyWith(
+                color: AppColors.greenDeep,
+                letterSpacing: 0.6,
+              ),
+            ),
+          ),
+          Text(
+            '$count/${TodaysMealsCard._dailyTarget}',
+            style: AppTypography.caption.copyWith(
+              color: AppColors.fgFaint,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CoverageBanner extends StatelessWidget {
+  const _CoverageBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.butterSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md - 2,
+        vertical: AppSizes.sm + 2,
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: AppSizes.checkbox + 4,
+            height: AppSizes.checkbox + 4,
+            decoration: const BoxDecoration(
+              color: AppColors.coralSoft,
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: const Text('🌱', style: TextStyle(fontSize: 14, height: 1)),
+          ),
+          const SizedBox(width: AppSizes.sm + 2),
+          Expanded(
+            child: Text(
+              "Today's meals balance allergens and nutrition.",
+              style: AppTypography.textTheme.labelMedium?.copyWith(
+                color: AppColors.fgStrong,
+                height: 1.3,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MealRow extends StatelessWidget {
+  const _MealRow({required this.entry});
+
+  final MealPlanEntry entry;
+
+  String _capitalize(String value) =>
+      value.isEmpty ? value : '${value[0].toUpperCase()}${value.substring(1)}';
+
+  @override
+  Widget build(BuildContext context) {
+    final mealTime = entry.mealTime;
+    final label = (mealTime == null || mealTime.isEmpty)
+        ? 'Meal'
+        : _capitalize(mealTime);
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        onTap: () => context.pushNamed(
+          AppRoute.recipeDetail.name,
+          pathParameters: {'recipeId': entry.recipeId},
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSizes.xs),
+          child: Row(
+            children: [
+              Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  gradient: const LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [AppColors.tanBase, AppColors.coral],
+                  ),
+                  borderRadius: BorderRadius.circular(AppSizes.radiusLg - 2),
+                ),
+                alignment: Alignment.center,
+                child: const Text(
+                  '🍲',
+                  style: TextStyle(fontSize: 24, height: 1),
+                ),
+              ),
+              const SizedBox(width: AppSizes.sp12),
+              Expanded(
+                child: Text(
+                  label,
+                  style: AppTypography.textTheme.labelLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.fgStrong,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const Icon(
+                Icons.chevron_right,
+                size: AppSizes.iconMd,
+                color: AppColors.fgFaint,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NoMealsInline extends StatelessWidget {
+  const _NoMealsInline();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.sm,
+        vertical: AppSizes.sm + 2,
+      ),
+      child: Text(
+        'No meals today',
+        style: AppTypography.textTheme.bodyMedium?.copyWith(
+          color: AppColors.fgFaint,
+        ),
+      ),
+    );
   }
 }

--- a/lib/src/features/home/widgets/todays_meals_card.dart
+++ b/lib/src/features/home/widgets/todays_meals_card.dart
@@ -154,6 +154,7 @@ class _CoverageBanner extends StatelessWidget {
               "Today's meals balance allergens and nutrition.",
               style: AppTypography.textTheme.labelMedium?.copyWith(
                 color: AppColors.fgStrong,
+                fontWeight: FontWeight.w700,
                 height: 1.3,
               ),
             ),
@@ -205,7 +206,7 @@ class _MealRow extends StatelessWidget {
                 alignment: Alignment.center,
                 child: const Text(
                   '🍲',
-                  style: TextStyle(fontSize: 24, height: 1),
+                  style: TextStyle(fontSize: 26, height: 1),
                 ),
               ),
               const SizedBox(width: AppSizes.sp12),

--- a/lib/src/features/home/widgets/todays_meals_card.dart
+++ b/lib/src/features/home/widgets/todays_meals_card.dart
@@ -130,7 +130,7 @@ class _CoverageBanner extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: AppColors.butterSoft,
-        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
       ),
       padding: const EdgeInsets.symmetric(
         horizontal: AppSizes.md - 2,


### PR DESCRIPTION
## Summary

Replaces the four NIB-86 placeholder widgets with real implementations per the NIB-120 redesign.

- `ongoing_introduced_card.dart` — derives first `inProgress` allergen from `kAllergenKeys` order; coral-gradient 62px thumb + emoji, name (display 16/700), 'Currently introducing' label, 3-segment coral-soft progress bar, chevron right. Whole card pushes `AppRoute.allergenTracker`. Renders `SizedBox.shrink()` when no inProgress allergen exists.
- `day_chip_row.dart` — decorative horizontal pill row (today + 6 prior days). 'Today' chip uses butter background + green-deep text; rest use surfaceVariant + fgMuted. No selection callback.
- `todays_meals_card.dart` — `Today, {Mon Day}` title3 outside; white card with TODAY'S MEALS overline (green-deep) + `n/2` meta, butter-soft coverage banner, then meal rows. Rows tap to `AppRoute.recipeDetail` with the entry's recipeId. Empty list renders an inline 'No meals today' placeholder (full empty-state lives in NIB-96).
- `helpful_guidance_card.dart` — section title3 + three white tip cards (butter glyph circle + display title + callout body) + design-system `TipCard` 'Important Health Disclaimer'.

## Figma frames

- Ongoing: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1242-10616
- Day-chip row: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1242-10628
- Today's meals: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1242-10630
- Helpful guidance: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1242-10648

## DS components consumed

- `TipCard` (`lib/src/common/components/cards/tip_card.dart`) — Helpful Guidance disclaimer card.
- Tokens only: `AppColors`, `AppTypography`, `AppSizes`. No hex / Nunito / withAlpha / `AllergenStatus.completed`.

## Carve-outs (data not in state, deferred to a follow-up)

- **OngoingIntroducedCard** — log counts are not in `HomeState` (only derived statuses). The 'X/3 times' subhead is omitted and the 3-segment progress bar renders all 3 empty rather than faking a fill. Hydrating log counts requires touching `home_controller.dart`, which is owned by NIB-86 and forbidden in this ticket.
- **TodaysMealsCard** — `MealPlanEntry` only carries `recipeId` (no recipe title / allergen tags). Rows show a generic thumb + the entry's `mealTime` label (capitalized, fallback 'Meal'); allergen tag chips are intentionally omitted. Recipe hydration belongs in `home_controller`, deferred.

## Acceptance criteria

- [x] OngoingIntroducedCard renders only when an inProgress allergen exists; taps push allergen tracker.
- [x] DayChipRow shows Today + 6 prior dates with Today highlighted (butter / green-deep).
- [x] TodaysMealsCard renders meal rows from `todaysMeals` + coverage banner; row tap fires `recipeDetail` with the entry's `recipeId`.
- [x] HelpfulGuidanceCard renders 3 tips + 'Important Health Disclaimer' tip card.
- [x] `flutter analyze` — 0 issues.
- [x] Existing tests still pass (`flutter test` — 423 passed).
- [x] `make gen` clean + idempotent (no diff on second run).
- [x] Zero hex / Nunito / withAlpha / `AllergenStatus.completed`.
- [x] Only the 4 allowed files modified.

## Gate results

- `make gen` — succeeded, 1044 outputs, clean second run.
- `flutter analyze` — `No issues found! (ran in 1.8s)`.
- `flutter test` — `All tests passed!` (423 tests).