### PR TITLE
feat(profile): delete account reason overlay + flow [NIB-78]

### DIFF
--- a/lib/src/features/profile/delete/delete_account_controller.dart
+++ b/lib/src/features/profile/delete/delete_account_controller.dart
@@ -1,0 +1,49 @@
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/account_service.dart';
+import 'package:nibbles/src/common/services/auth_service.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/profile/delete/delete_account_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'delete_account_controller.g.dart';
+
+/// Drives the delete-account flow opened from Profile (NIB-78).
+///
+/// `submit(reason)` orchestrates the destructive sequence:
+///  1. `AccountService.deleteAccount(reason)` (NIB-85 RPC).
+///  2. On success: `LocalFlagService.clearAll()` wipes onboarding/completion
+///     flags so a re-register on the same device replays onboarding cleanly.
+///  3. Then `AuthService.signOut()` — the GoRouter redirect handles the
+///     navigation to `/auth/login` (or `/onboarding/intro` since flags are
+///     cleared).
+///
+/// On failure: `errorMessage` is set so the overlay can render an inline P1
+/// error + retry CTA without dismissing.
+@riverpod
+class DeleteAccountController extends _$DeleteAccountController {
+  @override
+  DeleteAccountState build() => const DeleteAccountState();
+
+  Future<bool> submit(String reason) async {
+    state = state.copyWith(isSubmitting: true, errorMessage: null);
+
+    final result = await ref
+        .read(accountServiceProvider)
+        .deleteAccount(reason);
+
+    switch (result) {
+      case Success<void>():
+        await ref.read(localFlagServiceProvider).clearAll();
+        await ref.read(authServiceProvider.notifier).signOut();
+        // Don't touch `state` after signOut — the provider is likely disposed
+        // by the time the redirect tears the profile subtree down.
+        return true;
+      case Failure<void>(:final error):
+        state = state.copyWith(
+          isSubmitting: false,
+          errorMessage: error.message,
+        );
+        return false;
+    }
+  }
+}

