### PR TITLE
fix(profile): align edit screen with Figma 1200:10475 [NIB-62]

### DIFF
--- a/lib/src/features/profile/edit/profile_edit_screen.dart
+++ b/lib/src/features/profile/edit/profile_edit_screen.dart
@@ -16,13 +16,24 @@ import 'package:nibbles/src/features/profile/edit/profile_edit_state.dart';
 import 'package:nibbles/src/features/profile/profile_controller.dart';
 import 'package:nibbles/src/logging/analytics.dart';
 
+// ── Figma frame 1200:10475 spec values (profile-edit only) ──────────────
+// Avatar PNG is 143x143 in Figma; no asset shipped, so we keep the coral
+// circle + cream icon (same fallback used by ProfileAvatarCard) at 143px.
+const double _kEditAvatarSize = 143;
+// Form column inset: 16px left, 17px right (Figma); use 16 symmetrically.
+const double _kFormPaddingH = 16;
+// Field group gap (between fields) = 17; label→input gap = 11.
+const double _kFieldGroupGap = 17;
+const double _kLabelGap = 11;
+// Page background Grad-1 (linear-gradient 154.372deg butter→light-grey).
+const Color _kGradEnd = Color(0xFFF5F5F5);
+
 /// PR-02 — Edit Profile.
 ///
