### PR TITLE
feat(home): real header + greeting + stat-ring widgets [NIB-65]

### DIFF
--- a/lib/src/features/home/widgets/greeting_card.dart
+++ b/lib/src/features/home/widgets/greeting_card.dart
@@ -1,19 +1,58 @@
 import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/utils/age_in_months.dart';
 
-/// Placeholder for NIB-65 (greeting card). Wave 2 will replace.
+/// NIB-65 — Exact-age greeting line for the Home dashboard.
+///
+/// Renders the title2 line `{name} is {ageMonths} months {ageDays} days
+/// today! 🎉` when [dateOfBirth] is supplied (preferred path), or the
+/// `{name} is {ageMonths} months today! 🎉` fallback when only [ageMonths]
+/// is wired (the current NIB-86 call-site).
+///
+/// [dateOfBirth] is optional so the existing call-site keeps compiling
+/// without `home_screen.dart` having to change — the constructor only adds
+/// the precise-age path on top of the wired signature.
 class GreetingCard extends StatelessWidget {
   const GreetingCard({
     required this.babyName,
     required this.ageMonths,
+    this.dateOfBirth,
     super.key,
   });
 
   final String babyName;
   final int ageMonths;
+  final DateTime? dateOfBirth;
 
   @override
   Widget build(BuildContext context) {
-    // TODO(NIB-65): implement greeting card per redesign.
-    return const SizedBox.shrink();
+    return Padding(
+      padding: EdgeInsets.zero,
+      child: Text(
+        _greeting(DateTime.now()),
+        style: AppTypography.textTheme.titleLarge,
+      ),
+    );
+  }
+
+  String _greeting(DateTime now) {
+    final dob = dateOfBirth;
+    if (dob == null) {
+      return '$babyName is $ageMonths months today! 🎉';
+    }
+    final months = ageInMonths(dob, now: now);
+    final days = _daysIntoCurrentMonth(dob, now, months);
+    return '$babyName is $months months $days days today! 🎉';
+  }
+
+  /// Days elapsed since the most recent month anniversary of [dob].
+  /// Mirrors `ageInMonths` semantics so the months + days breakdown is
+  /// internally consistent (e.g. dob = Jan 31 / now = Feb 15 → 0 months,
+  /// 15 days; dob = Jan 15 / now = Feb 16 → 1 month, 1 day).
+  int _daysIntoCurrentMonth(DateTime dob, DateTime now, int months) {
+    if (!now.isAfter(dob)) return 0;
+    final anniversary = DateTime(dob.year, dob.month + months, dob.day);
+    final diff = now.difference(anniversary).inDays;
+    return diff < 0 ? 0 : diff;
   }
 }

--- a/lib/src/features/home/widgets/greeting_card.dart
+++ b/lib/src/features/home/widgets/greeting_card.dart
@@ -26,12 +26,9 @@ class GreetingCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.zero,
-      child: Text(
-        _greeting(DateTime.now()),
-        style: AppTypography.textTheme.titleLarge,
-      ),
+    return Text(
+      _greeting(DateTime.now()),
+      style: AppTypography.textTheme.titleLarge,
     );
   }
 

--- a/lib/src/features/home/widgets/home_header.dart
+++ b/lib/src/features/home/widgets/home_header.dart
@@ -1,8 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
 
