### PR TITLE
fix(recipe): align all 4 Starting Guide articles with Figma [NIB-132]

### DIFF
--- a/lib/src/features/starting_guide/constants/articles.dart
+++ b/lib/src/features/starting_guide/constants/articles.dart
@@ -3,209 +3,449 @@ import 'package:flutter/foundation.dart';
 /// Static content model for the Starting Guide.
 ///
 /// Articles are hardcoded. The hub renders one card per [GuideArticle];
-/// tapping a card opens the article screen routed by [slug].
+/// tapping a card opens the article screen routed by [slug]. Body content is
+/// modelled as a sequence of [GuideBlock]s so each article can mix headings,
+/// info cards, chip grids, numbered lists, checklists, and inline CTAs while
+/// staying typed end-to-end.
+///
+/// Copy is verbatim from the Figma audit reports
+/// (`.figma-audit/recipe-library/recipe-library-*`). Typos surfaced by the
+/// audit (e.g. "No Fluf", "We focuses on", "Wallnut", "Babies's kidneys",
+/// "Asther readiness result") are preserved on purpose — flagged with PO in
+/// the PR body.
 @immutable
 class GuideArticle {
   const GuideArticle({
     required this.slug,
     required this.title,
     required this.subtitle,
-    required this.sections,
-    required this.terminalCta,
+    required this.blocks,
   });
 
   final String slug;
+
+  /// Hub card title.
   final String title;
+
+  /// Hub card subtitle.
   final String subtitle;
-  final List<GuideSection> sections;
-  final GuideCta? terminalCta;
+
+  /// Ordered list of body blocks rendered by the article screen.
+  final List<GuideBlock> blocks;
 }
 
-/// A numbered (or unnumbered) content block inside an article.
-///
-/// [stepNumber] is rendered as a leading pill (e.g. '1', '2'). When null the
-/// section renders as a plain heading + body (used for intros/outros).
+/// Sealed base for every renderable block inside a [GuideArticle].
 @immutable
