### PR TITLE
feat(profile): soft-delete RPC + AccountRepository/Service + clearAll [NIB-85]

### DIFF
--- a/lib/src/common/data/repositories/account_repository.dart
+++ b/lib/src/common/data/repositories/account_repository.dart
@@ -1,0 +1,48 @@
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'account_repository.g.dart';
+
+/// Account-scoped operations that don't belong on AuthRepository (which is
+/// strictly Supabase auth) — namely, the NIB-120 soft-delete RPC.
+///
+/// The abstract interface is intentional even with a single method: it lets
+/// `AccountService` test against a `Mock implements AccountRepository` and
+/// matches the Repository pattern documented in CLAUDE.md.
+// ignore: one_member_abstracts
+abstract interface class AccountRepository {
+  /// Calls `request_account_deletion(p_reason)` — inserts a row into
+  /// `account_deletion_requests` and soft-deletes the user's babies. The
+  /// Supabase auth user is NOT removed here; that's an ops-side purge.
+  Future<Result<void>> requestAccountDeletion(String reason);
+}
+
+class AccountRepositoryImpl implements AccountRepository {
+  AccountRepositoryImpl({SupabaseClient? supabaseClient})
+    : _supabase = supabaseClient ?? Supabase.instance.client;
+
+  final SupabaseClient _supabase;
+
+  @override
+  Future<Result<void>> requestAccountDeletion(String reason) async {
+    try {
+      await _supabase.rpc<void>(
+        'request_account_deletion',
+        params: {'p_reason': reason},
+      );
+      return const Result.success(null);
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+}
+
+@Riverpod(keepAlive: true)
+// Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+// ignore: deprecated_member_use_from_same_package
+AccountRepository accountRepository(AccountRepositoryRef ref) =>
+    AccountRepositoryImpl();

--- a/lib/src/common/data/repositories/account_repository.g.dart
+++ b/lib/src/common/data/repositories/account_repository.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'account_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$accountRepositoryHash() => r'b23fea9e27508c4831e9e88b1d933c2d71ad70a5';
+
+/// See also [accountRepository].
+@ProviderFor(accountRepository)
+final accountRepositoryProvider = Provider<AccountRepository>.internal(
+  accountRepository,
+  name: r'accountRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$accountRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AccountRepositoryRef = ProviderRef<AccountRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/common/services/account_service.dart
+++ b/lib/src/common/services/account_service.dart
@@ -1,0 +1,23 @@
+import 'package:nibbles/src/common/data/repositories/account_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'account_service.g.dart';
+
+/// Thin facade over [AccountRepository]. NIB-78's profile UI calls
+/// [deleteAccount] with a reason from a user-selected enum; the actual
+/// soft-delete semantics live in the SQL RPC.
+class AccountService {
+  const AccountService(this._repo);
+
+  final AccountRepository _repo;
+
+  Future<Result<void>> deleteAccount(String reason) =>
+      _repo.requestAccountDeletion(reason);
+}
+
+@Riverpod(keepAlive: true)
+// Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+// ignore: deprecated_member_use_from_same_package
+AccountService accountService(AccountServiceRef ref) =>
+    AccountService(ref.watch(accountRepositoryProvider));

--- a/lib/src/common/services/account_service.g.dart
+++ b/lib/src/common/services/account_service.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'account_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$accountServiceHash() => r'3653cf753fae4482a8e360802646f039dbc4d07a';
+
+/// See also [accountService].
+@ProviderFor(accountService)
+final accountServiceProvider = Provider<AccountService>.internal(
+  accountService,
+  name: r'accountServiceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$accountServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AccountServiceRef = ProviderRef<AccountService>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/common/services/local_flag_service.dart
+++ b/lib/src/common/services/local_flag_service.dart
@@ -92,6 +92,25 @@ class LocalFlagService {
   /// across the same frame's rebuild.
   Future<void> markStartingGuideSeen() =>
       _box.put('starting_guide_seen', true);
+
+  // ---------------------------------------------------------------------------
+  // Account deletion (NIB-85 / NIB-120)
+  // ---------------------------------------------------------------------------
+
+  /// Set by the profile delete-account flow (NIB-78) BEFORE the auth
+  /// `signOut()` call so the router/splash can treat the session as deleted
+  /// even if a stale Supabase session is still cached.
+  bool isAccountDeleted() =>
+      _box.get('account_deleted', defaultValue: false) as bool;
+
+  /// Awaitable so the flag is durable before signOut() races.
+  Future<void> setAccountDeleted() => _box.put('account_deleted', true);
+
+  /// Wipes every key in the `local_flags` box. Called by the delete-account
+  /// flow BEFORE signing out so that re-registering on the same device
+  /// replays onboarding from scratch (no stale `onboarding_*_done`,
+  /// `program_completion_shown_*`, `starting_guide_seen`, etc.).
+  Future<void> clearAll() => _box.clear();
 }
 
 @riverpod

--- a/supabase/migrations/20260530000001_account_deletion_soft.sql
+++ b/supabase/migrations/20260530000001_account_deletion_soft.sql
@@ -1,0 +1,77 @@
+-- NIB-85 / NIB-120 — Soft account deletion.
+--
+-- Adds a soft-delete column on babies and a new account_deletion_requests
+-- table that stores the user's deletion reason + timestamp. The
+-- request_account_deletion(p_reason) RPC is SECURITY DEFINER so it can mark
+-- the row + soft-delete the user's babies atomically while still being safe
+-- under RLS (it captures auth.uid() internally).
+--
+-- The Supabase auth user row is NOT deleted here — that is handled by an
+-- ops-side cron purge in a future ticket. The client treats the account as
+-- deleted purely via the deletion-request row + signed-out state.
+
+-- ---------------------------------------------------------------------------
+-- 1) babies.deleted_at
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE babies
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+-- ---------------------------------------------------------------------------
+-- 2) account_deletion_requests
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS account_deletion_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  reason TEXT NOT NULL,
+  requested_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE account_deletion_requests ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "users can insert their own deletion request"
+  ON account_deletion_requests;
+CREATE POLICY "users can insert their own deletion request"
+  ON account_deletion_requests
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "users can read their own deletion request"
+  ON account_deletion_requests;
+CREATE POLICY "users can read their own deletion request"
+  ON account_deletion_requests
+  FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- 3) request_account_deletion RPC
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION request_account_deletion(p_reason TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated' USING ERRCODE = '28000';
+  END IF;
+
+  INSERT INTO account_deletion_requests (user_id, reason)
+  VALUES (v_user_id, p_reason);
+
+  UPDATE babies
+     SET deleted_at = now()
+   WHERE user_id = v_user_id
+     AND deleted_at IS NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION request_account_deletion(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION request_account_deletion(TEXT) TO authenticated;

--- a/test/common/data/repositories/account_repository_test.dart
+++ b/test/common/data/repositories/account_repository_test.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/account_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _MockSupabaseClient extends Mock implements SupabaseClient {}
+
+/// Test seam: a SupabaseClient whose `rpc(...)` is intercepted by a
+/// behaviour closure. The closure decides whether the awaited rpc resolves
+/// with a value or throws (the repo only cares about that distinction).
+///
+/// We can't easily construct a real `PostgrestFilterBuilder<T>` in tests, so
+/// the closure returns a `_FakeBuilder<T>` which implements `Future<T>` and
+/// `PostgrestFilterBuilder<T>` via `noSuchMethod`.
+class _SupabaseClientWithRpc extends _MockSupabaseClient {
+  _SupabaseClientWithRpc(this._behaviour);
+
+  final FutureOr<Object?> Function(String fn, Map<String, dynamic>? params)
+      _behaviour;
+
+  @override
+  PostgrestFilterBuilder<T> rpc<T>(
+    String fn, {
+    Map<String, dynamic>? params,
+    dynamic get = false,
+  }) {
+    return _FakeBuilder<T>(() async => await _behaviour(fn, params) as T);
+  }
+}
+
+// PostgrestFilterBuilder is @immutable but we need to memoise the awaited
+// future once. Lint suppression matches other test fakes in the codebase.
+// ignore: must_be_immutable
+class _FakeBuilder<T> implements PostgrestFilterBuilder<T> {
+  _FakeBuilder(this._run);
+
+  final Future<T> Function() _run;
+  Future<T>? _cached;
+  Future<T> get _future => _cached ??= _run();
+
+  @override
+  Future<R> then<R>(
+    FutureOr<R> Function(T value) onValue, {
+    Function? onError,
+  }) => _future.then(onValue, onError: onError);
+
+  @override
+  Future<T> catchError(
+    Function onError, {
+    bool Function(Object error)? test,
+  }) => _future.catchError(onError, test: test);
+
+  @override
+  Future<T> whenComplete(FutureOr<void> Function() action) =>
+      _future.whenComplete(action);
+
+  @override
+  Future<T> timeout(
+    Duration timeLimit, {
+    FutureOr<T> Function()? onTimeout,
+  }) => _future.timeout(timeLimit, onTimeout: onTimeout);
+
+  @override
+  Stream<T> asStream() => _future.asStream();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('AccountRepositoryImpl.requestAccountDeletion', () {
+    test(
+        'returns Result.success(null) on a clean rpc call '
+        'and forwards reason as p_reason', () async {
+      String? capturedFn;
+      Map<String, dynamic>? capturedParams;
+      final client = _SupabaseClientWithRpc((fn, params) {
+        capturedFn = fn;
+        capturedParams = params;
+        return null;
+      });
+      final sut = AccountRepositoryImpl(supabaseClient: client);
+
+      final result = await sut.requestAccountDeletion('too_expensive');
+
+      expect(result, isA<Success<void>>());
+      expect(capturedFn, 'request_account_deletion');
+      expect(capturedParams, {'p_reason': 'too_expensive'});
+    });
+
+    test('maps PostgrestException to Failure(ServerException)', () async {
+      final client = _SupabaseClientWithRpc((_, __) {
+        throw const PostgrestException(message: 'rls denied', code: '42501');
+      });
+      final sut = AccountRepositoryImpl(supabaseClient: client);
+
+      final result = await sut.requestAccountDeletion('not_useful');
+
+      expect(result, isA<Failure<void>>());
+      final failure = result as Failure<void>;
+      expect(failure.error, isA<ServerException>());
+      expect(failure.error.message, 'rls denied');
+    });
+
+    test('maps any other thrown Object to Failure(UnknownException)',
+        () async {
+      final client = _SupabaseClientWithRpc((_, __) {
+        throw Exception('boom');
+      });
+      final sut = AccountRepositoryImpl(supabaseClient: client);
+
+      final result = await sut.requestAccountDeletion('other');
+
+      expect(result, isA<Failure<void>>());
+      expect((result as Failure<void>).error, isA<UnknownException>());
+    });
+  });
+}

--- a/test/common/services/account_service_test.dart
+++ b/test/common/services/account_service_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/account_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/account_service.dart';
+
+class _MockAccountRepository extends Mock implements AccountRepository {}
+
+void main() {
+  late _MockAccountRepository mockRepo;
+  late AccountService sut;
+
+  setUp(() {
+    mockRepo = _MockAccountRepository();
+    sut = AccountService(mockRepo);
+  });
+
+  group('AccountService.deleteAccount', () {
+    test('forwards the reason to the repository and returns success',
+        () async {
+      when(
+        () => mockRepo.requestAccountDeletion(any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      final result = await sut.deleteAccount('too_expensive');
+
+      expect(result, isA<Success<void>>());
+      verify(() => mockRepo.requestAccountDeletion('too_expensive')).called(1);
+    });
+
+    test('returns Result.failure when repository fails', () async {
+      when(() => mockRepo.requestAccountDeletion(any())).thenAnswer(
+        (_) async => const Result.failure(ServerException('rpc failed')),
+      );
+
+      final result = await sut.deleteAccount('not_useful');
+
+      expect(result, isA<Failure<void>>());
+      expect((result as Failure<void>).error, isA<ServerException>());
+      expect(result.error.message, 'rpc failed');
+    });
+  });
+}

--- a/test/common/services/local_flag_service_test.dart
+++ b/test/common/services/local_flag_service_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+
+void main() {
+  late Box<dynamic> box;
+  late LocalFlagService sut;
+
+  setUpAll(() {
+    Hive.init('.dart_tool/test_hive_local_flag_service');
+  });
+
+  setUp(() async {
+    // Unique box per test to avoid cross-test bleed when tests run in parallel.
+    final name = 'local_flags_${DateTime.now().microsecondsSinceEpoch}';
+    box = await Hive.openBox<dynamic>(name);
+    sut = LocalFlagService(box);
+  });
+
+  tearDown(() async {
+    await box.close();
+  });
+
+  tearDownAll(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  group('LocalFlagService.clearAll', () {
+    test('wipes every key in the local_flags box', () async {
+      sut
+        ..setHasLaunched()
+        ..setOnboardingReadinessDone()
+        ..setOnboardingBabySetupDone()
+        ..setOnboardingDone()
+        ..setProgramCompletionShown('baby-001');
+      await sut.markStartingGuideSeen();
+      await sut.setAccountDeleted();
+
+      // Sanity — the box really did have entries.
+      expect(box.length, greaterThan(0));
+
+      await sut.clearAll();
+
+      expect(box.length, 0);
+      expect(sut.hasLaunched(), isFalse);
+      expect(sut.isOnboardingReadinessDone(), isFalse);
+      expect(sut.isOnboardingBabySetupDone(), isFalse);
+      expect(sut.isOnboardingDone(), isFalse);
+      expect(sut.isProgramCompletionShown('baby-001'), isFalse);
+      expect(sut.isStartingGuideSeen(), isFalse);
+      expect(sut.isAccountDeleted(), isFalse);
+    });
+  });
+
+  group('LocalFlagService.account_deleted flag', () {
+    test('defaults to false and flips to true via setAccountDeleted',
+        () async {
+      expect(sut.isAccountDeleted(), isFalse);
+
+      await sut.setAccountDeleted();
+
+      expect(sut.isAccountDeleted(), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

NIB-120 wave 1 — backend surface the NIB-78 Delete Account UI will call. Soft-delete only: a new `account_deletion_requests` row + `babies.deleted_at = now()` for every baby owned by the user. The Supabase auth user row is NOT removed at runtime; an ops-side cron purge will handle that in a follow-up.

## User action required (SQL migration)

`supabase/migrations/20260530000001_account_deletion_soft.sql` MUST be applied to both Supabase environments before the runtime code can call the RPC:

1. `nibbles-dev` — apply via Supabase CLI / dashboard before merging the NIB-78 UI ticket.
2. `nibbles-prod` — apply before the next prod release that ships the delete-account flow.

The migration is idempotent (`ADD COLUMN IF NOT EXISTS`, `CREATE TABLE IF NOT EXISTS`, `DROP POLICY IF EXISTS` + recreate, `CREATE OR REPLACE FUNCTION`).

### Migration contents

- `ALTER TABLE babies ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ` — soft-delete flag.
- `CREATE TABLE IF NOT EXISTS account_deletion_requests` (`id`, `user_id` FK to `auth.users`, `reason`, `requested_at`).
- RLS on `account_deletion_requests`: authenticated users can `INSERT` and `SELECT` rows where `user_id = auth.uid()` only.
- `request_account_deletion(p_reason TEXT) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER` — captures `auth.uid()`, inserts the deletion row, soft-deletes the user's babies. Grants `EXECUTE` to `authenticated`.

## Soft-delete rationale (NIB-120 locked)

- Reason persisted so support / product can analyse churn before purge.
- 30-day-ish window for an ops cron to hard-purge the auth user; out of scope for MVP.
- Client treats the account as deleted via `LocalFlagService.isAccountDeleted()` + signed-out state — no UI for cancellation in MVP.

## Surface added

- `AccountRepository` interface + `AccountRepositoryImpl(SupabaseClient)` — wraps the RPC, maps `PostgrestException` to `ServerException` and any other thrown object to `UnknownException`.
- `accountRepositoryProvider` (`@Riverpod(keepAlive: true)`) constructs the impl from `Supabase.instance.client`.
- `AccountService(repo).deleteAccount(reason) -> Future<Result<void>>`.
- `accountServiceProvider` wires the repo through Riverpod.
- `LocalFlagService.clearAll()` — wraps `box.clear()`. NIB-78 calls this BEFORE `signOut()` so re-registering on the same device replays onboarding from scratch (no stale `onboarding_*_done`, `program_completion_shown_*`, `starting_guide_seen`).
- `LocalFlagService.setAccountDeleted()` / `isAccountDeleted()` — small flag the router/splash can consult to harden the deleted-but-cached-session edge case.

## Acceptance criteria

- [x] SQL migration committed under `supabase/migrations/` with user-action call-out above.
- [x] `AccountRepository` interface + `AccountRepositoryImpl`.
- [x] `AccountService.deleteAccount(reason)` returns `Result<void>` via the repo.
- [x] `accountRepositoryProvider` + `accountServiceProvider` (riverpod, keepAlive).
- [x] `LocalFlagService.clearAll()` added.
- [x] 7 new unit tests pass (3 repo, 2 service, 2 local-flag).
- [x] No files outside the spec allowlist touched.

## Gate results

- `make gen` — clean + idempotent (re-run produced no diff).
- `flutter analyze` — `No issues found!`
- `flutter test` — `455 +0` (baseline 448 + 7 new).