### PR TITLE
feat(profile): give feedback feature + supabase table + route [NIB-70]

### DIFF
--- a/lib/src/common/data/repositories/feedback_repository.dart
+++ b/lib/src/common/data/repositories/feedback_repository.dart
@@ -1,0 +1,46 @@
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'feedback_repository.g.dart';
+
+/// Write-only feedback ingestion. Inserts a row into the `feedback` table;
+/// reads are admin-only (no SELECT policy), so this repo only exposes
+/// [submit].
+// ignore: one_member_abstracts
+abstract interface class FeedbackRepository {
+  /// Inserts a feedback row for the current user. The caller has already
+  /// validated the message is non-empty; this method trims it before insert
+  /// to match the SQL length check.
+  Future<Result<void>> submit(String message);
+}
+
+class FeedbackRepositoryImpl implements FeedbackRepository {
+  FeedbackRepositoryImpl({SupabaseClient? supabaseClient})
+    : _supabase = supabaseClient ?? Supabase.instance.client;
+
+  final SupabaseClient _supabase;
+
+  @override
+  Future<Result<void>> submit(String message) async {
+    try {
+      final userId = _supabase.auth.currentUser?.id;
+      await _supabase.from('feedback').insert({
+        'user_id': userId,
+        'message': message.trim(),
+      });
+      return const Result.success(null);
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+}
+
+@Riverpod(keepAlive: true)
+// Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+// ignore: deprecated_member_use_from_same_package
+FeedbackRepository feedbackRepository(FeedbackRepositoryRef ref) =>
+    FeedbackRepositoryImpl();

--- a/lib/src/common/data/repositories/feedback_repository.g.dart
+++ b/lib/src/common/data/repositories/feedback_repository.g.dart
@@ -1,27 +1,28 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'routes.dart';
+part of 'feedback_repository.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'fdce46d093079b4f10f6661f9b74b2180691f13a';
+String _$feedbackRepositoryHash() =>
+    r'5cf127a5dd9fec747e2d1b51341ce46124ca616f';
 
-/// See also [goRouter].
-@ProviderFor(goRouter)
-final goRouterProvider = Provider<GoRouter>.internal(
-  goRouter,
-  name: r'goRouterProvider',
+/// See also [feedbackRepository].
+@ProviderFor(feedbackRepository)
+final feedbackRepositoryProvider = Provider<FeedbackRepository>.internal(
+  feedbackRepository,
+  name: r'feedbackRepositoryProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$goRouterHash,
+      : _$feedbackRepositoryHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef GoRouterRef = ProviderRef<GoRouter>;
+typedef FeedbackRepositoryRef = ProviderRef<FeedbackRepository>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/common/services/feedback_service.dart
+++ b/lib/src/common/services/feedback_service.dart
@@ -1,0 +1,23 @@
+import 'package:nibbles/src/common/data/repositories/feedback_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'feedback_service.g.dart';
+
+/// Thin facade over [FeedbackRepository]. The feedback feature is a
+/// straight passthrough today; the service exists to keep the controller
+/// agnostic of the repository and to match the project's
+/// Controller -> Service -> Repository pattern.
+class FeedbackService {
+  const FeedbackService(this._repo);
+
+  final FeedbackRepository _repo;
+
+  Future<Result<void>> submit(String message) => _repo.submit(message);
+}
+
+@Riverpod(keepAlive: true)
+// Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+// ignore: deprecated_member_use_from_same_package
+FeedbackService feedbackService(FeedbackServiceRef ref) =>
+    FeedbackService(ref.watch(feedbackRepositoryProvider));

--- a/lib/src/common/services/feedback_service.g.dart
+++ b/lib/src/common/services/feedback_service.g.dart
@@ -1,27 +1,27 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'routes.dart';
+part of 'feedback_service.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'fdce46d093079b4f10f6661f9b74b2180691f13a';
+String _$feedbackServiceHash() => r'25807526a965139e948aebcdcc505d406cec2728';
 
-/// See also [goRouter].
-@ProviderFor(goRouter)
-final goRouterProvider = Provider<GoRouter>.internal(
-  goRouter,
-  name: r'goRouterProvider',
+/// See also [feedbackService].
+@ProviderFor(feedbackService)
+final feedbackServiceProvider = Provider<FeedbackService>.internal(
+  feedbackService,
+  name: r'feedbackServiceProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$goRouterHash,
+      : _$feedbackServiceHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef GoRouterRef = ProviderRef<GoRouter>;
+typedef FeedbackServiceRef = ProviderRef<FeedbackService>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/profile/feedback/feedback_controller.dart
+++ b/lib/src/features/profile/feedback/feedback_controller.dart
@@ -1,0 +1,42 @@
+import 'package:nibbles/src/common/services/feedback_service.dart';
+import 'package:nibbles/src/features/profile/feedback/feedback_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'feedback_controller.g.dart';
+
+@riverpod
+class FeedbackController extends _$FeedbackController {
+  @override
+  FeedbackState build() => const FeedbackState();
+
+  void updateMessage(String value) {
+    state = state.copyWith(message: value, errorMessage: null);
+  }
+
+  /// Submits the current message. Returns true on success, false on
+  /// failure. The Send button is gated on a non-blank message + not
+  /// already submitting, so we only need to short-circuit those here as
+  /// belt-and-braces.
+  Future<bool> submit() async {
+    final trimmed = state.message.trim();
+    if (trimmed.isEmpty || state.isSubmitting) return false;
+
+    state = state.copyWith(isSubmitting: true, errorMessage: null);
+
+    final result = await ref.read(feedbackServiceProvider).submit(trimmed);
+
+    return result.when(
+      success: (_) {
+        state = state.copyWith(isSubmitting: false);
+        return true;
+      },
+      failure: (error) {
+        state = state.copyWith(
+          isSubmitting: false,
+          errorMessage: error.message,
+        );
+        return false;
+      },
+    );
+  }
+}

--- a/lib/src/features/profile/feedback/feedback_controller.g.dart
+++ b/lib/src/features/profile/feedback/feedback_controller.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'feedback_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$feedbackControllerHash() =>
+    r'd1f6d919331f138f7912ecbf5b04b9b425969dd8';
+
+/// See also [FeedbackController].
+@ProviderFor(FeedbackController)
+final feedbackControllerProvider =
+    AutoDisposeNotifierProvider<FeedbackController, FeedbackState>.internal(
+      FeedbackController.new,
+      name: r'feedbackControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$feedbackControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$FeedbackController = AutoDisposeNotifier<FeedbackState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/profile/feedback/feedback_screen.dart
+++ b/lib/src/features/profile/feedback/feedback_screen.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/features/profile/feedback/feedback_controller.dart';
+import 'package:nibbles/src/features/profile/widgets/profile_header.dart';
+
+/// Give Feedback screen. Butter-soft "Settings" header, single multiline
+/// textarea, helper caption, and a full-width green-deep CTA. Mirrors the
+/// ProfileScreen kit pattern — no shell, no bottom nav (full-screen push).
+class FeedbackScreen extends ConsumerWidget {
+  const FeedbackScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(feedbackControllerProvider);
+    final controller = ref.read(feedbackControllerProvider.notifier);
+    final textTheme = Theme.of(context).textTheme;
+
+    void goBack() => context.canPop() ? context.pop() : context.go('/home');
+
+    final canSubmit = state.message.trim().isNotEmpty && !state.isSubmitting;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SafeArea(
+            bottom: false,
+            child: ColoredBox(
+              color: AppColors.butterSoft,
+              child: ProfileHeader(onBack: goBack),
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.pagePaddingH,
+                AppSizes.lg,
+                AppSizes.pagePaddingH,
+                AppSizes.pagePaddingV,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'Give Feedback',
+                    style: textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.fgStrong,
+                    ),
+                  ),
+                  const SizedBox(height: AppSizes.sm),
+                  Text(
+                    "Tell us what's working, what's not, or what you'd love "
+                    'to see next. We read every message.',
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: AppColors.fgMuted,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: AppSizes.lg),
+                  _FeedbackField(
+                    initialValue: state.message,
+                    enabled: !state.isSubmitting,
+                    onChanged: controller.updateMessage,
+                  ),
+                  const SizedBox(height: AppSizes.sm),
+                  Text(
+                    'Max 2,000 characters.',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: AppColors.fgFaint,
+                    ),
+                  ),
+                  const SizedBox(height: AppSizes.xl),
+                  AppPillButton(
+                    key: const Key('feedback_send_button'),
+                    label: state.isSubmitting ? 'Sending…' : 'Send Feedback',
+                    onPressed: canSubmit ? () => _submit(context, ref) : null,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _submit(BuildContext context, WidgetRef ref) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final controller = ref.read(feedbackControllerProvider.notifier);
+    final ok = await controller.submit();
+    if (!context.mounted) return;
+
+    if (ok) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Thank you for your feedback!')),
+      );
+      context.pop();
+    } else {
+      messenger.showSnackBar(
+        const SnackBar(content: Text("Couldn't send feedback. Try again.")),
+      );
+    }
+  }
+}
+
+/// Multiline textarea matching the kit `.field` fill (bgInput) + radiusMd.
+/// Sized for 5-8 visible lines.
+class _FeedbackField extends StatefulWidget {
+  const _FeedbackField({
+    required this.initialValue,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  final String initialValue;
+  final bool enabled;
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<_FeedbackField> createState() => _FeedbackFieldState();
+}
+
+class _FeedbackFieldState extends State<_FeedbackField> {
+  late final TextEditingController _controller;
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue);
+    _focusNode = FocusNode()..addListener(_onFocusChanged);
+  }
+
+  void _onFocusChanged() => setState(() {});
+
+  @override
+  void dispose() {
+    _focusNode
+      ..removeListener(_onFocusChanged)
+      ..dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final focused = _focusNode.hasFocus;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 120),
+      decoration: BoxDecoration(
+        color: focused ? AppColors.surface : AppColors.bgInput,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        border: Border.all(
+          color: focused ? AppColors.greenDeep : AppColors.borderSoft,
+          width: focused ? 2 : 1,
+        ),
+        boxShadow: focused
+            ? [
+                BoxShadow(
+                  color: AppColors.green.withValues(alpha: 0.18),
+                  spreadRadius: 3,
+                ),
+              ]
+            : null,
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md - 2,
+        vertical: AppSizes.sp12,
+      ),
+      child: TextField(
+        key: const Key('feedback_message_field'),
+        controller: _controller,
+        focusNode: _focusNode,
+        enabled: widget.enabled,
+        onChanged: widget.onChanged,
+        minLines: 6,
+        maxLines: 10,
+        maxLength: 2000,
+        textCapitalization: TextCapitalization.sentences,
+        keyboardType: TextInputType.multiline,
+        cursorColor: AppColors.greenDeep,
+        style: theme.textTheme.bodyLarge?.copyWith(color: AppColors.fgStrong),
+        decoration: InputDecoration(
+          isCollapsed: true,
+          border: InputBorder.none,
+          counterText: '',
+          hintText: 'Share your thoughts…',
+          hintStyle: theme.textTheme.bodyLarge?.copyWith(
+            color: AppColors.greenSoft,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/profile/feedback/feedback_state.dart
+++ b/lib/src/features/profile/feedback/feedback_state.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'feedback_state.freezed.dart';
+
+@freezed
+class FeedbackState with _$FeedbackState {
+  const factory FeedbackState({
+    @Default('') String message,
+    @Default(false) bool isSubmitting,
+    String? errorMessage,
+  }) = _FeedbackState;
+}

--- a/lib/src/features/profile/feedback/feedback_state.freezed.dart
+++ b/lib/src/features/profile/feedback/feedback_state.freezed.dart
@@ -1,0 +1,197 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'feedback_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$FeedbackState {
+  String get message => throw _privateConstructorUsedError;
+  bool get isSubmitting => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+
+  /// Create a copy of FeedbackState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $FeedbackStateCopyWith<FeedbackState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $FeedbackStateCopyWith<$Res> {
+  factory $FeedbackStateCopyWith(
+    FeedbackState value,
+    $Res Function(FeedbackState) then,
+  ) = _$FeedbackStateCopyWithImpl<$Res, FeedbackState>;
+  @useResult
+  $Res call({String message, bool isSubmitting, String? errorMessage});
+}
+
+/// @nodoc
+class _$FeedbackStateCopyWithImpl<$Res, $Val extends FeedbackState>
+    implements $FeedbackStateCopyWith<$Res> {
+  _$FeedbackStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of FeedbackState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+    Object? isSubmitting = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            message: null == message
+                ? _value.message
+                : message // ignore: cast_nullable_to_non_nullable
+                      as String,
+            isSubmitting: null == isSubmitting
+                ? _value.isSubmitting
+                : isSubmitting // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$FeedbackStateImplCopyWith<$Res>
+    implements $FeedbackStateCopyWith<$Res> {
+  factory _$$FeedbackStateImplCopyWith(
+    _$FeedbackStateImpl value,
+    $Res Function(_$FeedbackStateImpl) then,
+  ) = __$$FeedbackStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String message, bool isSubmitting, String? errorMessage});
+}
+
+/// @nodoc
+class __$$FeedbackStateImplCopyWithImpl<$Res>
+    extends _$FeedbackStateCopyWithImpl<$Res, _$FeedbackStateImpl>
+    implements _$$FeedbackStateImplCopyWith<$Res> {
+  __$$FeedbackStateImplCopyWithImpl(
+    _$FeedbackStateImpl _value,
+    $Res Function(_$FeedbackStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of FeedbackState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+    Object? isSubmitting = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _$FeedbackStateImpl(
+        message: null == message
+            ? _value.message
+            : message // ignore: cast_nullable_to_non_nullable
+                  as String,
+        isSubmitting: null == isSubmitting
+            ? _value.isSubmitting
+            : isSubmitting // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$FeedbackStateImpl implements _FeedbackState {
+  const _$FeedbackStateImpl({
+    this.message = '',
+    this.isSubmitting = false,
+    this.errorMessage,
+  });
+
+  @override
+  @JsonKey()
+  final String message;
+  @override
+  @JsonKey()
+  final bool isSubmitting;
+  @override
+  final String? errorMessage;
+
+  @override
+  String toString() {
+    return 'FeedbackState(message: $message, isSubmitting: $isSubmitting, errorMessage: $errorMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$FeedbackStateImpl &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.isSubmitting, isSubmitting) ||
+                other.isSubmitting == isSubmitting) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, message, isSubmitting, errorMessage);
+
+  /// Create a copy of FeedbackState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$FeedbackStateImplCopyWith<_$FeedbackStateImpl> get copyWith =>
+      __$$FeedbackStateImplCopyWithImpl<_$FeedbackStateImpl>(this, _$identity);
+}
+
+abstract class _FeedbackState implements FeedbackState {
+  const factory _FeedbackState({
+    final String message,
+    final bool isSubmitting,
+    final String? errorMessage,
+  }) = _$FeedbackStateImpl;
+
+  @override
+  String get message;
+  @override
+  bool get isSubmitting;
+  @override
+  String? get errorMessage;
+
+  /// Create a copy of FeedbackState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$FeedbackStateImplCopyWith<_$FeedbackStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/profile/profile_screen.dart
+++ b/lib/src/features/profile/profile_screen.dart
@@ -130,11 +130,8 @@ class _ProfileContent extends ConsumerWidget {
                   SettingsRow(
                     key: const Key('profile_feedback_row'),
                     title: 'Give Feedback',
-                    // TODO(NIB-70): push profileFeedback route when added.
-                    onTap: () => _showComingSoon(
-                      context,
-                      'Feedback coming soon.',
-                    ),
+                    onTap: () =>
+                        context.pushNamed(AppRoute.profileFeedback.name),
                   ),
                   const SizedBox(height: AppSizes.sp12),
                   SettingsRow(

--- a/lib/src/routing/route_enums.dart
+++ b/lib/src/routing/route_enums.dart
@@ -51,7 +51,8 @@ enum AppRoute {
   allergenComplete(path: '/home/allergen/complete', name: 'allergen-complete'),
   recipeDetail(path: '/home/recipes/:recipeId', name: 'recipe-detail'),
   profile(path: '/home/profile', name: 'profile'),
-  profileEdit(path: '/home/profile/edit', name: 'profile-edit');
+  profileEdit(path: '/home/profile/edit', name: 'profile-edit'),
+  profileFeedback(path: '/home/profile/feedback', name: 'profile-feedback');
 
   const AppRoute({required this.path, required this.name});
 

--- a/lib/src/routing/routes.dart
+++ b/lib/src/routing/routes.dart
@@ -25,6 +25,7 @@ import 'package:nibbles/src/features/onboarding/name/onboarding_name_screen.dart
 import 'package:nibbles/src/features/onboarding/readiness/onboarding_readiness_screen.dart';
 import 'package:nibbles/src/features/onboarding/result/onboarding_result_screen.dart';
 import 'package:nibbles/src/features/profile/edit/profile_edit_screen.dart';
+import 'package:nibbles/src/features/profile/feedback/feedback_screen.dart';
 import 'package:nibbles/src/features/profile/profile_screen.dart';
 import 'package:nibbles/src/features/recipe/detail/recipe_detail_screen.dart';
 import 'package:nibbles/src/features/recipe/library/recipe_library_screen.dart';
@@ -316,6 +317,12 @@ GoRouter goRouter(Ref ref) {
                         name: AppRoute.profileEdit.name,
                         parentNavigatorKey: rootNavigatorKey,
                         builder: (context, state) => const ProfileEditScreen(),
+                      ),
+                      GoRoute(
+                        path: 'feedback',
+                        name: AppRoute.profileFeedback.name,
+                        parentNavigatorKey: rootNavigatorKey,
+                        builder: (context, state) => const FeedbackScreen(),
                       ),
                     ],
                   ),

--- a/supabase/migrations/20260530000002_feedback.sql
+++ b/supabase/migrations/20260530000002_feedback.sql
@@ -1,0 +1,25 @@
+-- NIB-70 — Give Feedback.
+--
+-- A simple write-only feedback table. Users append rows via the in-app Give
+-- Feedback form (Profile -> Settings). Reads are admin-only (no SELECT
+-- policy) — there is no per-user history in MVP.
+--
+-- user_id ON DELETE SET NULL so that a feedback row survives an account
+-- deletion / soft-delete and remains useful for product triage even after
+-- the author is gone.
+
+CREATE TABLE IF NOT EXISTS feedback (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  message TEXT NOT NULL CHECK (length(message) BETWEEN 1 AND 2000),
+  submitted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE feedback ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "users can insert their own feedback" ON feedback;
+CREATE POLICY "users can insert their own feedback"
+  ON feedback
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = auth.uid());

--- a/test/common/data/repositories/feedback_repository_test.dart
+++ b/test/common/data/repositories/feedback_repository_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/feedback_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _MockSupabaseClient extends Mock implements SupabaseClient {}
+
+class _MockQueryBuilder extends Mock implements SupabaseQueryBuilder {}
+
+class _MockGoTrueClient extends Mock implements GoTrueClient {}
+
+class _FakeUser extends Fake implements User {
+  @override
+  String get id => 'user-1';
+}
+
+/// Fake terminal for `.insert(...)` — implements `Future<void>` via a
+/// behaviour closure that either resolves or throws. Mirrors the
+/// `_FakeSingleTerminal` pattern in `recipe_repository_test.dart`.
+class _FakeInsertTerminal implements PostgrestFilterBuilder<void> {
+  _FakeInsertTerminal(this._behaviour);
+
+  final FutureOr<void> Function() _behaviour;
+
+  Future<void> get _future => Future<void>.sync(_behaviour);
+
+  @override
+  Future<R> then<R>(
+    FutureOr<R> Function(void value) onValue, {
+    Function? onError,
+  }) => _future.then(onValue, onError: onError);
+
+  @override
+  Future<void> catchError(
+    Function onError, {
+    bool Function(Object error)? test,
+  }) => _future.catchError(onError, test: test);
+
+  @override
+  Future<void> whenComplete(FutureOr<void> Function() action) =>
+      _future.whenComplete(action);
+
+  @override
+  Future<void> timeout(
+    Duration timeLimit, {
+    FutureOr<void> Function()? onTimeout,
+  }) => _future.timeout(timeLimit, onTimeout: onTimeout);
+
+  @override
+  Stream<void> asStream() => _future.asStream();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError(
+      'Unexpected call on _FakeInsertTerminal: ${invocation.memberName}',
+    );
+  }
+}
+
+/// Query builder fake that captures the `.insert(...)` payload and
+/// dispatches the awaited future through [behaviour].
+//
+// SupabaseQueryBuilder is `@immutable` but we need to record the insert
+// payload once for assertion. Matches the lint suppression on
+// `_FakeBuilder` in `account_repository_test.dart`.
+// ignore: must_be_immutable
+class _CapturingQueryBuilder extends _MockQueryBuilder {
+  _CapturingQueryBuilder(this.behaviour);
+
+  final FutureOr<void> Function() behaviour;
+  Map<String, dynamic>? capturedValues;
+
+  @override
+  PostgrestFilterBuilder<void> insert(
+    Object values, {
+    dynamic defaultToNull = true,
+  }) {
+    capturedValues = values as Map<String, dynamic>;
+    return _FakeInsertTerminal(behaviour);
+  }
+}
+
+void main() {
+  group('FeedbackRepositoryImpl.submit', () {
+    test(
+      'inserts {user_id, trimmed message} into feedback and returns success',
+      () async {
+        final mockSupabase = _MockSupabaseClient();
+        final mockAuth = _MockGoTrueClient();
+        final builder = _CapturingQueryBuilder(() {});
+
+        when(() => mockSupabase.auth).thenReturn(mockAuth);
+        when(() => mockAuth.currentUser).thenReturn(_FakeUser());
+        when(
+          () => mockSupabase.from('feedback'),
+        ).thenAnswer((_) => builder);
+
+        final sut = FeedbackRepositoryImpl(supabaseClient: mockSupabase);
+        final result = await sut.submit('  hello there  ');
+
+        expect(result, isA<Success<void>>());
+        expect(builder.capturedValues, {
+          'user_id': 'user-1',
+          'message': 'hello there',
+        });
+      },
+    );
+
+    test('maps PostgrestException to Failure(ServerException)', () async {
+      final mockSupabase = _MockSupabaseClient();
+      final mockAuth = _MockGoTrueClient();
+      final builder = _CapturingQueryBuilder(() {
+        throw const PostgrestException(message: 'rls denied', code: '42501');
+      });
+
+      when(() => mockSupabase.auth).thenReturn(mockAuth);
+      when(() => mockAuth.currentUser).thenReturn(_FakeUser());
+      when(
+        () => mockSupabase.from('feedback'),
+      ).thenAnswer((_) => builder);
+
+      final sut = FeedbackRepositoryImpl(supabaseClient: mockSupabase);
+      final result = await sut.submit('anything');
+
+      expect(result, isA<Failure<void>>());
+      final failure = result as Failure<void>;
+      expect(failure.error, isA<ServerException>());
+      expect(failure.error.message, 'rls denied');
+    });
+
+    test('maps any other thrown Object to Failure(UnknownException)',
+        () async {
+      final mockSupabase = _MockSupabaseClient();
+      final mockAuth = _MockGoTrueClient();
+      final builder = _CapturingQueryBuilder(() {
+        throw Exception('boom');
+      });
+
+      when(() => mockSupabase.auth).thenReturn(mockAuth);
+      when(() => mockAuth.currentUser).thenReturn(_FakeUser());
+      when(
+        () => mockSupabase.from('feedback'),
+      ).thenAnswer((_) => builder);
+
+      final sut = FeedbackRepositoryImpl(supabaseClient: mockSupabase);
+      final result = await sut.submit('boom-message');
+
+      expect(result, isA<Failure<void>>());
+      expect((result as Failure<void>).error, isA<UnknownException>());
+    });
+  });
+}

--- a/test/common/services/feedback_service_test.dart
+++ b/test/common/services/feedback_service_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/feedback_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/feedback_service.dart';
+
+class _MockFeedbackRepository extends Mock implements FeedbackRepository {}
+
+void main() {
+  late _MockFeedbackRepository mockRepo;
+  late FeedbackService sut;
+
+  setUp(() {
+    mockRepo = _MockFeedbackRepository();
+    sut = FeedbackService(mockRepo);
+  });
+
+  group('FeedbackService.submit', () {
+    test('forwards the message to the repository and returns success',
+        () async {
+      when(
+        () => mockRepo.submit(any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      final result = await sut.submit('love the app!');
+
+      expect(result, isA<Success<void>>());
+      verify(() => mockRepo.submit('love the app!')).called(1);
+    });
+
+    test('returns Result.failure when repository fails', () async {
+      when(() => mockRepo.submit(any())).thenAnswer(
+        (_) async => const Result.failure(ServerException('rls denied')),
+      );
+
+      final result = await sut.submit('something');
+
+      expect(result, isA<Failure<void>>());
+      expect((result as Failure<void>).error, isA<ServerException>());
+      expect(result.error.message, 'rls denied');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- New Give Feedback feature module under `lib/src/features/profile/feedback/` (screen + controller + state).
- New `feedback` table with write-only RLS (`INSERT` for `authenticated`; no SELECT — admin-only reads).
- New `FeedbackRepository` + `FeedbackService` Riverpod providers, returning `Result<void>` end-to-end.
- New full-screen route `profileFeedback` at `/home/profile/feedback` (pushed with `parentNavigatorKey: rootNavigatorKey`, mirrors `profileEdit`).
- 1-line wire-up in `profile_screen.dart`: the Give Feedback `SettingsRow` now `pushNamed`s the new route (TODO removed).

## User action required (dev + prod)

- Apply the new migration `supabase/migrations/20260530000002_feedback.sql` on `nibbles-dev` and `nibbles-prod`. Creates `feedback` table, enables RLS, and grants the per-user INSERT policy.

## Acceptance criteria

- [x] SQL migration file present with `feedback` table + RLS.
- [x] `FeedbackRepository` + `FeedbackService` + Riverpod providers shipped.
- [x] New feature module under `lib/src/features/profile/feedback/`.
- [x] Route + GoRoute added; full-screen push via `rootNavigatorKey`.
- [x] `profile_screen.dart` Give Feedback row pushes the new route (1-line change).
- [x] 2-4 unit tests (2 service + 3 repository).
- [x] `flutter analyze` 0 issues.
- [x] `make gen` clean + idempotent (re-run produces no diff).
- [x] No files outside the allowlist modified.

## Files touched

- NEW `supabase/migrations/20260530000002_feedback.sql`
- NEW `lib/src/common/data/repositories/feedback_repository.dart` (+ `.g.dart`)
- NEW `lib/src/common/services/feedback_service.dart` (+ `.g.dart`)
- NEW `lib/src/features/profile/feedback/feedback_screen.dart`
- NEW `lib/src/features/profile/feedback/feedback_controller.dart` (+ `.g.dart`)
- NEW `lib/src/features/profile/feedback/feedback_state.dart` (+ `.freezed.dart`)
- MOD `lib/src/routing/route_enums.dart` (1 enum entry)
- MOD `lib/src/routing/routes.dart` (1 GoRoute) + regen `routes.g.dart`
- MOD `lib/src/features/profile/profile_screen.dart` (1-line `onTap` change in the Give Feedback row)
- NEW `test/common/services/feedback_service_test.dart`
- NEW `test/common/data/repositories/feedback_repository_test.dart`

## Gate results

- `make gen`: succeeded (idempotent on re-run).
- `flutter analyze`: `No issues found!`
- `flutter test`: `All tests passed!` (454 +6 ~ skipped).

## Test plan

- [ ] Apply migration on Supabase dev; confirm `feedback` table + RLS policy exist.
- [ ] Open app -> Profile -> Settings -> Give Feedback -> screen pushes full-screen (no bottom nav).
- [ ] Send button disabled when message is blank/whitespace or while submitting.
- [ ] Submit a message -> SnackBar 'Thank you for your feedback!' + screen pops.
- [ ] Force a failure (e.g. revoke INSERT policy) -> SnackBar 'Couldn't send feedback. Try again.', screen stays.
- [ ] Confirm a row is written with `user_id = auth.uid()` and trimmed message.