### PR TITLE
feat(infra): QA bypass flag for visual-gate render phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: gen gen-watch run-dev run-prod clean fix
+.PHONY: gen gen-watch run-dev run-prod run-qa build-qa-sim clean fix
 
 gen:
 	dart run build_runner build --delete-conflicting-outputs
@@ -11,6 +11,14 @@ run-dev:
 
 run-prod:
 	flutter run -t lib/main.dart --flavor prod
+
+# QA bypass — boots straight into /home with synthetic auth/baby. Used by the
+# visual-gate render phase in the build pipeline.
+run-qa:
+	flutter run -t lib/main_dev.dart --flavor dev --dart-define=NIBBLES_QA_BYPASS=true
+
+build-qa-sim:
+	flutter build ios --simulator --debug -t lib/main_dev.dart --no-codesign --dart-define=NIBBLES_QA_BYPASS=true
 
 clean:
 	flutter clean && flutter pub get

--- a/lib/src/app/qa_bypass.dart
+++ b/lib/src/app/qa_bypass.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:nibbles/src/app/constants/hive_box_names.dart';
+import 'package:nibbles/src/common/data/repositories/allergen_repository.dart';
+import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/repositories/baby_profile_repository.dart';
+import 'package:nibbles/src/common/data/repositories/meal_plan_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
+import 'package:nibbles/src/common/domain/entities/reaction_detail.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Compile-time QA bypass switch.
+///
+/// When passed via `--dart-define=NIBBLES_QA_BYPASS=true`, the app boots
+/// straight into `/home` without real auth, a real Supabase session, or a
+/// real baby record. Used by the visual-gate render phase in the build
+/// pipeline. When the flag is false (default), everything below is inert and
+/// production behaviour is unchanged.
+const bool kQaBypass = bool.fromEnvironment(
+  'NIBBLES_QA_BYPASS',
+);
+
+/// Synthetic baby surfaced by [_QaBabyProfileRepository] so screens that need
+/// a baby record (Home, Profile, Profile Edit) render without a Supabase row.
+Baby _syntheticBaby() {
+  final now = DateTime.now();
+  // 6 months ago, day-anchored.
+  final dob = DateTime(now.year, now.month - 6, now.day);
+  return Baby(
+    id: 'qa-baby-id',
+    userId: 'qa-user-id',
+    name: 'QA Tester',
+    dateOfBirth: dob,
+    gender: Gender.preferNotToSay,
+    onboardingCompleted: true,
+  );
+}
+
+/// Pre-populates the four onboarding flags in the `local_flags` Hive box so
+/// the GoRouter redirect chain lets the user reach `/home` (and any sub-route)
+/// without authenticating or running onboarding.
+///
+/// Must be called AFTER `Hive.openBox<dynamic>('local_flags')` and BEFORE
+/// `runApp`. No-op when [kQaBypass] is false.
+Future<void> seedQaLocalFlags() async {
+  if (!kQaBypass) return;
+  final box = Hive.box<dynamic>(HiveBoxNames.localFlags);
+  await box.putAll(<String, dynamic>{
+    'app_has_launched': true,
+    'onboarding_readiness_done': true,
+    'onboarding_baby_setup_done': true,
+    'onboarding_done': true,
+  });
+}
+
+/// ProviderScope overrides that swap the four Supabase-backed repositories
+/// for synthetic in-memory fakes. Returns an empty list when [kQaBypass] is
+/// false so the no-flag path stays completely inert.
+///
+/// The override seam is the Repository layer (matches the project's "Supabase
+/// only in repos" rule). Real `AuthService`, `BabyProfileService`,
+/// `AllergenService`, and `MealPlanService` logic flows on top unchanged.
+List<Override> qaBypassOverrides() {
+  if (!kQaBypass) return const [];
+  return [
+    authRepositoryProvider.overrideWithValue(const _QaAuthRepository()),
+    babyProfileRepositoryProvider.overrideWithValue(
+      _QaBabyProfileRepository(),
+    ),
+    allergenRepositoryProvider.overrideWithValue(const _QaAllergenRepository()),
+    mealPlanRepositoryProvider.overrideWithValue(const _QaMealPlanRepository()),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Fake repositories
+// ---------------------------------------------------------------------------
+
+class _QaAuthRepository implements AuthRepository {
+  const _QaAuthRepository();
+
+  @override
+  bool get isLoggedIn => true;
+
+  @override
+  String? get currentUserEmail => 'qa@nibbles.test';
+
+  /// MUST be an empty stream that never emits. `AuthService.build` listens
+  /// here and flips `state = authState.session != null` on every emission —
+  /// an emission with a null session would route the user to `/auth/login`.
+  @override
+  Stream<AuthState> get authStateStream => const Stream.empty();
+
+  @override
+  Future<Result<void>> signUp(String email, String password) async =>
+      const Result.success(null);
+
+  @override
+  Future<Result<void>> signIn(String email, String password) async =>
+      const Result.success(null);
+
+  @override
+  Future<Result<bool>> signInWithGoogle() async => const Result.success(true);
+
+  @override
+  Future<Result<bool>> signInWithApple() async => const Result.success(true);
+
+  @override
+  Future<Result<void>> signOut() async => const Result.success(null);
+
+  @override
+  Future<Result<void>> resetPassword(String email) async =>
+      const Result.success(null);
+
+  @override
+  Future<Result<void>> updatePassword(String newPassword) async =>
+      const Result.success(null);
+
+  @override
+  Future<Result<void>> updateEmail(String newEmail) async =>
+      const Result.success(null);
+}
+
+class _QaBabyProfileRepository implements BabyProfileRepository {
+  _QaBabyProfileRepository();
+
+  late final Baby _baby = _syntheticBaby();
+
+  @override
+  Future<Result<Baby>> createBaby(
+    String name,
+    DateTime dob, [
+    Gender gender = Gender.preferNotToSay,
+  ]) async => Result.success(_baby);
+
+  @override
+  Future<Baby?> getBaby() async => _baby;
+
+  @override
+  Future<Result<Baby>> updateBaby(
+    String babyId,
+    String name,
+    DateTime dob,
+    Gender gender,
+  ) async => Result.success(_baby);
+
+  @override
+  Future<Result<void>> createAllergenProgramState(String babyId) async =>
+      const Result.success(null);
+
+  @override
+  Future<bool> isOnboardingCompleted() async => true;
+}
+
+class _QaAllergenRepository implements AllergenRepository {
+  const _QaAllergenRepository();
+
+  @override
+  Future<Result<List<Allergen>>> getAllergens({bool refresh = false}) async =>
+      const Result.success(<Allergen>[]);
+
+  @override
+  Future<Result<AllergenProgramState>> getProgramState(String babyId) async =>
+      const Result.failure(UnknownException('QA bypass: no program state.'));
+
+  @override
+  Future<Result<List<AllergenLog>>> getLogs(
+    String babyId, {
+    String? allergenKey,
+  }) async => const Result.success(<AllergenLog>[]);
+
+  @override
+  Future<Result<AllergenLog>> saveLog(AllergenLog log) async =>
+      Result.success(log);
+
+  @override
+  Future<Result<AllergenLog>> updateLog(AllergenLog log) async =>
+      Result.success(log);
+
+  @override
+  Future<Result<void>> deleteLog(String logId) async =>
+      const Result.success(null);
+
+  @override
+  Future<Result<ReactionDetail>> saveReactionDetail(
+    ReactionDetail detail,
+  ) async => Result.success(detail);
+
+  @override
+  Future<Result<void>> advanceProgramState(
+    String babyId,
+    String nextAllergenKey,
+    int nextSequenceOrder,
+  ) async => const Result.success(null);
+
+  @override
+  Future<Result<void>> completeProgramState(String babyId) async =>
+      const Result.success(null);
+
+  @override
+  Future<Result<ReactionDetail?>> getReactionDetail(String logId) async =>
+      const Result.success(null);
+}
+
+class _QaMealPlanRepository implements MealPlanRepository {
+  const _QaMealPlanRepository();
+
+  @override
+  Future<Result<List<MealPlanEntry>>> getWeekMeals(
+    String babyId,
+    DateTime weekStart,
+    DateTime weekEnd,
+  ) async => const Result.success(<MealPlanEntry>[]);
+
+  @override
+  Future<Result<List<MealPlanEntry>>> getEntriesInRange(
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
+  ) async => const Result.success(<MealPlanEntry>[]);
+
+  @override
+  Future<Result<MealPlanEntry>> assignRecipe(
+    String babyId,
+    String recipeId,
+    DateTime planDate,
+    TimeOfDay? mealTime,
+  ) async => const Result.failure(UnknownException('QA bypass: noop.'));
+
+  @override
+  Future<Result<List<MealPlanEntry>>> appendBulk(
+    List<MealPlanEntryInsert> entries,
+  ) async => const Result.success(<MealPlanEntry>[]);
+
+  @override
+  Future<Result<void>> clearWeek(
+    String babyId,
+    DateTime weekStart,
+    DateTime weekEnd,
+  ) async => const Result.success(null);
+
+  @override
+  Future<Result<void>> deleteRange(
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
+  ) async => const Result.success(null);
+
+  @override
+  Future<Result<void>> removeEntry(String entryId) async =>
+      const Result.success(null);
+
+  @override
+  Future<Result<void>> clearDay(String babyId, DateTime date) async =>
+      const Result.success(null);
+}

--- a/lib/src/app/runner.dart
+++ b/lib/src/app/runner.dart
@@ -10,6 +10,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:nibbles/firebase_options.dart';
 import 'package:nibbles/src/app.dart';
 import 'package:nibbles/src/app/config/flavor_config.dart';
+import 'package:nibbles/src/app/qa_bypass.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -52,6 +53,11 @@ Future<void> bootstrap({required Flavor flavor}) async {
   await Hive.openBox<String>('allergens');
   await Hive.openBox<dynamic>('local_flags');
 
+  // 3a. QA bypass — when `--dart-define=NIBBLES_QA_BYPASS=true` is set, pre-
+  // populate the four onboarding flags so the GoRouter redirect reaches
+  // `/home` without auth. No-op when the flag is false.
+  await seedQaLocalFlags();
+
   // 4. Firebase init (firebase options wired in NIB-3)
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
 
@@ -76,5 +82,10 @@ Future<void> bootstrap({required Flavor flavor}) async {
       : FlavorConfig.instance.revenueCatGoogleKey;
   await Purchases.configure(PurchasesConfiguration(revenueCatKey));
 
-  runApp(const ProviderScope(child: App()));
+  runApp(
+    ProviderScope(
+      overrides: qaBypassOverrides(),
+      child: const App(),
+    ),
+  );
 }


### PR DESCRIPTION
## Summary

Adds a compile-time flag (`--dart-define=NIBBLES_QA_BYPASS=true`) that lets the app boot straight into `/home` (and any deep-linked sub-route) without real auth, a real Supabase session, or a real baby record. Used by the visual-gate render phase in the build pipeline. When the flag is false (production / normal dev), behavior is completely unchanged.

## Mechanism

The override seam is the **Repository layer** (matches the project's "Supabase only in repos" rule). Real `AuthService`, `BabyProfileService`, `AllergenService`, and `MealPlanService` logic flows on top unchanged.

When `kQaBypass == true`:

1. **Seed local_flags Hive box** (`seedQaLocalFlags()` called in `runner.dart` between Hive open and `runApp`):
   - `app_has_launched = true`
   - `onboarding_readiness_done = true`
   - `onboarding_baby_setup_done = true`
   - `onboarding_done = true`
2. **Override 4 repository providers** via `ProviderScope.overrides`:
   - `authRepositoryProvider` → `isLoggedIn=true`, `currentUserEmail='qa@nibbles.test'`, `authStateStream=Stream.empty()` (must never emit — an emission with `session==null` would route to `/auth/login`)
   - `babyProfileRepositoryProvider` → `getBaby()` returns a synthetic `Baby` (name "QA Tester", DOB 6 months ago, `Gender.preferNotToSay`, `onboarding_completed=true`); `isOnboardingCompleted()` → true
   - `allergenRepositoryProvider` → `getLogs/getAllergens` return `Success(empty)` so Home doesn't render the error scaffold from a no-session network call
   - `mealPlanRepositoryProvider` → `getEntriesInRange/getWeekMeals` return `Success(empty)` for the same reason

When `kQaBypass == false` (default): `seedQaLocalFlags()` short-circuits; `qaBypassOverrides()` returns `const []`. Zero side effects.

## Files changed

- `lib/src/app/qa_bypass.dart` — new file. `kQaBypass` constant, `seedQaLocalFlags()`, `qaBypassOverrides()`, four `_Qa*Repository` fakes.
- `lib/src/app/runner.dart` — calls `seedQaLocalFlags()` after Hive open, passes `qaBypassOverrides()` to `ProviderScope`.
- `Makefile` — adds `run-qa` and `build-qa-sim` targets.

## How to use

- `make run-qa` — runs the dev flavor with the bypass.
- `make build-qa-sim` — builds the debug simulator `.app` for the visual gate.

## Test plan

- [x] `make gen` — clean.
- [x] `flutter analyze` — **0 issues**.
- [x] `flutter test` — **481 passed, 1 skipped**. No tests touch `NIBBLES_QA_BYPASS`, so the no-flag path stays inert as confirmed by the green run.
- [x] `make build-qa-sim` — produces `build/ios/iphonesimulator/Runner.app`.
- [x] Installed `Runner.app` on simulator `9E45D46A-DAD8-4B3A-AAAD-9F34841CAE74` (iPhone 17), launched `com.aydev.nibbles`, waited for boot. `axe describe-ui` confirms the Home dashboard is reached (NOT `/auth/login`):
  ```
  AXLabel: "Nibbles"
  AXLabel: "Ready to start?"
  AXLabel: "Track allergen introductions and plan baby's meals."
  AXLabel: "Create First Meal"
  AXLabel: "Getting Started Tips"
  AXLabel: "Start with single-ingredient foods"
  AXLabel: "Introduce allergens early"
  AXLabel: "Watch, wait, repeat"
  AXLabel: "Home\nTab 1 of 4"
  AXLabel: "Meals\nTab 2 of 4"
  AXLabel: "Grocery\nTab 3 of 4"
  AXLabel: "Recipes\nTab 4 of 4"
  ```
  No `Login`/`Sign in`/`Welcome to`/`Onboarding` labels present.

## Caveats

- `profile_controller.dart:18` still reads `Supabase.instance.client.auth.currentUser?.email` directly (legacy pattern); under bypass this returns `null`. ProfileScreen does not display email, so this is inert. **Not touched** to keep this PR scoped to additive infra.
- `currentBabyIdProvider` is not overridden directly — it derives from the overridden `babyProfileRepositoryProvider`, so the synthetic id propagates correctly.