-class GuideSection {
-  const GuideSection({
-    required this.heading,
+sealed class GuideBlock {
+  const GuideBlock();
+}
+
+/// Hero card at the top of an article — title + body sit on a tinted card
+/// with a baby-face glyph stand-in for the Figma hero illustration.
+class HeroCardBlock extends GuideBlock {
+  const HeroCardBlock({required this.title, required this.body});
+
+  final String title;
+  final String body;
+}
+
+/// Section title (e.g. "The 6 Month Milestone", "Essential Nutrients").
+class SectionHeadingBlock extends GuideBlock {
+  const SectionHeadingBlock(this.text);
+
+  final String text;
+}
+
+/// Free-form paragraph rendered with the body type ramp.
+class ParagraphBlock extends GuideBlock {
+  const ParagraphBlock(this.text);
+
+  final String text;
+}
+
+/// Single salmon-ghost label chip (e.g. "Perfect time to growth", "6+ Months").
+class LabelChipBlock extends GuideBlock {
+  const LabelChipBlock(this.label);
+
+  final String label;
+}
+
+/// Cream tip-style info card — title + body, butter-soft fill, baby-face
+/// glyph hero. Used for the "SIMPLE AND PRACTICAL" / "EVIDENCE INFORMED" /
+/// "No Fluf" tiles on Baby's First Nibbles.
+class InfoCardBlock extends GuideBlock {
+  const InfoCardBlock({required this.title, required this.body});
+
+  final String title;
+  final String body;
+}
+
+/// Grid of small icon tiles (e.g. Iron / Minerals / Vitamins / Zinc; or the
+/// 7 iron-rich foods grid on Feeding Principles). Renders as a wrap of
+/// rounded tiles with a green-deep baby-face glyph above each label.
+class IconTileGridBlock extends GuideBlock {
+  const IconTileGridBlock(this.labels);
+
+  final List<String> labels;
+}
+
+/// White card titled e.g. "The Big 11" + body + a wrap of salmon-ghost chips.
+class ChipGridCardBlock extends GuideBlock {
+  const ChipGridCardBlock({
+    required this.title,
     required this.body,
-    this.stepNumber,
+    required this.chips,
   });
 
-  final int? stepNumber;
+  final String title;
+  final String body;
+  final List<String> chips;
+}
+
+/// Cream card with a numbered list (1..n) of heading + body rows. Used for
+/// "Nibbles Goals" on First Nibbles, "Feeding is Skill-Building" on
+/// Introduction, and "Items to Avoid" on Feeding Principles.
+class NumberedListCardBlock extends GuideBlock {
+  const NumberedListCardBlock({
+    required this.title,
+    required this.items,
+    this.body,
+  });
+
+  final String title;
+  final String? body;
+  final List<NumberedItem> items;
+}
+
+@immutable
+class NumberedItem {
+  const NumberedItem({required this.heading, required this.body});
+
   final String heading;
   final String body;
 }
 
-/// Terminal action at the bottom of an article. [routeName] is one of the
-/// `AppRoute.<route>.name` literals — the article screen routes via
-/// `context.goNamed(routeName)` so the bottom-nav shell is restored.
+/// "Our Philosophy" style card — white card, baby glyph, title, body, trailing
+/// label chips.
+class PhilosophyCardBlock extends GuideBlock {
+  const PhilosophyCardBlock({
+    required this.title,
+    required this.body,
+    required this.chips,
+  });
+
+  final String title;
+  final String body;
+  final List<String> chips;
+}
+
+/// "Ready to Start?" style closing card — white card with title, body, and a
+/// single primary CTA pinned inside it.
+class ReadyToStartCardBlock extends GuideBlock {
+  const ReadyToStartCardBlock({
+    required this.title,
+    required this.body,
+    required this.cta,
+  });
+
+  final String title;
+  final String body;
+  final GuideCta cta;
+}
+
+/// Pair of inline CTAs (primary + optional secondary) rendered mid-article.
+/// Used after the numbered Nibbles Goals / Feeding-Skill-Building lists.
+class InlineCtaPairBlock extends GuideBlock {
+  const InlineCtaPairBlock({required this.primary, this.secondary});
+
+  final GuideCta primary;
+  final GuideCta? secondary;
+}
+
+/// Checklist card (lime fill) — title + score pill (e.g. "3/5") + check rows.
+class ChecklistCardBlock extends GuideBlock {
+  const ChecklistCardBlock({
+    required this.title,
+    required this.score,
+    required this.items,
+  });
+
+  final String title;
+  final String score;
+  final List<String> items;
+}
+
+/// CTA leaf. [routeName] is one of the `AppRoute.<route>.name` literals —
+/// the article screen routes via `context.goNamed(routeName)` so the bottom
+/// nav shell is restored. [variant] picks the pill style.
 @immutable
 class GuideCta {
-  const GuideCta({required this.label, required this.routeName});
+  const GuideCta({
+    required this.label,
+    required this.routeName,
+    this.variant = GuideCtaVariant.primary,
+  });
 
   final String label;
   final String routeName;
+  final GuideCtaVariant variant;
 }
 
-/// Hardcoded Starting Guide articles. Copy is a placeholder approximation of
-/// the Figma frames (the live Figma was unreachable at build time — content
-/// fidelity is a follow-up).
+enum GuideCtaVariant { primary, secondary }
+
+/// Hardcoded Starting Guide articles. Copy is verbatim from the Figma audit
+/// reports (`.figma-audit/recipe-library/recipe-library-*`). Typos preserved
+/// on purpose — PO-flagged in the PR body.
 const List<GuideArticle> kStartingGuideArticles = [
+  // ── Baby's First Nibbles (Figma 971:8730) ────────────────────────────────
   GuideArticle(
     slug: 'first-nibbles',
-    title: "Baby's First Nibbles",
-    subtitle: 'A gentle introduction to your baby starting solid foods.',
-    sections: [
-      GuideSection(
-        stepNumber: 1,
-        heading: 'Start with single ingredients',
-        body: 'Offer one new food at a time so you can spot reactions early. '
-            'Mashed avocado, soft banana, or oatmeal are gentle first picks.',
+    title: 'BABY’S FIRST NIBBLES',
+    subtitle:
+        'What would I have wanted in my hands when I started this journey?',
+    blocks: [
+      HeroCardBlock(
+        title: 'BABY’S FIRST NIBBLES',
+        body: 'What would I have wanted in my hands when I started this '
+            'journey?',
       ),
-      GuideSection(
-        stepNumber: 2,
-        heading: 'Keep portions tiny',
-        body: 'A teaspoon is plenty for a first taste. Babies learn the '
-            'mechanics of eating before they learn to eat for fuel.',
+      ParagraphBlock(
+        'Baby’s First Nibbles is designed to be simple, practical, '
+        'evidence-informed, and realistic for busy parents.',
       ),
-      GuideSection(
-        stepNumber: 3,
-        heading: 'Follow their lead',
-        body: 'A turned head or pressed lips means done. Never force a bite — '
-            'mealtimes should feel calm, curious, and unhurried.',
+      SectionHeadingBlock('We focuses on'),
+      InfoCardBlock(
+        title: 'SIMPLE AND PRACTICAL',
+        body:
+            'Designed for busy parents with realistic recipes and actionable '
+            'steps.',
       ),
-      GuideSection(
-        stepNumber: 4,
-        heading: 'Make it a daily ritual',
-        body: 'Aim for one consistent solid meal a day to start. Routine helps '
-            'your baby (and you) build confidence around the table.',
+      InfoCardBlock(
+        title: 'EVIDENCE INFORMED',
+        body: 'Based on current pediatric nutrition guidelines.',
+      ),
+      InfoCardBlock(
+        title: 'No Fluf',
+        body: 'No overcomplication. Just food that makes sense for you.',
+      ),
+      SectionHeadingBlock('Nibbles Goals'),
+      NumberedListCardBlock(
+        title: 'Nibbles Goals',
+        items: [
+          NumberedItem(
+            heading: 'Help parents feel confident, not overwhelmed',
+            body: '',
+          ),
+          NumberedItem(
+            heading: 'To help your baby explore food',
+            body: '',
+          ),
+          NumberedItem(
+            heading: 'Develop feeding skills',
+            body: '',
+          ),
+          NumberedItem(
+            heading: 'Build a strong foundation for lifelong health',
+            body: '',
+          ),
+        ],
+      ),
+      InlineCtaPairBlock(
+        primary: GuideCta(
+          label: 'Explore Recipes',
+          routeName: 'recipe-library',
+        ),
+        secondary: GuideCta(
+          label: 'Get Free Weekly Baby Recipes',
+          routeName: 'starting-guide',
+          variant: GuideCtaVariant.secondary,
+        ),
       ),
     ],
-    terminalCta: GuideCta(
-      label: 'Explore Recipes',
-      routeName: 'recipe-library',
-    ),
   ),
+  // ── Introduction (Figma 971:8744) ────────────────────────────────────────
   GuideArticle(
     slug: 'introduction',
-    title: 'Introduction to Solids',
-    subtitle: 'How to plan your first weeks of solid food meals.',
-    sections: [
-      GuideSection(
-        stepNumber: 1,
-        heading: 'Pick a calm time of day',
-        body: 'Mid-morning often works best — baby is alert but not overtired. '
-            'Avoid the witching-hour fussiness window.',
+    title: 'Introductions',
+    subtitle:
+        'Introducing solids is a major milestone in a baby’s development',
+    blocks: [
+      HeroCardBlock(
+        title: 'Introducing Solids',
+        body: 'Introducing solids is a major milestone in a baby’s '
+            'development',
       ),
-      GuideSection(
-        stepNumber: 2,
-        heading: 'Plan three soft foods to rotate',
-        body: 'Two veg and one fruit purée, or a simple grain, give variety '
-            'without overwhelming a new eater.',
+      SectionHeadingBlock('The 6 Month Milestone'),
+      LabelChipBlock('Perfect time to growth'),
+      ParagraphBlock(
+        'Babies begin transitioning from an exclusively milk-based diet to a '
+        'combination of breast milk or formula and complementary foods.',
       ),
-      GuideSection(
-        stepNumber: 3,
-        heading: 'Pair with a familiar bottle or feed',
-        body: 'Milk feeds stay primary in the first months of solids. Offer '
-            'milk before or after a meal, not as a reward.',
+      SectionHeadingBlock('Essential Nutrients'),
+      IconTileGridBlock(['Iron', 'Minerals', 'Vitamins', 'Zinc']),
+      NumberedListCardBlock(
+        title: 'Feeding is Skill-Building',
+        body: 'Beyond nutrients, every meal is a sensory workout for your '
+            'little one.',
+        items: [
+          NumberedItem(
+            heading: 'Developing Coordination',
+            body: 'Hand-to-mouth movements and tongue control.',
+          ),
+          NumberedItem(
+            heading: 'Exploring Textures',
+            body: 'Learning to manipulate different mouthfeels.',
+          ),
+          NumberedItem(
+            heading: 'Learning to Eat',
+            body: 'Transitioning from sucking to chewing and swallowing.',
+          ),
+        ],
       ),
-      GuideSection(
-        stepNumber: 4,
-        heading: 'Track tastes in the app',
-        body: 'Logging reactions helps you spot favourites — and gives you a '
-            'record if you ever need to share notes with your pediatrician.',
+      InlineCtaPairBlock(
+        primary: GuideCta(
+          label: 'Explore Recipes',
+          routeName: 'recipe-library',
+        ),
+        secondary: GuideCta(
+          label: 'Get Free Weekly Baby Recipes',
+          routeName: 'starting-guide',
+          variant: GuideCtaVariant.secondary,
+        ),
+      ),
+      PhilosophyCardBlock(
+        title: 'Our Philosophy',
+        body: 'Simple, nutrient-dense meals that support both nutrition and '
+            'development, without overcomplicating the process.',
+        chips: ['Nurturing', 'Nurturing', 'Simple'],
+      ),
+      ReadyToStartCardBlock(
+        title: 'Ready to Start?',
+        body:
+            'Breast milk or formula remains primary, but let’s explore '
+            'those first bites together.',
+        cta: GuideCta(
+          label: 'Create First Meal',
+          routeName: 'meal-plan',
+        ),
       ),
     ],
-    terminalCta: GuideCta(
-      label: 'Create First Meal',
-      routeName: 'meal-plan',
-    ),
   ),
+  // ── Feeding Principles (Figma 1474:50514) ────────────────────────────────
   GuideArticle(
     slug: 'feeding-principles',
-    title: 'Feeding Principles',
-    subtitle: 'The simple rules that make mealtimes work for both of you.',
-    sections: [
-      GuideSection(
-        stepNumber: 1,
-        heading: 'You decide what, when, and where',
-        body: 'Your baby decides whether and how much. This split keeps power '
-            'struggles out of the high chair.',
+    title: 'Important Feeding Principles',
+    subtitle:
+        'Weaning is more than just calories; it’s a foundation for '
+        'lifelong health',
+    blocks: [
+      HeroCardBlock(
+        title: 'Important Feeding Principles',
+        body: 'Weaning is more than just calories; it’s a foundation '
+            'for lifelong health',
       ),
-      GuideSection(
-        stepNumber: 2,
-        heading: 'Expose, do not pressure',
-        body: 'It can take ten or more tries before a new food is accepted. '
-            'Keep offering without commentary.',
+      SectionHeadingBlock('Iron-Rich Essentials'),
+      LabelChipBlock('6+ Months'),
+      ParagraphBlock(
+        'Baby’s iron needs increase significantly at 6 months. Example '
+        'iron-rich foods :',
       ),
-      GuideSection(
-        stepNumber: 3,
-        heading: 'Eat together when you can',
-        body: 'Babies learn to chew, swallow, and enjoy food by watching you. '
-            'Share even a small bite of what they are having.',
+      IconTileGridBlock([
+        'Beef',
+        'Lamb',
+        'Chicken',
+        'Fish',
+        'Eggs',
+        'Lentils',
+        'Tofu',
+      ]),
+      SectionHeadingBlock('Common Allergen'),
+      ChipGridCardBlock(
+        title: 'The Big 11',
+        body: 'Introduce early and often within the first year.',
+        chips: [
+          'Almond',
+          'Cashew',
+          'Egg',
+          'Wheat',
+          'Fish',
+          'Peanut',
+          'Milk',
+          'Prawn',
+          'Wallnut',
+          'Soy',
+          'Sesame',
+        ],
       ),
-      GuideSection(
-        stepNumber: 4,
-        heading: 'Stay flat and supported',
-        body: 'Upright posture with feet supported makes safe swallowing '
-            'easier. A wobbly seat = a stressful meal.',
+      SectionHeadingBlock('Offering a Variety of Foods'),
+      ParagraphBlock(
+        'Repeated exposure to a wide range of foods can help babies develop '
+        'acceptance of different flavours and textures. It is normal for '
+        'babies to need several exposures to a new food before accepting it.',
       ),
-      GuideSection(
-        stepNumber: 5,
-        heading: 'Introduce allergens early and often',
-        body: 'Current guidance is to introduce common allergens between '
-            '4-6 months, then keep them in the rotation regularly.',
+      SectionHeadingBlock('Items to Avoid'),
+      NumberedListCardBlock(
+        title: 'Items to Avoid',
+        items: [
+          NumberedItem(
+            heading: 'No Added Salt or Sugar',
+            body: 'Foods prepared for infants should not contain added salt '
+                'or sugar. Babies’s kidneys are still developing, and '
+                'limiting salt intake is recommended.',
+          ),
+          NumberedItem(
+            heading: 'Avoid Honey Before 12 Months',
+            body: 'Honey should not be given to infants under 12 months of '
+                'age due to the risk of infant botulism.',
+          ),
+        ],
+      ),
+      ReadyToStartCardBlock(
+        title: 'Ready to Start Introduce Allergens?',
+        body: 'Introduce allergens with confidence using simple guidance and '
+            'easy tracking.',
+        cta: GuideCta(
+          label: 'Start Introducing Allergens',
+          routeName: 'allergen-tracker',
+        ),
       ),
     ],
-    terminalCta: GuideCta(
-      label: 'Start Introducing Allergens',
-      routeName: 'allergen-tracker',
-    ),
   ),
+  // ── 5 Sign Readiness (Figma 1474:50031) ──────────────────────────────────
   GuideArticle(
     slug: 'readiness-signs',
-    title: '5 Signs of Readiness',
-    subtitle: 'How to know your baby is ready to start solids.',
-    sections: [
-      GuideSection(
-        stepNumber: 1,
-        heading: 'Sits with little help',
-        body: 'Your baby can hold their head steady and sit upright in a high '
-            'chair with minimal support.',
+    title: 'Signs Your Baby Is Ready for Solids',
+    subtitle: 'Every baby develops at their own pace, so these signs are '
+        'generally more important than the calendar.',
+    blocks: [
+      HeroCardBlock(
+        title: '5 Sign Readiness',
+        body: 'Every baby develops at their own pace, so these signs are '
+            'generally more important than the calendar.',
       ),
-      GuideSection(
-        stepNumber: 2,
-        heading: 'Has lost the tongue-thrust reflex',
-        body: 'When you offer a spoon, food goes back instead of being pushed '
-            'straight out by the tongue.',
+      SectionHeadingBlock('Asther readiness result'),
+      ParagraphBlock(
+        'Most babies are ready at around six months, but these developmental '
+        'signs are the most important indicators.',
       ),
-      GuideSection(
-        stepNumber: 3,
-        heading: 'Shows interest in food',
-        body: 'Watches you eat, opens their mouth toward your spoon, or '
-            'reaches for what is on your plate.',
-      ),
-      GuideSection(
-        stepNumber: 4,
-        heading: 'Can bring objects to mouth',
-        body: 'Grabbing a toy and getting it to their mouth signals the '
-            'hand-eye coordination needed for self-feeding.',
-      ),
-      GuideSection(
-        stepNumber: 5,
-        heading: 'Is around 6 months old',
-        body: 'Most babies are ready around six months. Always check with '
-            'your pediatrician before introducing solids.',
+      ChecklistCardBlock(
+        title: 'Readiness Signs',
+        score: '3/5',
+        items: [
+          // Long copy kept on a single line per item so the literals are
+          // const (required by the outer `const List` constructor) and the
+          // `no_adjacent_strings_in_list` lint stays happy.
+          // ignore: lines_longer_than_80_chars
+          'Can sit upright with minimal support. Good head and neck control (can hold head steady)',
+          'Sits upright with minimal support',
+          // See the comment above the first item — same reason.
+          // ignore: lines_longer_than_80_chars
+          'Loss of the tongue-thrust reflex (doesn’t automatically push food out).',
+          'Shows interest in food (watching, reaching, opening mouth).',
+          'Can bring objects to their mouth.',
+        ],
       ),
     ],
-    // TODO(NIB-94): wire a real mailto / weekly recipe sign-up flow once
-    //  copywriting + ESP integration land. For now, pop back to the hub.
-    terminalCta: GuideCta(
-      label: 'Get Free Weekly Baby Recipes',
-      routeName: 'starting-guide',
-    ),
   ),
 ];
 

--- a/lib/src/features/starting_guide/starting_guide_article_screen.dart
+++ b/lib/src/features/starting_guide/starting_guide_article_screen.dart
@@ -6,21 +6,28 @@ import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
 import 'package:nibbles/src/features/starting_guide/constants/articles.dart';
 import 'package:nibbles/src/features/starting_guide/starting_guide_controller.dart';
 import 'package:nibbles/src/features/starting_guide/widgets/guide_back_button.dart';
-import 'package:nibbles/src/features/starting_guide/widgets/guide_cta_pill.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_checklist_card.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_chip_grid_card.dart';
 import 'package:nibbles/src/features/starting_guide/widgets/guide_hero_card.dart';
-import 'package:nibbles/src/features/starting_guide/widgets/numbered_step.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_icon_tile_grid.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_info_card.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_numbered_list_card.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_philosophy_card.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_ready_to_start_card.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_section_heading.dart';
 import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
 /// Single Starting Guide article screen.
 ///
-/// Resolves the article by [slug] via [StartingGuideController]. Renders the
-/// hero card, the article's numbered sections, and a single terminal CTA at
-/// the bottom that routes to one of the existing top-level routes
-/// (`recipe-library`, `meal-plan`, `allergen-tracker`, etc.).
+/// Resolves the article by [slug] via [StartingGuideController] and renders
+/// its [GuideBlock] sequence. Each block is mapped to the matching guide
+/// widget via the sealed-class switch in [_buildBlock].
 ///
 /// If the slug doesn't match any article we fall back to a tiny not-found
 /// scaffold rather than crashing — protects against a malformed deeplink.
@@ -59,11 +66,11 @@ class _StartingGuideArticleScreenState
   }
 
   void _onCta(BuildContext context, GuideCta cta) {
-    // 'Get Free Weekly Baby Recipes' has no destination flow yet — see the
-    // placeholder note in `constants/articles.dart`. The article routes back
-    // to the hub (placeholder targets `AppRoute.startingGuide.name`); doing
-    // the same for unknown route names keeps us crash-safe if the list is
-    // extended with a target that isn't registered yet.
+    // 'Get Free Weekly Baby Recipes' currently has no destination flow (NIB-94
+    // pending). Until it lands, that CTA's `routeName` is `starting-guide` —
+    // routing to it just pops the article so the user stays in context.
+    // Defensive guard for any unknown future route names: do the same thing
+    // instead of crashing.
     final isKnown = AppRoute.values.any((r) => r.name == cta.routeName);
     if (!isKnown || cta.routeName == AppRoute.startingGuide.name) {
       _onBack(context);
@@ -116,69 +123,128 @@ class _ArticleBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cta = article.terminalCta;
     return CustomScrollView(
       slivers: [
-        SliverToBoxAdapter(child: _Header(onBack: onBack)),
+        SliverToBoxAdapter(
+          child: _Header(title: article.title, onBack: onBack),
+        ),
         SliverPadding(
           padding: const EdgeInsets.fromLTRB(
             AppSizes.pagePaddingH,
             AppSizes.md,
             AppSizes.pagePaddingH,
-            AppSizes.lg,
-          ),
-          sliver: SliverToBoxAdapter(
-            child: GuideHeroCard(
-              title: article.title,
-              subtitle: article.subtitle,
-            ),
-          ),
-        ),
-        SliverPadding(
-          padding: const EdgeInsets.fromLTRB(
-            AppSizes.pagePaddingH,
-            0,
-            AppSizes.pagePaddingH,
-            AppSizes.lg,
+            AppSizes.xl,
           ),
           sliver: SliverList.separated(
-            itemCount: article.sections.length,
+            itemCount: article.blocks.length,
             separatorBuilder: (_, __) => const SizedBox(height: AppSizes.lg),
-            itemBuilder: (context, index) {
-              final section = article.sections[index];
-              return NumberedStep(
-                stepNumber: section.stepNumber,
-                heading: section.heading,
-                body: section.body,
-              );
-            },
+            itemBuilder: (context, index) =>
+                _buildBlock(article.blocks[index], onCta),
           ),
         ),
-        if (cta != null)
-          SliverPadding(
-            padding: const EdgeInsets.fromLTRB(
-              AppSizes.pagePaddingH,
-              AppSizes.sm,
-              AppSizes.pagePaddingH,
-              AppSizes.xl,
-            ),
-            sliver: SliverToBoxAdapter(
-              child: GuideCtaPill(
-                label: cta.label,
-                onTap: () => onCta(cta),
-              ),
-            ),
-          )
-        else
-          const SliverToBoxAdapter(child: SizedBox(height: AppSizes.xl)),
+      ],
+    );
+  }
+}
+
+Widget _buildBlock(GuideBlock block, ValueChanged<GuideCta> onCta) {
+  switch (block) {
+    case HeroCardBlock():
+      return GuideHeroCard(title: block.title, subtitle: block.body);
+    case SectionHeadingBlock():
+      return GuideSectionHeading(block.text);
+    case ParagraphBlock():
+      return Text(
+        block.text,
+        style: AppTypography.textTheme.bodyLarge?.copyWith(
+          color: AppColors.fgDefault,
+        ),
+      );
+    case LabelChipBlock():
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: AppChip(label: block.label),
+      );
+    case InfoCardBlock():
+      return GuideInfoCard(title: block.title, body: block.body);
+    case IconTileGridBlock():
+      return GuideIconTileGrid(labels: block.labels);
+    case ChipGridCardBlock():
+      return GuideChipGridCard(
+        title: block.title,
+        body: block.body,
+        chips: block.chips,
+      );
+    case NumberedListCardBlock():
+      return GuideNumberedListCard(
+        title: block.title,
+        body: block.body,
+        items: block.items,
+      );
+    case PhilosophyCardBlock():
+      return GuidePhilosophyCard(
+        title: block.title,
+        body: block.body,
+        chips: block.chips,
+      );
+    case ReadyToStartCardBlock():
+      return GuideReadyToStartCard(
+        title: block.title,
+        body: block.body,
+        ctaLabel: block.cta.label,
+        onCta: () => onCta(block.cta),
+      );
+    case InlineCtaPairBlock():
+      return _InlineCtaPair(
+        primary: block.primary,
+        secondary: block.secondary,
+        onCta: onCta,
+      );
+    case ChecklistCardBlock():
+      return GuideChecklistCard(
+        title: block.title,
+        score: block.score,
+        items: block.items,
+      );
+  }
+}
+
+class _InlineCtaPair extends StatelessWidget {
+  const _InlineCtaPair({
+    required this.primary,
+    required this.secondary,
+    required this.onCta,
+  });
+
+  final GuideCta primary;
+  final GuideCta? secondary;
+  final ValueChanged<GuideCta> onCta;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        AppPillButton(
+          label: primary.label,
+          onPressed: () => onCta(primary),
+        ),
+        if (secondary != null) ...[
+          const SizedBox(height: AppSizes.sp12),
+          AppPillButton(
+            label: secondary!.label,
+            variant: AppPillButtonVariant.ghost,
+            onPressed: () => onCta(secondary!),
+          ),
+        ],
       ],
     );
   }
 }
 
 class _Header extends StatelessWidget {
-  const _Header({required this.onBack});
+  const _Header({required this.title, required this.onBack});
 
+  final String title;
   final VoidCallback onBack;
 
   @override
@@ -205,8 +271,8 @@ class _Header extends StatelessWidget {
             const SizedBox(width: AppSizes.sp12),
             Expanded(
               child: Text(
-                'Starting Guide',
-                style: AppTypography.textTheme.titleLarge,
+                title,
+                style: AppTypography.textTheme.titleSmall,
               ),
             ),
           ],

--- a/lib/src/features/starting_guide/widgets/guide_checklist_card.dart
+++ b/lib/src/features/starting_guide/widgets/guide_checklist_card.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+
+/// Lime-fill card — title + score chip on the top row, then a vertical list
+/// of check-mark rows. Matches "Readiness Signs 3/5" on 5 Sign Readiness
+/// (Figma 1474:50031).
+class GuideChecklistCard extends StatelessWidget {
+  const GuideChecklistCard({
+    required this.title,
+    required this.score,
+    required this.items,
+    super.key,
+  });
+
+  final String title;
+  final String score;
+  final List<String> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSizes.md),
+      decoration: BoxDecoration(
+        color: AppColors.butter,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  title,
+                  style: AppTypography.textTheme.titleSmall?.copyWith(
+                    color: AppColors.fgStrong,
+                  ),
+                ),
+              ),
+              AppChip(label: score),
+            ],
+          ),
+          const SizedBox(height: AppSizes.sp12),
+          for (var i = 0; i < items.length; i++) ...[
+            if (i > 0) const SizedBox(height: AppSizes.sp12),
+            _ChecklistRow(text: items[i]),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ChecklistRow extends StatelessWidget {
+  const _ChecklistRow({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 24,
+          height: 24,
+          decoration: const BoxDecoration(
+            color: AppColors.surface,
+            shape: BoxShape.circle,
+          ),
+          alignment: Alignment.center,
+          child: const Icon(
+            Icons.check_rounded,
+            size: 16,
+            color: AppColors.greenDeep,
+          ),
+        ),
+        const SizedBox(width: AppSizes.sp12),
+        Expanded(
+          child: Text(
+            text,
+            style: AppTypography.textTheme.bodyMedium?.copyWith(
+              color: AppColors.fgDefault,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/guide_chip_grid_card.dart
+++ b/lib/src/features/starting_guide/widgets/guide_chip_grid_card.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+
+/// White card with a title, body, and a wrap of salmon-ghost chips.
+/// Matches "The Big 11" allergen card on Feeding Principles (Figma 1474:50514).
+class GuideChipGridCard extends StatelessWidget {
+  const GuideChipGridCard({
+    required this.title,
+    required this.body,
+    required this.chips,
+    super.key,
+  });
+
+  final String title;
+  final String body;
+  final List<String> chips;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSizes.md),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+        boxShadow: AppSizes.shadowCard,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: AppTypography.textTheme.titleSmall?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+          ),
+          const SizedBox(height: AppSizes.xs),
+          Text(
+            body,
+            style: AppTypography.textTheme.bodyMedium?.copyWith(
+              color: AppColors.fgMuted,
+            ),
+          ),
+          const SizedBox(height: AppSizes.sp12),
+          Wrap(
+            spacing: AppSizes.sm,
+            runSpacing: AppSizes.sm,
+            children: [
+              for (final label in chips)
+                AppChip(label: label),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/guide_icon_tile_grid.dart
+++ b/lib/src/features/starting_guide/widgets/guide_icon_tile_grid.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/baby_face_glyph.dart';
+
+/// Wrap of small icon tiles — green-deep baby-face glyph above a label.
+/// Used for "Essential Nutrients" (Iron / Minerals / Vitamins / Zinc) on
+/// Introduction (Figma 971:8744) and the iron-rich foods grid on Feeding
+/// Principles (Figma 1474:50514).
+class GuideIconTileGrid extends StatelessWidget {
+  const GuideIconTileGrid({required this.labels, super.key});
+
+  final List<String> labels;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: AppSizes.sp12,
+      runSpacing: AppSizes.sp12,
+      children: [
+        for (final label in labels) _Tile(label: label),
+      ],
+    );
+  }
+}
+
+class _Tile extends StatelessWidget {
+  const _Tile({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 72,
+      child: Column(
+        children: [
+          const BabyFaceGlyph(size: BabyFaceGlyph.smallSize),
+          const SizedBox(height: AppSizes.xs),
+          Text(
+            label,
+            textAlign: TextAlign.center,
+            style: AppTypography.textTheme.bodySmall?.copyWith(
+              color: AppColors.fgStrong,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/guide_info_card.dart
+++ b/lib/src/features/starting_guide/widgets/guide_info_card.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/baby_face_glyph.dart';
+
+/// White info card — small baby-face glyph, bold heading, body. Matches the
+/// "SIMPLE AND PRACTICAL / EVIDENCE INFORMED / No Fluf" tiles on Baby's First
+/// Nibbles (Figma 971:8730).
+class GuideInfoCard extends StatelessWidget {
+  const GuideInfoCard({
+    required this.title,
+    required this.body,
+    super.key,
+  });
+
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSizes.md),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+        boxShadow: AppSizes.shadowCard,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const BabyFaceGlyph(size: BabyFaceGlyph.smallSize),
+          const SizedBox(height: AppSizes.sm),
+          Text(
+            title,
+            style: AppTypography.textTheme.titleSmall?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+          ),
+          const SizedBox(height: AppSizes.xs),
+          Text(
+            body,
+            style: AppTypography.textTheme.bodyMedium?.copyWith(
+              color: AppColors.fgMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/guide_numbered_list_card.dart
+++ b/lib/src/features/starting_guide/widgets/guide_numbered_list_card.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/features/starting_guide/constants/articles.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/numbered_step.dart';
+
+/// Butter-soft card containing a title, optional lead paragraph, and a
+/// numbered list of [NumberedStep] rows. Used by Nibbles Goals (First
+/// Nibbles), Feeding is Skill-Building (Introduction), Items to Avoid
+/// (Feeding Principles).
+class GuideNumberedListCard extends StatelessWidget {
+  const GuideNumberedListCard({
+    required this.title,
+    required this.items,
+    this.body,
+    super.key,
+  });
+
+  final String title;
+  final String? body;
+  final List<NumberedItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSizes.md),
+      decoration: BoxDecoration(
+        color: AppColors.bgCardTint,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: AppTypography.textTheme.titleSmall?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+          ),
+          if (body != null) ...[
+            const SizedBox(height: AppSizes.xs),
+            Text(
+              body!,
+              style: AppTypography.textTheme.bodyMedium?.copyWith(
+                color: AppColors.fgMuted,
+              ),
+            ),
+          ],
+          const SizedBox(height: AppSizes.sp12),
+          for (var i = 0; i < items.length; i++) ...[
+            if (i > 0) const SizedBox(height: AppSizes.sp12),
+            NumberedStep(
+              stepNumber: i + 1,
+              heading: items[i].heading,
+              body: items[i].body,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/guide_philosophy_card.dart
+++ b/lib/src/features/starting_guide/widgets/guide_philosophy_card.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/baby_face_glyph.dart';
+
+/// White card — leaf-style glyph, title, body, trailing label chips. Matches
+/// the "Our Philosophy" card on Introduction (Figma 971:8744).
+class GuidePhilosophyCard extends StatelessWidget {
+  const GuidePhilosophyCard({
+    required this.title,
+    required this.body,
+    required this.chips,
+    super.key,
+  });
+
+  final String title;
+  final String body;
+  final List<String> chips;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSizes.md),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+        boxShadow: AppSizes.shadowCard,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const BabyFaceGlyph(size: BabyFaceGlyph.smallSize),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: AppTypography.textTheme.titleSmall?.copyWith(
+                    color: AppColors.fgStrong,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.xs),
+                Text(
+                  body,
+                  style: AppTypography.textTheme.bodyMedium?.copyWith(
+                    color: AppColors.fgMuted,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.sp12),
+                Wrap(
+                  spacing: AppSizes.sm,
+                  runSpacing: AppSizes.sm,
+                  children: [
+                    for (final label in chips) AppChip(label: label),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/guide_ready_to_start_card.dart
+++ b/lib/src/features/starting_guide/widgets/guide_ready_to_start_card.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+
+/// White closing card — centered title + body + a single primary pill CTA.
+/// Matches the "Ready to Start?" cards at the end of Introduction (Figma
+/// 971:8744) and Feeding Principles (Figma 1474:50514).
+class GuideReadyToStartCard extends StatelessWidget {
+  const GuideReadyToStartCard({
+    required this.title,
+    required this.body,
+    required this.ctaLabel,
+    required this.onCta,
+    super.key,
+  });
+
+  final String title;
+  final String body;
+  final String ctaLabel;
+  final VoidCallback onCta;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSizes.lg),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+        boxShadow: AppSizes.shadowCard,
+      ),
+      child: Column(
+        children: [
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            style: AppTypography.textTheme.titleMedium?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+          ),
+          const SizedBox(height: AppSizes.sm),
+          Text(
+            body,
+            textAlign: TextAlign.center,
+            style: AppTypography.textTheme.bodyMedium?.copyWith(
+              color: AppColors.fgMuted,
+            ),
+          ),
+          const SizedBox(height: AppSizes.md),
+          AppPillButton(
+            label: ctaLabel,
+            onPressed: onCta,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/guide_section_heading.dart
+++ b/lib/src/features/starting_guide/widgets/guide_section_heading.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+
+/// Bold section title rendered between blocks inside an article. Maps to the
+/// Figma Title 2/Bold (Parkinsans 20/700 h28) — uses [TextTheme.titleMedium]
+/// which the app theme defines as 20/700.
+class GuideSectionHeading extends StatelessWidget {
+  const GuideSectionHeading(this.text, {super.key});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: AppTypography.textTheme.titleMedium?.copyWith(
+        color: AppColors.fgStrong,
+      ),
+    );
+  }
+}

--- a/lib/src/features/starting_guide/widgets/numbered_step.dart
+++ b/lib/src/features/starting_guide/widgets/numbered_step.dart
@@ -47,13 +47,15 @@ class NumberedStep extends StatelessWidget {
                   ),
                 ),
               ),
-              const SizedBox(height: AppSizes.xs),
-              Text(
-                body,
-                style: AppTypography.textTheme.bodyMedium?.copyWith(
-                  color: AppColors.fgMuted,
+              if (body.isNotEmpty) ...[
+                const SizedBox(height: AppSizes.xs),
+                Text(
+                  body,
+                  style: AppTypography.textTheme.bodyMedium?.copyWith(
+                    color: AppColors.fgMuted,
+                  ),
                 ),
-              ),
+              ],
             ],
           ),
         ),

--- a/test/features/starting_guide/starting_guide_article_screen_test.dart
+++ b/test/features/starting_guide/starting_guide_article_screen_test.dart
@@ -1,10 +1,9 @@
 // Widget tests for the Starting Guide article screen.
 //
 // Asserts:
-//   * a known slug ('first-nibbles') renders the matching article's title,
-//     all sections, and its terminal CTA label
-//   * tapping the terminal CTA calls `goNamed` on a known top-level route
-//     — asserted by a stub destination route that surfaces the routed path
+//   * a known slug ('first-nibbles') renders the article's hero title and
+//     section copy (verbatim from the Figma audit)
+//   * tapping the article's primary inline CTA routes to recipe-library
 //   * an unknown slug falls back to the in-screen 'Article not found' UI
 //     (no crash, no exception)
 //
@@ -48,6 +47,22 @@ class _RecipeLibraryStub extends StatelessWidget {
       const Scaffold(body: Center(child: Text('LIBRARY_STUB')));
 }
 
+class _MealPlanStub extends StatelessWidget {
+  const _MealPlanStub();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: Text('MEAL_PLAN_STUB')));
+}
+
+class _AllergenStub extends StatelessWidget {
+  const _AllergenStub();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: Text('ALLERGEN_STUB')));
+}
+
 GoRouter _makeRouter({required String slug}) => GoRouter(
   initialLocation: AppRoute.startingGuideArticle.path.replaceFirst(
     ':slug',
@@ -70,6 +85,16 @@ GoRouter _makeRouter({required String slug}) => GoRouter(
       name: AppRoute.recipeLibrary.name,
       builder: (_, __) => const _RecipeLibraryStub(),
     ),
+    GoRoute(
+      path: AppRoute.mealPlan.path,
+      name: AppRoute.mealPlan.name,
+      builder: (_, __) => const _MealPlanStub(),
+    ),
+    GoRoute(
+      path: AppRoute.allergenTracker.path,
+      name: AppRoute.allergenTracker.name,
+      builder: (_, __) => const _AllergenStub(),
+    ),
   ],
 );
 
@@ -78,13 +103,29 @@ Widget _buildSut({required String slug}) => ProviderScope(
 );
 
 Future<void> _pump(WidgetTester tester, {required String slug}) async {
-  tester.view.physicalSize = const Size(1080, 2400);
+  tester.view.physicalSize = const Size(1080, 3600);
   tester.view.devicePixelRatio = 1;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
 
   await tester.pumpWidget(_buildSut(slug: slug));
   await tester.pumpAndSettle();
+}
+
+/// Collects every CTA across the article's blocks (inline pair + ready-card)
+/// so tests don't have to know the block layout.
+List<GuideCta> _allCtas(GuideArticle article) {
+  final out = <GuideCta>[];
+  for (final block in article.blocks) {
+    if (block is InlineCtaPairBlock) {
+      out.add(block.primary);
+      final secondary = block.secondary;
+      if (secondary != null) out.add(secondary);
+    } else if (block is ReadyToStartCardBlock) {
+      out.add(block.cta);
+    }
+  }
+  return out;
 }
 
 void main() {
@@ -96,7 +137,7 @@ void main() {
 
   group('StartingGuideArticleScreen — known slug', () {
     testWidgets(
-      "'first-nibbles' renders the matching article's title and CTA",
+      "'first-nibbles' renders the article's hub title in the header",
       (tester) async {
         const slug = 'first-nibbles';
         await _pump(tester, slug: slug);
@@ -105,29 +146,14 @@ void main() {
           (a) => a.slug == slug,
         );
 
-        // Title is rendered (it appears in the hero card AND header — at least
-        // one).
+        // Hub title is verbatim from Figma — it shows in the header and the
+        // hero card so we expect it at least once.
         expect(find.text(article.title), findsWidgets);
-        // Terminal CTA label is rendered exactly once.
-        expect(find.text(article.terminalCta!.label), findsOneWidget);
       },
     );
 
-    testWidgets("'first-nibbles' renders every section heading", (
-      tester,
-    ) async {
-      const slug = 'first-nibbles';
-      await _pump(tester, slug: slug);
-
-      final article = kStartingGuideArticles.firstWhere((a) => a.slug == slug);
-
-      for (final section in article.sections) {
-        expect(find.text(section.heading), findsOneWidget);
-      }
-    });
-
     testWidgets(
-      "'first-nibbles' terminal CTA tap → goNamed routes to recipe-library",
+      "'first-nibbles' renders every section heading + info-card title",
       (tester) async {
         const slug = 'first-nibbles';
         await _pump(tester, slug: slug);
@@ -135,13 +161,83 @@ void main() {
         final article = kStartingGuideArticles.firstWhere(
           (a) => a.slug == slug,
         );
-        expect(article.terminalCta!.routeName, AppRoute.recipeLibrary.name);
 
-        await tester.tap(find.text(article.terminalCta!.label));
+        for (final block in article.blocks) {
+          if (block is SectionHeadingBlock) {
+            expect(
+              find.text(block.text),
+              findsWidgets,
+              reason: 'section heading "${block.text}" missing',
+            );
+          } else if (block is InfoCardBlock) {
+            expect(
+              find.text(block.title),
+              findsOneWidget,
+              reason: 'info card "${block.title}" missing',
+            );
+          }
+        }
+      },
+    );
+
+    testWidgets(
+      "'first-nibbles' primary CTA → routes to recipe-library",
+      (tester) async {
+        const slug = 'first-nibbles';
+        await _pump(tester, slug: slug);
+
+        final article = kStartingGuideArticles.firstWhere(
+          (a) => a.slug == slug,
+        );
+        final ctas = _allCtas(article);
+        final primary = ctas.firstWhere(
+          (c) => c.routeName == AppRoute.recipeLibrary.name,
+        );
+
+        await tester.ensureVisible(find.text(primary.label));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(primary.label));
         await tester.pumpAndSettle();
 
-        // Routed to the recipe-library stub.
         expect(find.text('LIBRARY_STUB'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      "'introduction' renders Essential Nutrients icon tiles",
+      (tester) async {
+        await _pump(tester, slug: 'introduction');
+
+        for (final label in ['Iron', 'Minerals', 'Vitamins', 'Zinc']) {
+          expect(find.text(label), findsWidgets);
+        }
+      },
+    );
+
+    testWidgets(
+      "'feeding-principles' renders 'The Big 11' allergen chips",
+      (tester) async {
+        await _pump(tester, slug: 'feeding-principles');
+
+        // Sample a few chips from The Big 11. 'Egg' is also in the iron-rich
+        // grid as 'Eggs' (plural) — checking distinct labels avoids overlap.
+        for (final label in ['Almond', 'Cashew', 'Wallnut', 'Sesame']) {
+          expect(
+            find.text(label),
+            findsWidgets,
+            reason: 'allergen chip "$label" missing',
+          );
+        }
+      },
+    );
+
+    testWidgets(
+      "'readiness-signs' renders the Readiness Signs checklist + score",
+      (tester) async {
+        await _pump(tester, slug: 'readiness-signs');
+
+        expect(find.text('Readiness Signs'), findsOneWidget);
+        expect(find.text('3/5'), findsOneWidget);
       },
     );
   });


### PR DESCRIPTION
## NIB-132 — Starting Guide articles aligned with Figma

Reworks the 4 Starting Guide articles (Baby's First Nibbles, Introductions, Important Feeding Principles, Signs Your Baby Is Ready for Solids) to match the Figma audit artifacts exactly. The flat `GuideSection { heading, body, stepNumber }` model couldn't carry the actual layouts (info-card grids, chip clouds, score-pill checklist, multi-CTA blocks), so the content model is rebuilt as a typed sequence of `GuideBlock` variants.

### Acceptance criteria
- [x] Verbatim copy from `.figma-audit/recipe-library/recipe-library-baby-first-nibbles`
- [x] Verbatim copy from `.figma-audit/recipe-library/recipe-library-introduction`
- [x] Verbatim copy from `.figma-audit/recipe-library/recipe-library-feeding-principals`
- [x] Verbatim copy from `.figma-audit/recipe-library/recipe-library-introduction-2` (5 Sign Readiness)
- [x] Hub card titles match the Starting Guide index frame (BABY'S FIRST NIBBLES, Introductions, Important Feeding Principles, Signs Your Baby Is Ready for Solids)
- [x] CTAs wired per Figma (see table below)
- [x] Tokens from `variables.json` mapped to existing `AppColors` / `AppSizes` / `AppTypography`
- [x] Loading / error / not-found states reachable
- [x] `make gen` clean, no unrelated regen
- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 484 passed

### Figma frames
| Article | Node id |
|---|---|
| Baby's First Nibbles | 971:8730 |
| Introduction | 971:8744 |
| Feeding Principles | 1474:50514 |
| 5 Sign Readiness | 1474:50031 |
| Hub index (titles source) | 971:8692 |

### Audit report paths
- `.figma-audit/recipe-library/recipe-library-baby-first-nibbles/report.md`
- `.figma-audit/recipe-library/recipe-library-introduction/report.md`
- `.figma-audit/recipe-library/recipe-library-feeding-principals/report.md`
- `.figma-audit/recipe-library/recipe-library-introduction-2/report.md`
- `.figma-audit/recipe-library/recipe-library-starting-guide/report.md` (hub titles)

### CTA wiring
| Article | CTA | Route |
|---|---|---|
| First Nibbles | Explore Recipes | recipe-library |
| First Nibbles | Get Free Weekly Baby Recipes | starting-guide (pop; NIB-94 pending) |
| Introduction | Explore Recipes | recipe-library |
| Introduction | Get Free Weekly Baby Recipes | starting-guide (pop; NIB-94 pending) |
| Introduction | Create First Meal | meal-plan |
| Feeding Principles | Start Introducing Allergens | allergen-tracker |
| 5 Sign Readiness | (none — Figma frame has no CTA) | — |

### Reused vs new widgets
Reused: `BabyFaceGlyph`, `AppChip` (salmon-ghost = neutral tone), `AppPillButton` (primary + ghost), `NumberedStep`, `GuideHeroCard`, `GuideBackButton`, `ArticleCard`.
New: `GuideSectionHeading`, `GuideInfoCard`, `GuideIconTileGrid`, `GuideChipGridCard`, `GuideNumberedListCard`, `GuidePhilosophyCard`, `GuideReadyToStartCard`, `GuideChecklistCard`.

### Copy typos preserved verbatim (PO-flag for design)
The audit reports flag these as verbatim Figma copy — preserved as-is per spec; surfacing here so design can correct in Figma:
- "BABY'S FIRST NIBBLES" — "No Fluf" (missing second f), "We focuses on" (subject/verb)
- Introduction — "Perfect time to growth" (article missing), philosophy chips list contains "Nurturing" twice
- Feeding Principles — "The Big 11" includes typo "Wallnut"; allergen labels (Almond, Cashew, Egg, Wheat, Fish, Peanut, Milk, Prawn, Wallnut, Soy, Sesame) don't map 1:1 to the Nibbles canonical allergen list (peanut, egg, dairy, tree_nuts, sesame, soy, wheat, fish, shellfish) — copy is rendered as-is; canonical list is unchanged
- Feeding Principles — "Babies's kidneys" (extra possessive)
- 5 Sign Readiness — section heading "Asther readiness result" (likely "Asher's"/your baby's readiness result); hero title "5 Sign Readiness" (singular)
- Smart quotes / curly apostrophes (U+2019) preserved across all four articles

### Out of scope
- Hero photos (IMG_6924, IMG_6919, IMG_6931, etc.) from the audit are not in the repo. The `BabyFaceGlyph` stand-in stays for now per the existing pattern; pixel-perfect imagery is a follow-up once assets land.