### PR TITLE
feat(home): implement 3 empty-state variants [NIB-96]

### DIFF
--- a/lib/src/features/home/widgets/home_empty_state_full.dart
+++ b/lib/src/features/home/widgets/home_empty_state_full.dart
@@ -1,15 +1,134 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/cards/tip_card.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Placeholder for NIB-96 (full empty state — no baby OR zero activity).
-/// Wave 2 will replace.
+/// NIB-96: full "Ready to start?" empty state.
+///
+/// Butter-wash card with title + body copy and a primary "Create First Meal"
+/// pill, followed by a static "Getting Started Tips" section with 3 tip
+/// cards. The CTA invokes [onCreateMealPlan]; when null, falls back to
+/// routing to the meal plan tab (NIB-86 wires no callback through
+/// `home_screen`).
 class HomeEmptyStateFull extends StatelessWidget {
-  const HomeEmptyStateFull({this.babyName, super.key});
+  const HomeEmptyStateFull({
+    this.babyName,
+    this.onCreateMealPlan,
+    super.key,
+  });
 
+  /// Optional baby name. Preserved from the NIB-86 placeholder signature;
+  /// the spec copy is name-agnostic, so this is currently unused for
+  /// rendering.
   final String? babyName;
+
+  /// Invoked when the user taps "Create First Meal". Defaults to navigating
+  /// to the meal plan tab via `context.goNamed(AppRoute.mealPlan.name)`.
+  final VoidCallback? onCreateMealPlan;
+
+  void _onPressed(BuildContext context) {
+    final cb = onCreateMealPlan;
+    if (cb != null) {
+      cb();
+      return;
+    }
+    context.goNamed(AppRoute.mealPlan.name);
+  }
 
   @override
   Widget build(BuildContext context) {
-    // TODO(NIB-96): implement full empty state per redesign.
-    return const SizedBox.shrink();
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.pagePaddingV,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ReadyToStartCard(onPressed: () => _onPressed(context)),
+          const SizedBox(height: AppSizes.lg),
+          const Text(
+            'Getting Started Tips',
+            style: AppTypography.sectionTitle,
+          ),
+          const SizedBox(height: AppSizes.sm),
+          const TipCard(
+            title: 'Start with single-ingredient foods',
+            body: 'Offer one new food at a time so reactions are easy to spot.',
+          ),
+          const SizedBox(height: AppSizes.sm),
+          const TipCard(
+            title: 'Introduce allergens early',
+            body: 'Peanut, egg and dairy work best from around 6 months.',
+          ),
+          const SizedBox(height: AppSizes.sm),
+          const TipCard(
+            title: 'Watch, wait, repeat',
+            body: 'Offer each new food 2-3 days apart before adding the next.',
+          ),
+          const SizedBox(height: AppSizes.xl),
+        ],
+      ),
+    );
+  }
+}
+
+/// Butter-wash "Ready to start?" card. Shared between [HomeEmptyStateFull]
+/// and `HomeEmptyStateShort`. Renders the headline + body copy and a primary
+/// "Create First Meal" pill driven by [onPressed].
+class ReadyToStartCard extends StatelessWidget {
+  const ReadyToStartCard({required this.onPressed, super.key});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [AppColors.butter, AppColors.butterSoft],
+        ),
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+        boxShadow: AppSizes.shadowCard,
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.lg,
+        vertical: AppSizes.lg,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Ready to start?',
+            textAlign: TextAlign.center,
+            style: textTheme.displaySmall?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+          ),
+          const SizedBox(height: AppSizes.sm),
+          Text(
+            "Track allergen introductions and plan baby's meals.",
+            textAlign: TextAlign.center,
+            style: textTheme.bodyLarge?.copyWith(
+              color: AppColors.fgDefault,
+            ),
+          ),
+          const SizedBox(height: AppSizes.lg),
+          AppPillButton(
+            label: 'Create First Meal',
+            onPressed: onPressed,
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/src/features/home/widgets/home_empty_state_full.dart
+++ b/lib/src/features/home/widgets/home_empty_state_full.dart
@@ -119,7 +119,7 @@ class ReadyToStartCard extends StatelessWidget {
             "Track allergen introductions and plan baby's meals.",
             textAlign: TextAlign.center,
             style: textTheme.bodyLarge?.copyWith(
-              color: AppColors.fgDefault,
+              color: AppColors.fgFaint,
             ),
           ),
           const SizedBox(height: AppSizes.lg),

--- a/lib/src/features/home/widgets/home_empty_state_short.dart
+++ b/lib/src/features/home/widgets/home_empty_state_short.dart
@@ -1,15 +1,48 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/features/home/widgets/home_empty_state_full.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Placeholder for NIB-96 (short empty-state variant — some logs but no meals
-/// today, etc.). Wave 2 will replace.
+/// NIB-96: short "Ready to start?" empty state.
+///
+/// Used when the ongoing-introduced card and day chips need hiding (program
+/// not started). Renders only the butter-wash "Ready to start?" card and its
+/// primary CTA — no Getting Started Tips section below. Reuses
+/// [ReadyToStartCard] from [HomeEmptyStateFull].
 class HomeEmptyStateShort extends StatelessWidget {
-  const HomeEmptyStateShort({this.babyName, super.key});
+  const HomeEmptyStateShort({
+    this.babyName,
+    this.onCreateMealPlan,
+    super.key,
+  });
 
+  /// Optional baby name. Preserved from the NIB-86 placeholder signature;
+  /// the spec copy is name-agnostic, so this is currently unused for
+  /// rendering.
   final String? babyName;
+
+  /// Invoked when the user taps "Create First Meal". Defaults to navigating
+  /// to the meal plan tab via `context.goNamed(AppRoute.mealPlan.name)`.
+  final VoidCallback? onCreateMealPlan;
+
+  void _onPressed(BuildContext context) {
+    final cb = onCreateMealPlan;
+    if (cb != null) {
+      cb();
+      return;
+    }
+    context.goNamed(AppRoute.mealPlan.name);
+  }
 
   @override
   Widget build(BuildContext context) {
-    // TODO(NIB-96): implement short empty state per redesign.
-    return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+        vertical: AppSizes.sm,
+      ),
+      child: ReadyToStartCard(onPressed: () => _onPressed(context)),
+    );
   }
 }