--- a/lib/src/features/profile/delete/delete_account_controller.g.dart
+++ b/lib/src/features/profile/delete/delete_account_controller.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'delete_account_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$deleteAccountControllerHash() =>
+    r'9be7673cc2102bd6120a1a2782425f5a3c23b1af';
+
+/// Drives the delete-account flow opened from Profile (NIB-78).
+///
+/// `submit(reason)` orchestrates the destructive sequence:
+///  1. `AccountService.deleteAccount(reason)` (NIB-85 RPC).
+///  2. On success: `LocalFlagService.clearAll()` wipes onboarding/completion
+///     flags so a re-register on the same device replays onboarding cleanly.
+///  3. Then `AuthService.signOut()` — the GoRouter redirect handles the
+///     navigation to `/auth/login` (or `/onboarding/intro` since flags are
+///     cleared).
+///
+/// On failure: `errorMessage` is set so the overlay can render an inline P1
+/// error + retry CTA without dismissing.
+///
+/// Copied from [DeleteAccountController].
+@ProviderFor(DeleteAccountController)
+final deleteAccountControllerProvider =
+    AutoDisposeNotifierProvider<
+      DeleteAccountController,
+      DeleteAccountState
+    >.internal(
+      DeleteAccountController.new,
+      name: r'deleteAccountControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$deleteAccountControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$DeleteAccountController = AutoDisposeNotifier<DeleteAccountState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/profile/delete/delete_account_overlay.dart
+++ b/lib/src/features/profile/delete/delete_account_overlay.dart
@@ -1,0 +1,298 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/features/profile/delete/delete_account_controller.dart';
+import 'package:nibbles/src/features/profile/delete/widgets/reason_choice_row.dart';
+
+/// 6 reason strings — hardcoded per NIB-78 spec. The selected string is
+/// passed verbatim to `AccountService.deleteAccount(reason)`.
+const List<String> _kReasons = [
+  "I'm not getting value from the app",
+  "I'm using a different app",
+  'Too many notifications / not enough',
+  'Privacy concerns',
+  'I had a bad experience',
+  'Other',
+];
+
+/// Opens the Delete Account reason overlay (Figma 1216:11954).
+///
+/// Modal bottom sheet, `isScrollControlled: true`. Returns once dismissed —
+/// either by Cancel/close, by tapping the scrim, or after a successful
+/// deletion (the sheet pops itself before signOut triggers the redirect).
+Future<void> showDeleteAccountOverlay(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppSizes.radiusLg),
+      ),
+    ),
+    builder: (_) => const _DeleteAccountSheet(),
+  );
+}
+
+class _DeleteAccountSheet extends ConsumerStatefulWidget {
+  const _DeleteAccountSheet();
+
+  @override
+  ConsumerState<_DeleteAccountSheet> createState() =>
+      _DeleteAccountSheetState();
+}
+
+class _DeleteAccountSheetState extends ConsumerState<_DeleteAccountSheet> {
+  String? _selectedReason;
+
+  Future<void> _onContinue() async {
+    final reason = _selectedReason;
+    if (reason == null) return;
+
+    final ok = await ref
+        .read(deleteAccountControllerProvider.notifier)
+        .submit(reason);
+
+    if (!mounted) return;
+    // On success, dismiss the sheet so it doesn't linger over the post-redirect
+    // /auth/login (or /onboarding/intro since flags were just cleared). Modal
+    // bottom sheets aren't popped by GoRouter redirects — pop it explicitly.
+    if (ok) Navigator.of(context).pop();
+    // On failure, leave the sheet open; the controller has populated
+    // `errorMessage` and the UI rebuilds with the inline error + retry.
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final media = MediaQuery.of(context);
+    final state = ref.watch(deleteAccountControllerProvider);
+    final theme = Theme.of(context);
+    final submitting = state.isSubmitting;
+    final reasonPicked = _selectedReason != null;
+
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: media.size.height * 0.92,
+        ),
+        child: Padding(
+          padding: EdgeInsets.only(bottom: media.viewInsets.bottom),
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.pagePaddingH,
+                AppSizes.sm,
+                AppSizes.pagePaddingH,
+                AppSizes.lg,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _SheetHeader(
+                    onClose: submitting
+                        ? null
+                        : () => Navigator.of(context).pop(),
+                  ),
+                  const SizedBox(height: AppSizes.sm),
+                  Text(
+                    'Why are you leaving us?',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.headlineSmall?.copyWith(
+                      color: AppColors.fgStrong,
+                    ),
+                  ),
+                  const SizedBox(height: AppSizes.sm),
+                  Text(
+                    'We’d love a quick reason so we can keep improving for '
+                    'other little ones.',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: AppColors.fgMuted,
+                    ),
+                  ),
+                  const SizedBox(height: AppSizes.lg),
+                  for (var i = 0; i < _kReasons.length; i++) ...[
+                    ReasonChoiceRow(
+                      key: Key('delete_reason_$i'),
+                      label: _kReasons[i],
+                      selected: _selectedReason == _kReasons[i],
+                      onTap: submitting
+                          ? () {}
+                          : () => setState(() {
+                              _selectedReason = _kReasons[i];
+                            }),
+                    ),
+                    if (i != _kReasons.length - 1)
+                      const SizedBox(height: AppSizes.sm),
+                  ],
+                  const SizedBox(height: AppSizes.md),
+                  Text(
+                    'This action cannot be undone.',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: AppColors.destructive,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  if (state.errorMessage != null) ...[
+                    const SizedBox(height: AppSizes.sm),
+                    _InlineError(
+                      message: state.errorMessage!,
+                      onRetry: reasonPicked && !submitting ? _onContinue : null,
+                    ),
+                  ],
+                  const SizedBox(height: AppSizes.md),
+                  AppPillButton(
+                    key: const Key('delete_account_continue_button'),
+                    label: submitting ? 'Deleting…' : 'Continue',
+                    variant: AppPillButtonVariant.destructive,
+                    onPressed: (reasonPicked && !submitting)
+                        ? _onContinue
+                        : null,
+                  ),
+                  const SizedBox(height: AppSizes.sm),
+                  AppPillButton(
+                    key: const Key('delete_account_cancel_button'),
+                    label: 'Cancel',
+                    variant: AppPillButtonVariant.ghost,
+                    onPressed: submitting
+                        ? null
+                        : () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SheetHeader extends StatelessWidget {
+  const _SheetHeader({required this.onClose});
+
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Expanded(
+          child: Padding(
+            padding: EdgeInsets.only(top: AppSizes.sm),
+            child: _BrandLockup(),
+          ),
+        ),
+        IconButton(
+          key: const Key('delete_account_close_button'),
+          icon: const Icon(Icons.close, size: AppSizes.iconMd),
+          color: AppColors.fgMuted,
+          onPressed: onClose,
+          tooltip: 'Close',
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(
+            minWidth: AppSizes.roundButtonSm,
+            minHeight: AppSizes.roundButtonSm,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _BrandLockup extends StatelessWidget {
+  const _BrandLockup();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          'nibbles',
+          style: AppTypography.brandWordmark.copyWith(
+            fontSize: 28,
+            letterSpacing: -0.56,
+          ),
+        ),
+        const SizedBox(width: AppSizes.xs),
+        Container(
+          width: 28,
+          height: 28,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: AppColors.butter,
+            borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+          ),
+          child: const Text(
+            '👑',
+            style: TextStyle(
+              fontFamily: FontFamily.parkinsans,
+              fontSize: 16,
+              height: 1,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InlineError extends StatelessWidget {
+  const _InlineError({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(AppSizes.sp12),
+      decoration: BoxDecoration(
+        color: AppColors.destructiveSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        border: Border.all(color: AppColors.destructive.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.error_outline,
+            size: AppSizes.iconSm + 2,
+            color: AppColors.destructive,
+          ),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: Text(
+              message,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: AppColors.destructive,
+              ),
+            ),
+          ),
+          if (onRetry != null)
+            TextButton(
+              key: const Key('delete_account_retry_button'),
+              onPressed: onRetry,
+              style: TextButton.styleFrom(
+                foregroundColor: AppColors.destructive,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.sm,
+                  vertical: AppSizes.xs,
+                ),
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              child: const Text('Retry'),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/profile/delete/delete_account_state.dart
+++ b/lib/src/features/profile/delete/delete_account_state.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'delete_account_state.freezed.dart';
+
+@freezed
+class DeleteAccountState with _$DeleteAccountState {
+  const factory DeleteAccountState({
+    @Default(false) bool isSubmitting,
+    String? errorMessage,
+  }) = _DeleteAccountState;
+}

--- a/lib/src/features/profile/delete/delete_account_state.freezed.dart
+++ b/lib/src/features/profile/delete/delete_account_state.freezed.dart
@@ -1,0 +1,174 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'delete_account_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$DeleteAccountState {
+  bool get isSubmitting => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+
+  /// Create a copy of DeleteAccountState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $DeleteAccountStateCopyWith<DeleteAccountState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DeleteAccountStateCopyWith<$Res> {
+  factory $DeleteAccountStateCopyWith(
+    DeleteAccountState value,
+    $Res Function(DeleteAccountState) then,
+  ) = _$DeleteAccountStateCopyWithImpl<$Res, DeleteAccountState>;
+  @useResult
+  $Res call({bool isSubmitting, String? errorMessage});
+}
+
+/// @nodoc
+class _$DeleteAccountStateCopyWithImpl<$Res, $Val extends DeleteAccountState>
+    implements $DeleteAccountStateCopyWith<$Res> {
+  _$DeleteAccountStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of DeleteAccountState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? isSubmitting = null, Object? errorMessage = freezed}) {
+    return _then(
+      _value.copyWith(
+            isSubmitting: null == isSubmitting
+                ? _value.isSubmitting
+                : isSubmitting // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$DeleteAccountStateImplCopyWith<$Res>
+    implements $DeleteAccountStateCopyWith<$Res> {
+  factory _$$DeleteAccountStateImplCopyWith(
+    _$DeleteAccountStateImpl value,
+    $Res Function(_$DeleteAccountStateImpl) then,
+  ) = __$$DeleteAccountStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool isSubmitting, String? errorMessage});
+}
+
+/// @nodoc
+class __$$DeleteAccountStateImplCopyWithImpl<$Res>
+    extends _$DeleteAccountStateCopyWithImpl<$Res, _$DeleteAccountStateImpl>
+    implements _$$DeleteAccountStateImplCopyWith<$Res> {
+  __$$DeleteAccountStateImplCopyWithImpl(
+    _$DeleteAccountStateImpl _value,
+    $Res Function(_$DeleteAccountStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of DeleteAccountState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? isSubmitting = null, Object? errorMessage = freezed}) {
+    return _then(
+      _$DeleteAccountStateImpl(
+        isSubmitting: null == isSubmitting
+            ? _value.isSubmitting
+            : isSubmitting // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$DeleteAccountStateImpl implements _DeleteAccountState {
+  const _$DeleteAccountStateImpl({
+    this.isSubmitting = false,
+    this.errorMessage,
+  });
+
+  @override
+  @JsonKey()
+  final bool isSubmitting;
+  @override
+  final String? errorMessage;
+
+  @override
+  String toString() {
+    return 'DeleteAccountState(isSubmitting: $isSubmitting, errorMessage: $errorMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DeleteAccountStateImpl &&
+            (identical(other.isSubmitting, isSubmitting) ||
+                other.isSubmitting == isSubmitting) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, isSubmitting, errorMessage);
+
+  /// Create a copy of DeleteAccountState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DeleteAccountStateImplCopyWith<_$DeleteAccountStateImpl> get copyWith =>
+      __$$DeleteAccountStateImplCopyWithImpl<_$DeleteAccountStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _DeleteAccountState implements DeleteAccountState {
+  const factory _DeleteAccountState({
+    final bool isSubmitting,
+    final String? errorMessage,
+  }) = _$DeleteAccountStateImpl;
+
+  @override
+  bool get isSubmitting;
+  @override
+  String? get errorMessage;
+
+  /// Create a copy of DeleteAccountState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$DeleteAccountStateImplCopyWith<_$DeleteAccountStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/profile/delete/widgets/reason_choice_row.dart
+++ b/lib/src/features/profile/delete/widgets/reason_choice_row.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+
+/// Single-select button-choice row used in the Delete Account overlay
+/// (Figma 1216:11954). Mirrors kit `.pillbtn--ghost` semantics — butter-soft
+/// fill, Parkinsans 600 label, full-width pill — but pre-selected the fill
+/// deepens to `butter` and the label/border darkens for affordance.
+class ReasonChoiceRow extends StatelessWidget {
+  const ReasonChoiceRow({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    super.key,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final fill = selected ? AppColors.butter : AppColors.butterSoft;
+    final fg = selected ? AppColors.greenDeep : AppColors.fgDefault;
+    final borderColor = selected
+        ? AppColors.greenDeep
+        : AppColors.borderSoft;
+
+    return Material(
+      color: fill,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        side: BorderSide(
+          color: borderColor,
+          width: selected ? 1.5 : 1,
+        ),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        child: SizedBox(
+          width: double.infinity,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.md,
+              vertical: AppSizes.sp12 + 2,
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    label,
+                    style: AppTypography.button.copyWith(
+                      fontFamily: FontFamily.parkinsans,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: fg,
+                      height: 1.294,
+                    ),
+                  ),
+                ),
+                if (selected)
+                  const Icon(
+                    Icons.check_circle,
+                    size: AppSizes.iconSm + 2,
+                    color: AppColors.greenDeep,
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/profile/profile_screen.dart
+++ b/lib/src/features/profile/profile_screen.dart
@@ -6,6 +6,7 @@ import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/features/profile/delete/delete_account_overlay.dart';
 import 'package:nibbles/src/features/profile/profile_controller.dart';
 import 'package:nibbles/src/features/profile/profile_state.dart';
 import 'package:nibbles/src/features/profile/widgets/premium_teaser_card.dart';
@@ -147,11 +148,7 @@ class _ProfileContent extends ConsumerWidget {
                     key: const Key('profile_delete_account_row'),
                     title: 'Delete account',
                     danger: true,
-                    // TODO(NIB-78): push delete overlay when ticket ships.
-                    onTap: () => _showComingSoon(
-                      context,
-                      'Account deletion coming soon.',
-                    ),
+                    onTap: () => showDeleteAccountOverlay(context),
                   ),
                 ],
               ),

--- a/test/features/profile/delete/delete_account_controller_test.dart
+++ b/test/features/profile/delete/delete_account_controller_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/account_repository.dart';
+import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/profile/delete/delete_account_controller.dart';
+import 'package:nibbles/src/features/profile/delete/delete_account_state.dart';
+
+class _MockAccountRepository extends Mock implements AccountRepository {}
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+class _MockLocalFlagService extends Mock implements LocalFlagService {}
+
+void main() {
+  late _MockAccountRepository mockAccountRepo;
+  late _MockAuthRepository mockAuthRepo;
+  late _MockLocalFlagService mockFlags;
+  late ProviderContainer container;
+
+  setUp(() {
+    mockAccountRepo = _MockAccountRepository();
+    mockAuthRepo = _MockAuthRepository();
+    mockFlags = _MockLocalFlagService();
+
+    when(() => mockAuthRepo.isLoggedIn).thenReturn(true);
+    when(
+      () => mockAuthRepo.authStateStream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(() => mockAuthRepo.signOut())
+        .thenAnswer((_) async => const Result.success(null));
+    when(mockFlags.clearAll).thenAnswer((_) async {});
+
+    container = ProviderContainer(
+      overrides: [
+        accountRepositoryProvider.overrideWithValue(mockAccountRepo),
+        authRepositoryProvider.overrideWithValue(mockAuthRepo),
+        localFlagServiceProvider.overrideWithValue(mockFlags),
+      ],
+    )
+    // Hold the controller alive across awaits so state isn't lost to
+    // auto-dispose between assertions.
+    ..listen<DeleteAccountState>(
+      deleteAccountControllerProvider,
+      (_, __) {},
+    );
+  });
+
+  tearDown(() => container.dispose());
+
+  DeleteAccountController readController() =>
+      container.read(deleteAccountControllerProvider.notifier);
+
+  group('DeleteAccountController.submit', () {
+    test(
+      'success: calls deleteAccount → clearAll → signOut and returns true',
+      () async {
+        when(() => mockAccountRepo.requestAccountDeletion(any()))
+            .thenAnswer((_) async => const Result.success(null));
+
+        final ok = await readController().submit('Privacy concerns');
+
+        expect(ok, isTrue);
+        verify(
+          () => mockAccountRepo.requestAccountDeletion('Privacy concerns'),
+        ).called(1);
+        verify(mockFlags.clearAll).called(1);
+        verify(() => mockAuthRepo.signOut()).called(1);
+      },
+    );
+
+    test(
+      'failure: sets errorMessage, returns false, does NOT clear flags or '
+      'sign out',
+      () async {
+        when(() => mockAccountRepo.requestAccountDeletion(any())).thenAnswer(
+          (_) async =>
+              const Result.failure(ServerException('deletion failed')),
+        );
+
+        final ok = await readController().submit('Other');
+
+        expect(ok, isFalse);
+        final state = container.read(deleteAccountControllerProvider);
+        expect(state.isSubmitting, isFalse);
+        expect(state.errorMessage, 'deletion failed');
+        verifyNever(mockFlags.clearAll);
+        verifyNever(() => mockAuthRepo.signOut());
+      },
+    );
+
+    test(
+      'submit clears any prior errorMessage before calling the service',
+      () async {
+        when(() => mockAccountRepo.requestAccountDeletion(any())).thenAnswer(
+          (_) async => const Result.failure(NetworkException('offline')),
+        );
+
+        // First attempt fails — errorMessage gets set.
+        await readController().submit('Other');
+        expect(
+          container.read(deleteAccountControllerProvider).errorMessage,
+          'offline',
+        );
+
+        // Retry succeeds — errorMessage must be cleared by the time we
+        // reach the success branch.
+        when(() => mockAccountRepo.requestAccountDeletion(any()))
+            .thenAnswer((_) async => const Result.success(null));
+
+        final ok = await readController().submit('Other');
+
+        expect(ok, isTrue);
+        // After success, signOut was called so the provider state's final
+        // observable value is whatever was set before the success branch:
+        // {isSubmitting: true, errorMessage: null}.
+        final state = container.read(deleteAccountControllerProvider);
+        expect(state.errorMessage, isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Implements NIB-78 — the Delete Account reason-overlay bottom sheet and the destructive flow that consumes NIB-85's `AccountService.deleteAccount(reason)`.

**Figma frames**
- Settings row: `node-id=1189-10278`
- Overlay: `node-id=1216-11954`

**Flow**
1. `AccountService.deleteAccount(reason)` (NIB-85 RPC)
2. On `Result.success`: `LocalFlagService.clearAll()` wipes onboarding/program-completion flags
3. Then `AuthService.signOut()` — the GoRouter redirect handles routing to `/auth/login` (or `/onboarding/intro` since flags are cleared)
4. On `Result.failure`: P1 inline error + Retry CTA in the overlay; sheet stays open

**Profile call-site change**
- One-line swap in `profile_screen.dart`: Delete row `onTap` now `() => showDeleteAccountOverlay(context)` (previously `_showComingSoon(...)` TODO).
- One added import — unavoidable given the helper lives in the new feature folder.

**DS components consumed (no edits)**
- `AppPillButton` — `destructive` variant for Continue, `ghost` for Cancel
- `AppColors` / `AppTypography` / `AppSizes` tokens — zero hex, zero Nunito, zero `withAlpha`
- `SettingsRow` (NIB-52) — consumed only

## Acceptance criteria

- [x] Overlay matches Figma 1216:11954 (X close + brand lockup + title + body + 6 reason rows + warning + Continue + Cancel)
- [x] Continue disabled until a reason is selected
- [x] Success path calls `deleteAccount` -> `clearAll` -> `signOut`; redirect handles navigation
- [x] Failure path renders inline P1 error + Retry inside the overlay
- [x] `profile_screen.dart` Delete row opens the overlay (1-line change + 1 import)
- [x] 3 unit tests for `DeleteAccountController` (success, failure, retry-clears-error)
- [x] No files outside the allowlist touched
- [x] No `setAccountDeleted()` call (intentional — `clearAll()` wipes the same key; spec keeps scope tight, only NIB-85's doc comment references the flag)

## Gate results

- `make gen` — clean + idempotent (second run: 0 outputs, 0 actions)
- `flutter analyze` — `No issues found!` (3.6s)
- `flutter test` — `+452 ~6: All tests passed!` (24s, the 6 are pre-existing skips)

## Notes for the reviewer

- The sheet pops itself on success before the redirect fires — `showModalBottomSheet` pushes an imperative route that GoRouter redirects do not pop. Cancel/close still pop normally.
- Every post-await use of `context` is `mounted`-guarded.
- Crashlytics / analytics instrumentation is intentionally deferred to NIB-92.