### PR TITLE
chore(home): add widget tests for dashboard states, nav taps, error/retry [NIB-111]

### DIFF
--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -1,29 +1,65 @@
+// Widget tests for the redesigned Home dashboard screen.
+//
+// NIB-111: net-new coverage for the four dashboard states (populated,
+// empty-full, empty-short-equivalent, no-meals), navigation tap routing
+// (ongoing card -> allergen tracker, meal row -> recipe detail, empty-state
+// CTA -> meal plan tab), and the error/retry path.
+//
+// Strategy:
+//   * Override `homeControllerProvider(babyId)` with a canned `HomeState`
+//     (mirrors `recipe_library_screen_test.dart`'s controller-fake pattern)
+//     and override `currentBabyIdProvider` so `_HomeBody` resolves to the
+//     same id.
+//   * Stub destination routes with identifiable text so navigation taps can
+//     be asserted by routed marker text (no NavigatorObserver needed).
+//   * Neutralise Firebase + analytics via `setupFirebaseCoreMocks()` +
+//     a no-op `FirebaseAnalyticsPlatform` so the production code paths
+//     that hit `Analytics.instance` directly do not throw.
+//
+// Branching notes (intentionally do NOT modify lib/**):
+//   * `HomeScreen` has only two empty-state code paths today — both render
+//     `HomeEmptyStateFull`. The "no baby" path and the "baby exists but no
+//     activity" (`HomeState.hasNoActivity`) path are covered; a distinct
+//     `HomeEmptyStateShort` branch is not surfaced by the screen.
+//   * `HomeNoMealsState` is likewise not wired by the screen — empty
+//     `todaysMeals` inside the populated dashboard surfaces the inline
+//     "No meals today" placeholder rendered by `TodaysMealsCard`.
+//   * `HomeHeader.onAvatarTap` is never wired by the screen, so the
+//     avatar -> profile navigation has no production behaviour to assert.
+//   * The screen's error scaffold CTA reads "Try Again", not "Retry".
+
+// Firebase platform-interface packages are transitive deps; the public
+// barrels do not re-export FirebaseAnalyticsPlatform / setupFirebaseCoreMocks.
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:firebase_analytics_platform_interface/firebase_analytics_platform_interface.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:mocktail/mocktail.dart';
-import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
-import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
-import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:nibbles/src/features/home/home_controller.dart';
 import 'package:nibbles/src/features/home/home_screen.dart';
+import 'package:nibbles/src/features/home/home_state.dart';
+import 'package:nibbles/src/features/home/widgets/day_chip_row.dart';
+import 'package:nibbles/src/features/home/widgets/greeting_card.dart';
+import 'package:nibbles/src/features/home/widgets/helpful_guidance_card.dart';
+import 'package:nibbles/src/features/home/widgets/home_empty_state_full.dart';
+import 'package:nibbles/src/features/home/widgets/home_header.dart';
+import 'package:nibbles/src/features/home/widgets/ongoing_introduced_card.dart';
+import 'package:nibbles/src/features/home/widgets/stat_ring_card.dart';
+import 'package:nibbles/src/features/home/widgets/todays_meals_card.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
 
 // ---------------------------------------------------------------------------
-// NIB-86: render-smoke tests only. The home screen now delegates to placeholder
-// widgets (NIB-65 / NIB-77 / NIB-96 will implement). NIB-111 owns the full
-// widget test suite once the leaf widgets land.
+// Fixtures
 // ---------------------------------------------------------------------------
-
-class _MockBabyProfileService extends Mock implements BabyProfileService {}
-
-class _MockAllergenService extends Mock implements AllergenService {}
-
-class _MockMealPlanService extends Mock implements MealPlanService {}
 
 const _babyId = 'baby-001';
 
@@ -31,63 +67,507 @@ final _fakeBaby = Baby(
   id: _babyId,
   userId: 'user-001',
   name: 'Lily',
+  // Anchor DOB so age math is deterministic regardless of clock drift.
   dateOfBirth: DateTime(2025, 6),
   gender: Gender.female,
   onboardingCompleted: true,
 );
 