-/// Mirrors Figma frame 1200:10475 (`ProfileEditScreen` in
-/// `design/ui_kits/nibbles_mobile/ProfileScreen.jsx`): butter-soft wash
-/// header with a back chevron + "Change Profile" title, coral avatar puck,
-/// then a cream form pane with First Name / Last Name (Optional) / Email
-/// labelled fields and a full-width primary "Save" pill.
+/// Mirrors Figma frame 1200:10475: Grad-1 page wash (butter→#f5f5f5 at
+/// ~154°), back chip + "Change Profile" header, 143px coral avatar puck,
+/// then First Name / Last Name (Optional) / Email labelled fields and a
+/// primary "Save" pill.
 class ProfileEditScreen extends ConsumerStatefulWidget {
   const ProfileEditScreen({super.key});
 
@@ -56,8 +67,7 @@ class _ProfileEditScreenState extends ConsumerState<ProfileEditScreen> {
     final babyIdAsync = ref.watch(currentBabyIdProvider);
 
     return babyIdAsync.when(
-      loading: () => const Scaffold(
-        backgroundColor: AppColors.background,
+      loading: () => const _ProfileEditScaffold(
         body: Center(child: CircularProgressIndicator()),
       ),
       error: (_, __) => _ProfileEditError(
@@ -87,8 +97,7 @@ class _ProfileEditBody extends ConsumerWidget {
     final asyncState = ref.watch(profileEditControllerProvider(babyId));
 
     return asyncState.when(
-      loading: () => const Scaffold(
-        backgroundColor: AppColors.background,
+      loading: () => const _ProfileEditScaffold(
         body: Center(child: CircularProgressIndicator()),
       ),
       error: (err, _) => _ProfileEditError(
@@ -154,86 +163,95 @@ class _ProfileEditFormState extends ConsumerState<_ProfileEditForm> {
 
     void goBack() => context.canPop() ? context.pop() : context.go('/home');
 
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          SafeArea(
-            bottom: false,
-            child: ColoredBox(
-              color: AppColors.butterSoft,
-              child: Column(
-                children: [
-                  _EditHeader(onBack: goBack),
-                  const _EditAvatar(),
-                ],
-              ),
-            ),
-          ),
-          Expanded(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.fromLTRB(
-                AppSizes.pagePaddingH,
-                AppSizes.sm,
-                AppSizes.pagePaddingH,
-                AppSizes.md,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  AppTextField(
-                    key: const Key('edit_first_name_field'),
-                    label: 'First Name',
-                    controller: _firstNameController,
-                    onChanged: controller.updateFirstName,
-                    textInputAction: TextInputAction.next,
-                  ),
-                  const SizedBox(height: AppSizes.md),
-                  AppTextField(
-                    key: const Key('edit_last_name_field'),
-                    label: 'Last Name (Optional)',
-                    controller: _lastNameController,
-                    onChanged: controller.updateLastName,
-                    textInputAction: TextInputAction.next,
-                  ),
-                  const SizedBox(height: AppSizes.md),
-                  AppTextField(
-                    key: const Key('edit_email_field'),
-                    label: 'Email',
-                    controller: _emailController,
-                    keyboardType: TextInputType.emailAddress,
-                    textInputAction: TextInputAction.done,
-                    onChanged: (value) {
-                      if (!_emailTouched) {
-                        setState(() => _emailTouched = true);
-                      }
-                      controller.updateEmail(value);
-                    },
-                    errorText: _emailTouched && !emailValid
-                        ? 'Enter a valid email address.'
-                        : null,
-                  ),
-                  if (formState.errorMessage != null) ...[
-                    const SizedBox(height: AppSizes.sm),
-                    Text(
-                      formState.errorMessage!,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: AppColors.error,
+    final labelStyle = theme.textTheme.titleSmall?.copyWith(
+      fontSize: 15,
+      fontWeight: FontWeight.w600,
+      height: 22 / 15,
+      color: AppColors.fgStrong,
+    );
+
+    return _ProfileEditScaffold(
+      body: SafeArea(
+        bottom: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _EditHeader(onBack: goBack),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(
+                  _kFormPaddingH,
+                  0,
+                  _kFormPaddingH,
+                  AppSizes.md,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const _EditAvatar(),
+                    const SizedBox(height: _kFieldGroupGap),
+                    _LabelledField(
+                      label: 'First Name',
+                      labelStyle: labelStyle,
+                      field: AppTextField(
+                        key: const Key('edit_first_name_field'),
+                        controller: _firstNameController,
+                        onChanged: controller.updateFirstName,
+                        textInputAction: TextInputAction.next,
                       ),
                     ),
+                    const SizedBox(height: _kFieldGroupGap),
+                    _LabelledField(
+                      label: 'Last Name (Optional)',
+                      labelStyle: labelStyle,
+                      field: AppTextField(
+                        key: const Key('edit_last_name_field'),
+                        controller: _lastNameController,
+                        onChanged: controller.updateLastName,
+                        textInputAction: TextInputAction.next,
+                      ),
+                    ),
+                    const SizedBox(height: _kFieldGroupGap),
+                    _LabelledField(
+                      label: 'Email',
+                      labelStyle: labelStyle,
+                      field: AppTextField(
+                        key: const Key('edit_email_field'),
+                        controller: _emailController,
+                        keyboardType: TextInputType.emailAddress,
+                        textInputAction: TextInputAction.done,
+                        onChanged: (value) {
+                          if (!_emailTouched) {
+                            setState(() => _emailTouched = true);
+                          }
+                          controller.updateEmail(value);
+                        },
+                        errorText: _emailTouched && !emailValid
+                            ? 'Enter a valid email address.'
+                            : null,
+                      ),
+                    ),
+                    if (formState.errorMessage != null) ...[
+                      const SizedBox(height: AppSizes.sm),
+                      Text(
+                        formState.errorMessage!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: AppColors.error,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: AppSizes.xl - 4),
+                    AppPillButton(
+                      key: const Key('edit_profile_save_button'),
+                      label: formState.isLoading ? 'Saving…' : 'Save',
+                      onPressed: canSave ? _save : null,
+                    ),
                   ],
-                  const SizedBox(height: AppSizes.xl - 4),
-                  AppPillButton(
-                    key: const Key('edit_profile_save_button'),
-                    label: formState.isLoading ? 'Saving…' : 'Save',
-                    onPressed: canSave ? _save : null,
-                  ),
-                ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -258,6 +276,34 @@ class _ProfileEditFormState extends ConsumerState<_ProfileEditForm> {
   }
 }
 
+/// Scaffold with the Grad-1 page wash (Figma: linear-gradient 154.372deg
+/// from #fffcd5 at 19.168% to #f5f5f5 at 50%). Flutter's [LinearGradient]
+/// uses begin/end alignments; ~154° clockwise from "up" maps to a top-left
+/// → bottom-right diagonal — Alignment.topLeft → Alignment.bottomRight.
+class _ProfileEditScaffold extends StatelessWidget {
+  const _ProfileEditScaffold({required this.body});
+
+  final Widget body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.butterSoft,
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.19, 0.5],
+            colors: [AppColors.butterSoft, _kGradEnd],
+          ),
+        ),
+        child: body,
+      ),
+    );
+  }
+}
+
 class _EditHeader extends StatelessWidget {
   const _EditHeader({required this.onBack});
 
@@ -266,30 +312,26 @@ class _EditHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      color: AppColors.butterSoft,
+    return Padding(
       padding: const EdgeInsets.fromLTRB(
-        AppSizes.md + 2,
-        AppSizes.sm - 2,
-        AppSizes.md + 2,
-        AppSizes.md + 2,
+        AppSizes.sp12,
+        AppSizes.sm,
+        AppSizes.sp12,
+        AppSizes.sm,
       ),
       child: Row(
         children: [
-          SizedBox(
-            width: AppSizes.roundButtonSm,
-            child: AppRoundButton(
-              icon: const Icon(Icons.arrow_back_ios_new_rounded),
-              onPressed: onBack,
-              tone: AppRoundButtonTone.ghost,
-              size: AppRoundButtonSize.small,
-              semanticLabel: 'Back',
-            ),
+          AppRoundButton(
+            icon: const Icon(Icons.arrow_back_ios_new_rounded),
+            onPressed: onBack,
+            tone: AppRoundButtonTone.ghost,
+            size: AppRoundButtonSize.small,
+            semanticLabel: 'Back',
           ),
+          const SizedBox(width: AppSizes.sp2),
           Expanded(
             child: Text(
               'Change Profile',
-              textAlign: TextAlign.center,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.w700,
                 color: AppColors.fgStrong,
@@ -297,7 +339,6 @@ class _EditHeader extends StatelessWidget {
               ),
             ),
           ),
-          const SizedBox(width: AppSizes.roundButtonSm),
         ],
       ),
     );
@@ -309,31 +350,50 @@ class _EditAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: AppColors.butterSoft,
-      padding: const EdgeInsets.fromLTRB(
-        AppSizes.md + 2,
-        0,
-        AppSizes.md + 2,
-        AppSizes.md + 2,
-      ),
-      child: Center(
-        child: Container(
-          width: AppSizes.avatarXl,
-          height: AppSizes.avatarXl,
-          decoration: const BoxDecoration(
-            color: AppColors.coral,
-            shape: BoxShape.circle,
-          ),
-          child: const Center(
-            child: Icon(
-              Icons.child_care_rounded,
-              size: AppSizes.xxxl,
-              color: AppColors.cream,
-            ),
+    return Center(
+      child: Container(
+        width: _kEditAvatarSize,
+        height: _kEditAvatarSize,
+        decoration: const BoxDecoration(
+          color: AppColors.coral,
+          shape: BoxShape.circle,
+        ),
+        child: const Center(
+          child: Icon(
+            Icons.child_care_rounded,
+            // ~74px glyph fits the 143px coral puck while echoing the
+            // ProfileScreen avatar proportions (64 glyph in 120 puck).
+            size: 74,
+            color: AppColors.cream,
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Field row matching Figma: label (Parkinsans SemiBold 15) then field with
+/// an 11px gap. Used in the Profile Edit form for First/Last/Email.
+class _LabelledField extends StatelessWidget {
+  const _LabelledField({
+    required this.label,
+    required this.field,
+    required this.labelStyle,
+  });
+
+  final String label;
+  final Widget field;
+  final TextStyle? labelStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(label, style: labelStyle),
+        const SizedBox(height: _kLabelGap),
+        field,
+      ],
     );
   }
 }
@@ -347,8 +407,7 @@ class _ProfileEditError extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Scaffold(
-      backgroundColor: AppColors.background,
+    return _ProfileEditScaffold(
       body: SafeArea(
         child: Center(
           child: Padding(


### PR DESCRIPTION
## Summary
Profile Edit (PR-02) remediation to match Figma frame 1200:10475 (`Profile - edit`). Screen-local restyling only — no shared design-system component or theme token mutations (per kit-wins-over-pixels policy in `app_sizes.dart`/`app_pill_button.dart`).

## Deltas closed
- Page background → Grad-1 wash: `LinearGradient(begin: topLeft, end: bottomRight, stops: [0.19, 0.5], colors: [butterSoft (#fffcd5), #f5f5f5])` (Figma 154.372deg ≈ TL→BR).
- Coral avatar puck sized to 143×143 (Figma spec). Asset PNG `Nibbles Graphic_Circle Peach 1` not shipped; fall back to the same `Icons.child_care_rounded` + cream glyph pattern used by `ProfileAvatarCard` to stay consistent.
- Header back chip + "Change Profile" title — left-aligned title row matching Figma (no centered fake-symmetry padding).
- Form inset 16px L/R (was page-padding 20).
- Field group gap 17, label→input gap 11 (Figma tokens 17 / 11).
- Field labels rendered externally with Parkinsans SemiBold 15 / lineHeight 22 (Headline/SemiBold) instead of the AppTextField internal Figtree-700 label.
- Error and loading states now use the same Grad-1 scaffold so back navigation keeps the wash.

## Acceptance criteria
- [x] Verbatim copy: `Change Profile`, `First Name`, `Last Name (Optional)`, `Email`, `Save`.
- [x] Save CTA uses `AppPillButton` primary (DS-tracked).
- [x] Loading / error / populated states all rendered through `_ProfileEditScaffold` (gradient).
- [x] No shared component mutation, no theme token addition.
- [x] `make gen` → no unrelated regenerated files staged.
- [x] `flutter analyze` → 0 issues.
- [x] `flutter test` → 481 passed, 1 skipped.

## Figma references
- Frame: 1200:10475 — Profile - edit
- File: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1200-10475

## Audit artifacts
- `.figma-audit/profile-edit/profile-edit/report.md`
- `.figma-audit/profile-edit/profile-edit/screenshot.png`
- `.figma-audit/profile-edit/profile-edit/variables.json`

## Test plan
- [ ] Open the app, navigate `/home → Profile → Edit`, verify gradient wash, 143 avatar, label typography, and field spacing match the Figma render.
- [ ] Edit first name, save → snackbar `Profile updated.`, returns to `/home/profile`.
- [ ] Edit email → snackbar `Please check your inbox to confirm the new email.`
- [ ] Loading and error states show the gradient background.