### PR TITLE
feat(profile): analytics + crashlytics for edit/feedback/delete flows [NIB-92]

### DIFF
--- a/lib/src/features/profile/delete/delete_account_controller.dart
+++ b/lib/src/features/profile/delete/delete_account_controller.dart
@@ -1,11 +1,50 @@
+import 'dart:async';
+
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/services/account_service.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/profile/delete/delete_account_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'delete_account_controller.g.dart';
+
+/// Injectable Crashlytics recorder so unit tests can assert the non-fatal
+/// payload without touching real Firebase. Mirrors the
+/// `AllergenCrashRecorderFn` pattern from NIB-125.
+typedef DeleteAccountCrashRecorderFn =
+    Future<void> Function(
+      Object error,
+      StackTrace stack, {
+      String? reason,
+      List<String>? information,
+    });
+
+Future<void> _defaultDeleteAccountCrashRecorder(
+  Object error,
+  StackTrace stack, {
+  String? reason,
+  List<String>? information,
+}) => FirebaseCrashlytics.instance.recordError(
+  error,
+  stack,
+  reason: reason,
+  information: information ?? const <Object>[],
+  // Non-fatal: deleteAccount failures still surface a P1 inline error + retry.
+  // ignore: avoid_redundant_argument_values
+  fatal: false,
+);
+
+/// Provider for the [DeleteAccountCrashRecorderFn]. Tests override this to
+/// capture the recorded payload without hitting Crashlytics.
+@Riverpod(keepAlive: true)
+DeleteAccountCrashRecorderFn deleteAccountCrashRecorder(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  DeleteAccountCrashRecorderRef ref,
+) => _defaultDeleteAccountCrashRecorder;
 
 /// Drives the delete-account flow opened from Profile (NIB-78).
 ///