-Widget _wrap(List<Override> overrides) => ProviderScope(
-  overrides: overrides,
-  child: MaterialApp.router(
-    routerConfig: GoRouter(
-      initialLocation: '/',
-      routes: [GoRoute(path: '/', builder: (_, __) => const HomeScreen())],
-    ),
-  ),
+MealPlanEntry _meal(String id, String recipeId, {String? mealTime}) =>
+    MealPlanEntry(
+      id: id,
+      babyId: _babyId,
+      recipeId: recipeId,
+      planDate: DateTime.now(),
+      mealTime: mealTime,
+    );
+
+/// Populated state with a mix of statuses (peanut inProgress drives the
+/// OngoingIntroducedCard) and two meals today.
+HomeState _populatedState() => HomeState(
+  baby: _fakeBaby,
+  allergenStatuses: const {
+    'peanut': AllergenStatus.inProgress,
+    'egg': AllergenStatus.safe,
+    'dairy': AllergenStatus.safe,
+    'tree_nuts': AllergenStatus.flagged,
+    'sesame': AllergenStatus.notStarted,
+    'soy': AllergenStatus.notStarted,
+    'wheat': AllergenStatus.notStarted,
+    'fish': AllergenStatus.notStarted,
+    'shellfish': AllergenStatus.notStarted,
+  },
+  todaysMeals: [
+    _meal('mp-1', 'recipe-aaa', mealTime: 'breakfast'),
+    _meal('mp-2', 'recipe-bbb', mealTime: 'lunch'),
+  ],
 );
 
-void main() {
-  late _MockBabyProfileService mockBabyService;
-  late _MockAllergenService mockAllergenService;
-  late _MockMealPlanService mockMealPlanService;
+/// Populated baby + statuses but ZERO meals today — exercises the
+/// `TodaysMealsCard` inline "No meals today" placeholder while still
+/// rendering the full dashboard chrome.
+HomeState _populatedNoMealsState() => HomeState(
+  baby: _fakeBaby,
+  allergenStatuses: const {
+    'peanut': AllergenStatus.inProgress,
+    'egg': AllergenStatus.safe,
+  },
+);
 
-  setUp(() {
-    mockBabyService = _MockBabyProfileService();
-    mockAllergenService = _MockAllergenService();
-    mockMealPlanService = _MockMealPlanService();
-  });
+/// Baby exists but every allergen is `notStarted` and no meals today —
+/// `HomeState.hasNoActivity == true` so the screen renders the empty-state
+/// full variant.
+HomeState _emptyFullState() => HomeState(
+  baby: _fakeBaby,
+  allergenStatuses: const {
+    'peanut': AllergenStatus.notStarted,
+    'egg': AllergenStatus.notStarted,
+  },
+);
 
-  List<Override> buildOverrides() => [
-    babyProfileServiceProvider.overrideWithValue(mockBabyService),
-    allergenServiceProvider.overrideWithValue(mockAllergenService),
-    mealPlanServiceProvider.overrideWithValue(mockMealPlanService),
+// ---------------------------------------------------------------------------
+// Firebase no-op platform — drops every `Analytics.instance` call.
+// ---------------------------------------------------------------------------
+
+class _NoopAnalyticsPlatform extends FirebaseAnalyticsPlatform {
+  _NoopAnalyticsPlatform() : super();
+
+  @override
+  FirebaseAnalyticsPlatform delegateFor({
+    required FirebaseApp app,
+    Map<String, dynamic>? webOptions,
+  }) => this;
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    Map<String, Object?>? parameters,
+    AnalyticsCallOptions? callOptions,
+  }) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Marker destination stubs — assert routed-to by their text.
+// ---------------------------------------------------------------------------
+
+const _allergenTrackerMarker = 'ALLERGEN_TRACKER_STUB';
+const _mealPlanMarker = 'MEAL_PLAN_STUB';
+const _profileMarker = 'PROFILE_STUB';
+
+class _RecipeDetailStub extends StatelessWidget {
+  const _RecipeDetailStub({required this.recipeId});
+
+  final String recipeId;
+
+  @override
+  Widget build(BuildContext context) =>
+      Scaffold(body: Center(child: Text('RECIPE_DETAIL_STUB:$recipeId')));
+}
+
+GoRouter _testRouter() => GoRouter(
+  initialLocation: '/',
+  routes: [
+    GoRoute(path: '/', builder: (_, __) => const HomeScreen()),
+    GoRoute(
+      path: AppRoute.allergenTracker.path,
+      name: AppRoute.allergenTracker.name,
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text(_allergenTrackerMarker))),
+    ),
+    GoRoute(
+      path: AppRoute.mealPlan.path,
+      name: AppRoute.mealPlan.name,
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text(_mealPlanMarker))),
+    ),
+    GoRoute(
+      path: AppRoute.profile.path,
+      name: AppRoute.profile.name,
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text(_profileMarker))),
+    ),
+    GoRoute(
+      path: AppRoute.recipeDetail.path,
+      name: AppRoute.recipeDetail.name,
+      builder: (_, state) =>
+          _RecipeDetailStub(recipeId: state.pathParameters['recipeId'] ?? ''),
+    ),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Fake controllers
+// ---------------------------------------------------------------------------
+
+class _FakeHomeController extends HomeController {
+  _FakeHomeController(this._initialState);
+
+  final HomeState _initialState;
+
+  @override
+  Future<HomeState> build(String babyId) async => _initialState;
+}
+
+/// Used by the error/retry test to assert
+/// `ref.invalidate(homeControllerProvider)` recreates the notifier and
+/// re-runs `build` (instance fields don't survive invalidation, so we
+/// count via a closure).
+class _ThrowingHomeController extends HomeController {
+  _ThrowingHomeController(this._onBuild);
+
+  final void Function() _onBuild;
+
+  @override
+  Future<HomeState> build(String babyId) async {
+    _onBuild();
+    throw Exception('boom');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SUT builder
+// ---------------------------------------------------------------------------
+
+Widget _buildSut({
+  required List<Override> overrides,
+  GoRouter? router,
+}) => ProviderScope(
+  overrides: overrides,
+  child: MaterialApp.router(routerConfig: router ?? _testRouter()),
+);
+
+List<Override> _overridesFor({
+  String? babyId,
+  HomeState? state,
+  HomeController Function()? controllerFactory,
+}) {
+  final ovs = <Override>[
+    currentBabyIdProvider.overrideWith((ref) async => babyId),
   ];
+  if (babyId != null) {
+    final factory = controllerFactory ??
+        () => _FakeHomeController(state ?? _populatedState());
+    ovs.add(homeControllerProvider(babyId).overrideWith(factory));
+  }
+  return ovs;
+}
 
-  testWidgets('renders without errors when baby + services resolve', (
-    tester,
-  ) async {
-    when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);
-    when(() => mockAllergenService.getAllergenStatuses(_babyId)).thenAnswer(
-      (_) async => const Result.success(<String, AllergenStatus>{}),
-    );
-    when(() => mockMealPlanService.getRolling7(_babyId)).thenAnswer(
-      (_) async => const Result.success(<MealPlanEntry>[]),
-    );
+Future<void> _pump(
+  WidgetTester tester, {
+  required List<Override> overrides,
+  GoRouter? router,
+}) async {
+  // Tall viewport so the scrollable column lays out without overflow.
+  tester.view.physicalSize = const Size(1080, 2400);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
 
-    await tester.pumpWidget(_wrap(buildOverrides()));
-    await tester.pumpAndSettle();
+  await tester.pumpWidget(_buildSut(overrides: overrides, router: router));
+  await tester.pumpAndSettle();
+}
 
-    expect(find.byType(HomeScreen), findsOneWidget);
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  setUpAll(() async {
+    setupFirebaseCoreMocks();
+    await Firebase.initializeApp();
+    FirebaseAnalyticsPlatform.instance = _NoopAnalyticsPlatform();
   });
 
-  testWidgets('renders empty state scaffold when no baby exists', (
-    tester,
-  ) async {
-    when(() => mockBabyService.getBaby()).thenAnswer((_) async => null);
+  // -------------------------------------------------------------------------
+  // NIB-86 render-smoke (kept from the existing slim file).
+  // -------------------------------------------------------------------------
+  group('HomeScreen — render smoke (NIB-86 baseline)', () {
+    testWidgets('renders without errors when baby + state resolve', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        overrides: _overridesFor(babyId: _babyId, state: _populatedState()),
+      );
+      expect(find.byType(HomeScreen), findsOneWidget);
+    });
 
-    await tester.pumpWidget(_wrap(buildOverrides()));
-    await tester.pumpAndSettle();
+    testWidgets('renders empty state scaffold when no baby exists', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        overrides: _overridesFor(),
+      );
+      expect(find.byType(HomeScreen), findsOneWidget);
+      expect(find.byType(HomeEmptyStateFull), findsOneWidget);
+    });
+  });
 
-    expect(find.byType(HomeScreen), findsOneWidget);
+  // -------------------------------------------------------------------------
+  // 1. Dashboard states
+  // -------------------------------------------------------------------------
+  group('HomeScreen — populated state', () {
+    testWidgets(
+      'renders header + greeting + rings + ongoing + chips + meals + tips',
+      (tester) async {
+        await _pump(
+          tester,
+          overrides: _overridesFor(babyId: _babyId, state: _populatedState()),
+        );
+
+        expect(find.byType(HomeHeader), findsOneWidget);
+        expect(find.byType(GreetingCard), findsOneWidget);
+        expect(find.byType(StatRingCard), findsOneWidget);
+        expect(find.byType(OngoingIntroducedCard), findsOneWidget);
+        // OngoingIntroducedCard renders SizedBox.shrink unless inProgress
+        // exists; the populated fixture has peanut inProgress, so the
+        // ONGOING INTRODUCED label MUST render.
+        expect(find.text('ONGOING INTRODUCED'), findsOneWidget);
+        expect(find.byType(DayChipRow), findsOneWidget);
+        expect(find.byType(TodaysMealsCard), findsOneWidget);
+        expect(find.byType(HelpfulGuidanceCard), findsOneWidget);
+      },
+    );
+
+    testWidgets("greeting shows baby name + 'months today' line", (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        overrides: _overridesFor(babyId: _babyId, state: _populatedState()),
+      );
+
+      // GreetingCard renders text containing the baby name + age phrasing.
+      expect(find.textContaining('Lily'), findsWidgets);
+      expect(find.textContaining('months today!'), findsOneWidget);
+    });
+
+    testWidgets('meal rows render one Material row per todays meal entry', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        overrides: _overridesFor(babyId: _babyId, state: _populatedState()),
+      );
+
+      // Two meals -> two capitalised meal-time labels.
+      expect(find.text('Breakfast'), findsOneWidget);
+      expect(find.text('Lunch'), findsOneWidget);
+    });
+  });
+
+  group('HomeScreen — empty-full state (baby + no activity)', () {
+    testWidgets(
+      'baby present but `hasNoActivity` -> HomeEmptyStateFull renders',
+      (tester) async {
+        await _pump(
+          tester,
+          overrides: _overridesFor(babyId: _babyId, state: _emptyFullState()),
+        );
+
+        expect(find.byType(HomeEmptyStateFull), findsOneWidget);
+        // Dashboard chrome is intentionally absent in empty-full.
+        expect(find.byType(HomeHeader), findsNothing);
+        expect(find.byType(StatRingCard), findsNothing);
+        expect(find.byType(TodaysMealsCard), findsNothing);
+        // Ready-to-start CTA copy.
+        expect(find.text('Ready to start?'), findsOneWidget);
+        expect(find.text('Create First Meal'), findsOneWidget);
+      },
+    );
+  });
+
+  group('HomeScreen — empty-full state (no baby)', () {
+    // The screen has only two empty-state code paths; both render
+    // HomeEmptyStateFull. There is no separate HomeEmptyStateShort branch
+    // at the screen level (see widget-level test for the standalone
+    // HomeEmptyStateShort). This test stands in for the "empty-short"
+    // ticket bullet -- the screen's branching is documented above.
+    testWidgets(
+      'babyId resolves to null -> HomeEmptyStateFull (full empty branch)',
+      (tester) async {
+        await _pump(tester, overrides: _overridesFor());
+
+        expect(find.byType(HomeEmptyStateFull), findsOneWidget);
+        expect(find.byType(HomeHeader), findsNothing);
+        // Getting Started Tips title is part of the full variant.
+        expect(find.text('Getting Started Tips'), findsOneWidget);
+      },
+    );
+  });
+
+  group('HomeScreen — no-meals (populated dashboard, empty todays meals)', () {
+    testWidgets(
+      'empty todaysMeals -> TodaysMealsCard inline placeholder renders',
+      (tester) async {
+        await _pump(
+          tester,
+          overrides: _overridesFor(
+            babyId: _babyId,
+            state: _populatedNoMealsState(),
+          ),
+        );
+
+        // Full dashboard chrome still renders (we are NOT in empty-full).
+        expect(find.byType(HomeHeader), findsOneWidget);
+        expect(find.byType(StatRingCard), findsOneWidget);
+        expect(find.byType(TodaysMealsCard), findsOneWidget);
+        // Inline empty-meals placeholder text.
+        expect(find.text('No meals today'), findsOneWidget);
+        // Counter shows 0/2.
+        expect(find.text('0/2'), findsOneWidget);
+      },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Navigation taps
+  // -------------------------------------------------------------------------
+  group('HomeScreen — navigation taps', () {
+    testWidgets(
+      'tap ongoing card -> pushes /home/allergen/tracker',
+      (tester) async {
+        await _pump(
+          tester,
+          overrides: _overridesFor(babyId: _babyId, state: _populatedState()),
+        );
+
+        // OngoingIntroducedCard wraps an InkWell inside a Material; tap
+        // by descendant from the card type so we hit the tappable region.
+        final inkwell = find.descendant(
+          of: find.byType(OngoingIntroducedCard),
+          matching: find.byType(InkWell),
+        );
+        expect(inkwell, findsOneWidget);
+        await tester.tap(inkwell);
+        await tester.pumpAndSettle();
+
+        expect(find.text(_allergenTrackerMarker), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tap a meal row -> pushes /home/recipes/:recipeId with the entry id',
+      (tester) async {
+        await _pump(
+          tester,
+          overrides: _overridesFor(babyId: _babyId, state: _populatedState()),
+        );
+
+        // First meal row -> recipe-aaa.
+        await tester.tap(find.text('Breakfast'));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('RECIPE_DETAIL_STUB:recipe-aaa'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'tap a different meal row -> pushes /home/recipes/:recipeId with that id',
+      (tester) async {
+        await _pump(
+          tester,
+          overrides: _overridesFor(babyId: _babyId, state: _populatedState()),
+        );
+
+        // Second meal row -> recipe-bbb.
+        await tester.tap(find.text('Lunch'));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('RECIPE_DETAIL_STUB:recipe-bbb'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'tap empty-state Create First Meal CTA -> switches to meal plan tab',
+      (tester) async {
+        await _pump(
+          tester,
+          overrides: _overridesFor(babyId: _babyId, state: _emptyFullState()),
+        );
+
+        expect(find.byType(HomeEmptyStateFull), findsOneWidget);
+        await tester.tap(find.text('Create First Meal'));
+        await tester.pumpAndSettle();
+
+        expect(find.text(_mealPlanMarker), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tap empty-state CTA from no-baby branch -> switches to meal plan tab',
+      (tester) async {
+        await _pump(tester, overrides: _overridesFor());
+
+        expect(find.byType(HomeEmptyStateFull), findsOneWidget);
+        await tester.tap(find.text('Create First Meal'));
+        await tester.pumpAndSettle();
+
+        expect(find.text(_mealPlanMarker), findsOneWidget);
+      },
+    );
+
+    // NOTE: avatar -> profile is INTENTIONALLY uncovered at the screen
+    // level. `HomeHeader.onAvatarTap` is never wired by `HomeScreen`, so
+    // there is no production behaviour to assert (and per project rules
+    // we MUST NOT modify lib/**). A standalone HomeHeader unit test would
+    // be tautological. Documented in the PR body.
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Error / retry
+  // -------------------------------------------------------------------------
+  group('HomeScreen — error and retry', () {
+    testWidgets(
+      'controller throws -> error scaffold renders with Try Again CTA',
+      (tester) async {
+        var buildCount = 0;
+        await _pump(
+          tester,
+          overrides: _overridesFor(
+            babyId: _babyId,
+            controllerFactory: () => _ThrowingHomeController(() {
+              buildCount += 1;
+            }),
+          ),
+        );
+
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.text('Try Again'), findsOneWidget);
+        expect(buildCount, 1);
+      },
+    );
+
+    testWidgets(
+      'tap Try Again -> controller rebuild (invalidate fires a new build)',
+      (tester) async {
+        var buildCount = 0;
+        await _pump(
+          tester,
+          overrides: _overridesFor(
+            babyId: _babyId,
+            controllerFactory: () => _ThrowingHomeController(() {
+              buildCount += 1;
+            }),
+          ),
+        );
+
+        expect(buildCount, 1);
+        await tester.tap(find.text('Try Again'));
+        await tester.pumpAndSettle();
+
+        // Invalidate disposes + recreates the notifier -> build runs again.
+        expect(buildCount, 2);
+        // Error scaffold still up because the rebuild also throws.
+        expect(find.text('Try Again'), findsOneWidget);
+      },
+    );
   });
 }

--- a/test/features/home/widgets/home_empty_state_full_test.dart
+++ b/test/features/home/widgets/home_empty_state_full_test.dart
@@ -1,0 +1,66 @@
+// NIB-111 — Optional widget-level coverage for `HomeEmptyStateFull`.
+//
+// Verifies the Ready-to-Start card + Getting Started Tips render and that
+// the CTA invokes the supplied `onCreateMealPlan` callback when provided.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/components/cards/tip_card.dart';
+import 'package:nibbles/src/features/home/widgets/home_empty_state_full.dart';
+
+Widget _wrap(Widget child) =>
+    MaterialApp(home: Scaffold(body: SafeArea(child: child)));
+
+void main() {
+  testWidgets(
+    'renders ReadyToStartCard title + body + Create First Meal CTA',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(HomeEmptyStateFull(onCreateMealPlan: () {})),
+      );
+
+      expect(find.text('Ready to start?'), findsOneWidget);
+      expect(
+        find.text("Track allergen introductions and plan baby's meals."),
+        findsOneWidget,
+      );
+      expect(find.text('Create First Meal'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'renders the 3 Getting Started Tips section',
+    (tester) async {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _wrap(HomeEmptyStateFull(onCreateMealPlan: () {})),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Getting Started Tips'), findsOneWidget);
+      expect(find.byType(TipCard), findsNWidgets(3));
+      expect(find.text('Start with single-ingredient foods'), findsOneWidget);
+      expect(find.text('Introduce allergens early'), findsOneWidget);
+      expect(find.text('Watch, wait, repeat'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'tapping Create First Meal invokes the onCreateMealPlan callback',
+    (tester) async {
+      var calls = 0;
+      await tester.pumpWidget(
+        _wrap(HomeEmptyStateFull(onCreateMealPlan: () => calls += 1)),
+      );
+
+      await tester.tap(find.text('Create First Meal'));
+      await tester.pumpAndSettle();
+
+      expect(calls, 1);
+    },
+  );
+}

--- a/test/features/home/widgets/ongoing_introduced_card_test.dart
+++ b/test/features/home/widgets/ongoing_introduced_card_test.dart
@@ -1,0 +1,164 @@
+// NIB-111 — Optional widget-level coverage for `OngoingIntroducedCard`.
+//
+// Asserts the empty branch collapses (`SizedBox.shrink`) and the in-progress
+// branch surfaces the allergen's display name + emoji.
+
+// Firebase platform-interface packages are transitive deps; the public
+// barrels do not re-export FirebaseAnalyticsPlatform / setupFirebaseCoreMocks.
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:firebase_analytics_platform_interface/firebase_analytics_platform_interface.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/features/home/widgets/ongoing_introduced_card.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+class _NoopAnalyticsPlatform extends FirebaseAnalyticsPlatform {
+  _NoopAnalyticsPlatform() : super();
+
+  @override
+  FirebaseAnalyticsPlatform delegateFor({
+    required FirebaseApp app,
+    Map<String, dynamic>? webOptions,
+  }) => this;
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    Map<String, Object?>? parameters,
+    AnalyticsCallOptions? callOptions,
+  }) async {}
+}
+
+GoRouter _router(Widget child) => GoRouter(
+  initialLocation: '/',
+  routes: [
+    GoRoute(path: '/', builder: (_, __) => Scaffold(body: child)),
+    GoRoute(
+      path: AppRoute.allergenTracker.path,
+      name: AppRoute.allergenTracker.name,
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text('TRACKER_STUB'))),
+    ),
+  ],
+);
+
+Widget _wrap(Widget child) =>
+    MaterialApp.router(routerConfig: _router(child));
+
+void main() {
+  setUpAll(() async {
+    setupFirebaseCoreMocks();
+    await Firebase.initializeApp();
+    FirebaseAnalyticsPlatform.instance = _NoopAnalyticsPlatform();
+  });
+
+  testWidgets(
+    'no inProgress allergen -> renders SizedBox.shrink (collapses)',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const OngoingIntroducedCard(
+            allergenStatuses: {
+              'peanut': AllergenStatus.safe,
+              'egg': AllergenStatus.notStarted,
+            },
+          ),
+        ),
+      );
+
+      expect(find.text('ONGOING INTRODUCED'), findsNothing);
+      // The card collapses; no name labels render.
+      expect(find.text('Peanut'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'one inProgress allergen -> renders ONGOING INTRODUCED + name + emoji',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const OngoingIntroducedCard(
+            allergenStatuses: {
+              'peanut': AllergenStatus.inProgress,
+              'egg': AllergenStatus.notStarted,
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('ONGOING INTRODUCED'), findsOneWidget);
+      expect(find.text('Peanut'), findsOneWidget);
+      expect(find.text('Currently introducing'), findsOneWidget);
+      // Peanut emoji is in the AllergenEmoji constant — renders inside thumb.
+      expect(find.text('🥜'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'picks first inProgress in canonical kAllergenKeys order',
+    (tester) async {
+      // egg comes before dairy in the canonical sequence.
+      await tester.pumpWidget(
+        _wrap(
+          const OngoingIntroducedCard(
+            allergenStatuses: {
+              'peanut': AllergenStatus.safe,
+              'egg': AllergenStatus.inProgress,
+              'dairy': AllergenStatus.inProgress,
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Egg'), findsOneWidget);
+      // Dairy should not be the surfaced card (egg wins by order).
+      expect(find.text('Dairy'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'multi-word allergen key (tree_nuts) is rendered title-cased with space',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const OngoingIntroducedCard(
+            allergenStatuses: {
+              'tree_nuts': AllergenStatus.inProgress,
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Tree Nuts'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'tapping the card pushes the allergen tracker route',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const OngoingIntroducedCard(
+            allergenStatuses: {
+              'peanut': AllergenStatus.inProgress,
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(InkWell));
+      await tester.pumpAndSettle();
+
+      expect(find.text('TRACKER_STUB'), findsOneWidget);
+    },
+  );
+}

--- a/test/features/home/widgets/stat_ring_card_test.dart
+++ b/test/features/home/widgets/stat_ring_card_test.dart
@@ -1,0 +1,108 @@
+// NIB-111 — Optional widget-level coverage for `StatRingCard`.
+//
+// Asserts the two ring values (TODAY MEALS + ALLERGEN) bind to the
+// constructor inputs and that the optional `Iron Rich` chip is gated
+// on `hasIronRichRecipes`.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+import 'package:nibbles/src/features/home/widgets/stat_ring_card.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+  home: Scaffold(
+    body: Padding(padding: const EdgeInsets.all(16), child: child),
+  ),
+);
+
+void main() {
+  group('StatRingCard — labels + counts', () {
+    testWidgets(
+      'renders ALLERGEN ring with safeCount over the canonical /9 denominator',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const StatRingCard(
+              safeCount: 3,
+              flaggedCount: 1,
+              notStartedCount: 5,
+              inProgressCount: 0,
+              todayMealCount: 1,
+              todayMealTarget: 2,
+            ),
+          ),
+        );
+
+        expect(find.text('ALLERGEN'), findsOneWidget);
+        expect(find.text('TODAY MEALS'), findsOneWidget);
+        // Allergen ring: 3 / 9.
+        expect(find.text('3'), findsOneWidget);
+        expect(find.text('/9'), findsOneWidget);
+        // Today meals ring: 1 / 2.
+        expect(find.text('1'), findsOneWidget);
+        expect(find.text('/2'), findsOneWidget);
+      },
+    );
+
+    testWidgets('zero safeCount renders ring with 0/9', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const StatRingCard(
+            safeCount: 0,
+            flaggedCount: 0,
+            notStartedCount: 9,
+            inProgressCount: 0,
+          ),
+        ),
+      );
+
+      expect(find.text('0'), findsWidgets);
+      expect(find.text('/9'), findsOneWidget);
+      // Default todayMealTarget = 0 -> '/0'.
+      expect(find.text('/0'), findsOneWidget);
+    });
+  });
+
+  group('StatRingCard — Iron Rich chip gating', () {
+    testWidgets(
+      'hasIronRichRecipes = false -> only Active Program Allergens chip',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const StatRingCard(
+              safeCount: 1,
+              flaggedCount: 0,
+              notStartedCount: 8,
+              inProgressCount: 0,
+            ),
+          ),
+        );
+
+        expect(find.byType(AppChip), findsOneWidget);
+        expect(find.text('✓ Active Program Allergens'), findsOneWidget);
+        expect(find.text('✓ Iron Rich'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'hasIronRichRecipes = true -> both chips render',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const StatRingCard(
+              safeCount: 1,
+              flaggedCount: 0,
+              notStartedCount: 8,
+              inProgressCount: 0,
+              hasIronRichRecipes: true,
+            ),
+          ),
+        );
+
+        expect(find.byType(AppChip), findsNWidgets(2));
+        expect(find.text('✓ Iron Rich'), findsOneWidget);
+        expect(find.text('✓ Active Program Allergens'), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes the Home milestone (NIB-111) with net-new widget tests covering
the 4 dashboard states, navigation tap routing, and the error/retry
path on the redesigned Home screen.

All new test code lives under `test/**` — `lib/**` is untouched per
ticket scope.

## Files touched (test-only)

| File | New tests |
|---|---|
| `test/features/home/home_screen_test.dart` (extended) | +13 |
| `test/features/home/widgets/stat_ring_card_test.dart` (new) | +4 |
| `test/features/home/widgets/ongoing_introduced_card_test.dart` (new) | +5 |
| `test/features/home/widgets/home_empty_state_full_test.dart` (new) | +3 |
| **Total net-new** | **+25** |

## Coverage map

### Dashboard states (home_screen_test.dart)
- Populated state — HomeHeader, GreetingCard, StatRingCard, OngoingIntroducedCard (in-progress branch), DayChipRow, TodaysMealsCard with rows, HelpfulGuidanceCard all render.
- Empty-full (baby + `hasNoActivity`) — HomeEmptyStateFull renders, dashboard chrome absent, Ready-to-Start copy present.
- Empty-full (no baby) — `currentBabyIdProvider -> null` -> HomeEmptyStateFull with Getting Started Tips.
- No-meals (populated with empty `todaysMeals`) — TodaysMealsCard inline 'No meals today' placeholder + 0/2 counter, dashboard chrome still up.

### Navigation taps (home_screen_test.dart)
- Ongoing card -> `/home/allergen/tracker`.
- Meal row -> `/home/recipes/:recipeId` (both meals asserted independently to prove path-parameter wiring).
- Empty-state CTA -> `/home/meal` (covered from both empty-full branches: baby + no-activity AND no-baby).

### Error / retry (home_screen_test.dart)
- Controller throws -> error scaffold with `error_outline` icon + `Try Again` CTA.
- Tap `Try Again` -> `ref.invalidate(homeControllerProvider)` -> controller rebuild verified via closure-counter (instance fields don't survive invalidation).

### Optional widget-level (test/features/home/widgets/)
- StatRingCard — ALLERGEN ring binds `safeCount` over canonical /9 denominator, TODAY MEALS ring binds count/target, Iron Rich chip gated on `hasIronRichRecipes`.
- OngoingIntroducedCard — empty branch collapses to SizedBox.shrink, single in-progress allergen renders name + emoji + 'Currently introducing', first-in-canonical-order wins when multiple are in-progress, multi-word keys (tree_nuts -> 'Tree Nuts') render correctly, tapping pushes the tracker route.
- HomeEmptyStateFull — Ready-to-Start title/body/CTA + Getting Started Tips section (3 TipCards) render, CTA invokes supplied `onCreateMealPlan` callback.

## Documented coverage gaps (no `lib/**` changes — per ticket scope)

- **Avatar -> profile tap**: `HomeHeader.onAvatarTap` is never wired by `HomeScreen`. There is no production behaviour to assert at the screen level, and a standalone HomeHeader unit test passing its own callback would be tautological (it would not verify routing). Skipped per ticket: 'If a widget can't be tested without exposing a public seam, document the gap and skip — do NOT modify production code.'
- **HomeEmptyStateShort branch at the screen level**: `home_screen.dart` does not import `HomeEmptyStateShort`. Both empty-state code paths (`baby == null` and `state.hasNoActivity`) render `HomeEmptyStateFull`. There is no screen branching that surfaces Short. (HomeEmptyStateShort is a sibling widget reachable elsewhere; not in scope for the home screen widget test.)
- **HomeNoMealsState at the screen level**: `home_screen.dart` does not import `HomeNoMealsState`. Empty `todaysMeals` inside the populated dashboard surfaces TodaysMealsCard's inline `_NoMealsInline` ('No meals today'); the standalone `HomeNoMealsState` widget is not rendered by the screen.
- **Error message string**: the production error CTA reads `Try Again`, not `Retry` as the ticket bullet phrased it. Tests assert the actual production string.

## No new dependencies

Reuses `flutter_test`, `flutter_riverpod`, `go_router`, `mocktail`, and `firebase_core_platform_interface/test` (already used by `recipe_library_screen_test.dart` for the same Firebase-mocks pattern). No `pubspec.yaml` changes.

## Gate results

- `make gen` — clean, idempotent on second run.
- `flutter analyze` — `No issues found! (ran in 3.2s)`.
- `flutter test` — `All tests passed!` 448 total (up from 423 baseline -> +25 net-new).

## Acceptance criteria

- [x] 4 dashboard states (populated, empty-full, empty-short equivalent via no-baby/no-activity, no-meals) covered.
- [x] 3 navigation taps wired at screen level (ongoing -> tracker, meal row -> detail with path param, empty-state CTA -> meal plan). Avatar -> profile gap documented.
- [x] Error/retry covered with controller rebuild assertion via closure counter.
- [x] `flutter analyze` zero issues.
- [x] `flutter test` zero failures, 448 total > 423 baseline.
- [x] No `lib/**` modifications.