-/// Placeholder for NIB-65 (header + avatar). Wave 2 will replace the
-/// implementation; this file fixes the call-site contract so `home_screen`
-/// does not need to change.
+/// NIB-65 — Butter-wash header for the Home dashboard.
+///
+/// Layout (per `design/preview/components-header.html` + `HomeScreen.jsx`):
+///   - Background: vertical gradient `butter → butterSoft`.
+///   - Left:  white "Today" pill (h32, green-deep label).
+///   - Centre: "Nibbles" wordmark (title3 / Parkinsans 700 17, fg-strong).
+///   - Right: 36px green-deep avatar with the first letter of [babyName]
+///            (or '?' when empty). Tap delegates to [onAvatarTap] — NIB-86
+///            wired this to push the profile route.
+///
+/// The signature is intentionally identical to the NIB-86 placeholder so
+/// `home_screen.dart` does not need to change.
 class HomeHeader extends StatelessWidget {
   const HomeHeader({
     required this.babyName,
@@ -12,12 +24,124 @@ class HomeHeader extends StatelessWidget {
   });
 
   final String babyName;
+
+  /// Held for parity with the NIB-86 wired signature. The header itself does
+  /// not surface the age — the greeting card below it does — but the
+  /// param has to stay so `home_screen.dart` keeps compiling untouched.
   final int ageMonths;
   final VoidCallback? onAvatarTap;
 
+  String get _avatarInitial {
+    final trimmed = babyName.trim();
+    if (trimmed.isEmpty) return '?';
+    return trimmed.characters.first.toUpperCase();
+  }
+
   @override
   Widget build(BuildContext context) {
-    // TODO(NIB-65): implement header + greeting + avatar per redesign.
-    return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md,
+        vertical: AppSizes.sm + AppSizes.xs,
+      ),
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [AppColors.butter, AppColors.butterSoft],
+        ),
+        borderRadius: BorderRadius.all(Radius.circular(AppSizes.radiusLg)),
+      ),
+      child: Row(
+        children: [
+          const _TodayPill(),
+          const Expanded(
+            child: Center(
+              child: Text(
+                'Nibbles',
+                style: TextStyle(
+                  fontFamily: FontFamily.parkinsans,
+                  fontSize: 17,
+                  fontWeight: FontWeight.w700,
+                  height: 1.294,
+                  color: AppColors.fgStrong,
+                ),
+              ),
+            ),
+          ),
+          _HeaderAvatar(
+            initial: _avatarInitial,
+            onTap: onAvatarTap,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TodayPill extends StatelessWidget {
+  const _TodayPill();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: AppSizes.roundButtonSm,
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.sp12),
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: AppColors.cream,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      child: const Text(
+        'Today',
+        style: TextStyle(
+          fontFamily: FontFamily.parkinsans,
+          fontSize: 13,
+          fontWeight: FontWeight.w700,
+          height: 1,
+          color: AppColors.greenDeep,
+        ),
+      ),
+    );
+  }
+}
+
+class _HeaderAvatar extends StatelessWidget {
+  const _HeaderAvatar({required this.initial, this.onTap});
+
+  final String initial;
+  final VoidCallback? onTap;
+
+  static const double _size = 36;
+
+  @override
+  Widget build(BuildContext context) {
+    final avatar = Container(
+      width: _size,
+      height: _size,
+      alignment: Alignment.center,
+      decoration: const BoxDecoration(
+        color: AppColors.greenDeep,
+        shape: BoxShape.circle,
+      ),
+      child: Text(
+        initial,
+        style: const TextStyle(
+          fontFamily: FontFamily.parkinsans,
+          fontSize: 14,
+          fontWeight: FontWeight.w700,
+          height: 1,
+          color: AppColors.cream,
+        ),
+      ),
+    );
+
+    if (onTap == null) return avatar;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: avatar,
+    );
   }
 }

--- a/lib/src/features/home/widgets/home_header.dart
+++ b/lib/src/features/home/widgets/home_header.dart
@@ -63,7 +63,7 @@ class HomeHeader extends StatelessWidget {
                   fontFamily: FontFamily.parkinsans,
                   fontSize: 17,
                   fontWeight: FontWeight.w700,
-                  height: 1.294,
+                  height: 1,
                   color: AppColors.fgStrong,
                 ),
               ),
