### PR TITLE
fix(profile): Figma-aligned remediation [NIB-52]

### DIFF
--- a/lib/src/features/profile/profile_screen.dart
+++ b/lib/src/features/profile/profile_screen.dart
@@ -108,89 +108,98 @@ class _ProfileContent extends ConsumerWidget {
 
     void goBack() => context.canPop() ? context.pop() : context.go('/home');
 
+    // Figma audit (node 1189:10278): screen background is
+    // linear-gradient(152.612deg, #FFFCD5 19.168%, #F5F5F5 50%) (Grad-1).
     return Scaffold(
       backgroundColor: AppColors.background,
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          SafeArea(
-            bottom: false,
-            child: ColoredBox(
-              color: AppColors.butterSoft,
-              child: Column(
-                children: [
-                  ProfileHeader(onBack: goBack),
-                  ProfileAvatarCard(
-                    name: baby.name,
-                    ageLabel: _ageLabel(baby.dateOfBirth),
-                    onEdit: () => context.pushNamed(
-                      AppRoute.profileEdit.name,
-                    ),
-                  ),
-                ],
-              ),
-            ),
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            // 152.612deg in CSS ≈ Alignment(sinθ, -cosθ).
+            // sin(152.612°) ≈ 0.460, cos(152.612°) ≈ -0.888.
+            begin: Alignment(-0.460, 0.888),
+            end: Alignment(0.460, -0.888),
+            stops: [0.19168, 0.5],
+            colors: [AppColors.butterSoft, Color(0xFFF5F5F5)],
           ),
-          Expanded(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.fromLTRB(
-                AppSizes.pagePaddingH,
-                AppSizes.md,
-                AppSizes.pagePaddingH,
-                AppSizes.pagePaddingV,
+        ),
+        child: SafeArea(
+          bottom: false,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              ProfileHeader(onBack: goBack),
+              Expanded(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSizes.md,
+                    0,
+                    AppSizes.md,
+                    AppSizes.pagePaddingV,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      ProfileAvatarCard(
+                        name: baby.name,
+                        ageLabel: _ageLabel(baby.dateOfBirth),
+                        onEdit: () => context.pushNamed(
+                          AppRoute.profileEdit.name,
+                        ),
+                      ),
+                      const PremiumTeaserCard(),
+                      const SizedBox(height: AppSizes.lg),
+                      SettingsRow(
+                        key: const Key('profile_manage_subscription_row'),
+                        title: 'Manage Subscription',
+                        subtitle: state.subscriptionLabel ?? 'No Subscription',
+                        // TODO(NIB-73): push paywall when ticket ships.
+                        onTap: () => _showComingSoon(
+                          context,
+                          'Subscription management coming soon.',
+                        ),
+                      ),
+                      const SizedBox(height: AppSizes.sp12),
+                      SettingsRow(
+                        key: const Key('profile_feedback_row'),
+                        title: 'Give Feedback',
+                        onTap: () =>
+                            context.pushNamed(AppRoute.profileFeedback.name),
+                      ),
+                      const SizedBox(height: AppSizes.sp12),
+                      SettingsRow(
+                        key: const Key('profile_sign_out_button'),
+                        title: 'Sign out',
+                        onTap: () => _confirmSignOut(context, ref),
+                      ),
+                      const SizedBox(height: AppSizes.sp12),
+                      SettingsRow(
+                        key: const Key('profile_delete_account_row'),
+                        title: 'Delete account',
+                        danger: true,
+                        onTap: () => showDeleteAccountOverlay(context),
+                      ),
+                    ],
+                  ),
+                ),
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const PremiumTeaserCard(),
-                  const SizedBox(height: AppSizes.md + 2),
-                  SettingsRow(
-                    key: const Key('profile_manage_subscription_row'),
-                    title: 'Manage Subscription',
-                    subtitle: state.subscriptionLabel ?? 'No Subscription',
-                    // TODO(NIB-73): push paywall when ticket ships.
-                    onTap: () => _showComingSoon(
-                      context,
-                      'Subscription management coming soon.',
-                    ),
-                  ),
-                  const SizedBox(height: AppSizes.sp12),
-                  SettingsRow(
-                    key: const Key('profile_feedback_row'),
-                    title: 'Give Feedback',
-                    onTap: () =>
-                        context.pushNamed(AppRoute.profileFeedback.name),
-                  ),
-                  const SizedBox(height: AppSizes.sp12),
-                  SettingsRow(
-                    key: const Key('profile_sign_out_button'),
-                    title: 'Sign out',
-                    onTap: () => _confirmSignOut(context, ref),
-                  ),
-                  const SizedBox(height: AppSizes.sp12),
-                  SettingsRow(
-                    key: const Key('profile_delete_account_row'),
-                    title: 'Delete account',
-                    danger: true,
-                    onTap: () => showDeleteAccountOverlay(context),
-                  ),
-                ],
-              ),
-            ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
 
   String _ageLabel(DateTime dob) {
+    // Figma audit (node 1189:12442) verbatim: "6 month 88 days" — i.e. "month"
+    // singular regardless of count, "days" plural regardless of count.
     final now = DateTime.now();
     final totalMonths = (now.year - dob.year) * 12 + now.month - dob.month;
     final months = totalMonths < 0 ? 0 : totalMonths;
     final monthStart = DateTime(now.year, now.month - months, dob.day);
     final days = now.difference(monthStart).inDays;
     final clampedDays = days < 0 ? 0 : days;
-    return '$months months $clampedDays days';
+    return '$months month $clampedDays days';
   }
 
   void _showComingSoon(BuildContext context, String message) {

--- a/lib/src/features/profile/widgets/premium_teaser_card.dart
+++ b/lib/src/features/profile/widgets/premium_teaser_card.dart
@@ -3,11 +3,14 @@ import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 
-/// Static premium teaser card — butter-soft surface, scaled-down `nibbles`
-/// wordmark, butter crown badge, body copy.
+/// Static premium teaser card — Figma node 1200:10685.
 ///
-/// Static for MVP (NIB-73 wires the paywall push). Mirrors
-/// `design/ui_kits/nibbles_mobile/ProfileScreen.jsx` premium card.
+/// Layout: vertical column. Top row holds the scaled-down `nibbles` wordmark
+/// (~79x19) and the Nibble crown badge (26x26) at gap 12; below sits the
+/// upsell body copy.
+/// Surface = Nibble-primary-cream (#fffcd5 / `butterSoft`), 1px
+/// Nibble-primary-Lime (#eaec8c / `butter`) border, radius 10, padding 12.
+/// Static for MVP (NIB-73 wires the paywall push).
 class PremiumTeaserCard extends StatelessWidget {
   const PremiumTeaserCard({super.key});
 
@@ -24,36 +27,40 @@ class PremiumTeaserCard extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: AppColors.butterSoft,
-        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        border: Border.all(color: AppColors.butter),
       ),
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.md,
-        vertical: AppSizes.md - 2,
-      ),
-      child: Row(
+      padding: const EdgeInsets.all(AppSizes.sp12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('nibbles', style: wordmark),
-          const SizedBox(width: AppSizes.sm - 2),
-          Container(
-            width: 26,
-            height: 26,
-            decoration: BoxDecoration(
-              color: AppColors.butter,
-              borderRadius: BorderRadius.circular(AppSizes.sm),
-            ),
-            child: const Icon(
-              Icons.workspace_premium_rounded,
-              size: 18,
-              color: AppColors.greenDeep,
-            ),
-          ),
-          const SizedBox(width: AppSizes.sp12 + 2),
-          Expanded(
-            child: Text(
-              'Unlock premium personalized guidance and exclusive recipes.',
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: AppColors.fgDefault,
+          Row(
+            children: [
+              Text('nibbles', style: wordmark),
+              const SizedBox(width: AppSizes.sp12),
+              Container(
+                width: 26,
+                height: 26,
+                decoration: BoxDecoration(
+                  color: AppColors.butter,
+                  borderRadius: BorderRadius.circular(AppSizes.sm),
+                ),
+                child: const Icon(
+                  Icons.workspace_premium_rounded,
+                  size: 18,
+                  color: AppColors.greenDeep,
+                ),
               ),
+            ],
+          ),
+          const SizedBox(height: AppSizes.sp12),
+          // Body/Regular — Figtree 400 15/22.
+          Text(
+            'Unlock premium personalized guidance and exclusive recipes.',
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: AppColors.text,
+              fontSize: 15,
+              height: 22 / 15,
             ),
           ),
         ],

--- a/lib/src/features/profile/widgets/profile_avatar_card.dart
+++ b/lib/src/features/profile/widgets/profile_avatar_card.dart
@@ -1,13 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
-import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 
-/// Coral circular avatar + baby name + age caption + ghost Edit pill.
+/// Avatar / identity block on Profile (Figma node 1189:12440).
 ///
-/// Mirrors `design/ui_kits/nibbles_mobile/ProfileScreen.jsx` — 120px coral
-/// circle holding a cream baby silhouette, headline name, faint age caption,
-/// 110-wide ghost Edit pill below.
+/// Layout (column, gap 24):
+///  - 143x143 coral avatar circle (Nibble-primary-Salmon #f8a175).
+///  - Name (Title 1/Bold — Parkinsans 700 22 / lh 34) + age subtitle
+///    (Body/Regular — Figtree 400 15 / lh 22), 4px gap between.
+///  - 108x48 butter pill "Edit" (radius 24, Parkinsans SemiBold 15,
+///    forestDarkn label).
+///
+/// Asset note: the Figma file references an external Nibbles peach-circle
+/// PNG (madam-app path) that is not bundled in this repo; the coral circle
+/// + cream baby-face glyph is the agreed code approximation until the
+/// asset ships (see audit `asset_urls.txt`).
 class ProfileAvatarCard extends StatelessWidget {
   const ProfileAvatarCard({
     required this.name,
@@ -20,23 +28,24 @@ class ProfileAvatarCard extends StatelessWidget {
   final String ageLabel;
   final VoidCallback onEdit;
 
+  static const double _avatarDiameter = 143;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Container(
-      color: AppColors.butterSoft,
+    return Padding(
       padding: const EdgeInsets.fromLTRB(
-        AppSizes.md + 2,
+        AppSizes.md,
         0,
-        AppSizes.md + 2,
+        AppSizes.md,
         AppSizes.lg,
       ),
       child: Column(
         children: [
           Container(
-            width: AppSizes.avatarXl,
-            height: AppSizes.avatarXl,
+            width: _avatarDiameter,
+            height: _avatarDiameter,
             decoration: const BoxDecoration(
               color: AppColors.coral,
               shape: BoxShape.circle,
@@ -44,38 +53,61 @@ class ProfileAvatarCard extends StatelessWidget {
             child: const Center(
               child: Icon(
                 Icons.child_care_rounded,
-                size: 64,
+                size: 72,
                 color: AppColors.cream,
               ),
             ),
           ),
-          const SizedBox(height: AppSizes.sp12),
+          const SizedBox(height: AppSizes.lg),
+          // Title 1/Bold — Parkinsans 700 22 / lh 34.
           Text(
             name,
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.w800,
-              color: AppColors.fgStrong,
-              height: 1,
+            style: const TextStyle(
+              fontFamily: FontFamily.parkinsans,
+              fontSize: 22,
+              fontWeight: FontWeight.w700,
+              height: 34 / 22,
+              color: AppColors.text,
             ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: AppSizes.xs),
+          // Body/Regular — Figtree 400 15 / lh 22.
           Text(
             ageLabel,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: AppColors.fgFaint,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: AppColors.text,
+              fontSize: 15,
+              height: 22 / 15,
             ),
             textAlign: TextAlign.center,
           ),
-          const SizedBox(height: AppSizes.sm),
+          const SizedBox(height: AppSizes.lg),
+          // Edit pill — 108x48 butter, radius 24, Parkinsans SemiBold 15.
+          // Figma node 1189:12428.
           SizedBox(
-            width: 110,
-            child: AppPillButton(
-              key: const Key('profile_edit_button'),
-              label: 'Edit',
-              onPressed: onEdit,
-              variant: AppPillButtonVariant.ghost,
-              size: AppPillButtonSize.small,
+            width: 108,
+            height: 48,
+            child: Material(
+              color: AppColors.butter,
+              shape: const StadiumBorder(),
+              child: InkWell(
+                key: const Key('profile_edit_button'),
+                onTap: onEdit,
+                customBorder: const StadiumBorder(),
+                child: const Center(
+                  child: Text(
+                    'Edit',
+                    style: TextStyle(
+                      fontFamily: FontFamily.parkinsans,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      height: 22 / 15,
+                      color: AppColors.greenDeep,
+                    ),
+                  ),
+                ),
+              ),
             ),
           ),
         ],

--- a/lib/src/features/profile/widgets/profile_header.dart
+++ b/lib/src/features/profile/widgets/profile_header.dart
@@ -3,11 +3,12 @@ import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
 
-/// Butter-soft wash header for the Profile / Settings screen.
+/// Profile / Settings screen header — Figma node 1189:10786.
 ///
-/// Mirrors `design/ui_kits/nibbles_mobile/ProfileScreen.jsx`:
-/// background `butterSoft`, 32px ghost back chevron on the left, centered
-/// "Settings" title (titleSmall 17/700), 32px right slot for layout symmetry.
+/// Layout: a single row of (back chip → "Settings" title), title is
+/// LEFT-aligned hugging the chip (no center). Sits on top of the screen's
+/// shared butter-soft gradient (no per-widget background fill).
+/// Title is Title 3/Bold — Parkinsans 700 17.
 class ProfileHeader extends StatelessWidget {
   const ProfileHeader({required this.onBack, super.key});
 
@@ -17,38 +18,30 @@ class ProfileHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Container(
-      color: AppColors.butterSoft,
+    return Padding(
       padding: const EdgeInsets.fromLTRB(
-        AppSizes.md + 2,
+        AppSizes.sp12,
         AppSizes.sm - 2,
-        AppSizes.md + 2,
+        AppSizes.sp12,
         AppSizes.lg,
       ),
       child: Row(
         children: [
-          SizedBox(
-            width: AppSizes.roundButtonSm,
-            child: AppRoundButton(
-              icon: const Icon(Icons.arrow_back_ios_new_rounded),
-              onPressed: onBack,
-              tone: AppRoundButtonTone.ghost,
-              size: AppRoundButtonSize.small,
-              semanticLabel: 'Back',
+          AppRoundButton(
+            icon: const Icon(Icons.arrow_back_ios_new_rounded),
+            onPressed: onBack,
+            tone: AppRoundButtonTone.ghost,
+            size: AppRoundButtonSize.small,
+            semanticLabel: 'Back',
+          ),
+          const SizedBox(width: AppSizes.sp2),
+          Text(
+            'Settings',
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: AppColors.fgStrong,
             ),
           ),
-          Expanded(
-            child: Text(
-              'Settings',
-              textAlign: TextAlign.center,
-              style: theme.textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.w700,
-                color: AppColors.fgStrong,
-                height: 1,
-              ),
-            ),
-          ),
-          const SizedBox(width: AppSizes.roundButtonSm),
         ],
       ),
     );

--- a/lib/src/features/profile/widgets/settings_row.dart
+++ b/lib/src/features/profile/widgets/settings_row.dart
@@ -27,7 +27,8 @@ class SettingsRow extends StatelessWidget {
     final titleColor = danger ? AppColors.destructive : AppColors.fgStrong;
     final chevronColor = danger ? AppColors.destructive : AppColors.greenDeep;
 
-    final radius = BorderRadius.circular(AppSizes.radiusXl);
+    // Figma audit (node 1207:15365 etc.): list rows use radius 10 and p-12.
+    final radius = BorderRadius.circular(AppSizes.radiusMd);
 
     return Material(
       color: AppColors.cream,
@@ -42,31 +43,31 @@ class SettingsRow extends StatelessWidget {
           onTap: onTap,
           borderRadius: radius,
           child: Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSizes.md,
-              vertical: AppSizes.md - 2,
-            ),
+            padding: const EdgeInsets.all(AppSizes.sp12),
             child: Row(
               children: [
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      // Headline/SemiBold — Parkinsans 600 15/22.
                       Text(
                         title,
                         style: theme.textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.w700,
+                          fontWeight: FontWeight.w600,
                           fontSize: 15,
+                          height: 22 / 15,
                           color: titleColor,
-                          height: 1.2,
                         ),
                       ),
                       if (subtitle != null) ...[
-                        const SizedBox(height: AppSizes.sp2),
+                        // Body/Regular — Figtree 400 15/22.
                         Text(
                           subtitle!,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: AppColors.fgFaint,
+                          style: theme.textTheme.bodyLarge?.copyWith(
+                            color: AppColors.text,
+                            fontSize: 15,
+                            height: 22 / 15,
                           ),
                         ),
                       ],


### PR DESCRIPTION
## Summary
Pixel-level remediation of the Profile / Settings screen against the Figma audit spec (node 1189:10278). Architecture and tests untouched — only visual tokens, layout, and copy are normalized.

## Changes
- **Header**: Settings title is left-aligned beside the back chip (was centered). Drops local fill so the screen gradient shows through.
- **Avatar card**: Avatar bumped 120 to 143. Name now Title 1/Bold (Parkinsans 700 22/lh34); age subtitle now Body/Regular (Figtree 15/lh22) in default text color.
- **Edit pill**: 108x48 butter (#eaec8c) stadium, radius 24, Parkinsans SemiBold 15 in forestDarkn (#3d5236). Replaces the AppPillButton.small (40h) approximation.
- **Premium teaser**: Radius 20 to 10 (radiusMd). Adds 1px butter border. Layout switched to column (logo + crown row, then body). Padding 16 to 12.
- **Settings rows**: Radius 20 to 10 (radiusMd). Padding to 12. Title weight Bold to SemiBold (Headline/SemiBold). Subtitle font ramped to Body/Regular 15/22 in default text color.
- **Screen background**: Replaces split butterSoft/cream backdrop with the Grad-1 linear gradient (#FFFCD5 19.168 to #F5F5F5 50, 152.612deg).
- **Age label**: Copy format adjusted to '<n> month <m> days' (singular 'month', plural 'days') per Figma verbatim copy.

## Acceptance criteria
- [x] Header title left-aligned, Title 3/Bold Parkinsans 17.
- [x] Avatar 143x143 coral circle (peach-circle PNG asset not bundled in repo; coral + baby-face icon approximation per audit asset note).
- [x] Edit pill 108x48 butter, radius 24, Parkinsans SemiBold 15 forestDarkn.
- [x] Premium card: cream fill, 1px butter border, radius 10, p-12.
- [x] 4 settings rows: cream fill, radius 10, p-12, chevron right, in order Manage Subscription -> Give Feedback -> Sign out -> Delete account.
- [x] Verbatim copy preserved: 'Settings', 'Edit', 'Unlock premium personalized guidance and exclusive recipes.', 'Manage Subscription', 'No Subscription', 'Give Feedback', 'Sign out', 'Delete account'.
- [x] Tokens mapped from variables.json (Nibble-primary-Lime to AppColors.butter, cream to butterSoft, ForestDarkn to greenDeep, Salmon to coral).
- [x] flutter analyze: 0 issues.
- [x] flutter test: 481 passed, 1 skipped (pre-existing).

## Figma frame ids
- Profile screen root: 1189:10278
- Header: 1189:10786
- Avatar/name/Edit: 1189:12440, 1189:12428
- Premium card: 1200:10685
- Settings rows: 1207:15365, 1200:10469, 1189:12504, 1189:12498

## Audit report
- .figma-audit/profile-edit/profile/report.md
- .figma-audit/profile-edit/profile/screenshot.png
- .figma-audit/profile-edit/profile/variables.json

## Asset note
The peach-circle avatar PNG and nibbles-logo PNG reference external madam-app paths and are not in this repo's assets/images. Kept the coral-circle + cream-icon approximation (matches existing profile_edit_screen.dart pattern) until the assets ship — flagged in widget docstring.

## Test plan
- [x] Existing NIB-99 widget tests all pass (header/avatar/premium/rows present, row taps wired, sign-out dialog, delete overlay).
- [x] No structural changes — widget classes and test Keys preserved.