@@ -35,10 +74,22 @@ class DeleteAccountController extends _$DeleteAccountController {
       case Success<void>():
         await ref.read(localFlagServiceProvider).clearAll();
         await ref.read(authServiceProvider.notifier).signOut();
+        // Success — fire-and-forget. No PII (reason is logged on intent fire).
+        unawaited(
+          ref.read(analyticsProvider).logAccountDeletionCompleted(),
+        );
         // Don't touch `state` after signOut — the provider is likely disposed
         // by the time the redirect tears the profile subtree down.
         return true;
       case Failure<void>(:final error):
+        // P1 path: record non-fatal BEFORE the inline error SnackBar fires.
+        // information = ['reason=<reason>'] for triage; no PII.
+        await ref.read(deleteAccountCrashRecorderProvider)(
+          'profile_account_deletion_failure: ${error.message}',
+          StackTrace.current,
+          reason: 'profile_account_deletion_failure',
+          information: <String>['reason=$reason'],
+        );
         state = state.copyWith(
           isSubmitting: false,
           errorMessage: error.message,

--- a/lib/src/features/profile/delete/delete_account_controller.g.dart
+++ b/lib/src/features/profile/delete/delete_account_controller.g.dart
@@ -6,8 +6,31 @@ part of 'delete_account_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$deleteAccountCrashRecorderHash() =>
+    r'16e79ff904d8e06d9dcbd2b52a9f43e5d9ec1061';
+
+/// Provider for the [DeleteAccountCrashRecorderFn]. Tests override this to
+/// capture the recorded payload without hitting Crashlytics.
+///
+/// Copied from [deleteAccountCrashRecorder].
+@ProviderFor(deleteAccountCrashRecorder)
+final deleteAccountCrashRecorderProvider =
+    Provider<DeleteAccountCrashRecorderFn>.internal(
+      deleteAccountCrashRecorder,
+      name: r'deleteAccountCrashRecorderProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$deleteAccountCrashRecorderHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef DeleteAccountCrashRecorderRef =
+    ProviderRef<DeleteAccountCrashRecorderFn>;
 String _$deleteAccountControllerHash() =>
-    r'9be7673cc2102bd6120a1a2782425f5a3c23b1af';
+    r'a051fe95d9ac3553ace7ccf275cd1e9b186d890b';
 
 /// Drives the delete-account flow opened from Profile (NIB-78).
 ///

--- a/lib/src/features/profile/delete/delete_account_overlay.dart
+++ b/lib/src/features/profile/delete/delete_account_overlay.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nibbles/gen/fonts.gen.dart';
@@ -7,6 +9,7 @@ import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/features/profile/delete/delete_account_controller.dart';
 import 'package:nibbles/src/features/profile/delete/widgets/reason_choice_row.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 
 /// 6 reason strings — hardcoded per NIB-78 spec. The selected string is
 /// passed verbatim to `AccountService.deleteAccount(reason)`.
@@ -49,9 +52,35 @@ class _DeleteAccountSheet extends ConsumerStatefulWidget {
 class _DeleteAccountSheetState extends ConsumerState<_DeleteAccountSheet> {
   String? _selectedReason;
 
+  @override
+  void initState() {
+    super.initState();
+    // Fire screen_view('delete_account_overlay') once on mount via post-frame.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_logScreenView());
+    });
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await ref
+          .read(analyticsProvider)
+          .logScreenView(screenName: 'delete_account_overlay');
+    } on Object catch (_) {
+      // Analytics is best-effort; never surface to the UI.
+    }
+  }
+
   Future<void> _onContinue() async {
     final reason = _selectedReason;
     if (reason == null) return;
+
+    // Intent event — fires BEFORE the destructive call. Reason is one of the
+    // 6 hardcoded `_kReasons` strings (stable enum, NOT PII / NOT free text).
+    unawaited(
+      ref.read(analyticsProvider).logAccountDeletionStarted(reason: reason),
+    );
 
     final ok = await ref
         .read(deleteAccountControllerProvider.notifier)

--- a/lib/src/features/profile/edit/profile_edit_controller.dart
+++ b/lib/src/features/profile/edit/profile_edit_controller.dart
@@ -1,11 +1,43 @@
+import 'dart:async';
+
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/profile/edit/profile_edit_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'profile_edit_controller.g.dart';
+
+/// Injectable Crashlytics recorder so unit tests can assert the non-fatal
+/// payload without touching real Firebase. Mirrors the
+/// `AllergenCrashRecorderFn` pattern from NIB-125.
+typedef ProfileEditCrashRecorderFn =
+    Future<void> Function(Object error, StackTrace stack, {String? reason});
+
+Future<void> _defaultProfileEditCrashRecorder(
+  Object error,
+  StackTrace stack, {
+  String? reason,
+}) => FirebaseCrashlytics.instance.recordError(
+  error,
+  stack,
+  reason: reason,
+  // Non-fatal: updateEmail failures still surface a P1 inline error + retry.
+  // ignore: avoid_redundant_argument_values
+  fatal: false,
+);
+
+/// Provider for the [ProfileEditCrashRecorderFn]. Tests override this to
+/// capture the recorded payload without hitting Crashlytics.
+@Riverpod(keepAlive: true)
+ProfileEditCrashRecorderFn profileEditCrashRecorder(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  ProfileEditCrashRecorderRef ref,
+) => _defaultProfileEditCrashRecorder;
 
 @riverpod
 class ProfileEditController extends _$ProfileEditController {
@@ -94,6 +126,14 @@ class ProfileEditController extends _$ProfileEditController {
           .read(authServiceProvider.notifier)
           .updateEmail(newEmail);
       if (emailResult.isFailure) {
+        // P1 path: record non-fatal BEFORE the UI shows the inline error.
+        // Reason is a stable enum string — no email value, no PII.
+        await ref.read(profileEditCrashRecorderProvider)(
+          'profile_email_update_failure: '
+              '${emailResult.errorOrNull?.message ?? 'unknown'}',
+          StackTrace.current,
+          reason: 'profile_email_update_failure',
+        );
         state = AsyncData(
           current.copyWith(
             isLoading: false,
@@ -105,6 +145,12 @@ class ProfileEditController extends _$ProfileEditController {
     }
 
     state = AsyncData(current.copyWith(isLoading: false));
+    // Success path — fire-and-forget. Param is a bool only (no PII).
+    unawaited(
+      ref
+          .read(analyticsProvider)
+          .logProfileEditSaved(emailChanged: emailChanged),
+    );
     return ProfileEditSaveResult(
       success: true,
       emailChanged: emailChanged,

--- a/lib/src/features/profile/edit/profile_edit_controller.g.dart
+++ b/lib/src/features/profile/edit/profile_edit_controller.g.dart
@@ -6,8 +6,30 @@ part of 'profile_edit_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$profileEditCrashRecorderHash() =>
+    r'15c5c0af8188b5328486b968fea04e5b79d25482';
+
+/// Provider for the [ProfileEditCrashRecorderFn]. Tests override this to
+/// capture the recorded payload without hitting Crashlytics.
+///
+/// Copied from [profileEditCrashRecorder].
+@ProviderFor(profileEditCrashRecorder)
+final profileEditCrashRecorderProvider =
+    Provider<ProfileEditCrashRecorderFn>.internal(
+      profileEditCrashRecorder,
+      name: r'profileEditCrashRecorderProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$profileEditCrashRecorderHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef ProfileEditCrashRecorderRef = ProviderRef<ProfileEditCrashRecorderFn>;
 String _$profileEditControllerHash() =>
-    r'80eeb05bf4c12705fd8c6ecacd1ad6ff2026f09f';
+    r'94b216ab96fa3787cc60e2d91352cd553d8f362c';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/profile/edit/profile_edit_screen.dart
+++ b/lib/src/features/profile/edit/profile_edit_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -12,6 +14,7 @@ import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/profile/edit/profile_edit_controller.dart';
 import 'package:nibbles/src/features/profile/edit/profile_edit_state.dart';
 import 'package:nibbles/src/features/profile/profile_controller.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 
 /// PR-02 — Edit Profile.
 ///
@@ -20,11 +23,36 @@ import 'package:nibbles/src/features/profile/profile_controller.dart';
 /// header with a back chevron + "Change Profile" title, coral avatar puck,
 /// then a cream form pane with First Name / Last Name (Optional) / Email
 /// labelled fields and a full-width primary "Save" pill.
-class ProfileEditScreen extends ConsumerWidget {
+class ProfileEditScreen extends ConsumerStatefulWidget {
   const ProfileEditScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ProfileEditScreen> createState() => _ProfileEditScreenState();
+}
+
+class _ProfileEditScreenState extends ConsumerState<ProfileEditScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Fire screen_view('profile_edit') once on mount via post-frame callback.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_logScreenView());
+    });
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await ref
+          .read(analyticsProvider)
+          .logScreenView(screenName: 'profile_edit');
+    } on Object catch (_) {
+      // Analytics is best-effort; never surface to the UI.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final babyIdAsync = ref.watch(currentBabyIdProvider);
 
     return babyIdAsync.when(

--- a/lib/src/features/profile/feedback/feedback_controller.dart
+++ b/lib/src/features/profile/feedback/feedback_controller.dart
@@ -1,8 +1,41 @@
+import 'dart:async';
+
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/services/feedback_service.dart';
 import 'package:nibbles/src/features/profile/feedback/feedback_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'feedback_controller.g.dart';
+
+/// Injectable Crashlytics recorder so unit tests can assert the non-fatal
+/// payload without touching real Firebase. Mirrors the
+/// `AllergenCrashRecorderFn` pattern from NIB-125.
+typedef FeedbackCrashRecorderFn =
+    Future<void> Function(Object error, StackTrace stack, {String? reason});
+
+Future<void> _defaultFeedbackCrashRecorder(
+  Object error,
+  StackTrace stack, {
+  String? reason,
+}) => FirebaseCrashlytics.instance.recordError(
+  error,
+  stack,
+  reason: reason,
+  // Non-fatal: feedback submit failures still surface a P2 SnackBar retry.
+  // ignore: avoid_redundant_argument_values
+  fatal: false,
+);
+
+/// Provider for the [FeedbackCrashRecorderFn]. Tests override this to capture
+/// the recorded payload without hitting Crashlytics.
+@Riverpod(keepAlive: true)
+FeedbackCrashRecorderFn feedbackCrashRecorder(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  FeedbackCrashRecorderRef ref,
+) => _defaultFeedbackCrashRecorder;
 
 @riverpod
 class FeedbackController extends _$FeedbackController {
@@ -25,18 +58,25 @@ class FeedbackController extends _$FeedbackController {
 
     final result = await ref.read(feedbackServiceProvider).submit(trimmed);
 
-    return result.when(
-      success: (_) {
+    switch (result) {
+      case Success<void>():
         state = state.copyWith(isSubmitting: false);
+        // Success — fire-and-forget. NO message text in the event.
+        unawaited(ref.read(analyticsProvider).logFeedbackSubmitted());
         return true;
-      },
-      failure: (error) {
+      case Failure<void>(:final error):
+        // P2 path: record non-fatal BEFORE the SnackBar fires. Reason is a
+        // stable enum string — no message text, no PII.
+        await ref.read(feedbackCrashRecorderProvider)(
+          'profile_feedback_submit_failure: ${error.message}',
+          StackTrace.current,
+          reason: 'profile_feedback_submit_failure',
+        );
         state = state.copyWith(
           isSubmitting: false,
           errorMessage: error.message,
         );
         return false;
-      },
-    );
+    }
   }
 }

--- a/lib/src/features/profile/feedback/feedback_controller.g.dart
+++ b/lib/src/features/profile/feedback/feedback_controller.g.dart
@@ -6,8 +6,30 @@ part of 'feedback_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$feedbackCrashRecorderHash() =>
+    r'd1c749ee65e3484864e30b5687d51fc1cb9a8b1e';
+
+/// Provider for the [FeedbackCrashRecorderFn]. Tests override this to capture
+/// the recorded payload without hitting Crashlytics.
+///
+/// Copied from [feedbackCrashRecorder].
+@ProviderFor(feedbackCrashRecorder)
+final feedbackCrashRecorderProvider =
+    Provider<FeedbackCrashRecorderFn>.internal(
+      feedbackCrashRecorder,
+      name: r'feedbackCrashRecorderProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$feedbackCrashRecorderHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef FeedbackCrashRecorderRef = ProviderRef<FeedbackCrashRecorderFn>;
 String _$feedbackControllerHash() =>
-    r'd1f6d919331f138f7912ecbf5b04b9b425969dd8';
+    r'4e646c81910ecf466b8af7128730f8c3710c3f15';
 
 /// See also [FeedbackController].
 @ProviderFor(FeedbackController)

--- a/lib/src/features/profile/feedback/feedback_screen.dart
+++ b/lib/src/features/profile/feedback/feedback_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -6,15 +8,41 @@ import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/features/profile/feedback/feedback_controller.dart';
 import 'package:nibbles/src/features/profile/widgets/profile_header.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 
 /// Give Feedback screen. Butter-soft "Settings" header, single multiline
 /// textarea, helper caption, and a full-width green-deep CTA. Mirrors the
 /// ProfileScreen kit pattern — no shell, no bottom nav (full-screen push).
-class FeedbackScreen extends ConsumerWidget {
+class FeedbackScreen extends ConsumerStatefulWidget {
   const FeedbackScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<FeedbackScreen> createState() => _FeedbackScreenState();
+}
+
+class _FeedbackScreenState extends ConsumerState<FeedbackScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Fire screen_view('profile_feedback') once on mount via post-frame.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_logScreenView());
+    });
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await ref
+          .read(analyticsProvider)
+          .logScreenView(screenName: 'profile_feedback');
+    } on Object catch (_) {
+      // Analytics is best-effort; never surface to the UI.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final state = ref.watch(feedbackControllerProvider);
     final controller = ref.read(feedbackControllerProvider.notifier);
     final textTheme = Theme.of(context).textTheme;
@@ -79,7 +107,7 @@ class FeedbackScreen extends ConsumerWidget {
                   AppPillButton(
                     key: const Key('feedback_send_button'),
                     label: state.isSubmitting ? 'Sending…' : 'Send Feedback',
-                    onPressed: canSubmit ? () => _submit(context, ref) : null,
+                    onPressed: canSubmit ? _submit : null,
                   ),
                 ],
               ),
@@ -90,11 +118,11 @@ class FeedbackScreen extends ConsumerWidget {
     );
   }
 
-  Future<void> _submit(BuildContext context, WidgetRef ref) async {
+  Future<void> _submit() async {
     final messenger = ScaffoldMessenger.of(context);
     final controller = ref.read(feedbackControllerProvider.notifier);
     final ok = await controller.submit();
-    if (!context.mounted) return;
+    if (!mounted) return;
 
     if (ok) {
       messenger.showSnackBar(

--- a/lib/src/features/profile/profile_screen.dart
+++ b/lib/src/features/profile/profile_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -13,13 +15,38 @@ import 'package:nibbles/src/features/profile/widgets/premium_teaser_card.dart';
 import 'package:nibbles/src/features/profile/widgets/profile_avatar_card.dart';
 import 'package:nibbles/src/features/profile/widgets/profile_header.dart';
 import 'package:nibbles/src/features/profile/widgets/settings_row.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-class ProfileScreen extends ConsumerWidget {
+class ProfileScreen extends ConsumerStatefulWidget {
   const ProfileScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends ConsumerState<ProfileScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Fire screen_view('profile') once on mount via a post-frame callback.
+    // Best-effort + unawaited so a Firebase hiccup never throws into the frame.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_logScreenView());
+    });
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await ref.read(analyticsProvider).logScreenView(screenName: 'profile');
+    } on Object catch (_) {
+      // Analytics is best-effort; never surface to the UI.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final babyIdAsync = ref.watch(currentBabyIdProvider);
 
     return babyIdAsync.when(
@@ -194,6 +221,7 @@ class _ProfileContent extends ConsumerWidget {
 
     if (confirmed ?? false) {
       await ref.read(authServiceProvider.notifier).signOut();
+      unawaited(ref.read(analyticsProvider).logLogout());
       // GoRouter redirect handles navigation to /auth/login.
     }
   }

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -431,6 +431,33 @@ class Analytics {
   }
 
   // ---------------------------------------------------------------------------
+  // Profile (NIB-92) — non-PII only: email_changed bool + stable reason enum.
+  // NEVER feedback message text, email values, baby IDs, or free text.
+  // ---------------------------------------------------------------------------
+
+  Future<void> logProfileEditSaved({required bool emailChanged}) async {
+    await _logEvent(
+      'profile_edit_saved',
+      parameters: {'email_changed': emailChanged},
+    );
+  }
+
+  Future<void> logFeedbackSubmitted() async {
+    await _logEvent('feedback_submitted');
+  }
+
+  Future<void> logAccountDeletionStarted({required String reason}) async {
+    await _logEvent(
+      'account_deletion_started',
+      parameters: {'reason': reason},
+    );
+  }
+
+  Future<void> logAccountDeletionCompleted() async {
+    await _logEvent('account_deletion_completed');
+  }
+
+  // ---------------------------------------------------------------------------
   // Screen tracking
   // ---------------------------------------------------------------------------
 

--- a/test/features/profile/delete/delete_account_controller_test.dart
+++ b/test/features/profile/delete/delete_account_controller_test.dart
@@ -8,6 +8,9 @@ import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/profile/delete/delete_account_controller.dart';
 import 'package:nibbles/src/features/profile/delete/delete_account_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../../support/fake_analytics.dart';
 
 class _MockAccountRepository extends Mock implements AccountRepository {}
 
@@ -19,12 +22,14 @@ void main() {
   late _MockAccountRepository mockAccountRepo;
   late _MockAuthRepository mockAuthRepo;
   late _MockLocalFlagService mockFlags;
+  late FakeAnalytics fakeAnalytics;
   late ProviderContainer container;
 
   setUp(() {
     mockAccountRepo = _MockAccountRepository();
     mockAuthRepo = _MockAuthRepository();
     mockFlags = _MockLocalFlagService();
+    fakeAnalytics = FakeAnalytics();
 
     when(() => mockAuthRepo.isLoggedIn).thenReturn(true);
     when(
@@ -39,6 +44,12 @@ void main() {
         accountRepositoryProvider.overrideWithValue(mockAccountRepo),
         authRepositoryProvider.overrideWithValue(mockAuthRepo),
         localFlagServiceProvider.overrideWithValue(mockFlags),
+        analyticsProvider.overrideWithValue(fakeAnalytics),
+        // No-op Crashlytics recorder — tests assert behaviour, not non-fatal
+        // payload (NIB-99 owns the recorder payload coverage).
+        deleteAccountCrashRecorderProvider.overrideWithValue(
+          (_, __, {String? reason, List<String>? information}) async {},
+        ),
       ],
     )
     // Hold the controller alive across awaits so state isn't lost to

--- a/test/support/fake_analytics.dart
+++ b/test/support/fake_analytics.dart
@@ -265,6 +265,21 @@ class FakeAnalytics implements Analytics {
       _record('home_create_first_meal_tapped');
 
   @override
+  Future<void> logProfileEditSaved({required bool emailChanged}) async =>
+      _record('profile_edit_saved', {'email_changed': emailChanged});
+
+  @override
+  Future<void> logFeedbackSubmitted() async => _record('feedback_submitted');
+
+  @override
+  Future<void> logAccountDeletionStarted({required String reason}) async =>
+      _record('account_deletion_started', {'reason': reason});
+
+  @override
+  Future<void> logAccountDeletionCompleted() async =>
+      _record('account_deletion_completed');
+
+  @override
   Future<void> logScreenView({required String screenName}) async =>
       _record('screen_view', {'screen_name': screenName});
 }


### PR DESCRIPTION
## Summary

Instruments the redesigned Profile flows for analytics on success/intent paths and Crashlytics non-fatals on the 3 P1/P2 failure paths. No PII — params are bool / stable enum strings only.

## New analytics methods (`lib/src/logging/analytics.dart`)

| Event | Params | Notes |
|---|---|---|
| `profile_edit_saved` | `email_changed: bool` | After Result.success in `ProfileEditController.save()` |
| `feedback_submitted` | none | After Result.success in `FeedbackController.submit()` |
| `account_deletion_started` | `reason: String` (stable enum) | Intent — fires BEFORE the destructive call |
| `account_deletion_completed` | none | After success + `clearAll()` + `signOut()` |

Existing events wired up: `logScreenView` (4 screens) + `logLogout` (on profile sign-out).

## Fire sites (file:line)

### Analytics
- `lib/src/features/profile/profile_screen.dart:42` — `logScreenView(screenName: 'profile')` on mount
- `lib/src/features/profile/profile_screen.dart:224` — `logLogout()` after `signOut()` success
- `lib/src/features/profile/edit/profile_edit_screen.dart:48` — `logScreenView(screenName: 'profile_edit')` on mount
- `lib/src/features/profile/edit/profile_edit_controller.dart:152` — `logProfileEditSaved(emailChanged: …)` after Result.success
- `lib/src/features/profile/feedback/feedback_screen.dart:38` — `logScreenView(screenName: 'profile_feedback')` on mount
- `lib/src/features/profile/feedback/feedback_controller.dart:65` — `logFeedbackSubmitted()` after Result.success
- `lib/src/features/profile/delete/delete_account_overlay.dart:69` — `logScreenView(screenName: 'delete_account_overlay')` on mount
- `lib/src/features/profile/delete/delete_account_overlay.dart:82` — `logAccountDeletionStarted(reason: …)` on Continue tap (BEFORE submit)
- `lib/src/features/profile/delete/delete_account_controller.dart:79` — `logAccountDeletionCompleted()` after success + clearAll + signOut

### Crashlytics non-fatals (typedef-injected recorders, AllergenCrashRecorderFn pattern)
- `lib/src/features/profile/edit/profile_edit_controller.dart:131` — `reason: 'profile_email_update_failure'` on `updateEmail` failure
- `lib/src/features/profile/feedback/feedback_controller.dart:70` — `reason: 'profile_feedback_submit_failure'` on `FeedbackService.submit` failure
- `lib/src/features/profile/delete/delete_account_controller.dart:87` — `reason: 'profile_account_deletion_failure'`, `information=['reason=<reason>']` on `AccountService.deleteAccount` failure

All non-fatals fire AFTER `Result.failure` is detected and BEFORE the P1/P2 UI message.

## PII confirmation

- `email_changed` is a `bool` — the new email value is NEVER logged.
- `reason` is one of the 6 hardcoded `_kReasons` strings (stable enum) — NOT free text, NOT PII.
- `screen_name` is a hardcoded constant — `'profile' | 'profile_edit' | 'profile_feedback' | 'delete_account_overlay'`.
- Feedback message text is NEVER logged. No baby IDs. No email values. No user IDs.
- Crashlytics `information` strings are scoped to the stable enum reason only.

All fire-and-forget paths use `unawaited(...)` and the screen-mount calls are wrapped in `try/catch` swallowing so a Firebase hiccup never throws into a frame callback.

## Acceptance criteria

- [x] `analytics.dart` exposes the 4 new methods + reuses existing `logScreenView` / `logLogout`
- [x] All fire sites AFTER `Result.success` (intent events on user action)
- [x] Crashlytics non-fatals recorded on the 3 specified failure paths
- [x] PII gate clean — no message text / email values / baby IDs / free text in any param
- [x] `flutter analyze` 0 issues
- [x] Existing tests still pass (455 passed, 6 skipped, 0 failed)
- [x] `make gen` clean + idempotent
- [x] No files outside the allowed list modified

## Gate results

- `make gen`: clean, idempotent (second run produced no diff)
- `flutter analyze`: `No issues found! (ran in 2.9s)`
- `flutter test`: `455 passed, 6 skipped, 0 failed`

## Notes

- 3 new `*CrashRecorderFn` typedefs + Riverpod providers added (mirrors `MealPrepCrashRecorderFn` / `AllergenCrashRecorderFn`) so NIB-99 can override them in tests without touching Firebase.
- `delete_account_controller_test.dart` updated to override the new `analyticsProvider` + `deleteAccountCrashRecorderProvider` — existing test expectations unchanged.

Closes NIB-92.