--- a/lib/src/features/home/widgets/home_no_meals_state.dart
+++ b/lib/src/features/home/widgets/home_no_meals_state.dart
@@ -1,15 +1,81 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/cards/app_card.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Placeholder for NIB-96 (no-meals-today empty-state variant). Wave 2 will
-/// replace.
+/// NIB-96: dashed "No Meals Mapped Yet" empty state.
+///
+/// Decorative-only (no drag-and-drop). Renders a dashed-border card with the
+/// title + body copy and a primary "+ Add" pill that invokes [onAddMeal];
+/// when null, falls back to routing to the meal plan tab (NIB-86 wires no
+/// callback through `home_screen`).
 class HomeNoMealsState extends StatelessWidget {
-  const HomeNoMealsState({this.babyName, super.key});
+  const HomeNoMealsState({
+    this.babyName,
+    this.onAddMeal,
+    super.key,
+  });
 
+  /// Optional baby name. Preserved from the NIB-86 placeholder signature;
+  /// the spec copy is name-agnostic, so this is currently unused for
+  /// rendering.
   final String? babyName;
+
+  /// Invoked when the user taps "+ Add". Defaults to navigating to the meal
+  /// plan tab via `context.goNamed(AppRoute.mealPlan.name)`.
+  final VoidCallback? onAddMeal;
+
+  void _onPressed(BuildContext context) {
+    final cb = onAddMeal;
+    if (cb != null) {
+      cb();
+      return;
+    }
+    context.goNamed(AppRoute.mealPlan.name);
+  }
 
   @override
   Widget build(BuildContext context) {
-    // TODO(NIB-96): implement no-meals state per redesign.
-    return const SizedBox.shrink();
+    final textTheme = Theme.of(context).textTheme;
+
+    return AppCard(
+      variant: AppCardVariant.dashed,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.lg,
+        vertical: AppSizes.lg,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'No Meals Mapped Yet',
+            textAlign: TextAlign.center,
+            style: textTheme.displaySmall?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+          ),
+          const SizedBox(height: AppSizes.sm),
+          Text(
+            "Tap below to add today's first meal.",
+            textAlign: TextAlign.center,
+            style: textTheme.bodyLarge?.copyWith(
+              color: AppColors.fgMuted,
+            ),
+          ),
+          const SizedBox(height: AppSizes.md),
+          Align(
+            child: AppPillButton(
+              label: '+ Add',
+              size: AppPillButtonSize.small,
+              expand: false,
+              onPressed: () => _onPressed(context),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/src/features/home/widgets/home_no_meals_state.dart
+++ b/lib/src/features/home/widgets/home_no_meals_state.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/common/components/cards/app_card.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
@@ -50,19 +51,17 @@ class HomeNoMealsState extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Text(
+          const Text(
             'No Meals Mapped Yet',
             textAlign: TextAlign.center,
-            style: textTheme.displaySmall?.copyWith(
-              color: AppColors.fgStrong,
-            ),
+            style: AppTypography.emptyStateTitle,
           ),
           const SizedBox(height: AppSizes.sm),
           Text(
             "Tap below to add today's first meal.",
             textAlign: TextAlign.center,
-            style: textTheme.bodyLarge?.copyWith(
-              color: AppColors.fgMuted,
+            style: textTheme.bodySmall?.copyWith(
+              color: AppColors.fgFaint,
             ),
           ),
           const SizedBox(height: AppSizes.md),


### PR DESCRIPTION
## Summary

Replaces the NIB-86 placeholder widgets with real implementations per Figma. The Home screen chooses which variant to render based on state.

### Figma frames
- Empty (full — Ready to start): https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1242-10152
- Empty-short (no ongoing/day chips): https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1266-12135
- No-meals (dashed + Add box): https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1266-12400

### Files changed
- `lib/src/features/home/widgets/home_empty_state_full.dart`
- `lib/src/features/home/widgets/home_empty_state_short.dart`
- `lib/src/features/home/widgets/home_no_meals_state.dart`

### DS components consumed
- `AppPillButton` (primary, full + small)
- `AppCard` with `AppCardVariant.dashed`
- `TipCard`
- `AppColors` (butter / butterSoft / fgStrong / fgDefault / fgMuted / greenDeep via pill)
- `AppTypography` (`textTheme.displaySmall` for headlines, `sectionTitle`, `bodyLarge`)
- `AppSizes` (radii, spacing tokens, `shadowCard`)

### Callback wiring note
`home_screen.dart` is forbidden to modify (NIB-86 owns) and currently does not pass a callback. To preserve the placeholder constructor signature while still exposing the spec's named callbacks, the widgets expose optional `onCreateMealPlan` / `onAddMeal` params and fall back to `context.goNamed(AppRoute.mealPlan.name)` when null. The existing call site (`HomeEmptyStateFull(babyName: baby?.name)`) continues to compile unchanged.

## Acceptance criteria

- [x] All 3 widgets implemented per their Figma frames
- [x] CTAs invoke their callbacks (with safe default fallback to mealPlan route)
- [x] `flutter analyze` 0 issues
- [x] Existing tests still pass (423 passed, 0 failed)
- [x] `make gen` clean + idempotent (no surprise diff on second run)
- [x] Zero hex / Nunito / withAlpha / AllergenStatus.completed
- [x] Only the 3 allowed files modified

## Gate results

- `make gen`: succeeded, 0 errors, idempotent on rerun
- `flutter analyze`: `No issues found!`
- `flutter test`: `All tests passed!` (423 tests)