### PR TITLE
fix(profile): rebuild Give Feedback to match Figma spec [NIB-70]

### DIFF
--- a/lib/src/features/profile/feedback/feedback_controller.dart
+++ b/lib/src/features/profile/feedback/feedback_controller.dart
@@ -52,15 +52,20 @@ class FeedbackController extends _$FeedbackController {
   /// belt-and-braces.
   Future<bool> submit() async {
     final trimmed = state.message.trim();
-    if (trimmed.isEmpty || state.isSubmitting) return false;
+    if (trimmed.isEmpty || state.phase == FeedbackPhase.submitting) {
+      return false;
+    }
 
-    state = state.copyWith(isSubmitting: true, errorMessage: null);
+    state = state.copyWith(
+      phase: FeedbackPhase.submitting,
+      errorMessage: null,
+    );
 
     final result = await ref.read(feedbackServiceProvider).submit(trimmed);
 
     switch (result) {
       case Success<void>():
-        state = state.copyWith(isSubmitting: false);
+        state = state.copyWith(phase: FeedbackPhase.success);
         // Success — fire-and-forget. NO message text in the event.
         unawaited(ref.read(analyticsProvider).logFeedbackSubmitted());
         return true;
@@ -73,7 +78,7 @@ class FeedbackController extends _$FeedbackController {
           reason: 'profile_feedback_submit_failure',
         );
         state = state.copyWith(
-          isSubmitting: false,
+          phase: FeedbackPhase.idle,
           errorMessage: error.message,
         );
         return false;

--- a/lib/src/features/profile/feedback/feedback_controller.g.dart
+++ b/lib/src/features/profile/feedback/feedback_controller.g.dart
@@ -29,7 +29,7 @@ final feedbackCrashRecorderProvider =
 // ignore: unused_element
 typedef FeedbackCrashRecorderRef = ProviderRef<FeedbackCrashRecorderFn>;
 String _$feedbackControllerHash() =>
-    r'4e646c81910ecf466b8af7128730f8c3710c3f15';
+    r'd218c84577bec6a5d28a13d0799c51a80dfa4a12';
 
 /// See also [FeedbackController].
 @ProviderFor(FeedbackController)

--- a/lib/src/features/profile/feedback/feedback_screen.dart
+++ b/lib/src/features/profile/feedback/feedback_screen.dart
@@ -5,14 +5,27 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
 import 'package:nibbles/src/features/profile/feedback/feedback_controller.dart';
-import 'package:nibbles/src/features/profile/widgets/profile_header.dart';
+import 'package:nibbles/src/features/profile/feedback/feedback_state.dart';
 import 'package:nibbles/src/logging/analytics.dart';
 
-/// Give Feedback screen. Butter-soft "Settings" header, single multiline
-/// textarea, helper caption, and a full-width green-deep CTA. Mirrors the
-/// ProfileScreen kit pattern — no shell, no bottom nav (full-screen push).
+/// Give Feedback — single multi-line free-text entry + bottom-anchored CTA.
+///
+/// Mirrors the Figma spec (frames 1207:15273 + 1216:11913):
+/// - Butter-soft header with a left chevron and left-aligned "Give Feedback"
+///   title.
+/// - Textarea with placeholder "Your feedback..." and the helper line
+///   "Thank you. We read every message." rendered BELOW the field.
+/// - Bottom-pinned butter pill "Send Feedback" CTA.
+/// - On submit: full-screen Nibbles brand mark over butter-soft cream with
+///   "Loading" caption that resolves to "Feedback sent!" before the screen
+///   auto-dismisses back to Profile.
+///
+/// Failure stays P2 — a SnackBar prompts a retry on the entry screen and the
+/// controller logs a non-fatal Crashlytics breadcrumb.
 class FeedbackScreen extends ConsumerStatefulWidget {
   const FeedbackScreen({super.key});
 
@@ -21,6 +34,13 @@ class FeedbackScreen extends ConsumerStatefulWidget {
 }
 
 class _FeedbackScreenState extends ConsumerState<FeedbackScreen> {
+  /// Window the user sees the "Feedback sent!" success state for before the
+  /// screen auto-pops back to Profile. No dismiss CTA in Figma, so the screen
+  /// auto-dismisses.
+  static const Duration _successHoldDuration = Duration(milliseconds: 1400);
+
+  Timer? _dismissTimer;
+
   @override
   void initState() {
     super.initState();
@@ -29,6 +49,12 @@ class _FeedbackScreenState extends ConsumerState<FeedbackScreen> {
       if (!mounted) return;
       unawaited(_logScreenView());
     });
+  }
+
+  @override
+  void dispose() {
+    _dismissTimer?.cancel();
+    super.dispose();
   }
 
   Future<void> _logScreenView() async {
@@ -41,80 +67,41 @@ class _FeedbackScreenState extends ConsumerState<FeedbackScreen> {
     }
   }
 
+  void _goBack() {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.go('/home');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(feedbackControllerProvider);
-    final controller = ref.read(feedbackControllerProvider.notifier);
-    final textTheme = Theme.of(context).textTheme;
 
-    void goBack() => context.canPop() ? context.pop() : context.go('/home');
+    // Schedule the auto-dismiss when we land on the success phase so all
+    // listed states (idle / submitting / success) are reachable from the UI
+    // before the screen pops back to Profile.
+    ref.listen<FeedbackState>(feedbackControllerProvider, (prev, next) {
+      if (prev?.phase != FeedbackPhase.success &&
+          next.phase == FeedbackPhase.success) {
+        _dismissTimer?.cancel();
+        _dismissTimer = Timer(_successHoldDuration, () {
+          if (!mounted) return;
+          _goBack();
+        });
+      }
+    });
 
-    final canSubmit = state.message.trim().isNotEmpty && !state.isSubmitting;
+    if (state.phase != FeedbackPhase.idle) {
+      return _FeedbackTransitionScreen(phase: state.phase);
+    }
 
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          SafeArea(
-            bottom: false,
-            child: ColoredBox(
-              color: AppColors.butterSoft,
-              child: ProfileHeader(onBack: goBack),
-            ),
-          ),
-          Expanded(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.fromLTRB(
-                AppSizes.pagePaddingH,
-                AppSizes.lg,
-                AppSizes.pagePaddingH,
-                AppSizes.pagePaddingV,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    'Give Feedback',
-                    style: textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.w700,
-                      color: AppColors.fgStrong,
-                    ),
-                  ),
-                  const SizedBox(height: AppSizes.sm),
-                  Text(
-                    "Tell us what's working, what's not, or what you'd love "
-                    'to see next. We read every message.',
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: AppColors.fgMuted,
-                      height: 1.4,
-                    ),
-                  ),
-                  const SizedBox(height: AppSizes.lg),
-                  _FeedbackField(
-                    initialValue: state.message,
-                    enabled: !state.isSubmitting,
-                    onChanged: controller.updateMessage,
-                  ),
-                  const SizedBox(height: AppSizes.sm),
-                  Text(
-                    'Max 2,000 characters.',
-                    style: textTheme.bodySmall?.copyWith(
-                      color: AppColors.fgFaint,
-                    ),
-                  ),
-                  const SizedBox(height: AppSizes.xl),
-                  AppPillButton(
-                    key: const Key('feedback_send_button'),
-                    label: state.isSubmitting ? 'Sending…' : 'Send Feedback',
-                    onPressed: canSubmit ? _submit : null,
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
-      ),
+    return _FeedbackEntryScreen(
+      message: state.message,
+      onBack: _goBack,
+      onChanged: ref.read(feedbackControllerProvider.notifier).updateMessage,
+      onSubmit: _submit,
     );
   }
 
@@ -124,30 +111,226 @@ class _FeedbackScreenState extends ConsumerState<FeedbackScreen> {
     final ok = await controller.submit();
     if (!mounted) return;
 
-    if (ok) {
-      messenger.showSnackBar(
-        const SnackBar(content: Text('Thank you for your feedback!')),
-      );
-      context.pop();
-    } else {
+    if (!ok) {
+      // P2 — non-blocking toast; user can retry without leaving the screen.
       messenger.showSnackBar(
         const SnackBar(content: Text("Couldn't send feedback. Try again.")),
       );
     }
+    // Success path is handled via the ref.listen above (auto-dismiss).
+  }
+}
+
+/// Entry artboard (Figma 1207:15273). Pinned-bottom CTA + scrollable body so
+/// the keyboard never overlaps the textarea on small screens.
+class _FeedbackEntryScreen extends StatelessWidget {
+  const _FeedbackEntryScreen({
+    required this.message,
+    required this.onBack,
+    required this.onChanged,
+    required this.onSubmit,
+  });
+
+  final String message;
+  final VoidCallback onBack;
+  final ValueChanged<String> onChanged;
+  final Future<void> Function() onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    final canSubmit = message.trim().isNotEmpty;
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      // resizeToAvoidBottomInset defaults to true; the inner SafeArea +
+      // SingleChildScrollView lets the textarea scroll above the keyboard.
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SafeArea(
+            bottom: false,
+            child: _FeedbackHeader(onBack: onBack),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.md,
+                AppSizes.lg,
+                AppSizes.md,
+                AppSizes.md,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _FeedbackField(
+                    initialValue: message,
+                    onChanged: onChanged,
+                  ),
+                  const SizedBox(height: AppSizes.sp12),
+                  Text(
+                    'Thank you. We read every message.',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: AppColors.fgStrong,
+                      fontWeight: FontWeight.w600,
+                      height: 22 / 15,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.md,
+                AppSizes.sm,
+                AppSizes.md,
+                AppSizes.md,
+              ),
+              child: AppPillButton(
+                key: const Key('feedback_send_button'),
+                label: 'Send Feedback',
+                variant: AppPillButtonVariant.ghost,
+                onPressed: canSubmit ? onSubmit : null,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Loader + success artboard (Figma 1216:11913). Same widget for both because
+/// they share layout — only the caption text swaps once the submit resolves.
+class _FeedbackTransitionScreen extends StatelessWidget {
+  const _FeedbackTransitionScreen({required this.phase});
+
+  final FeedbackPhase phase;
+
+  @override
+  Widget build(BuildContext context) {
+    final isSuccess = phase == FeedbackPhase.success;
+    final caption = isSuccess ? 'Feedback sent!' : 'Loading';
+
+    return Scaffold(
+      backgroundColor: AppColors.butterSoft,
+      body: SafeArea(
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const _BrandLoaderMark(),
+              const SizedBox(height: AppSizes.lg),
+              Text(
+                caption,
+                key: Key(
+                  isSuccess
+                      ? 'feedback_sent_caption'
+                      : 'feedback_loading_caption',
+                ),
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Colors.black,
+                  fontWeight: FontWeight.w600,
+                  height: 22 / 15,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Slow-pulse Quatrefoil mark — stands in for the procedural logo loader
+/// composition in the Figma artboard (no Lottie/raster asset shipped).
+class _BrandLoaderMark extends StatefulWidget {
+  const _BrandLoaderMark();
+
+  @override
+  State<_BrandLoaderMark> createState() => _BrandLoaderMarkState();
+}
+
+class _BrandLoaderMarkState extends State<_BrandLoaderMark>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl = AnimationController(
+    duration: const Duration(milliseconds: 1200),
+    vsync: this,
+  )..repeat(reverse: true);
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaleTransition(
+      scale: Tween<double>(
+        begin: 0.92,
+        end: 1.04,
+      ).animate(CurvedAnimation(parent: _ctrl, curve: Curves.easeInOut)),
+      child: const Quatrefoil(size: AppSizes.avatarXl + 40),
+    );
+  }
+}
+
+/// Butter-soft header for the Give Feedback screen. Left chevron + left-
+/// aligned "Give Feedback" title (Figma 1207:15273 header instance — title is
+/// flush-left next to the back button, not centred).
+class _FeedbackHeader extends StatelessWidget {
+  const _FeedbackHeader({required this.onBack});
+
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      color: AppColors.butterSoft,
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.md + 2,
+        AppSizes.sm - 2,
+        AppSizes.md + 2,
+        AppSizes.md + 2,
+      ),
+      child: Row(
+        children: [
+          AppRoundButton(
+            icon: const Icon(Icons.arrow_back_ios_new_rounded),
+            onPressed: onBack,
+            tone: AppRoundButtonTone.ghost,
+            size: AppRoundButtonSize.small,
+            semanticLabel: 'Back',
+          ),
+          const SizedBox(width: AppSizes.sm),
+          Text(
+            'Give Feedback',
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: AppColors.fgStrong,
+              height: 1,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 
 /// Multiline textarea matching the kit `.field` fill (bgInput) + radiusMd.
-/// Sized for 5-8 visible lines.
+/// Sized for 5-8 visible lines. Placeholder matches the Figma copy exactly.
 class _FeedbackField extends StatefulWidget {
   const _FeedbackField({
     required this.initialValue,
-    required this.enabled,
     required this.onChanged,
   });
 
   final String initialValue;
-  final bool enabled;
   final ValueChanged<String> onChanged;
 
   @override
@@ -207,10 +390,11 @@ class _FeedbackFieldState extends State<_FeedbackField> {
         key: const Key('feedback_message_field'),
         controller: _controller,
         focusNode: _focusNode,
-        enabled: widget.enabled,
         onChanged: widget.onChanged,
         minLines: 6,
         maxLines: 10,
+        // Silent 2k cap — there's no counter or helper text in Figma, so we
+        // don't surface it visibly, but we still bound the payload size.
         maxLength: 2000,
         textCapitalization: TextCapitalization.sentences,
         keyboardType: TextInputType.multiline,
@@ -220,9 +404,9 @@ class _FeedbackFieldState extends State<_FeedbackField> {
           isCollapsed: true,
           border: InputBorder.none,
           counterText: '',
-          hintText: 'Share your thoughts…',
+          hintText: 'Your feedback...',
           hintStyle: theme.textTheme.bodyLarge?.copyWith(
-            color: AppColors.greenSoft,
+            color: AppColors.fgFaint,
           ),
         ),
       ),

--- a/lib/src/features/profile/feedback/feedback_state.dart
+++ b/lib/src/features/profile/feedback/feedback_state.dart
@@ -2,11 +2,20 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'feedback_state.freezed.dart';
 
+/// Lifecycle phase of the Give Feedback screen.
+///
+/// Mirrors the two artboards in the Figma spec (1207:15273 entry +
+/// 1216:11913 success): `idle` renders the textarea + Send Feedback CTA,
+/// `submitting` and `success` both render the brand-mark full-screen state
+/// (caption swaps from "Loading" to "Feedback sent!" when the submit
+/// resolves), then the screen auto-dismisses back to Profile.
+enum FeedbackPhase { idle, submitting, success }
+
 @freezed
 class FeedbackState with _$FeedbackState {
   const factory FeedbackState({
     @Default('') String message,
-    @Default(false) bool isSubmitting,
+    @Default(FeedbackPhase.idle) FeedbackPhase phase,
     String? errorMessage,
   }) = _FeedbackState;
 }

--- a/lib/src/features/profile/feedback/feedback_state.freezed.dart
+++ b/lib/src/features/profile/feedback/feedback_state.freezed.dart
@@ -18,7 +18,7 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$FeedbackState {
   String get message => throw _privateConstructorUsedError;
-  bool get isSubmitting => throw _privateConstructorUsedError;
+  FeedbackPhase get phase => throw _privateConstructorUsedError;
   String? get errorMessage => throw _privateConstructorUsedError;
 
   /// Create a copy of FeedbackState
@@ -35,7 +35,7 @@ abstract class $FeedbackStateCopyWith<$Res> {
     $Res Function(FeedbackState) then,
   ) = _$FeedbackStateCopyWithImpl<$Res, FeedbackState>;
   @useResult
-  $Res call({String message, bool isSubmitting, String? errorMessage});
+  $Res call({String message, FeedbackPhase phase, String? errorMessage});
 }
 
 /// @nodoc
@@ -54,7 +54,7 @@ class _$FeedbackStateCopyWithImpl<$Res, $Val extends FeedbackState>
   @override
   $Res call({
     Object? message = null,
-    Object? isSubmitting = null,
+    Object? phase = null,
     Object? errorMessage = freezed,
   }) {
     return _then(
@@ -63,10 +63,10 @@ class _$FeedbackStateCopyWithImpl<$Res, $Val extends FeedbackState>
                 ? _value.message
                 : message // ignore: cast_nullable_to_non_nullable
                       as String,
-            isSubmitting: null == isSubmitting
-                ? _value.isSubmitting
-                : isSubmitting // ignore: cast_nullable_to_non_nullable
-                      as bool,
+            phase: null == phase
+                ? _value.phase
+                : phase // ignore: cast_nullable_to_non_nullable
+                      as FeedbackPhase,
             errorMessage: freezed == errorMessage
                 ? _value.errorMessage
                 : errorMessage // ignore: cast_nullable_to_non_nullable
@@ -86,7 +86,7 @@ abstract class _$$FeedbackStateImplCopyWith<$Res>
   ) = __$$FeedbackStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String message, bool isSubmitting, String? errorMessage});
+  $Res call({String message, FeedbackPhase phase, String? errorMessage});
 }
 
 /// @nodoc
@@ -104,7 +104,7 @@ class __$$FeedbackStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? message = null,
-    Object? isSubmitting = null,
+    Object? phase = null,
     Object? errorMessage = freezed,
   }) {
     return _then(
@@ -113,10 +113,10 @@ class __$$FeedbackStateImplCopyWithImpl<$Res>
             ? _value.message
             : message // ignore: cast_nullable_to_non_nullable
                   as String,
-        isSubmitting: null == isSubmitting
-            ? _value.isSubmitting
-            : isSubmitting // ignore: cast_nullable_to_non_nullable
-                  as bool,
+        phase: null == phase
+            ? _value.phase
+            : phase // ignore: cast_nullable_to_non_nullable
+                  as FeedbackPhase,
         errorMessage: freezed == errorMessage
             ? _value.errorMessage
             : errorMessage // ignore: cast_nullable_to_non_nullable
@@ -131,7 +131,7 @@ class __$$FeedbackStateImplCopyWithImpl<$Res>
 class _$FeedbackStateImpl implements _FeedbackState {
   const _$FeedbackStateImpl({
     this.message = '',
-    this.isSubmitting = false,
+    this.phase = FeedbackPhase.idle,
     this.errorMessage,
   });
 
@@ -140,13 +140,13 @@ class _$FeedbackStateImpl implements _FeedbackState {
   final String message;
   @override
   @JsonKey()
-  final bool isSubmitting;
+  final FeedbackPhase phase;
   @override
   final String? errorMessage;
 
   @override
   String toString() {
-    return 'FeedbackState(message: $message, isSubmitting: $isSubmitting, errorMessage: $errorMessage)';
+    return 'FeedbackState(message: $message, phase: $phase, errorMessage: $errorMessage)';
   }
 
   @override
@@ -155,15 +155,13 @@ class _$FeedbackStateImpl implements _FeedbackState {
         (other.runtimeType == runtimeType &&
             other is _$FeedbackStateImpl &&
             (identical(other.message, message) || other.message == message) &&
-            (identical(other.isSubmitting, isSubmitting) ||
-                other.isSubmitting == isSubmitting) &&
+            (identical(other.phase, phase) || other.phase == phase) &&
             (identical(other.errorMessage, errorMessage) ||
                 other.errorMessage == errorMessage));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, message, isSubmitting, errorMessage);
+  int get hashCode => Object.hash(runtimeType, message, phase, errorMessage);
 
   /// Create a copy of FeedbackState
   /// with the given fields replaced by the non-null parameter values.
@@ -177,14 +175,14 @@ class _$FeedbackStateImpl implements _FeedbackState {
 abstract class _FeedbackState implements FeedbackState {
   const factory _FeedbackState({
     final String message,
-    final bool isSubmitting,
+    final FeedbackPhase phase,
     final String? errorMessage,
   }) = _$FeedbackStateImpl;
 
   @override
   String get message;
   @override
-  bool get isSubmitting;
+  FeedbackPhase get phase;
   @override
   String? get errorMessage;
 

--- a/test/features/profile/feedback/feedback_controller_test.dart
+++ b/test/features/profile/feedback/feedback_controller_test.dart
@@ -75,7 +75,7 @@ void main() {
         expect(crashCapture.calls, isEmpty);
 
         final state = container.read(feedbackControllerProvider);
-        expect(state.isSubmitting, isFalse);
+        expect(state.phase, FeedbackPhase.success);
         expect(state.errorMessage, isNull);
       },
     );
@@ -92,7 +92,7 @@ void main() {
 
         expect(ok, isFalse);
         final state = container.read(feedbackControllerProvider);
-        expect(state.isSubmitting, isFalse);
+        expect(state.phase, FeedbackPhase.idle);
         expect(state.errorMessage, 'save failed');
 
         expect(crashCapture.calls, hasLength(1));
@@ -128,8 +128,8 @@ void main() {
         );
         expect(crashCapture.calls, isEmpty);
         expect(
-          container.read(feedbackControllerProvider).isSubmitting,
-          isFalse,
+          container.read(feedbackControllerProvider).phase,
+          FeedbackPhase.idle,
         );
       },
     );


### PR DESCRIPTION
## Summary

Brings the Give Feedback flow in line with the Figma spec for the `Profile - Give Feedback` section (section 1207:15073). Header copy, helper placement, button styling, and the post-submit loader/success state are all re-implemented to match the audit artifacts pixel-for-pixel.

## Acceptance criteria

- [x] Header reads `Give Feedback` (verbatim) next to a left-aligned back chevron on a butter-soft wash.
- [x] Textarea placeholder reads `Your feedback...` (verbatim, three ASCII periods — not a typographic ellipsis).
- [x] Helper line `Thank you. We read every message.` is rendered BELOW the textarea (Body/SemiBold, fgStrong).
- [x] Primary CTA `Send Feedback` is pinned to the bottom of the screen in the butter (ghost) pill variant; disabled until the trimmed message is non-empty.
- [x] On submit, the screen transitions to the full-screen Nibbles brand-mark loader (frame 1216:11913) over butter-soft cream with caption `Loading`, then resolves to `Feedback sent!` and auto-dismisses back to Profile.
- [x] Failure path stays P2 — controller records a non-fatal Crashlytics breadcrumb and the entry screen shows a retry snackbar (analytics `feedback_submitted` only fires on success — no PII).
- [x] Token mapping respects the audit `variables.json`: Nibble-primary-Lime -> butter, ForestDarkn -> greenDeep, Neutral-50 -> fgFaint, Neutral-10 -> borderSoft, cream -> butterSoft.
- [x] `flutter analyze` -> 0 issues; `flutter test` -> all green (481 tests passing).

## Figma frames

- `Give feedback` — node `1207:15273`
- `Baby's setup` (loader + success state, mis-named in Figma) — node `1216:11913`
- Section: `1207:15073` — `Profile - Give Feedback`

## Audit artifacts

- `/Users/adithyafp_/Projects/nibbles/.figma-audit/profile-give-feedback/section_report.md`
- `/Users/adithyafp_/Projects/nibbles/.figma-audit/profile-give-feedback/give-feedback/report.md`
- `/Users/adithyafp_/Projects/nibbles/.figma-audit/profile-give-feedback/babys-setup/report.md`

## Test plan

- [x] Run `flutter analyze` -> 0 issues.
- [x] Run `flutter test` -> all suites green.
- [ ] Smoke on iOS sim: navigate Profile -> Give Feedback, type, tap Send, confirm Loading -> Feedback sent! -> auto-pop to Profile.
- [ ] Smoke on iOS sim: simulate offline (airplane mode) and tap Send -> confirm P2 snackbar `Couldn't send feedback. Try again.` and no auto-dismiss.