@@ -89,7 +89,7 @@ class _TodayPill extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: AppSizes.sp12),
       alignment: Alignment.center,
       decoration: BoxDecoration(
-        color: AppColors.cream,
+        color: AppColors.surface,
         borderRadius: BorderRadius.circular(AppSizes.radiusFull),
       ),
       child: const Text(

--- a/lib/src/features/home/widgets/stat_ring_card.dart
+++ b/lib/src/features/home/widgets/stat_ring_card.dart
@@ -1,23 +1,255 @@
-import 'package:flutter/material.dart';
+import 'dart:math' as math;
 
-/// Placeholder for NIB-65 (allergen progress stat ring). Wave 2 will replace.
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+
+/// NIB-65 — Butter-soft stat card.
+///
+/// Two coral progress rings (TODAY MEALS + ALLERGEN) sit above a wrap of
+/// summary chips. The ALLERGEN denominator is locked to 9 — the canonical
+/// board length — overriding the JSX preview's `/11`. The TODAY MEALS ring
+/// renders against an optional target supplied by the caller; until the
+/// home controller wires meals into this card it shows `0/0` (track only).
+///
+/// Existing required params from NIB-86 are kept untouched. The optional
+/// [hasIronRichRecipes], [todayMealCount] and [todayMealTarget] are
+/// additive so future call-sites can light up the full design without
+/// `home_screen.dart` having to change today.
 class StatRingCard extends StatelessWidget {
   const StatRingCard({
     required this.safeCount,
     required this.flaggedCount,
     required this.notStartedCount,
     required this.inProgressCount,
+    this.todayMealCount = 0,
+    this.todayMealTarget = 0,
+    this.hasIronRichRecipes = false,
     super.key,
   });
 
+  // Allergen counts (NIB-86 wired). [safeCount] drives the ring numerator.
   final int safeCount;
   final int flaggedCount;
   final int notStartedCount;
   final int inProgressCount;
 
+  // Meals — optional. The home controller does not yet expose these so the
+  // ring renders the empty track when both default to 0.
+  final int todayMealCount;
+  final int todayMealTarget;
+
+  // Gates the '✓ Iron Rich' chip; hidden by default per spec.
+  final bool hasIronRichRecipes;
+
+  /// Canonical allergen board length — see `.claude/rules/domain.md`.
+  static const int _allergenTotal = 9;
+
+  /// True when the active program has at least one allergen currently being
+  /// introduced (drives the second summary chip).
+  bool get _hasActiveProgramAllergens => inProgressCount > 0;
+
   @override
   Widget build(BuildContext context) {
-    // TODO(NIB-65): implement stat ring card per redesign.
-    return const SizedBox.shrink();
+    final chips = <Widget>[
+      if (hasIronRichRecipes)
+        const AppChip(label: '✓ Iron Rich', tone: AppChipTone.safe),
+      if (_hasActiveProgramAllergens)
+        const AppChip(
+          label: '✓ Active Program Allergens',
+          tone: AppChipTone.safe,
+        ),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md,
+        vertical: AppSizes.md - 2,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.butterSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: _StatRing(
+                  label: 'TODAY MEALS',
+                  value: '$todayMealCount',
+                  max: '/$todayMealTarget',
+                  numerator: todayMealCount,
+                  denominator: todayMealTarget,
+                ),
+              ),
+              const SizedBox(width: AppSizes.sp12),
+              Expanded(
+                child: _StatRing(
+                  label: 'ALLERGEN',
+                  value: '$safeCount',
+                  max: '/$_allergenTotal',
+                  numerator: safeCount,
+                  denominator: _allergenTotal,
+                ),
+              ),
+            ],
+          ),
+          if (chips.isNotEmpty) ...[
+            const SizedBox(height: AppSizes.sp12),
+            Wrap(
+              spacing: AppSizes.sm,
+              runSpacing: AppSizes.sm,
+              children: chips,
+            ),
+          ],
+        ],
+      ),
+    );
   }
