### PR TITLE
feat(shopping-list): add DS ShopRow tile + fix segmented font [NIB-54]

### DIFF
--- a/lib/src/app/themes/app_colors.dart
+++ b/lib/src/app/themes/app_colors.dart
@@ -72,6 +72,10 @@ abstract final class AppColors {
   // (NIB-107 Figma node 971:10029 — token "Nibble-primary-Burgundy").
   static const Color burgundy = Color(0xFF77393B);
 
+  // Shop-row delete glyph (.shop-row__del) — deeper than `error` per kit.css.
+  // No existing token: kit hardcodes #C62828 for the round red x glyph.
+  static const Color deleteGlyph = Color(0xFFC62828);
+
   // ── Semantic tokens ───────────────────────────────────────────
   static const Color fgStrong = Color(0xFF2C2C2C);
   static const Color fgDefault = Color(0xFF2D1F17);

--- a/lib/src/common/components/boilerplate/component_gallery.dart
+++ b/lib/src/common/components/boilerplate/component_gallery.dart
@@ -21,6 +21,7 @@ class _ComponentGalleryState extends State<ComponentGallery> {
   int _radioIndex = 0;
   int _navIndex = 0;
   int _dayIndex = 0;
+  bool _shopBought = false;
 
   @override
   Widget build(BuildContext context) {
@@ -213,6 +214,28 @@ class _ComponentGalleryState extends State<ComponentGallery> {
                   ),
                 ),
               ],
+            ),
+          ]),
+          _section('Shop rows', [
+            ShopRow(
+              label: 'Bananas',
+              isBought: _shopBought,
+              onToggle: () => setState(() => _shopBought = !_shopBought),
+              onDelete: () {},
+            ),
+            const SizedBox(height: AppSizes.sm),
+            ShopRow(
+              label: 'A really long ingredient name that should ellipsize',
+              isBought: false,
+              onToggle: () {},
+              onDelete: () {},
+            ),
+            const SizedBox(height: AppSizes.sm),
+            ShopRow(
+              label: 'Whole-wheat pasta',
+              isBought: true,
+              onToggle: () {},
+              onDelete: () {},
             ),
           ]),
           _section('Empty state', [

--- a/lib/src/common/components/cards/shop_row.dart
+++ b/lib/src/common/components/cards/shop_row.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Shopping-list row tile. Mirrors kit `.shop-row`:
+///
+/// * White card, 1px [AppColors.borderSoft] border, radiusMd.
+/// * Custom 22px square checkbox (radius 6, [AppColors.greenDeep] border;
+///   filled + cream check when [isBought]).
+/// * Body label, ellipsised on overflow, strikethrough + faint when [isBought].
+/// * Trailing round red x (10% [AppColors.error] tint, [AppColors.deleteGlyph]
+///   glyph) — destructive, single-tap.
+/// * Bought state swaps card bg to [AppColors.butterSoft] and border to
+///   [AppColors.butter].
+class ShopRow extends StatelessWidget {
+  const ShopRow({
+    required this.label,
+    required this.isBought,
+    required this.onToggle,
+    required this.onDelete,
+    super.key,
+  });
+
+  /// Item display name.
+  final String label;
+
+  /// `true` when the item is in the bought tab — applies bought styling.
+  final bool isBought;
+
+  /// Fires when the user taps the checkbox.
+  final VoidCallback onToggle;
+
+  /// Fires when the user taps the round red x.
+  final VoidCallback onDelete;
+
+  // Kit-spec sizes (.shop-row__cb / .shop-row__del).
+  static const double _affordance = 22;
+  static const double _cbRadius = 6;
+  static const double _checkGlyphSize = 13;
+  static const double _delGlyphSize = 14;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 120),
+      padding: const EdgeInsets.symmetric(
+        horizontal: 14,
+        vertical: AppSizes.sp12,
+      ),
+      decoration: BoxDecoration(
+        color: isBought ? AppColors.butterSoft : AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        border: Border.all(
+          color: isBought ? AppColors.butter : AppColors.borderSoft,
+        ),
+      ),
+      child: Row(
+        children: [
+          _ShopRowCheckbox(
+            value: isBought,
+            onTap: onToggle,
+          ),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: isBought ? AppColors.fgFaint : AppColors.fgDefault,
+                decoration:
+                    isBought ? TextDecoration.lineThrough : TextDecoration.none,
+                decorationColor: AppColors.fgFaint,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSizes.sp12),
+          _ShopRowDelete(onTap: onDelete, glyphSize: _delGlyphSize),
+        ],
+      ),
+    );
+  }
+
+  // Inner widgets are private classes — keep them off the public API.
+}
+
+class _ShopRowCheckbox extends StatelessWidget {
+  const _ShopRowCheckbox({required this.value, required this.onTap});
+
+  final bool value;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      checked: value,
+      button: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          width: ShopRow._affordance,
+          height: ShopRow._affordance,
+          decoration: BoxDecoration(
+            color: value ? AppColors.greenDeep : AppColors.surface,
+            borderRadius: BorderRadius.circular(ShopRow._cbRadius),
+            border: Border.all(color: AppColors.greenDeep, width: 1.5),
+          ),
+          child: value
+              ? const Center(
+                  child: Icon(
+                    Icons.check_rounded,
+                    size: ShopRow._checkGlyphSize,
+                    color: AppColors.cream,
+                  ),
+                )
+              : null,
+        ),
+      ),
+    );
+  }
+}
+
+class _ShopRowDelete extends StatelessWidget {
+  const _ShopRowDelete({required this.onTap, required this.glyphSize});
+
+  final VoidCallback onTap;
+  final double glyphSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: 'Delete',
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          width: ShopRow._affordance,
+          height: ShopRow._affordance,
+          decoration: BoxDecoration(
+            color: AppColors.error.withValues(alpha: 0.10),
+            borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+          ),
+          child: Center(
+            child: Icon(
+              Icons.close_rounded,
+              size: glyphSize,
+              color: AppColors.deleteGlyph,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/components.dart
+++ b/lib/src/common/components/components.dart
@@ -10,6 +10,7 @@ export 'buttons/app_round_button.dart';
 export 'calendar/day_chip.dart';
 export 'calendar/week_strip.dart';
 export 'cards/app_card.dart';
+export 'cards/shop_row.dart';
 export 'cards/tip_card.dart';
 export 'chips/app_chip.dart';
 export 'controls/app_checkbox.dart';

--- a/lib/src/common/components/controls/app_segmented_control.dart
+++ b/lib/src/common/components/controls/app_segmented_control.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 
 /// 2-up segmented control. Mirrors kit components-segmented preview:
-/// track #EAEAEA (borderSoft), radiusMd, active segment greenDeep/cream.
+/// track #EAEAEA (borderSoft), radiusMd, active segment greenDeep/cream,
+/// labels in Parkinsans display 700/15 (kit `var(--font-display)` 700 15px/1).
 class AppSegmentedControl extends StatelessWidget {
   const AppSegmentedControl({
     required this.segments,
@@ -18,8 +20,6 @@ class AppSegmentedControl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return Container(
       height: AppSizes.segmentedHeight,
       padding: const EdgeInsets.all(1),
@@ -43,8 +43,11 @@ class AppSegmentedControl extends StatelessWidget {
                 alignment: Alignment.center,
                 child: Text(
                   segments[i],
-                  style: theme.textTheme.bodyLarge?.copyWith(
+                  style: TextStyle(
+                    fontFamily: FontFamily.parkinsans,
+                    fontSize: 15,
                     fontWeight: FontWeight.w700,
+                    height: 1,
                     color: active ? AppColors.cream : AppColors.greenDeep,
                   ),
                 ),

--- a/test/common/components/cards/shop_row_test.dart
+++ b/test/common/components/cards/shop_row_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/common/components/cards/shop_row.dart';
+
+Widget _wrap({
+  required String label,
+  required bool isBought,
+  required VoidCallback onToggle,
+  required VoidCallback onDelete,
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Center(
+        child: ShopRow(
+          label: label,
+          isBought: isBought,
+          onToggle: onToggle,
+          onDelete: onDelete,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('ShopRow (NIB-54)', () {
+    testWidgets('renders label', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          label: 'Bananas',
+          isBought: false,
+          onToggle: () {},
+          onDelete: () {},
+        ),
+      );
+
+      expect(find.text('Bananas'), findsOneWidget);
+    });
+
+    testWidgets('tap on checkbox fires onToggle', (tester) async {
+      var toggled = 0;
+      await tester.pumpWidget(
+        _wrap(
+          label: 'Bananas',
+          isBought: false,
+          onToggle: () => toggled++,
+          onDelete: () {},
+        ),
+      );
+
+      // The unbought row has no check icon; tap the leading 22x22 box by
+      // hitting the Semantics node flagged checked: false.
+      final cb = find.byWidgetPredicate((w) {
+        if (w is! Semantics) return false;
+        final checked = w.properties.checked;
+        return checked != null && !checked;
+      });
+      await tester.tap(cb);
+      await tester.pump();
+
+      expect(toggled, 1);
+    });
+
+    testWidgets('tap on delete fires onDelete', (tester) async {
+      var deleted = 0;
+      await tester.pumpWidget(
+        _wrap(
+          label: 'Bananas',
+          isBought: false,
+          onToggle: () {},
+          onDelete: () => deleted++,
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.close_rounded));
+      await tester.pump();
+
+      expect(deleted, 1);
+    });
+
+    testWidgets('bought state shows check glyph and strikethrough label',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          label: 'Whole-wheat pasta',
+          isBought: true,
+          onToggle: () {},
+          onDelete: () {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Check glyph rendered.
+      expect(find.byIcon(Icons.check_rounded), findsOneWidget);
+
+      // Label is strikethrough + faint.
+      final label = tester.widget<Text>(find.text('Whole-wheat pasta'));
+      expect(label.style?.decoration, TextDecoration.lineThrough);
+      expect(label.style?.color, AppColors.fgFaint);
+    });
+
+    testWidgets('long label ellipsises', (tester) async {
+      const longText = 'A really long ingredient name that should ellipsize';
+      await tester.pumpWidget(
+        _wrap(
+          label: longText,
+          isBought: false,
+          onToggle: () {},
+          onDelete: () {},
+        ),
+      );
+
+      final label = tester.widget<Text>(find.text(longText));
+      expect(label.overflow, TextOverflow.ellipsis);
+      expect(label.maxLines, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the missing DS ShopRow tile, corrects the segmented control label font to match kit (`Parkinsans 700/15`, was Figtree), and introduces a `deleteGlyph` color token (#C62828) for the round red delete affordance. Quatrefoil already existed and matches spec — unchanged.

ShopRow is presentational-only (pure `StatelessWidget`); the existing `shopping_list_screen.dart` is NOT rewired — that's a separate ticket. ShopRow is added to the dev `ComponentGallery` for visual QA and is covered by a widget test mirroring the `brand_logo_test.dart` convention.

## Files

- `lib/src/common/components/cards/shop_row.dart` (new)
- `lib/src/common/components/controls/app_segmented_control.dart` (Parkinsans 15)
- `lib/src/app/themes/app_colors.dart` (+ `deleteGlyph`)
- `lib/src/common/components/components.dart` (export)
- `lib/src/common/components/boilerplate/component_gallery.dart` (gallery entry)
- `test/common/components/cards/shop_row_test.dart` (new)

## Acceptance criteria

- [x] Quatrefoil, SegmentedControl, and ShopRow render pixel-close to Figma 971:9851/971:9989 using DS tokens only (no hardcoded hex outside the foundation — added `deleteGlyph` token in `app_colors.dart`).
- [x] ShopRow toggles bought styling (butter-soft bg + butter border + strikethrough + faint label + check glyph) and exposes `onToggle` / `onDelete`.
- [x] Zero analyze warnings (`flutter analyze` clean).
- [x] Long item names ellipsize within the card.

## Gate results

- `make gen` — clean, idempotent (no diff on second run)
- `flutter analyze` — `No issues found!`
- `flutter test` — 486 passed, 1 skipped (no new failures)

## Out of scope

- Replacing `_ShoppingItemTile` in `shopping_list_screen.dart` with `ShopRow` (separate integration ticket).