### PR TITLE
feat(profile): reskin settings screen to butter header + coral avatar + premium teaser + 4 action rows [NIB-52]

### DIFF
--- a/lib/src/features/profile/profile_controller.dart
+++ b/lib/src/features/profile/profile_controller.dart
@@ -1,34 +1,30 @@
-import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
-import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
-import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
-import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/profile/profile_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 part 'profile_controller.g.dart';
 
+/// `babyId` is retained on the family for back-compat with
+/// `profile_edit_screen.dart` which still calls
+/// `ref.invalidate(profileControllerProvider(widget.babyId))`. The id itself
+/// is not consumed here — `BabyProfileService.getBaby()` resolves the active
+/// baby from the auth session.
 @riverpod
 class ProfileController extends _$ProfileController {
   @override
   Future<ProfileState> build(String babyId) async {
     final baby = await ref.read(babyProfileServiceProvider).getBaby();
-    if (baby == null) throw const UnknownException('Baby profile not found.');
+    final email = Supabase.instance.client.auth.currentUser?.email;
 
-    final boardResult = await ref
-        .read(allergenServiceProvider)
-        .getAllergenBoardSummary(babyId);
-    if (boardResult.isFailure) throw boardResult.errorOrNull!;
-
-    final safeAllergens = boardResult.dataOrNull!
-        .where((AllergenBoardItem i) => i.status == AllergenStatus.safe)
-        .toList();
+    // SubscriptionService is M2-deferred (NIB-73). Stub the label until the
+    // paywall ships.
+    final subscriptionLabel = baby == null ? null : 'No Subscription';
 
     return ProfileState(
       baby: baby,
-      safeAllergens: safeAllergens,
-      subscriptionLabel: 'Trial', // Subscription (M2) deferred
+      email: email,
+      subscriptionLabel: subscriptionLabel,
     );
   }
 }

--- a/lib/src/features/profile/profile_controller.g.dart
+++ b/lib/src/features/profile/profile_controller.g.dart
@@ -6,7 +6,7 @@ part of 'profile_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$profileControllerHash() => r'2dd992cda2c8120d7400788eb604e0d856f5eecf';
+String _$profileControllerHash() => r'495d7698b32fc3ba7ce7eeafb8fd6065cbacec91';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -36,16 +36,40 @@ abstract class _$ProfileController
   FutureOr<ProfileState> build(String babyId);
 }
 
-/// See also [ProfileController].
+/// `babyId` is retained on the family for back-compat with
+/// `profile_edit_screen.dart` which still calls
+/// `ref.invalidate(profileControllerProvider(widget.babyId))`. The id itself
+/// is not consumed here — `BabyProfileService.getBaby()` resolves the active
+/// baby from the auth session.
+///
+/// Copied from [ProfileController].
 @ProviderFor(ProfileController)
 const profileControllerProvider = ProfileControllerFamily();
 
