### PR TITLE
feat(home): analytics events for screen_view, ongoing allergen, create-meal CTA, recipe row [NIB-106]

### DIFF
--- a/lib/src/features/home/home_screen.dart
+++ b/lib/src/features/home/home_screen.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
@@ -14,6 +17,8 @@ import 'package:nibbles/src/features/home/widgets/home_header.dart';
 import 'package:nibbles/src/features/home/widgets/ongoing_introduced_card.dart';
 import 'package:nibbles/src/features/home/widgets/stat_ring_card.dart';
 import 'package:nibbles/src/features/home/widgets/todays_meals_card.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 /// NIB-86 scaffold.
 ///
@@ -22,11 +27,43 @@ import 'package:nibbles/src/features/home/widgets/todays_meals_card.dart';
 /// implementations land in NIB-65 (header + greeting + stat ring), NIB-77
 /// (ongoing card + day chips + today's meals + guidance) and NIB-96
 /// (empty-state variants).
-class HomeScreen extends ConsumerWidget {
+///
+/// Converted to [ConsumerStatefulWidget] in NIB-106 so `initState` can fire
+/// `logScreenView('home')` once on mount via a post-frame callback.
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Emit screen_view('home') once on the first frame. Guarded + unawaited
+    // so an uninitialised Firebase / analytics hiccup never throws into the
+    // frame callback (mirrors splash_screen.dart).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_logScreenView());
+    });
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await Analytics.instance.logScreenView(screenName: 'home');
+    } on Object catch (_) {
+      // Analytics is best-effort; never surface to the UI.
+    }
+  }
+
+  void _onCreateFirstMeal() {
+    unawaited(Analytics.instance.logHomeCreateFirstMealTapped());
+    context.goNamed(AppRoute.mealPlan.name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final babyIdAsync = ref.watch(currentBabyIdProvider);
 
     return babyIdAsync.when(
@@ -36,21 +73,27 @@ class HomeScreen extends ConsumerWidget {
       ),
       data: (babyId) {
         if (babyId == null) {
-          return const Scaffold(
+          return Scaffold(
             backgroundColor: AppColors.background,
-            body: SafeArea(child: HomeEmptyStateFull()),
+            body: SafeArea(
+              child: HomeEmptyStateFull(onCreateMealPlan: _onCreateFirstMeal),
+            ),
           );
         }
-        return _HomeBody(babyId: babyId);
+        return _HomeBody(
+          babyId: babyId,
+          onCreateFirstMeal: _onCreateFirstMeal,
+        );
       },
     );
   }
 }
 
 class _HomeBody extends ConsumerWidget {
-  const _HomeBody({required this.babyId});
+  const _HomeBody({required this.babyId, required this.onCreateFirstMeal});
 
   final String babyId;
+  final VoidCallback onCreateFirstMeal;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -62,15 +105,19 @@ class _HomeBody extends ConsumerWidget {
         message: err is AppException ? err.message : 'Something went wrong.',
         onRetry: () => ref.invalidate(homeControllerProvider(babyId)),
       ),
-      data: (state) => _HomeContent(state: state),
+      data: (state) => _HomeContent(
+        state: state,
+        onCreateFirstMeal: onCreateFirstMeal,
+      ),
     );
   }
 }
 
 class _HomeContent extends StatelessWidget {
-  const _HomeContent({required this.state});
+  const _HomeContent({required this.state, required this.onCreateFirstMeal});
 
   final HomeState state;
+  final VoidCallback onCreateFirstMeal;
 
   @override
   Widget build(BuildContext context) {
@@ -81,7 +128,10 @@ class _HomeContent extends StatelessWidget {
       return Scaffold(
         backgroundColor: AppColors.background,
         body: SafeArea(
-          child: HomeEmptyStateFull(babyName: baby?.name),
+          child: HomeEmptyStateFull(
+            babyName: baby?.name,
+            onCreateMealPlan: onCreateFirstMeal,
+          ),
         ),
       );
     }

--- a/lib/src/features/home/widgets/ongoing_introduced_card.dart
+++ b/lib/src/features/home/widgets/ongoing_introduced_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/constants/allergen_emoji.dart';
@@ -6,6 +8,7 @@ import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/services/helpers/derive_allergen_status.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
 /// Home — Ongoing-introduced card (NIB-77, Figma 1242:10616).
@@ -62,8 +65,14 @@ class OngoingIntroducedCard extends StatelessWidget {
           borderRadius: BorderRadius.circular(AppSizes.radiusXl),
           child: InkWell(
             borderRadius: BorderRadius.circular(AppSizes.radiusXl),
-            onTap: () =>
-                context.pushNamed(AppRoute.allergenTracker.name),
+            onTap: () {
+              unawaited(
+                Analytics.instance.logHomeOngoingAllergenTapped(
+                  allergenKey: key,
+                ),
+              );
+              context.pushNamed(AppRoute.allergenTracker.name);
+            },
             child: Ink(
               decoration: BoxDecoration(
                 color: AppColors.surface,

--- a/lib/src/features/home/widgets/todays_meals_card.dart
+++ b/lib/src/features/home/widgets/todays_meals_card.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
 /// Home — Today's meals card (NIB-77, Figma 1242:10630).
@@ -184,10 +187,15 @@ class _MealRow extends StatelessWidget {
       color: Colors.transparent,
       child: InkWell(
         borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-        onTap: () => context.pushNamed(
-          AppRoute.recipeDetail.name,
-          pathParameters: {'recipeId': entry.recipeId},
-        ),
+        onTap: () {
+          unawaited(
+            Analytics.instance.logRecipeViewed(recipeId: entry.recipeId),
+          );
+          context.pushNamed(
+            AppRoute.recipeDetail.name,
+            pathParameters: {'recipeId': entry.recipeId},
+          );
+        },
         child: Padding(
           padding: const EdgeInsets.all(AppSizes.xs),
           child: Row(

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -414,6 +414,23 @@ class Analytics {
   }
 
   // ---------------------------------------------------------------------------
+  // Home (NIB-106) — non-PII only: allergen_key + intent taps.
+  // ---------------------------------------------------------------------------
+
+  Future<void> logHomeOngoingAllergenTapped({
+    required String allergenKey,
+  }) async {
+    await _logEvent(
+      'home_ongoing_allergen_tapped',
+      parameters: {'allergen_key': allergenKey},
+    );
+  }
+
+  Future<void> logHomeCreateFirstMealTapped() async {
+    await _logEvent('home_create_first_meal_tapped');
+  }
+
+  // ---------------------------------------------------------------------------
   // Screen tracking
   // ---------------------------------------------------------------------------
 

--- a/test/support/fake_analytics.dart
+++ b/test/support/fake_analytics.dart
@@ -254,6 +254,17 @@ class FakeAnalytics implements Analytics {
       _record('meal_plan_add_to_shop_list', {'day_count': dayCount});
 
   @override
+  Future<void> logHomeOngoingAllergenTapped({
+    required String allergenKey,
+  }) async => _record('home_ongoing_allergen_tapped', {
+    'allergen_key': allergenKey,
+  });
+
+  @override
+  Future<void> logHomeCreateFirstMealTapped() async =>
+      _record('home_create_first_meal_tapped');
+
+  @override
   Future<void> logScreenView({required String screenName}) async =>
       _record('screen_view', {'screen_name': screenName});
 }


### PR DESCRIPTION
## Summary

Instruments the redesigned Home dashboard for success/intent analytics, per NIB-106. All params are non-PII (`allergen_key` stable lowercase, `recipe_id` UUID).

## New events (`lib/src/logging/analytics.dart`)

| Event | Params |
|---|---|
| `home_ongoing_allergen_tapped` | `allergen_key: string` |
| `home_create_first_meal_tapped` | none |

## Reused events

| Event | Params | Fire site |
|---|---|---|
| `screen_view` | `screen_name: 'home'` | `home_screen.dart` post-frame on mount |
| `recipe_viewed` | `recipe_id: string` | meal row `onTap` before `pushNamed(recipeDetail)` |

## Fire sites

- `lib/src/features/home/home_screen.dart:49` — `Analytics.instance.logScreenView(screenName: 'home')` inside `addPostFrameCallback` (guarded with try/catch mirroring `splash_screen.dart`).
- `lib/src/features/home/home_screen.dart:62` — `Analytics.instance.logHomeCreateFirstMealTapped()` inside `_onCreateFirstMeal`; wired into both `HomeEmptyStateFull` invocations (top-level no-baby branch and `_HomeContent` no-activity branch) via `onCreateMealPlan`.
- `lib/src/features/home/widgets/ongoing_introduced_card.dart:69` — `Analytics.instance.logHomeOngoingAllergenTapped(allergenKey: key)` before `context.pushNamed(allergenTracker)`.
- `lib/src/features/home/widgets/todays_meals_card.dart:191` — `Analytics.instance.logRecipeViewed(recipeId: entry.recipeId)` before `context.pushNamed(recipeDetail, ...)`.
- `test/support/fake_analytics.dart` — mirrors the 2 new method signatures so existing tests compile.

All analytics calls use `unawaited(...)` (fire-and-forget). `dart:async` imported where needed.

## PII confirmation

- `allergen_key` is the stable lowercase key (e.g. `peanut`, `egg`) — no PII.
- `recipe_id` is a UUID — no PII.
- No `baby_id`, no baby names, no free text emitted.

## Acceptance checklist

- [x] `analytics.dart` exposes the 2 new methods following the existing pattern.
- [x] `home_screen.dart` fires `logScreenView('home')` on mount.
- [x] Ongoing card tap fires `logHomeOngoingAllergenTapped(allergenKey)` BEFORE navigation.
- [x] Empty-state CTA fires `logHomeCreateFirstMealTapped()` BEFORE navigation.
- [x] Today's meals row tap fires `logRecipeViewed(recipeId)` BEFORE navigation.
- [x] PII gate clean — no baby_id/name/free-text params.
- [x] `flutter analyze` 0 issues.
- [x] `flutter test` — all 423 tests pass.
- [x] `make gen` clean + idempotent (second run produced no diff to gen outputs).
- [x] No files outside the allowed list modified.

## Gate results

- `make gen`: succeeded, 1045 outputs, no diff on second run.
- `flutter analyze`: `No issues found! (ran in 2.9s)`.
- `flutter test`: `00:24 +423: All tests passed!`.