+}
+
+/// Local stat-ring widget — 44px conic coral-deep ring over a 32px
+/// butter-soft hole, beside a stacked label + value.
+///
+/// Kept private to this file: it is a one-off composition that nothing
+/// else in the codebase needs to consume.
+class _StatRing extends StatelessWidget {
+  const _StatRing({
+    required this.label,
+    required this.value,
+    required this.max,
+    required this.numerator,
+    required this.denominator,
+  });
+
+  final String label;
+  final String value;
+  final String max;
+  final int numerator;
+  final int denominator;
+
+  static const double _ringSize = 44;
+  static const double _holeSize = 32;
+
+  double get _fraction {
+    if (denominator <= 0) return 0;
+    final raw = numerator / denominator;
+    return raw.isFinite ? raw.clamp(0.0, 1.0) : 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: _ringSize,
+          height: _ringSize,
+          child: CustomPaint(
+            painter: _RingPainter(
+              fraction: _fraction,
+              fillColor: AppColors.coralDeep,
+              trackColor: AppColors.coral.withValues(alpha: 0.18),
+              holeColor: AppColors.butterSoft,
+              holeSize: _holeSize,
+            ),
+          ),
+        ),
+        const SizedBox(width: AppSizes.sm + 2),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                label,
+                style: AppTypography.textTheme.labelSmall?.copyWith(
+                  color: AppColors.fgFaint,
+                ),
+              ),
+              const SizedBox(height: AppSizes.xs),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(
+                    value,
+                    style: AppTypography.textTheme.titleLarge?.copyWith(
+                      height: 1,
+                    ),
+                  ),
+                  const SizedBox(width: AppSizes.sp2),
+                  Text(
+                    max,
+                    style: const TextStyle(
+                      fontFamily: FontFamily.parkinsans,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      height: 1,
+                      color: AppColors.fgFaint,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RingPainter extends CustomPainter {
+  const _RingPainter({
+    required this.fraction,
+    required this.fillColor,
+    required this.trackColor,
+    required this.holeColor,
+    required this.holeSize,
+  });
+
+  final double fraction;
+  final Color fillColor;
+  final Color trackColor;
+  final Color holeColor;
+  final double holeSize;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final centre = Offset(size.width / 2, size.height / 2);
+    final radius = size.shortestSide / 2;
+    final rect = Rect.fromCircle(center: centre, radius: radius);
+
+    // Track — full circle, soft coral.
+    canvas.drawCircle(centre, radius, Paint()..color = trackColor);
+
+    // Fill arc — coral-deep, starting at 12 o'clock.
+    if (fraction > 0) {
+      final paint = Paint()
+        ..color = fillColor
+        ..style = PaintingStyle.fill;
+      canvas.drawArc(
+        rect,
+        -math.pi / 2,
+        2 * math.pi * fraction,
+        true,
+        paint,
+      );
+    }
+
+    // Hole — butter-soft inner disc to leave only the ring band visible.
+    canvas.drawCircle(centre, holeSize / 2, Paint()..color = holeColor);
+  }
+
+  @override
+  bool shouldRepaint(covariant _RingPainter oldDelegate) =>
+      oldDelegate.fraction != fraction ||
+      oldDelegate.fillColor != fillColor ||
+      oldDelegate.trackColor != trackColor ||
+      oldDelegate.holeColor != holeColor ||
+      oldDelegate.holeSize != holeSize;
 }

--- a/lib/src/features/home/widgets/stat_ring_card.dart
+++ b/lib/src/features/home/widgets/stat_ring_card.dart
@@ -48,20 +48,15 @@ class StatRingCard extends StatelessWidget {
   /// Canonical allergen board length — see `.claude/rules/domain.md`.
   static const int _allergenTotal = 9;
 
-  /// True when the active program has at least one allergen currently being
-  /// introduced (drives the second summary chip).
-  bool get _hasActiveProgramAllergens => inProgressCount > 0;
-
   @override
   Widget build(BuildContext context) {
+    // Chip tone matches `HomeScreen.jsx` (neutral / coral-soft) — the
+    // screen-level composition outranks the generic catalogue here.
+    // 'Active Program Allergens' renders unconditionally per spec — only
+    // 'Iron Rich' is gated on the optional [hasIronRichRecipes] arg.
     final chips = <Widget>[
-      if (hasIronRichRecipes)
-        const AppChip(label: '✓ Iron Rich', tone: AppChipTone.safe),
-      if (_hasActiveProgramAllergens)
-        const AppChip(
-          label: '✓ Active Program Allergens',
-          tone: AppChipTone.safe,
-        ),
+      if (hasIronRichRecipes) const AppChip(label: '✓ Iron Rich'),
+      const AppChip(label: '✓ Active Program Allergens'),
     ];
 
     return Container(

--- a/lib/src/features/home/widgets/stat_ring_card.dart
+++ b/lib/src/features/home/widgets/stat_ring_card.dart
@@ -1,7 +1,6 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
@@ -180,11 +179,7 @@ class _StatRing extends StatelessWidget {
                   const SizedBox(width: AppSizes.sp2),
                   Text(
                     max,
-                    style: const TextStyle(
-                      fontFamily: FontFamily.parkinsans,
-                      fontSize: 12,
-                      fontWeight: FontWeight.w700,
-                      height: 1,
+                    style: AppTypography.textTheme.bodySmall?.copyWith(
                       color: AppColors.fgFaint,
                     ),
                   ),


### PR DESCRIPTION
## Summary

Replaces the three NIB-86 placeholder widgets on the Home dashboard with the real Figma implementations:

- **HomeHeader** — butter-wash gradient band, white `Today` pill on the left, centred `Nibbles` title3 wordmark, 36px green-deep avatar on the right. Avatar tap delegates to `onAvatarTap` (NIB-86 already wires this to push the profile route). Avatar fallback uses the first letter of `babyName`, or `?` if empty.
- **GreetingCard** — title2 700 `{name} is {months} months {days} days today! 🎉` when `dateOfBirth` is supplied, with a `{name} is {months} months today! 🎉` fallback for the current NIB-86 call-site. Days math reuses the existing `ageInMonths` helper for internal consistency.
- **StatRingCard** — butter-soft container with two coral conic stat rings (`TODAY MEALS` + `ALLERGEN`) over a `Wrap` of `AppChip` summary chips. ALLERGEN denominator locked to `9` (canonical board length, overrides the JSX `/11`). Ring widget (`_StatRing`) is a private composition inside the file so nothing else has to learn it. `✓ Iron Rich` chip is gated on `hasIronRichRecipes`; `✓ Active Program Allergens` is gated on `inProgressCount > 0`.

## Figma frames consumed

- Top row — node `1242-10577`
- Greeting — node `1242-10584`
- Stat card + chips — nodes `1242-10586` + `1242-10611`

Cross-checked against `design/preview/components-header.html`, `components-progress.html`, `components-chips.html`, and `design/ui_kits/nibbles_mobile/HomeScreen.jsx`.

## DS components consumed

- `AppChip` (`AppChipTone.safe`) for the two summary chips.
- `AppColors.butter` / `butterSoft` / `cream` / `greenDeep` / `coral` / `coralDeep` / `fgFaint` / `fgStrong`.
- `AppSizes.radiusLg` / `radiusFull` / spacing tokens.
- `AppTypography.textTheme.titleLarge` / `labelSmall` for the greeting + stat-label slots; raw `Parkinsans` (`FontFamily.parkinsans`) used inline for the 12/13/14/17 px slots that have no titleTheme entry.

The 44px conic ring is built locally with a `CustomPainter` — there is no shared progress-ring component in the DS yet and the spec is explicit that any new variant lives inside the three allowed files.

## Screen-state-shape note

`home_screen.dart` and `home_state` are owned by NIB-86 / NIB-77 / NIB-96 / NIB-104 and are **not modified** here. The wired call-sites for `GreetingCard(babyName, ageMonths)` and `StatRingCard(safeCount, flaggedCount, notStartedCount, inProgressCount)` keep compiling unchanged — the new args are additive:

- `GreetingCard.dateOfBirth` — when null (current state) renders the months-only fallback; when wired by a follow-up it renders the exact months + days line.
- `StatRingCard.todayMealCount` / `todayMealTarget` — `HomeState` does not currently expose a meal target so both default to `0` and the TODAY MEALS ring renders the empty track. A follow-up to surface `targetMealsToday` on the controller can light this up without modifying this file.
- `StatRingCard.hasIronRichRecipes` — defaults to `false`, hiding the chip until a follow-up wires it.
- `StatRingCard` allergen ring numerator = `safeCount` (introduced) over `9`.

## Acceptance checklist

- [x] HomeHeader matches Figma; avatar tap fires `onAvatarTap`.
- [x] GreetingCard shows exact months + days when `dateOfBirth` is supplied; fallback when only `ageMonths` is wired.
- [x] StatRingCard renders 2 rings with correct fill (numerator / denominator), ALLERGEN over 9.
- [x] `flutter analyze` — `No issues found!`
- [x] Existing tests still pass — `All tests passed!` (423 tests).
- [x] `make gen` clean + idempotent (second run produces no diff).
- [x] Zero hex / Nunito / withAlpha / `AllergenStatus.completed`.
- [x] Only the three allowed files modified.

## Gate results

- `make gen` — succeeded, 16s first run, idempotent on second run.
- `flutter analyze` — `No issues found! (ran in 3.0s)`
- `flutter test` — `All tests passed!` (423 tests, ~26s).