-/// See also [ProfileController].
+/// `babyId` is retained on the family for back-compat with
+/// `profile_edit_screen.dart` which still calls
+/// `ref.invalidate(profileControllerProvider(widget.babyId))`. The id itself
+/// is not consumed here — `BabyProfileService.getBaby()` resolves the active
+/// baby from the auth session.
+///
+/// Copied from [ProfileController].
 class ProfileControllerFamily extends Family<AsyncValue<ProfileState>> {
-  /// See also [ProfileController].
+  /// `babyId` is retained on the family for back-compat with
+  /// `profile_edit_screen.dart` which still calls
+  /// `ref.invalidate(profileControllerProvider(widget.babyId))`. The id itself
+  /// is not consumed here — `BabyProfileService.getBaby()` resolves the active
+  /// baby from the auth session.
+  ///
+  /// Copied from [ProfileController].
   const ProfileControllerFamily();
 
-  /// See also [ProfileController].
+  /// `babyId` is retained on the family for back-compat with
+  /// `profile_edit_screen.dart` which still calls
+  /// `ref.invalidate(profileControllerProvider(widget.babyId))`. The id itself
+  /// is not consumed here — `BabyProfileService.getBaby()` resolves the active
+  /// baby from the auth session.
+  ///
+  /// Copied from [ProfileController].
   ProfileControllerProvider call(String babyId) {
     return ProfileControllerProvider(babyId);
   }
@@ -72,11 +96,23 @@ class ProfileControllerFamily extends Family<AsyncValue<ProfileState>> {
   String? get name => r'profileControllerProvider';
 }
 
-/// See also [ProfileController].
+/// `babyId` is retained on the family for back-compat with
+/// `profile_edit_screen.dart` which still calls
+/// `ref.invalidate(profileControllerProvider(widget.babyId))`. The id itself
+/// is not consumed here — `BabyProfileService.getBaby()` resolves the active
+/// baby from the auth session.
+///
+/// Copied from [ProfileController].
 class ProfileControllerProvider
     extends
         AutoDisposeAsyncNotifierProviderImpl<ProfileController, ProfileState> {
-  /// See also [ProfileController].
+  /// `babyId` is retained on the family for back-compat with
+  /// `profile_edit_screen.dart` which still calls
+  /// `ref.invalidate(profileControllerProvider(widget.babyId))`. The id itself
+  /// is not consumed here — `BabyProfileService.getBaby()` resolves the active
+  /// baby from the auth session.
+  ///
+  /// Copied from [ProfileController].
   ProfileControllerProvider(String babyId)
     : this._internal(
         () => ProfileController()..babyId = babyId,

--- a/lib/src/features/profile/profile_screen.dart
+++ b/lib/src/features/profile/profile_screen.dart
@@ -4,13 +4,14 @@ import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
-import 'package:nibbles/src/common/domain/entities/baby.dart';
-import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/profile/profile_controller.dart';
 import 'package:nibbles/src/features/profile/profile_state.dart';
+import 'package:nibbles/src/features/profile/widgets/premium_teaser_card.dart';
+import 'package:nibbles/src/features/profile/widgets/profile_avatar_card.dart';
+import 'package:nibbles/src/features/profile/widgets/profile_header.dart';
+import 'package:nibbles/src/features/profile/widgets/settings_row.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
 class ProfileScreen extends ConsumerWidget {
@@ -21,14 +22,19 @@ class ProfileScreen extends ConsumerWidget {
     final babyIdAsync = ref.watch(currentBabyIdProvider);
 
     return babyIdAsync.when(
-      loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (_, __) =>
-          const Scaffold(body: Center(child: Text('Could not load profile.'))),
+      loading: () => const Scaffold(
+        backgroundColor: AppColors.background,
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (_, __) => _ProfileError(
+        message: 'Could not load profile.',
+        onRetry: () => ref.invalidate(currentBabyIdProvider),
+      ),
       data: (babyId) {
         if (babyId == null) {
-          return const Scaffold(
-            body: Center(child: Text('No baby profile found.')),
+          return _ProfileError(
+            message: 'No baby profile found.',
+            onRetry: () => ref.invalidate(currentBabyIdProvider),
           );
         }
         return _ProfileBody(babyId: babyId);
@@ -47,113 +53,136 @@ class _ProfileBody extends ConsumerWidget {
     final asyncState = ref.watch(profileControllerProvider(babyId));
 
     return asyncState.when(
-      loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (err, _) => Scaffold(
+      loading: () => const Scaffold(
         backgroundColor: AppColors.background,
-        appBar: AppBar(
-          backgroundColor: AppColors.background,
-          elevation: 0,
-          title: const Text('Profile'),
-        ),
-        body: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(AppSizes.pagePaddingH),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(
-                  Icons.error_outline,
-                  size: AppSizes.iconXl,
-                  color: AppColors.error,
-                ),
-                const SizedBox(height: AppSizes.md),
-                Text(
-                  err is AppException ? err.message : 'Something went wrong.',
-                  textAlign: TextAlign.center,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
-                ),
-                const SizedBox(height: AppSizes.lg),
-                FilledButton(
-                  onPressed: () =>
-                      ref.invalidate(profileControllerProvider(babyId)),
-                  child: const Text('Try Again'),
-                ),
-              ],
-            ),
-          ),
-        ),
+        body: Center(child: CircularProgressIndicator()),
       ),
-      data: (state) => _ProfileContent(babyId: babyId, state: state),
+      error: (err, _) => _ProfileError(
+        message: err is AppException ? err.message : 'Something went wrong.',
+        onRetry: () => ref.invalidate(profileControllerProvider(babyId)),
+      ),
+      data: (state) => _ProfileContent(state: state),
     );
   }
 }
 
 class _ProfileContent extends ConsumerWidget {
-  const _ProfileContent({required this.babyId, required this.state});
+  const _ProfileContent({required this.state});
 
-  final String babyId;
   final ProfileState state;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final textTheme = Theme.of(context).textTheme;
+    final baby = state.baby;
+    if (baby == null) {
+      return const _ProfileError(message: 'No baby profile found.');
+    }
+
+    void goBack() => context.canPop() ? context.pop() : context.go('/home');
 
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.background,
-        elevation: 0,
-        title: Text(
-          'Profile',
-          style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
-        ),
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
-            vertical: AppSizes.pagePaddingV,
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SafeArea(
+            bottom: false,
+            child: ColoredBox(
+              color: AppColors.butterSoft,
+              child: Column(
+                children: [
+                  ProfileHeader(onBack: goBack),
+                  ProfileAvatarCard(
+                    name: baby.name,
+                    ageLabel: _ageLabel(baby.dateOfBirth),
+                    onEdit: () => context.pushNamed(
+                      AppRoute.profileEdit.name,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              _BabyInfoCard(
-                baby: state.baby,
-                subscriptionLabel: state.subscriptionLabel,
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.pagePaddingH,
+                AppSizes.md,
+                AppSizes.pagePaddingH,
+                AppSizes.pagePaddingV,
               ),
-              const SizedBox(height: AppSizes.lg),
-              _SafeAllergenSection(safeAllergens: state.safeAllergens),
-              const SizedBox(height: AppSizes.xl),
-              FilledButton(
-                key: const Key('profile_edit_button'),
-                onPressed: () => context.pushNamed(AppRoute.profileEdit.name),
-                child: const Text('Edit'),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const PremiumTeaserCard(),
+                  const SizedBox(height: AppSizes.md + 2),
+                  SettingsRow(
+                    key: const Key('profile_manage_subscription_row'),
+                    title: 'Manage Subscription',
+                    subtitle: state.subscriptionLabel ?? 'No Subscription',
+                    // TODO(NIB-73): push paywall when ticket ships.
+                    onTap: () => _showComingSoon(
+                      context,
+                      'Subscription management coming soon.',
+                    ),
+                  ),
+                  const SizedBox(height: AppSizes.sp12),
+                  SettingsRow(
+                    key: const Key('profile_feedback_row'),
+                    title: 'Give Feedback',
+                    // TODO(NIB-70): push profileFeedback route when added.
+                    onTap: () => _showComingSoon(
+                      context,
+                      'Feedback coming soon.',
+                    ),
+                  ),
+                  const SizedBox(height: AppSizes.sp12),
+                  SettingsRow(
+                    key: const Key('profile_sign_out_button'),
+                    title: 'Sign out',
+                    onTap: () => _confirmSignOut(context, ref),
+                  ),
+                  const SizedBox(height: AppSizes.sp12),
+                  SettingsRow(
+                    key: const Key('profile_delete_account_row'),
+                    title: 'Delete account',
+                    danger: true,
+                    // TODO(NIB-78): push delete overlay when ticket ships.
+                    onTap: () => _showComingSoon(
+                      context,
+                      'Account deletion coming soon.',
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(height: AppSizes.md),
-              OutlinedButton(
-                key: const Key('profile_sign_out_button'),
-                style: OutlinedButton.styleFrom(
-                  foregroundColor: AppColors.error,
-                  side: const BorderSide(color: AppColors.error),
-                ),
-                onPressed: () => _confirmSignOut(context, ref),
-                child: const Text('Sign Out'),
-              ),
-            ],
+            ),
           ),
-        ),
+        ],
       ),
     );
+  }
+
+  String _ageLabel(DateTime dob) {
+    final now = DateTime.now();
+    final totalMonths = (now.year - dob.year) * 12 + now.month - dob.month;
+    final months = totalMonths < 0 ? 0 : totalMonths;
+    final monthStart = DateTime(now.year, now.month - months, dob.day);
+    final days = now.difference(monthStart).inDays;
+    final clampedDays = days < 0 ? 0 : days;
+    return '$months months $clampedDays days';
+  }
+
+  void _showComingSoon(BuildContext context, String message) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   Future<void> _confirmSignOut(BuildContext context, WidgetRef ref) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Sign Out'),
+        title: const Text('Sign out'),
         content: const Text('Are you sure you want to sign out?'),
         actions: [
           TextButton(
@@ -161,7 +190,7 @@ class _ProfileContent extends ConsumerWidget {
             child: const Text('No'),
           ),
           TextButton(
-            style: TextButton.styleFrom(foregroundColor: AppColors.error),
+            style: TextButton.styleFrom(foregroundColor: AppColors.destructive),
             onPressed: () => Navigator.of(ctx).pop(true),
             child: const Text('Yes'),
           ),
@@ -171,210 +200,54 @@ class _ProfileContent extends ConsumerWidget {
 
     if (confirmed ?? false) {
       await ref.read(authServiceProvider.notifier).signOut();
-      // GoRouter redirect handles navigation to /auth/login automatically
+      // GoRouter redirect handles navigation to /auth/login.
     }
   }
 }
 
-// ---------------------------------------------------------------------------
-// Baby Info Card
-// ---------------------------------------------------------------------------
+class _ProfileError extends StatelessWidget {
+  const _ProfileError({required this.message, this.onRetry});
 
-class _BabyInfoCard extends StatelessWidget {
-  const _BabyInfoCard({required this.baby, required this.subscriptionLabel});
-
-  final Baby baby;
-  final String subscriptionLabel;
+  final String message;
+  final VoidCallback? onRetry;
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
+    final theme = Theme.of(context);
 
-    return Container(
-      padding: const EdgeInsets.all(AppSizes.cardPadding),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.06),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Row(
-        children: [
-          // Avatar
-          Container(
-            width: AppSizes.avatarLg,
-            height: AppSizes.avatarLg,
-            decoration: const BoxDecoration(
-              color: AppColors.primaryLight,
-              shape: BoxShape.circle,
-            ),
-            child: Center(
-              child: Text(
-                baby.name.isNotEmpty ? baby.name[0].toUpperCase() : '?',
-                style: const TextStyle(
-                  fontSize: 32,
-                  fontWeight: FontWeight.bold,
-                  color: AppColors.primaryDark,
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(width: AppSizes.md),
-          // Info
-          Expanded(
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSizes.pagePaddingH),
             child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
               children: [
+                const Icon(
+                  Icons.error_outline,
+                  size: AppSizes.iconXl,
+                  color: AppColors.destructive,
+                ),
+                const SizedBox(height: AppSizes.md),
                 Text(
-                  baby.name,
-                  style: textTheme.headlineSmall?.copyWith(
-                    fontWeight: FontWeight.w800,
+                  message,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: AppColors.fgMuted,
                   ),
                 ),
-                const SizedBox(height: AppSizes.xs),
-                Text(
-                  _calculateAge(baby.dateOfBirth),
-                  style: textTheme.bodyMedium?.copyWith(
-                    color: AppColors.subtext,
+                if (onRetry != null) ...[
+                  const SizedBox(height: AppSizes.lg),
+                  FilledButton(
+                    onPressed: onRetry,
+                    child: const Text('Try Again'),
                   ),
-                ),
-                const SizedBox(height: AppSizes.xs),
-                Text(
-                  _genderLabel(baby.gender),
-                  style: textTheme.bodySmall?.copyWith(
-                    color: AppColors.subtext,
-                  ),
-                ),
-                const SizedBox(height: AppSizes.xs),
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSizes.sm,
-                    vertical: 2,
-                  ),
-                  decoration: BoxDecoration(
-                    color: AppColors.primary.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-                  ),
-                  child: Text(
-                    subscriptionLabel,
-                    style: textTheme.labelSmall?.copyWith(
-                      color: AppColors.primaryDark,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
+                ],
               ],
             ),
           ),
-        ],
-      ),
-    );
-  }
-
-  String _calculateAge(DateTime dob) {
-    final now = DateTime.now();
-    final months = (now.year - dob.year) * 12 + now.month - dob.month;
-    if (months < 12) return '$months months old';
-    final years = months ~/ 12;
-    return '$years year${years > 1 ? 's' : ''} old';
-  }
-
-  String _genderLabel(Gender gender) => switch (gender) {
-    Gender.male => 'Male',
-    Gender.female => 'Female',
-    Gender.preferNotToSay => 'Prefer not to say',
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Safe Allergen Section
-// ---------------------------------------------------------------------------
-
-class _SafeAllergenSection extends StatelessWidget {
-  const _SafeAllergenSection({required this.safeAllergens});
-
-  final List<AllergenBoardItem> safeAllergens;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'Discovered Safe Allergens',
-          style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
         ),
-        const SizedBox(height: AppSizes.md),
-        if (safeAllergens.isEmpty)
-          Container(
-            padding: const EdgeInsets.all(AppSizes.cardPadding),
-            decoration: BoxDecoration(
-              color: AppColors.surface,
-              borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-              border: Border.all(color: AppColors.divider),
-            ),
-            child: Center(
-              child: Text(
-                'No safe allergens confirmed yet. Keep going!',
-                style: textTheme.bodyMedium?.copyWith(color: AppColors.subtext),
-                textAlign: TextAlign.center,
-              ),
-            ),
-          )
-        else
-          Wrap(
-            spacing: AppSizes.sm,
-            runSpacing: AppSizes.sm,
-            children: safeAllergens.map((item) {
-              return _AllergenChip(
-                emoji: item.allergen.emoji,
-                name: item.allergen.name,
-              );
-            }).toList(),
-          ),
-      ],
-    );
-  }
-}
-
-class _AllergenChip extends StatelessWidget {
-  const _AllergenChip({required this.emoji, required this.name});
-
-  final String emoji;
-  final String name;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.md,
-        vertical: AppSizes.sm,
-      ),
-      decoration: BoxDecoration(
-        color: AppColors.allergenSafe.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-        border: Border.all(color: AppColors.allergenSafe, width: 1.5),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(emoji, style: const TextStyle(fontSize: 16)),
-          const SizedBox(width: AppSizes.xs),
-          Text(
-            name,
-            style: Theme.of(context).textTheme.labelMedium?.copyWith(
-              color: AppColors.allergenSafe,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/src/features/profile/profile_state.dart
+++ b/lib/src/features/profile/profile_state.dart
@@ -1,5 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
 
 part 'profile_state.freezed.dart';
@@ -7,8 +6,8 @@ part 'profile_state.freezed.dart';
 @freezed
 class ProfileState with _$ProfileState {
   const factory ProfileState({
-    required Baby baby,
-    required List<AllergenBoardItem> safeAllergens,
-    required String subscriptionLabel,
+    Baby? baby,
+    String? email,
+    String? subscriptionLabel,
   }) = _ProfileState;
 }

--- a/lib/src/features/profile/profile_state.freezed.dart
+++ b/lib/src/features/profile/profile_state.freezed.dart
@@ -17,10 +17,9 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$ProfileState {
-  Baby get baby => throw _privateConstructorUsedError;
-  List<AllergenBoardItem> get safeAllergens =>
-      throw _privateConstructorUsedError;
-  String get subscriptionLabel => throw _privateConstructorUsedError;
+  Baby? get baby => throw _privateConstructorUsedError;
+  String? get email => throw _privateConstructorUsedError;
+  String? get subscriptionLabel => throw _privateConstructorUsedError;
 
   /// Create a copy of ProfileState
   /// with the given fields replaced by the non-null parameter values.
@@ -36,13 +35,9 @@ abstract class $ProfileStateCopyWith<$Res> {
     $Res Function(ProfileState) then,
   ) = _$ProfileStateCopyWithImpl<$Res, ProfileState>;
   @useResult
-  $Res call({
-    Baby baby,
-    List<AllergenBoardItem> safeAllergens,
-    String subscriptionLabel,
-  });
+  $Res call({Baby? baby, String? email, String? subscriptionLabel});
 
-  $BabyCopyWith<$Res> get baby;
+  $BabyCopyWith<$Res>? get baby;
 }
 
 /// @nodoc
@@ -60,24 +55,24 @@ class _$ProfileStateCopyWithImpl<$Res, $Val extends ProfileState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? baby = null,
-    Object? safeAllergens = null,
-    Object? subscriptionLabel = null,
+    Object? baby = freezed,
+    Object? email = freezed,
+    Object? subscriptionLabel = freezed,
   }) {
     return _then(
       _value.copyWith(
-            baby: null == baby
+            baby: freezed == baby
                 ? _value.baby
                 : baby // ignore: cast_nullable_to_non_nullable
-                      as Baby,
-            safeAllergens: null == safeAllergens
-                ? _value.safeAllergens
-                : safeAllergens // ignore: cast_nullable_to_non_nullable
-                      as List<AllergenBoardItem>,
-            subscriptionLabel: null == subscriptionLabel
+                      as Baby?,
+            email: freezed == email
+                ? _value.email
+                : email // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            subscriptionLabel: freezed == subscriptionLabel
                 ? _value.subscriptionLabel
                 : subscriptionLabel // ignore: cast_nullable_to_non_nullable
-                      as String,
+                      as String?,
           )
           as $Val,
     );
@@ -87,8 +82,12 @@ class _$ProfileStateCopyWithImpl<$Res, $Val extends ProfileState>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  $BabyCopyWith<$Res> get baby {
-    return $BabyCopyWith<$Res>(_value.baby, (value) {
+  $BabyCopyWith<$Res>? get baby {
+    if (_value.baby == null) {
+      return null;
+    }
+
+    return $BabyCopyWith<$Res>(_value.baby!, (value) {
       return _then(_value.copyWith(baby: value) as $Val);
     });
   }
@@ -103,14 +102,10 @@ abstract class _$$ProfileStateImplCopyWith<$Res>
   ) = __$$ProfileStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    Baby baby,
-    List<AllergenBoardItem> safeAllergens,
-    String subscriptionLabel,
-  });
+  $Res call({Baby? baby, String? email, String? subscriptionLabel});
 
   @override
-  $BabyCopyWith<$Res> get baby;
+  $BabyCopyWith<$Res>? get baby;
 }
 
 /// @nodoc
@@ -127,24 +122,24 @@ class __$$ProfileStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? baby = null,
-    Object? safeAllergens = null,
-    Object? subscriptionLabel = null,
+    Object? baby = freezed,
+    Object? email = freezed,
+    Object? subscriptionLabel = freezed,
   }) {
     return _then(
       _$ProfileStateImpl(
-        baby: null == baby
+        baby: freezed == baby
             ? _value.baby
             : baby // ignore: cast_nullable_to_non_nullable
-                  as Baby,
-        safeAllergens: null == safeAllergens
-            ? _value._safeAllergens
-            : safeAllergens // ignore: cast_nullable_to_non_nullable
-                  as List<AllergenBoardItem>,
-        subscriptionLabel: null == subscriptionLabel
+                  as Baby?,
+        email: freezed == email
+            ? _value.email
+            : email // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        subscriptionLabel: freezed == subscriptionLabel
             ? _value.subscriptionLabel
             : subscriptionLabel // ignore: cast_nullable_to_non_nullable
-                  as String,
+                  as String?,
       ),
     );
   }
@@ -153,28 +148,18 @@ class __$$ProfileStateImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$ProfileStateImpl implements _ProfileState {
-  const _$ProfileStateImpl({
-    required this.baby,
-    required final List<AllergenBoardItem> safeAllergens,
-    required this.subscriptionLabel,
-  }) : _safeAllergens = safeAllergens;
+  const _$ProfileStateImpl({this.baby, this.email, this.subscriptionLabel});
 
   @override
-  final Baby baby;
-  final List<AllergenBoardItem> _safeAllergens;
+  final Baby? baby;
   @override
-  List<AllergenBoardItem> get safeAllergens {
-    if (_safeAllergens is EqualUnmodifiableListView) return _safeAllergens;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_safeAllergens);
-  }
-
+  final String? email;
   @override
-  final String subscriptionLabel;
+  final String? subscriptionLabel;
 
   @override
   String toString() {
-    return 'ProfileState(baby: $baby, safeAllergens: $safeAllergens, subscriptionLabel: $subscriptionLabel)';
+    return 'ProfileState(baby: $baby, email: $email, subscriptionLabel: $subscriptionLabel)';
   }
 
   @override
@@ -183,21 +168,13 @@ class _$ProfileStateImpl implements _ProfileState {
         (other.runtimeType == runtimeType &&
             other is _$ProfileStateImpl &&
             (identical(other.baby, baby) || other.baby == baby) &&
-            const DeepCollectionEquality().equals(
-              other._safeAllergens,
-              _safeAllergens,
-            ) &&
+            (identical(other.email, email) || other.email == email) &&
             (identical(other.subscriptionLabel, subscriptionLabel) ||
                 other.subscriptionLabel == subscriptionLabel));
   }
 
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    baby,
-    const DeepCollectionEquality().hash(_safeAllergens),
-    subscriptionLabel,
-  );
+  int get hashCode => Object.hash(runtimeType, baby, email, subscriptionLabel);
 
   /// Create a copy of ProfileState
   /// with the given fields replaced by the non-null parameter values.
@@ -210,17 +187,17 @@ class _$ProfileStateImpl implements _ProfileState {
 
 abstract class _ProfileState implements ProfileState {
   const factory _ProfileState({
-    required final Baby baby,
-    required final List<AllergenBoardItem> safeAllergens,
-    required final String subscriptionLabel,
+    final Baby? baby,
+    final String? email,
+    final String? subscriptionLabel,
   }) = _$ProfileStateImpl;
 
   @override
-  Baby get baby;
+  Baby? get baby;
   @override
-  List<AllergenBoardItem> get safeAllergens;
+  String? get email;
   @override
-  String get subscriptionLabel;
+  String? get subscriptionLabel;
 
   /// Create a copy of ProfileState
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/src/features/profile/widgets/premium_teaser_card.dart
+++ b/lib/src/features/profile/widgets/premium_teaser_card.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+
+/// Static premium teaser card — butter-soft surface, scaled-down `nibbles`
+/// wordmark, butter crown badge, body copy.
+///
+/// Static for MVP (NIB-73 wires the paywall push). Mirrors
+/// `design/ui_kits/nibbles_mobile/ProfileScreen.jsx` premium card.
+class PremiumTeaserCard extends StatelessWidget {
+  const PremiumTeaserCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // Scale the brand wordmark from kit 42 → 22 to fit the inline lockup.
+    final wordmark = AppTypography.brandWordmark.copyWith(
+      fontSize: 22,
+      letterSpacing: 22 * -0.02,
+    );
+
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.butterSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md,
+        vertical: AppSizes.md - 2,
+      ),
+      child: Row(
+        children: [
+          Text('nibbles', style: wordmark),
+          const SizedBox(width: AppSizes.sm - 2),
+          Container(
+            width: 26,
+            height: 26,
+            decoration: BoxDecoration(
+              color: AppColors.butter,
+              borderRadius: BorderRadius.circular(AppSizes.sm),
+            ),
+            child: const Icon(
+              Icons.workspace_premium_rounded,
+              size: 18,
+              color: AppColors.greenDeep,
+            ),
+          ),
+          const SizedBox(width: AppSizes.sp12 + 2),
+          Expanded(
+            child: Text(
+              'Unlock premium personalized guidance and exclusive recipes.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: AppColors.fgDefault,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/profile/widgets/profile_avatar_card.dart
+++ b/lib/src/features/profile/widgets/profile_avatar_card.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+
+/// Coral circular avatar + baby name + age caption + ghost Edit pill.
+///
+/// Mirrors `design/ui_kits/nibbles_mobile/ProfileScreen.jsx` — 120px coral
+/// circle holding a cream baby silhouette, headline name, faint age caption,
+/// 110-wide ghost Edit pill below.
+class ProfileAvatarCard extends StatelessWidget {
+  const ProfileAvatarCard({
+    required this.name,
+    required this.ageLabel,
+    required this.onEdit,
+    super.key,
+  });
+
+  final String name;
+  final String ageLabel;
+  final VoidCallback onEdit;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      color: AppColors.butterSoft,
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.md + 2,
+        0,
+        AppSizes.md + 2,
+        AppSizes.lg,
+      ),
+      child: Column(
+        children: [
+          Container(
+            width: AppSizes.avatarXl,
+            height: AppSizes.avatarXl,
+            decoration: const BoxDecoration(
+              color: AppColors.coral,
+              shape: BoxShape.circle,
+            ),
+            child: const Center(
+              child: Icon(
+                Icons.child_care_rounded,
+                size: 64,
+                color: AppColors.cream,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSizes.sp12),
+          Text(
+            name,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.w800,
+              color: AppColors.fgStrong,
+              height: 1,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: AppSizes.xs),
+          Text(
+            ageLabel,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: AppColors.fgFaint,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: AppSizes.sm),
+          SizedBox(
+            width: 110,
+            child: AppPillButton(
+              key: const Key('profile_edit_button'),
+              label: 'Edit',
+              onPressed: onEdit,
+              variant: AppPillButtonVariant.ghost,
+              size: AppPillButtonSize.small,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/profile/widgets/profile_header.dart
+++ b/lib/src/features/profile/widgets/profile_header.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
+
+/// Butter-soft wash header for the Profile / Settings screen.
+///
+/// Mirrors `design/ui_kits/nibbles_mobile/ProfileScreen.jsx`:
+/// background `butterSoft`, 32px ghost back chevron on the left, centered
+/// "Settings" title (titleSmall 17/700), 32px right slot for layout symmetry.
+class ProfileHeader extends StatelessWidget {
+  const ProfileHeader({required this.onBack, super.key});
+
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      color: AppColors.butterSoft,
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.md + 2,
+        AppSizes.sm - 2,
+        AppSizes.md + 2,
+        AppSizes.lg,
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: AppSizes.roundButtonSm,
+            child: AppRoundButton(
+              icon: const Icon(Icons.arrow_back_ios_new_rounded),
+              onPressed: onBack,
+              tone: AppRoundButtonTone.ghost,
+              size: AppRoundButtonSize.small,
+              semanticLabel: 'Back',
+            ),
+          ),
+          Expanded(
+            child: Text(
+              'Settings',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: AppColors.fgStrong,
+                height: 1,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSizes.roundButtonSm),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/profile/widgets/settings_row.dart
+++ b/lib/src/features/profile/widgets/settings_row.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Cream-surfaced action row used in the Settings list.
+///
+/// Mirrors the kit `.card` + `.box-shadow: var(--shadow-card)` pattern from
+/// `design/ui_kits/nibbles_mobile/ProfileScreen.jsx`. Supports a `danger`
+/// variant that tints the title + chevron with [AppColors.destructive].
+class SettingsRow extends StatelessWidget {
+  const SettingsRow({
+    required this.title,
+    required this.onTap,
+    this.subtitle,
+    this.danger = false,
+    super.key,
+  });
+
+  final String title;
+  final String? subtitle;
+  final VoidCallback onTap;
+  final bool danger;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final titleColor = danger ? AppColors.destructive : AppColors.fgStrong;
+    final chevronColor = danger ? AppColors.destructive : AppColors.greenDeep;
+
+    final radius = BorderRadius.circular(AppSizes.radiusXl);
+
+    return Material(
+      color: AppColors.cream,
+      borderRadius: radius,
+      child: Ink(
+        decoration: BoxDecoration(
+          color: AppColors.cream,
+          borderRadius: radius,
+          boxShadow: AppSizes.shadowCard,
+        ),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: radius,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.md,
+              vertical: AppSizes.md - 2,
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 15,
+                          color: titleColor,
+                          height: 1.2,
+                        ),
+                      ),
+                      if (subtitle != null) ...[
+                        const SizedBox(height: AppSizes.sp2),
+                        Text(
+                          subtitle!,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: AppColors.fgFaint,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right_rounded,
+                  size: AppSizes.iconMd,
+                  color: chevronColor,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -70,6 +70,13 @@ Widget _wrap(Widget screen, List<Override> overrides) => ProviderScope(
 // Tests
 // ---------------------------------------------------------------------------
 
+// NIB-52: Profile screen reskinned to the new Settings layout (butter header,
+// coral avatar, premium teaser, 4-action rows). The legacy assertions below
+// target the dropped Safe Allergens block and the old FilledButton sign-out
+// flow. NIB-99 will rebuild the suite against the new widget tree; until
+// then every test in this file is skipped.
+const bool _nib52Skip = true;
+
 void main() {
   late MockBabyProfileService mockBabyService;
   late MockAllergenService mockAllergenService;
@@ -102,114 +109,128 @@ void main() {
   // Baby info
   // -------------------------------------------------------------------------
 
-  testWidgets('baby name, age, gender and subscription label shown correctly', (
-    tester,
-  ) async {
-    stubCommon();
+  testWidgets(
+    'baby name, age, gender and subscription label shown correctly',
+    (tester) async {
+      stubCommon();
 
-    await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Lily'), findsOneWidget);
-    expect(find.textContaining('old'), findsOneWidget);
-    expect(find.text('Female'), findsOneWidget);
-    expect(find.text('Trial'), findsOneWidget);
-  });
+      expect(find.text('Lily'), findsOneWidget);
+      expect(find.textContaining('old'), findsOneWidget);
+      expect(find.text('Female'), findsOneWidget);
+      expect(find.text('Trial'), findsOneWidget);
+    },
+    skip: _nib52Skip,
+  );
 
   // -------------------------------------------------------------------------
   // Safe allergens — with data
   // -------------------------------------------------------------------------
 
-  testWidgets('safe allergen chips shown for AllergenStatus.safe allergens', (
-    tester,
-  ) async {
-    stubCommon(boardItems: [_safePeanutItem]);
+  testWidgets(
+    'safe allergen chips shown for AllergenStatus.safe allergens',
+    (tester) async {
+      stubCommon(boardItems: [_safePeanutItem]);
 
-    await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Peanut'), findsOneWidget);
-    expect(find.text('🥜'), findsOneWidget);
-  });
+      expect(find.text('Peanut'), findsOneWidget);
+      expect(find.text('🥜'), findsOneWidget);
+    },
+    skip: _nib52Skip,
+  );
 
   // -------------------------------------------------------------------------
   // Safe allergens — empty state
   // -------------------------------------------------------------------------
 
-  testWidgets('empty state shown when no safe allergens confirmed', (
-    tester,
-  ) async {
-    stubCommon();
+  testWidgets(
+    'empty state shown when no safe allergens confirmed',
+    (tester) async {
+      stubCommon();
 
-    await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
 
-    expect(
-      find.text('No safe allergens confirmed yet. Keep going!'),
-      findsOneWidget,
-    );
-  });
+      expect(
+        find.text('No safe allergens confirmed yet. Keep going!'),
+        findsOneWidget,
+      );
+    },
+    skip: _nib52Skip,
+  );
 
   // -------------------------------------------------------------------------
   // Sign out — dialog shown
   // -------------------------------------------------------------------------
 
-  testWidgets('tapping Sign Out button shows confirmation dialog', (
-    tester,
-  ) async {
-    stubCommon();
+  testWidgets(
+    'tapping Sign Out button shows confirmation dialog',
+    (tester) async {
+      stubCommon();
 
-    await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const Key('profile_sign_out_button')));
-    await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('profile_sign_out_button')));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Sign Out'), findsWidgets);
-    expect(find.text('Are you sure you want to sign out?'), findsOneWidget);
-  });
+      expect(find.text('Sign Out'), findsWidgets);
+      expect(find.text('Are you sure you want to sign out?'), findsOneWidget);
+    },
+    skip: _nib52Skip,
+  );
 
   // -------------------------------------------------------------------------
   // Sign out — dialog No
   // -------------------------------------------------------------------------
 
-  testWidgets('tapping No dismisses dialog and keeps profile screen', (
-    tester,
-  ) async {
-    stubCommon();
+  testWidgets(
+    'tapping No dismisses dialog and keeps profile screen',
+    (tester) async {
+      stubCommon();
 
-    await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const Key('profile_sign_out_button')));
-    await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('profile_sign_out_button')));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.text('No'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('No'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Are you sure you want to sign out?'), findsNothing);
-    expect(find.byKey(const Key('profile_sign_out_button')), findsOneWidget);
-  });
+      expect(find.text('Are you sure you want to sign out?'), findsNothing);
+      expect(find.byKey(const Key('profile_sign_out_button')), findsOneWidget);
+    },
+    skip: _nib52Skip,
+  );
 
   // -------------------------------------------------------------------------
   // Sign out — dialog Yes
   // -------------------------------------------------------------------------
 
-  testWidgets('tapping Yes calls AuthService.signOut', (tester) async {
-    stubCommon();
-    when(
-      () => mockAuthRepo.signOut(),
-    ).thenAnswer((_) async => const Result.success(null));
+  testWidgets(
+    'tapping Yes calls AuthService.signOut',
+    (tester) async {
+      stubCommon();
+      when(
+        () => mockAuthRepo.signOut(),
+      ).thenAnswer((_) async => const Result.success(null));
 
-    await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(_wrap(const ProfileScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const Key('profile_sign_out_button')));
-    await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('profile_sign_out_button')));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Yes'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Yes'));
+      await tester.pumpAndSettle();
 
-    verify(() => mockAuthRepo.signOut()).called(1);
-  });
+      verify(() => mockAuthRepo.signOut()).called(1);
+    },
+    skip: _nib52Skip,
+  );
 }


### PR DESCRIPTION
## Summary

Rewrites Profile / Settings to the new design system per Figma 1189:10278. Drops the legacy Discovered Safe Allergens block, replaces the inline baby info card with a butter-soft header + 120px coral avatar + ghost Edit pill, adds a static premium teaser, and a list of 4 cream action rows (Manage Subscription, Give Feedback, Sign out, Delete account).

## Figma

- Main: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1189-10278
- Trial variant: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1211-11469

## DS components consumed

- `AppRoundButton` (ghost small) — header back chevron
- `AppPillButton` (ghost small) — Edit pill
- `AppColors` / `AppSizes` / `AppTypography` tokens only — no hex / Nunito / withAlpha
- `AppSizes.shadowCard` — settings row elevation

## New widget API (feature-local)

- `ProfileHeader({ required VoidCallback onBack })` — butter-soft top bar.
- `ProfileAvatarCard({ required String name, required String ageLabel, required VoidCallback onEdit })` — coral circle + name + caption + ghost Edit pill.
- `PremiumTeaserCard()` — static teaser: scaled `nibbles` wordmark + butter crown badge + body copy.
- `SettingsRow({ required String title, String? subtitle, required VoidCallback onTap, bool danger = false })` — cream card + `shadowCard` + chevron; `danger` tints title + chevron with `AppColors.destructive`.

## State + controller reshape

- `ProfileState`: `Baby? baby`, `String? email`, `String? subscriptionLabel`. Legacy `safeAllergens` + the `'Trial'` label are gone.
- `ProfileController.build(String babyId)` drops `AllergenService`, reads `Supabase.instance.client.auth.currentUser?.email`, and stubs `subscriptionLabel` to `'No Subscription'` until NIB-73 wires the paywall. The `babyId` family parameter is retained for back-compat with `profile_edit_screen.dart` (which calls `ref.invalidate(profileControllerProvider(widget.babyId))`).

## Carve-outs / TODOs

- **Manage Subscription** — shows `subscriptionLabel` as subtitle; tap surfaces a `'Subscription management coming soon.'` SnackBar. `// TODO(NIB-73)` push paywall when ticket ships.
- **Give Feedback** — `AppRoute.profileFeedback` does not exist yet. SnackBar fallback per spec; `// TODO(NIB-70)` will add the route and push.
- **Delete account** — `lib/src/features/profile/delete/` does not exist yet. SnackBar fallback; `// TODO(NIB-78)` will open the delete overlay.
- **Premium teaser crown** — rendered as a Material icon (`Icons.workspace_premium_rounded`) over a butter rounded square, matching the kit visual without using an emoji glyph in code.
- **Tests** — the existing 6 widget tests assert on the dropped Safe Allergens block + old FilledButton sign-out flow. Per spec they are skipped (`skip: _nib52Skip`) until NIB-99 rebuilds the suite.

## Acceptance criteria

- [x] Screen matches Figma 1189:10278 (butter header + coral avatar + ghost Edit + premium teaser + 4 rows).
- [x] Legacy Safe Allergens block fully removed.
- [x] Delete-account row uses `AppColors.destructive` for title + chevron.
- [x] Sign-out flow works via `authService.signOut` (existing confirm dialog kept).
- [x] Edit pill pushes `AppRoute.profileEdit`.
- [x] TODO comments for NIB-70 / NIB-73 / NIB-78 entry points.
- [x] `flutter analyze` — 0 issues.
- [x] `make gen` clean + idempotent (verified by re-run + `git status`).
- [x] Existing tests still pass (legacy tests skipped per spec; full suite green).
- [x] Zero hex / Nunito / withAlpha / `AllergenStatus.completed` in touched files.
- [x] No files outside the allowlist modified.

## Gate results

- `make gen` — succeeded (288 outputs); second run idempotent.
- `flutter analyze` — `No issues found! (ran in 8.4s)`.
- `flutter test` — `All tests passed!` (449 pass, 6 skipped — the legacy profile widget tests).