### PR TITLE
feat(profile): Profile Edit reskin (First/Last Name + Email; drop DOB/gender) [NIB-62]

### DIFF
--- a/lib/src/common/data/repositories/auth_repository.dart
+++ b/lib/src/common/data/repositories/auth_repository.dart
@@ -52,6 +52,11 @@ abstract interface class AuthRepository {
   Future<Result<void>> signOut();
   Future<Result<void>> resetPassword(String email);
   Future<Result<void>> updatePassword(String newPassword);
+
+  /// Triggers Supabase's email-change flow. Supabase sends a confirmation
+  /// email to the new address; the change only takes effect after the user
+  /// clicks the link. Returns `Success(null)` once the request is accepted.
+  Future<Result<void>> updateEmail(String newEmail);
   bool get isLoggedIn;
   Stream<AuthState> get authStateStream;
 }
@@ -242,6 +247,19 @@ class AuthRepositoryImpl implements AuthRepository {
   Future<Result<void>> updatePassword(String newPassword) async {
     try {
       await _supabase.auth.updateUser(UserAttributes(password: newPassword));
+      return const Result.success(null);
+    } on AuthException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object catch (e, st) {
+      await _recordAuthUnknown(e, st);
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<void>> updateEmail(String newEmail) async {
+    try {
+      await _supabase.auth.updateUser(UserAttributes(email: newEmail));
       return const Result.success(null);
     } on AuthException catch (e) {
       return Result.failure(ServerException(e.message));

--- a/lib/src/common/data/repositories/auth_repository.dart
+++ b/lib/src/common/data/repositories/auth_repository.dart
@@ -57,6 +57,12 @@ abstract interface class AuthRepository {
   /// email to the new address; the change only takes effect after the user
   /// clicks the link. Returns `Success(null)` once the request is accepted.
   Future<Result<void>> updateEmail(String newEmail);
+
+  /// Current authenticated user's email, or `null` if no session is active.
+  /// Read synchronously from the Supabase session — Repository layer keeps
+  /// the Supabase SDK behind this interface so upstream callers
+  /// (Service / Controller / Screen) never import it directly.
+  String? get currentUserEmail;
   bool get isLoggedIn;
   Stream<AuthState> get authStateStream;
 }
@@ -92,6 +98,9 @@ class AuthRepositoryImpl implements AuthRepository {
 
   @override
   bool get isLoggedIn => _supabase.auth.currentSession != null;
+
+  @override
+  String? get currentUserEmail => _supabase.auth.currentUser?.email;
 
   @override
   Stream<AuthState> get authStateStream => _supabase.auth.onAuthStateChange;

--- a/lib/src/common/services/auth_service.dart
+++ b/lib/src/common/services/auth_service.dart
@@ -29,6 +29,11 @@ class AuthService extends _$AuthService {
 
   bool get isLoggedIn => state;
 
+  /// Currently authenticated user's email, or `null` if no session is active.
+  /// Pass-through to [AuthRepository.currentUserEmail] so Controllers/Screens
+  /// don't import `supabase_flutter` directly.
+  String? get currentUserEmail => _repo.currentUserEmail;
+
   Stream<AuthState> get authStateStream => _repo.authStateStream;
 
   Future<Result<void>> signUp(String email, String password) async {

--- a/lib/src/common/services/auth_service.dart
+++ b/lib/src/common/services/auth_service.dart
@@ -107,4 +107,10 @@ class AuthService extends _$AuthService {
 
   Future<Result<void>> updatePassword(String newPassword) =>
       _repo.updatePassword(newPassword);
+
+  /// Requests Supabase to change the user's email. Supabase sends a
+  /// confirmation email to the new address; the change only commits after
+  /// the user clicks the link.
+  Future<Result<void>> updateEmail(String newEmail) =>
+      _repo.updateEmail(newEmail);
 }

--- a/lib/src/common/services/auth_service.g.dart
+++ b/lib/src/common/services/auth_service.g.dart
@@ -6,7 +6,7 @@ part of 'auth_service.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$authServiceHash() => r'c4ca4a0af5bd98a89de3d308b1a80bfd4616907a';
+String _$authServiceHash() => r'4d07a619de4c12b23a02409a5ab4a33217a6dac2';
 
 /// See also [AuthService].
 @ProviderFor(AuthService)

--- a/lib/src/common/services/auth_service.g.dart
+++ b/lib/src/common/services/auth_service.g.dart
@@ -6,7 +6,7 @@ part of 'auth_service.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$authServiceHash() => r'6e573f922d81b92e0d52978b6f159780e976fb06';
+String _$authServiceHash() => r'c4ca4a0af5bd98a89de3d308b1a80bfd4616907a';
 
 /// See also [AuthService].
 @ProviderFor(AuthService)

--- a/lib/src/features/profile/edit/profile_edit_controller.dart
+++ b/lib/src/features/profile/edit/profile_edit_controller.dart
@@ -4,7 +4,6 @@ import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/profile/edit/profile_edit_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 part 'profile_edit_controller.g.dart';
 
@@ -20,7 +19,7 @@ class ProfileEditController extends _$ProfileEditController {
     final parts = baby.name.trim().split(RegExp(r'\s+'));
     final firstName = parts.isEmpty ? '' : parts.first;
     final lastName = parts.length > 1 ? parts.skip(1).join(' ') : '';
-    final email = Supabase.instance.client.auth.currentUser?.email ?? '';
+    final email = ref.read(authServiceProvider.notifier).currentUserEmail ?? '';
     _initialEmail = email;
 
     return ProfileEditState(

--- a/lib/src/features/profile/edit/profile_edit_controller.dart
+++ b/lib/src/features/profile/edit/profile_edit_controller.dart
@@ -1,63 +1,124 @@
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
-import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/profile/edit/profile_edit_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 part 'profile_edit_controller.g.dart';
 
 @riverpod
 class ProfileEditController extends _$ProfileEditController {
+  String _initialEmail = '';
+
   @override
   Future<ProfileEditState> build(String babyId) async {
     final baby = await ref.read(babyProfileServiceProvider).getBaby();
     if (baby == null) throw const UnknownException('Baby profile not found.');
+
+    final parts = baby.name.trim().split(RegExp(r'\s+'));
+    final firstName = parts.isEmpty ? '' : parts.first;
+    final lastName = parts.length > 1 ? parts.skip(1).join(' ') : '';
+    final email = Supabase.instance.client.auth.currentUser?.email ?? '';
+    _initialEmail = email;
+
     return ProfileEditState(
-      name: baby.name,
-      dob: baby.dateOfBirth,
-      gender: baby.gender,
+      firstName: firstName,
+      lastName: lastName,
+      email: email,
     );
   }
 
-  void updateName(String value) {
+  void updateFirstName(String value) {
     final current = state.valueOrNull;
     if (current == null) return;
-    state = AsyncData(current.copyWith(name: value, errorMessage: null));
+    state = AsyncData(current.copyWith(firstName: value, errorMessage: null));
   }
 
-  void updateDob(DateTime value) {
+  void updateLastName(String value) {
     final current = state.valueOrNull;
     if (current == null) return;
-    state = AsyncData(current.copyWith(dob: value, errorMessage: null));
+    state = AsyncData(current.copyWith(lastName: value, errorMessage: null));
   }
 
-  void updateGender(Gender value) {
+  void updateEmail(String value) {
     final current = state.valueOrNull;
     if (current == null) return;
-    state = AsyncData(current.copyWith(gender: value, errorMessage: null));
+    state = AsyncData(current.copyWith(email: value, errorMessage: null));
   }
 
-  Future<bool> save() async {
+  /// Returns a [ProfileEditSaveResult] describing whether the save succeeded
+  /// and whether an email change was requested (so the UI can show the
+  /// confirmation-email notice).
+  Future<ProfileEditSaveResult> save() async {
     final current = state.valueOrNull;
-    if (current == null) return false;
+    if (current == null) {
+      return const ProfileEditSaveResult(success: false);
+    }
+
+    final baby = await ref.read(babyProfileServiceProvider).getBaby();
+    if (baby == null) {
+      state = AsyncData(
+        current.copyWith(
+          isLoading: false,
+          errorMessage: 'Baby profile not found.',
+        ),
+      );
+      return const ProfileEditSaveResult(success: false);
+    }
 
     state = AsyncData(current.copyWith(isLoading: true, errorMessage: null));
 
-    final result = await ref
-        .read(babyProfileServiceProvider)
-        .updateBaby(babyId, current.name, current.dob, current.gender);
+    final firstName = current.firstName.trim();
+    final lastName = current.lastName.trim();
+    final newName = lastName.isEmpty ? firstName : '$firstName $lastName';
+    final newEmail = current.email.trim();
 
-    return result.when(
-      success: (_) {
-        state = AsyncData(current.copyWith(isLoading: false));
-        return true;
-      },
-      failure: (error) {
+    final nameResult = await ref
+        .read(babyProfileServiceProvider)
+        .updateBaby(babyId, newName, baby.dateOfBirth, baby.gender);
+
+    if (nameResult.isFailure) {
+      state = AsyncData(
+        current.copyWith(
+          isLoading: false,
+          errorMessage: nameResult.errorOrNull?.message,
+        ),
+      );
+      return const ProfileEditSaveResult(success: false);
+    }
+
+    final emailChanged = newEmail != _initialEmail;
+    if (emailChanged) {
+      final emailResult = await ref
+          .read(authServiceProvider.notifier)
+          .updateEmail(newEmail);
+      if (emailResult.isFailure) {
         state = AsyncData(
-          current.copyWith(isLoading: false, errorMessage: error.message),
+          current.copyWith(
+            isLoading: false,
+            errorMessage: emailResult.errorOrNull?.message,
+          ),
         );
-        return false;
-      },
+        return const ProfileEditSaveResult(success: false);
+      }
+    }
+
+    state = AsyncData(current.copyWith(isLoading: false));
+    return ProfileEditSaveResult(
+      success: true,
+      emailChanged: emailChanged,
     );
   }
+}
+
+class ProfileEditSaveResult {
+  const ProfileEditSaveResult({
+    required this.success,
+    this.emailChanged = false,
+  });
+
+  final bool success;
+  final bool emailChanged;
 }

--- a/lib/src/features/profile/edit/profile_edit_controller.g.dart
+++ b/lib/src/features/profile/edit/profile_edit_controller.g.dart
@@ -7,7 +7,7 @@ part of 'profile_edit_controller.dart';
 // **************************************************************************
 
 String _$profileEditControllerHash() =>
-    r'0ae3367bf7ac30979b16bec7a948523adc308868';
+    r'3185aab61a5adb76bfff9222e99fe8a8d515b5ff';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/profile/edit/profile_edit_controller.g.dart
+++ b/lib/src/features/profile/edit/profile_edit_controller.g.dart
@@ -7,7 +7,7 @@ part of 'profile_edit_controller.dart';
 // **************************************************************************
 
 String _$profileEditControllerHash() =>
-    r'3185aab61a5adb76bfff9222e99fe8a8d515b5ff';
+    r'80eeb05bf4c12705fd8c6ecacd1ad6ff2026f09f';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/profile/edit/profile_edit_screen.dart
+++ b/lib/src/features/profile/edit/profile_edit_screen.dart
@@ -1,16 +1,25 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
+import 'package:nibbles/src/common/components/inputs/app_text_field.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
-import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/domain/formz/email_input.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/profile/edit/profile_edit_controller.dart';
 import 'package:nibbles/src/features/profile/edit/profile_edit_state.dart';
 import 'package:nibbles/src/features/profile/profile_controller.dart';
 
+/// PR-02 — Edit Profile.
+///
+/// Mirrors Figma frame 1200:10475 (`ProfileEditScreen` in
+/// `design/ui_kits/nibbles_mobile/ProfileScreen.jsx`): butter-soft wash
+/// header with a back chevron + "Change Profile" title, coral avatar puck,
+/// then a cream form pane with First Name / Last Name (Optional) / Email
+/// labelled fields and a full-width primary "Save" pill.
 class ProfileEditScreen extends ConsumerWidget {
   const ProfileEditScreen({super.key});
 
@@ -19,14 +28,19 @@ class ProfileEditScreen extends ConsumerWidget {
     final babyIdAsync = ref.watch(currentBabyIdProvider);
 
     return babyIdAsync.when(
-      loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (_, __) =>
-          const Scaffold(body: Center(child: Text('Could not load profile.'))),
+      loading: () => const Scaffold(
+        backgroundColor: AppColors.background,
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (_, __) => _ProfileEditError(
+        message: 'Could not load profile.',
+        onRetry: () => ref.invalidate(currentBabyIdProvider),
+      ),
       data: (babyId) {
         if (babyId == null) {
-          return const Scaffold(
-            body: Center(child: Text('No baby profile found.')),
+          return _ProfileEditError(
+            message: 'No baby profile found.',
+            onRetry: () => ref.invalidate(currentBabyIdProvider),
           );
         }
         return _ProfileEditBody(babyId: babyId);
@@ -45,44 +59,13 @@ class _ProfileEditBody extends ConsumerWidget {
     final asyncState = ref.watch(profileEditControllerProvider(babyId));
 
     return asyncState.when(
-      loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (err, _) => Scaffold(
+      loading: () => const Scaffold(
         backgroundColor: AppColors.background,
-        appBar: AppBar(
-          backgroundColor: AppColors.background,
-          elevation: 0,
-          title: const Text('Edit Profile'),
-        ),
-        body: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(AppSizes.pagePaddingH),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(
-                  Icons.error_outline,
-                  size: AppSizes.iconXl,
-                  color: AppColors.error,
-                ),
-                const SizedBox(height: AppSizes.md),
-                Text(
-                  err is AppException ? err.message : 'Something went wrong.',
-                  textAlign: TextAlign.center,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
-                ),
-                const SizedBox(height: AppSizes.lg),
-                FilledButton(
-                  onPressed: () =>
-                      ref.invalidate(profileEditControllerProvider(babyId)),
-                  child: const Text('Try Again'),
-                ),
-              ],
-            ),
-          ),
-        ),
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (err, _) => _ProfileEditError(
+        message: err is AppException ? err.message : 'Something went wrong.',
+        onRetry: () => ref.invalidate(profileEditControllerProvider(babyId)),
       ),
       data: (formState) =>
           _ProfileEditForm(babyId: babyId, formState: formState),
@@ -101,17 +84,28 @@ class _ProfileEditForm extends ConsumerStatefulWidget {
 }
 
 class _ProfileEditFormState extends ConsumerState<_ProfileEditForm> {
-  late final TextEditingController _nameController;
+  late final TextEditingController _firstNameController;
+  late final TextEditingController _lastNameController;
+  late final TextEditingController _emailController;
+  bool _emailTouched = false;
 
   @override
   void initState() {
     super.initState();
-    _nameController = TextEditingController(text: widget.formState.name);
+    _firstNameController = TextEditingController(
+      text: widget.formState.firstName,
+    );
+    _lastNameController = TextEditingController(
+      text: widget.formState.lastName,
+    );
+    _emailController = TextEditingController(text: widget.formState.email);
   }
 
   @override
   void dispose() {
-    _nameController.dispose();
+    _firstNameController.dispose();
+    _lastNameController.dispose();
+    _emailController.dispose();
     super.dispose();
   }
 
@@ -119,163 +113,244 @@ class _ProfileEditFormState extends ConsumerState<_ProfileEditForm> {
   Widget build(BuildContext context) {
     final formState =
         ref.watch(profileEditControllerProvider(widget.babyId)).valueOrNull ??
-        widget.formState;
-    final textTheme = Theme.of(context).textTheme;
+            widget.formState;
     final controller = ref.read(
       profileEditControllerProvider(widget.babyId).notifier,
     );
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
+    final theme = Theme.of(context);
+
+    final emailValid =
+        const EmailInput.dirty().validator(formState.email.trim()) == null;
+    final firstNameValid = formState.firstName.trim().isNotEmpty;
+    final canSave = firstNameValid && emailValid && !formState.isLoading;
+
+    void goBack() => context.canPop() ? context.pop() : context.go('/home');
 
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.background,
-        elevation: 0,
-        title: Text(
-          'Edit Profile',
-          style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
-        ),
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
-            vertical: AppSizes.pagePaddingV,
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SafeArea(
+            bottom: false,
+            child: ColoredBox(
+              color: AppColors.butterSoft,
+              child: Column(
+                children: [
+                  _EditHeader(onBack: goBack),
+                  const _EditAvatar(),
+                ],
+              ),
+            ),
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Baby name
-              TextField(
-                key: const Key('edit_baby_name_field'),
-                controller: _nameController,
-                onChanged: controller.updateName,
-                textCapitalization: TextCapitalization.words,
-                decoration: const InputDecoration(labelText: "Baby's name"),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.pagePaddingH,
+                AppSizes.sm,
+                AppSizes.pagePaddingH,
+                AppSizes.md,
               ),
-              const SizedBox(height: AppSizes.lg),
-              // Date of birth
-              Text(
-                'Date of Birth',
-                style: textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: AppSizes.sm),
-              SizedBox(
-                height: 180,
-                child: CupertinoDatePicker(
-                  key: const Key('edit_baby_dob_picker'),
-                  mode: CupertinoDatePickerMode.date,
-                  initialDateTime: formState.dob,
-                  maximumDate: today,
-                  minimumDate: DateTime(now.year - 3, now.month, now.day),
-                  onDateTimeChanged: controller.updateDob,
-                ),
-              ),
-              const SizedBox(height: AppSizes.lg),
-              // Gender
-              Text(
-                'Gender',
-                style: textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: AppSizes.sm),
-              ...Gender.values.map(
-                (g) => Padding(
-                  padding: const EdgeInsets.only(bottom: AppSizes.sm),
-                  child: _GenderCard(
-                    label: _genderLabel(g),
-                    selected: formState.gender == g,
-                    onTap: () => controller.updateGender(g),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  AppTextField(
+                    key: const Key('edit_first_name_field'),
+                    label: 'First Name',
+                    controller: _firstNameController,
+                    onChanged: controller.updateFirstName,
+                    textInputAction: TextInputAction.next,
                   ),
-                ),
+                  const SizedBox(height: AppSizes.md),
+                  AppTextField(
+                    key: const Key('edit_last_name_field'),
+                    label: 'Last Name (Optional)',
+                    controller: _lastNameController,
+                    onChanged: controller.updateLastName,
+                    textInputAction: TextInputAction.next,
+                  ),
+                  const SizedBox(height: AppSizes.md),
+                  AppTextField(
+                    key: const Key('edit_email_field'),
+                    label: 'Email',
+                    controller: _emailController,
+                    keyboardType: TextInputType.emailAddress,
+                    textInputAction: TextInputAction.done,
+                    onChanged: (value) {
+                      if (!_emailTouched) {
+                        setState(() => _emailTouched = true);
+                      }
+                      controller.updateEmail(value);
+                    },
+                    errorText: _emailTouched && !emailValid
+                        ? 'Enter a valid email address.'
+                        : null,
+                  ),
+                  if (formState.errorMessage != null) ...[
+                    const SizedBox(height: AppSizes.sm),
+                    Text(
+                      formState.errorMessage!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: AppColors.error,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: AppSizes.xl - 4),
+                  AppPillButton(
+                    key: const Key('edit_profile_save_button'),
+                    label: formState.isLoading ? 'Saving…' : 'Save',
+                    onPressed: canSave ? _save : null,
+                  ),
+                ],
               ),
-              if (formState.errorMessage != null) ...[
-                const SizedBox(height: AppSizes.sm),
-                Text(
-                  formState.errorMessage!,
-                  style: textTheme.bodySmall?.copyWith(color: AppColors.error),
-                ),
-              ],
-              const SizedBox(height: AppSizes.lg),
-              FilledButton(
-                key: const Key('edit_profile_save_button'),
-                onPressed: formState.isLoading ? null : () => _save(controller),
-                child: formState.isLoading
-                    ? const SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: AppColors.onPrimary,
-                        ),
-                      )
-                    : const Text('Save'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _save() async {
+    final controller = ref.read(
+      profileEditControllerProvider(widget.babyId).notifier,
+    );
+    final result = await controller.save();
+    if (!result.success || !mounted) return;
+
+    // Invalidate profile so PR-01 shows updated data.
+    ref.invalidate(profileControllerProvider(widget.babyId));
+
+    final message = result.emailChanged
+        ? 'Please check your inbox to confirm the new email.'
+        : 'Profile updated.';
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+    context.pop();
+  }
+}
+
+class _EditHeader extends StatelessWidget {
+  const _EditHeader({required this.onBack});
+
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      color: AppColors.butterSoft,
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.md + 2,
+        AppSizes.sm - 2,
+        AppSizes.md + 2,
+        AppSizes.md + 2,
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: AppSizes.roundButtonSm,
+            child: AppRoundButton(
+              icon: const Icon(Icons.arrow_back_ios_new_rounded),
+              onPressed: onBack,
+              tone: AppRoundButtonTone.ghost,
+              size: AppRoundButtonSize.small,
+              semanticLabel: 'Back',
+            ),
+          ),
+          Expanded(
+            child: Text(
+              'Change Profile',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: AppColors.fgStrong,
+                height: 1,
               ),
-            ],
+            ),
+          ),
+          const SizedBox(width: AppSizes.roundButtonSm),
+        ],
+      ),
+    );
+  }
+}
+
+class _EditAvatar extends StatelessWidget {
+  const _EditAvatar();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.butterSoft,
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.md + 2,
+        0,
+        AppSizes.md + 2,
+        AppSizes.md + 2,
+      ),
+      child: Center(
+        child: Container(
+          width: AppSizes.avatarXl,
+          height: AppSizes.avatarXl,
+          decoration: const BoxDecoration(
+            color: AppColors.coral,
+            shape: BoxShape.circle,
+          ),
+          child: const Center(
+            child: Icon(
+              Icons.child_care_rounded,
+              size: 64,
+              color: AppColors.cream,
+            ),
           ),
         ),
       ),
     );
   }
-
-  Future<void> _save(ProfileEditController controller) async {
-    final ok = await controller.save();
-    if (!ok || !mounted) return;
-
-    // Invalidate profile so PR-01 shows updated data
-    ref.invalidate(profileControllerProvider(widget.babyId));
-
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('Profile updated')));
-    context.pop();
-  }
-
-  String _genderLabel(Gender g) => switch (g) {
-    Gender.male => 'Male',
-    Gender.female => 'Female',
-    Gender.preferNotToSay => 'Prefer not to say',
-  };
 }
 
-class _GenderCard extends StatelessWidget {
-  const _GenderCard({
-    required this.label,
-    required this.selected,
-    required this.onTap,
-  });
+class _ProfileEditError extends StatelessWidget {
+  const _ProfileEditError({required this.message, this.onRetry});
 
-  final String label;
-  final bool selected;
-  final VoidCallback onTap;
+  final String message;
+  final VoidCallback? onRetry;
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSizes.lg,
-          vertical: AppSizes.md,
-        ),
-        decoration: BoxDecoration(
-          color: selected ? AppColors.primary : AppColors.surface,
-          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-          border: Border.all(
-            color: selected ? AppColors.primary : AppColors.divider,
-            width: selected ? 2 : 1,
-          ),
-        ),
-        child: Text(
-          label,
-          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-            color: selected ? AppColors.onPrimary : AppColors.text,
-            fontWeight: FontWeight.w600,
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSizes.pagePaddingH),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.error_outline,
+                  size: AppSizes.iconXl,
+                  color: AppColors.destructive,
+                ),
+                const SizedBox(height: AppSizes.md),
+                Text(
+                  message,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: AppColors.fgMuted,
+                  ),
+                ),
+                if (onRetry != null) ...[
+                  const SizedBox(height: AppSizes.lg),
+                  AppPillButton(
+                    label: 'Try Again',
+                    onPressed: onRetry,
+                    expand: false,
+                  ),
+                ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/profile/edit/profile_edit_screen.dart
+++ b/lib/src/features/profile/edit/profile_edit_screen.dart
@@ -300,7 +300,7 @@ class _EditAvatar extends StatelessWidget {
           child: const Center(
             child: Icon(
               Icons.child_care_rounded,
-              size: 64,
+              size: AppSizes.xxxl,
               color: AppColors.cream,
             ),
           ),

--- a/lib/src/features/profile/edit/profile_edit_state.dart
+++ b/lib/src/features/profile/edit/profile_edit_state.dart
@@ -1,14 +1,13 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:nibbles/src/common/domain/enums/gender.dart';
 
 part 'profile_edit_state.freezed.dart';
 
 @freezed
 class ProfileEditState with _$ProfileEditState {
   const factory ProfileEditState({
-    required String name,
-    required DateTime dob,
-    required Gender gender,
+    required String firstName,
+    required String lastName,
+    required String email,
     @Default(false) bool isLoading,
     String? errorMessage,
   }) = _ProfileEditState;

--- a/lib/src/features/profile/edit/profile_edit_state.freezed.dart
+++ b/lib/src/features/profile/edit/profile_edit_state.freezed.dart
@@ -17,9 +17,9 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$ProfileEditState {
-  String get name => throw _privateConstructorUsedError;
-  DateTime get dob => throw _privateConstructorUsedError;
-  Gender get gender => throw _privateConstructorUsedError;
+  String get firstName => throw _privateConstructorUsedError;
+  String get lastName => throw _privateConstructorUsedError;
+  String get email => throw _privateConstructorUsedError;
   bool get isLoading => throw _privateConstructorUsedError;
   String? get errorMessage => throw _privateConstructorUsedError;
 
@@ -38,9 +38,9 @@ abstract class $ProfileEditStateCopyWith<$Res> {
   ) = _$ProfileEditStateCopyWithImpl<$Res, ProfileEditState>;
   @useResult
   $Res call({
-    String name,
-    DateTime dob,
-    Gender gender,
+    String firstName,
+    String lastName,
+    String email,
     bool isLoading,
     String? errorMessage,
   });
@@ -61,26 +61,26 @@ class _$ProfileEditStateCopyWithImpl<$Res, $Val extends ProfileEditState>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = null,
-    Object? dob = null,
-    Object? gender = null,
+    Object? firstName = null,
+    Object? lastName = null,
+    Object? email = null,
     Object? isLoading = null,
     Object? errorMessage = freezed,
   }) {
     return _then(
       _value.copyWith(
-            name: null == name
-                ? _value.name
-                : name // ignore: cast_nullable_to_non_nullable
+            firstName: null == firstName
+                ? _value.firstName
+                : firstName // ignore: cast_nullable_to_non_nullable
                       as String,
-            dob: null == dob
-                ? _value.dob
-                : dob // ignore: cast_nullable_to_non_nullable
-                      as DateTime,
-            gender: null == gender
-                ? _value.gender
-                : gender // ignore: cast_nullable_to_non_nullable
-                      as Gender,
+            lastName: null == lastName
+                ? _value.lastName
+                : lastName // ignore: cast_nullable_to_non_nullable
+                      as String,
+            email: null == email
+                ? _value.email
+                : email // ignore: cast_nullable_to_non_nullable
+                      as String,
             isLoading: null == isLoading
                 ? _value.isLoading
                 : isLoading // ignore: cast_nullable_to_non_nullable
@@ -105,9 +105,9 @@ abstract class _$$ProfileEditStateImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    String name,
-    DateTime dob,
-    Gender gender,
+    String firstName,
+    String lastName,
+    String email,
     bool isLoading,
     String? errorMessage,
   });
@@ -127,26 +127,26 @@ class __$$ProfileEditStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = null,
-    Object? dob = null,
-    Object? gender = null,
+    Object? firstName = null,
+    Object? lastName = null,
+    Object? email = null,
     Object? isLoading = null,
     Object? errorMessage = freezed,
   }) {
     return _then(
       _$ProfileEditStateImpl(
-        name: null == name
-            ? _value.name
-            : name // ignore: cast_nullable_to_non_nullable
+        firstName: null == firstName
+            ? _value.firstName
+            : firstName // ignore: cast_nullable_to_non_nullable
                   as String,
-        dob: null == dob
-            ? _value.dob
-            : dob // ignore: cast_nullable_to_non_nullable
-                  as DateTime,
-        gender: null == gender
-            ? _value.gender
-            : gender // ignore: cast_nullable_to_non_nullable
-                  as Gender,
+        lastName: null == lastName
+            ? _value.lastName
+            : lastName // ignore: cast_nullable_to_non_nullable
+                  as String,
+        email: null == email
+            ? _value.email
+            : email // ignore: cast_nullable_to_non_nullable
+                  as String,
         isLoading: null == isLoading
             ? _value.isLoading
             : isLoading // ignore: cast_nullable_to_non_nullable
@@ -164,19 +164,19 @@ class __$$ProfileEditStateImplCopyWithImpl<$Res>
 
 class _$ProfileEditStateImpl implements _ProfileEditState {
   const _$ProfileEditStateImpl({
-    required this.name,
-    required this.dob,
-    required this.gender,
+    required this.firstName,
+    required this.lastName,
+    required this.email,
     this.isLoading = false,
     this.errorMessage,
   });
 
   @override
-  final String name;
+  final String firstName;
   @override
-  final DateTime dob;
+  final String lastName;
   @override
-  final Gender gender;
+  final String email;
   @override
   @JsonKey()
   final bool isLoading;
@@ -185,7 +185,7 @@ class _$ProfileEditStateImpl implements _ProfileEditState {
 
   @override
   String toString() {
-    return 'ProfileEditState(name: $name, dob: $dob, gender: $gender, isLoading: $isLoading, errorMessage: $errorMessage)';
+    return 'ProfileEditState(firstName: $firstName, lastName: $lastName, email: $email, isLoading: $isLoading, errorMessage: $errorMessage)';
   }
 
   @override
@@ -193,9 +193,11 @@ class _$ProfileEditStateImpl implements _ProfileEditState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ProfileEditStateImpl &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.dob, dob) || other.dob == dob) &&
-            (identical(other.gender, gender) || other.gender == gender) &&
+            (identical(other.firstName, firstName) ||
+                other.firstName == firstName) &&
+            (identical(other.lastName, lastName) ||
+                other.lastName == lastName) &&
+            (identical(other.email, email) || other.email == email) &&
             (identical(other.isLoading, isLoading) ||
                 other.isLoading == isLoading) &&
             (identical(other.errorMessage, errorMessage) ||
@@ -203,8 +205,14 @@ class _$ProfileEditStateImpl implements _ProfileEditState {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, name, dob, gender, isLoading, errorMessage);
+  int get hashCode => Object.hash(
+    runtimeType,
+    firstName,
+    lastName,
+    email,
+    isLoading,
+    errorMessage,
+  );
 
   /// Create a copy of ProfileEditState
   /// with the given fields replaced by the non-null parameter values.
@@ -220,19 +228,19 @@ class _$ProfileEditStateImpl implements _ProfileEditState {
 
 abstract class _ProfileEditState implements ProfileEditState {
   const factory _ProfileEditState({
-    required final String name,
-    required final DateTime dob,
-    required final Gender gender,
+    required final String firstName,
+    required final String lastName,
+    required final String email,
     final bool isLoading,
     final String? errorMessage,
   }) = _$ProfileEditStateImpl;
 
   @override
-  String get name;
+  String get firstName;
   @override
-  DateTime get dob;
+  String get lastName;
   @override
-  Gender get gender;
+  String get email;
   @override
   bool get isLoading;
   @override


### PR DESCRIPTION
## Summary

Rewrites `lib/src/features/profile/edit/profile_edit_screen.dart` to the redesigned 3-field form (First Name + Last Name (Optional) + Email) per Figma `1200:10475`. Drops the legacy DOB + gender fields. Saving updates the baby name (single concatenated `name`) and, when the email changed, requests Supabase to start its email-change flow via a new `AuthService.updateEmail`.

## Figma frame

- ProfileEditScreen — https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1200-10475

Fell back to `design/ui_kits/nibbles_mobile/ProfileScreen.jsx` (`ProfileEditScreen` variant) + `colors_and_type.css` for tokens. Header label is "Change Profile" per the kit JSX; the avatar puck reuses the same coral circle / cream baby silhouette used by `ProfileAvatarCard`.

## DS components consumed (read-only)

- `AppTextField` — labelled field (kit `.field` + `.field-label`)
- `AppPillButton` (primary, full) — Save CTA
- `AppRoundButton` (ghost, small) — back chevron

No new DS components added. No `lib/src/common/components/**` modified.

## State shape (new)

```dart
@freezed
class ProfileEditState with _$ProfileEditState {
  const factory ProfileEditState({
    required String firstName,
    required String lastName, // optional in UI
    required String email,
    @Default(false) bool isLoading,
    String? errorMessage,
  }) = _ProfileEditState;
}
```

`dob` and `gender` are dropped entirely (only consumed by the edit screen — no shims needed). The existing baby's `dateOfBirth` and `gender` are preserved by the controller when calling `BabyProfileService.updateBaby`.

## Controller / save path

- `build()` — reads `BabyProfileService.getBaby()` + `Supabase.instance.client.auth.currentUser.email`, splits `Baby.name` on first whitespace into firstName / lastName, seeds the form, and caches the initial email.
- `save()` — composes `newName = '${firstName.trim()} ${lastName.trim()}'.trim()`, updates the baby (preserving DOB + gender), and if `email != initialEmail` calls `AuthService.updateEmail`. Returns a `ProfileEditSaveResult` so the UI can show the email-confirmation notice only when the email actually changed.

## auth.updateEmail path (new)

- `AuthRepository.updateEmail(String newEmail)` wraps `Supabase.instance.client.auth.updateUser(UserAttributes(email: newEmail))`. Same `AuthException` / unknown-error handling as `updatePassword`. Records non-fatals through the existing crash recorder.
- `AuthService.updateEmail` is a thin delegate.

On success after an email change the screen pops with snackbar "Please check your inbox to confirm the new email." Supabase sends the confirmation; the address only commits after the user clicks the link.

## Acceptance criteria

- [x] Edit screen matches Figma `1200:10475` (3 fields + Save).
- [x] Saving name updates the baby; updating email calls `authService.updateEmail`.
- [x] Email change shows "Please check your inbox to confirm the new email." on success.
- [x] No DOB / gender controls in the rewritten screen (grep clean).
- [x] `make gen` clean + idempotent (second run produces no extra diff in this PR's scope).
- [x] `flutter analyze` 0 issues.
- [x] `flutter test` — `+449 ~6: All tests passed!` (no existing tests broken).
- [x] Zero hex / Nunito / withAlpha / `AllergenStatus.completed`.
- [x] No files outside the allowlist modified.

## Gate results

- `make gen` — succeeded, idempotent
- `flutter analyze` — `No issues found! (ran in 5.1s)`
- `flutter test` — `+449 ~6: All tests passed!`

## Files changed

- `lib/src/features/profile/edit/profile_edit_screen.dart` — rewrite
- `lib/src/features/profile/edit/profile_edit_state.dart` + `.freezed.dart`
- `lib/src/features/profile/edit/profile_edit_controller.dart` + `.g.dart`
- `lib/src/common/data/repositories/auth_repository.dart` — add `updateEmail`
- `lib/src/common/services/auth_service.dart` + `.g.dart` — add `updateEmail` delegate