### PR TITLE
feat(infra): subscription success transition screen [NIB-130]

### DIFF
--- a/lib/src/features/subscription/success/subscription_success_controller.dart
+++ b/lib/src/features/subscription/success/subscription_success_controller.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nibbles/src/common/services/subscription_service.dart';
+import 'package:nibbles/src/features/subscription/success/subscription_success_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'subscription_success_controller.g.dart';
+
+/// NIB-130 — passive two-phase transition shown after a successful purchase.
+///
+/// Loop:
+/// 1. Render `loading` while we wait on entitlement provisioning. Two outs:
+///    a. `SubscriptionService.isActive` flips to true → settle immediately.
+///    b. `loadingTimeout` elapses → settle anyway (RC stub still returns
+///       false; the upstream paywall — not this screen — is responsible for
+///       surfacing a P1 modal on provisioning failure per NIB-130 spec).
+///    Either way, a `loadingMinDwell` floor keeps the petal animation
+///    on-screen long enough to read.
+/// 2. Render `success` (animation + "You all set!"). The screen schedules a
+///    short `successDwell` before navigating to `/home`.
+@riverpod
+class SubscriptionSuccessController extends _$SubscriptionSuccessController {
+  /// Floor on the loading frame so the animation never just flashes.
+  static const Duration loadingMinDwell = Duration(milliseconds: 1200);
+
+  /// Cap on entitlement-wait. Past this we settle to success regardless —
+  /// failure handling is upstream (see NIB-130 acceptance criteria).
+  static const Duration loadingTimeout = Duration(seconds: 4);
+
+  /// How long "You all set!" stays before the screen auto-routes to /home.
+  /// Consumed by the success screen to schedule the `/home` push.
+  static const Duration successDwell = Duration(milliseconds: 1500);
+
+  Timer? _settleTimer;
+  ProviderSubscription<bool>? _subSub;
+
+  @override
+  SubscriptionSuccessPhase build() {
+    ref.onDispose(() {
+      _settleTimer?.cancel();
+      _subSub?.close();
+    });
+
+    // Fire-and-forget activation analytics on first build. Guarded against an
+    // uninitialised Firebase in tests.
+    unawaited(_logSubscriptionActivated());
+
+    _scheduleSettle();
+    return SubscriptionSuccessPhase.loading;
+  }
+
+  /// Settles the loading state. Resolves on whichever fires first —
+  /// `SubscriptionService.isActive` flipping true OR the [loadingTimeout]
+  /// elapsing — but never before [loadingMinDwell].
+  void _scheduleSettle() {
+    final isActive = ref.read(subscriptionServiceProvider);
+
+    // Fast path — entitlement already active. Wait the min dwell, then flip.
+    if (isActive) {
+      _settleTimer = Timer(loadingMinDwell, _flipToSuccess);
+      return;
+    }
+
+    // Slow path — schedule both the timeout AND a listener on the service.
+    // First-fire wins, but both are still capped by min dwell via _flipAfter.
+    final start = DateTime.now();
+    _settleTimer = Timer(loadingTimeout, () => _flipAfter(start));
+    _subSub = ref.listen<bool>(subscriptionServiceProvider, (_, next) {
+      if (next) _flipAfter(start);
+    });
+  }
+
+  /// Flips to success after honoring the min-dwell floor relative to [start].
+  void _flipAfter(DateTime start) {
+    _settleTimer?.cancel();
+    final elapsed = DateTime.now().difference(start);
+    final remaining = loadingMinDwell - elapsed;
+    if (remaining <= Duration.zero) {
+      _flipToSuccess();
+      return;
+    }
+    _settleTimer = Timer(remaining, _flipToSuccess);
+  }
+
+  void _flipToSuccess() {
+    if (state == SubscriptionSuccessPhase.success) return;
+    state = SubscriptionSuccessPhase.success;
+  }
+
+  Future<void> _logSubscriptionActivated() async {
+    try {
+      // Reuse the existing logSubscriptionStarted event for activation —
+      // NIB-90 introduces dedicated events; until then this is the closest
+      // non-PII signal we can emit. Empty productId because the upstream
+      // paywall owns the actual product attribution.
+      await ref.read(analyticsProvider).logSubscriptionStarted(productId: '');
+    } on Object catch (_) {
+      // Best-effort; never block UI.
+    }
+  }
+}

--- a/lib/src/features/subscription/success/subscription_success_controller.g.dart
+++ b/lib/src/features/subscription/success/subscription_success_controller.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'subscription_success_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$subscriptionSuccessControllerHash() =>
+    r'ff342a52b9ddc3dca73544d4f53448aedad3dd81';
+
+/// NIB-130 — passive two-phase transition shown after a successful purchase.
+///
+/// Loop:
+/// 1. Render `loading` while we wait on entitlement provisioning. Two outs:
+///    a. `SubscriptionService.isActive` flips to true → settle immediately.
+///    b. `loadingTimeout` elapses → settle anyway (RC stub still returns
+///       false; the upstream paywall — not this screen — is responsible for
+///       surfacing a P1 modal on provisioning failure per NIB-130 spec).
+///    Either way, a `loadingMinDwell` floor keeps the petal animation
+///    on-screen long enough to read.
+/// 2. Render `success` (animation + "You all set!"). The screen schedules a
+///    short `successDwell` before navigating to `/home`.
+///
+/// Copied from [SubscriptionSuccessController].
+@ProviderFor(SubscriptionSuccessController)
+final subscriptionSuccessControllerProvider =
+    AutoDisposeNotifierProvider<
+      SubscriptionSuccessController,
+      SubscriptionSuccessPhase
+    >.internal(
+      SubscriptionSuccessController.new,
+      name: r'subscriptionSuccessControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$subscriptionSuccessControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$SubscriptionSuccessController =
+    AutoDisposeNotifier<SubscriptionSuccessPhase>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/subscription/success/subscription_success_screen.dart
+++ b/lib/src/features/subscription/success/subscription_success_screen.dart
@@ -1,0 +1,209 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+import 'package:nibbles/src/features/subscription/success/subscription_success_controller.dart';
+import 'package:nibbles/src/features/subscription/success/subscription_success_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+/// NIB-130 — passive post-purchase transition screen.
+///
+/// Two visual phases:
+///   * loading: petal blob + faint uppercase "LOADING" caption.
+///   * success: petal blob + bold "You all set!" body label, then auto-routes
+///     to `/home` after [SubscriptionSuccessController.successDwell].
+///
+/// No interactive elements; back is blocked while provisioning is in flight
+/// (and on the success frame until the auto-route fires) per spec.
+class SubscriptionSuccessScreen extends ConsumerStatefulWidget {
+  const SubscriptionSuccessScreen({super.key});
+
+  @override
+  ConsumerState<SubscriptionSuccessScreen> createState() =>
+      _SubscriptionSuccessScreenState();
+}
+
+class _SubscriptionSuccessScreenState
+    extends ConsumerState<SubscriptionSuccessScreen> {
+  Timer? _routeTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_logScreenView());
+    });
+  }
+
+  @override
+  void dispose() {
+    _routeTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await Analytics.instance.logScreenView(
+        screenName: 'subscription_success',
+      );
+    } on Object catch (_) {
+      // Best-effort; never surface to the UI.
+    }
+  }
+
+  void _scheduleRoute() {
+    _routeTimer?.cancel();
+    _routeTimer = Timer(
+      SubscriptionSuccessController.successDwell,
+      () {
+        if (!mounted) return;
+        context.goNamed(AppRoute.home.name);
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Schedule the auto-route exactly once on the loading→success transition.
+    // Listening (not watching) keeps the build pure; the timer + mounted guard
+    // make double-fires safe.
+    ref.listen<SubscriptionSuccessPhase>(
+      subscriptionSuccessControllerProvider,
+      (prev, next) {
+        if (next == SubscriptionSuccessPhase.success &&
+            prev != SubscriptionSuccessPhase.success) {
+          _scheduleRoute();
+        }
+      },
+    );
+
+    final phase = ref.watch(subscriptionSuccessControllerProvider);
+
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        backgroundColor: AppColors.butterSoft,
+        body: SafeArea(
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              const _PetalBlob(key: Key('subscription_success_blob')),
+              _PhaseLabel(phase: phase),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Layered petal mark mimicking the Figma `LoadingAnimation` frame:
+/// a pale outer quatrefoil + a sage inner quatrefoil + a soft butter glow
+/// dot at the core (Quatrefoil's circle core alone reads as flat).
+class _PetalBlob extends StatelessWidget {
+  const _PetalBlob({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: AppSizes.avatarXl * 1.84,
+      height: AppSizes.avatarXl * 1.84,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          // Outer pale-butter petal blob (spec petal layer 1+2 composite).
+          const Quatrefoil(
+            size: AppSizes.avatarXl * 1.84,
+            coreColor: AppColors.butter,
+          ),
+          // Inner sage petal — smaller, scales down to ~52% of outer.
+          const Quatrefoil(
+            size: AppSizes.avatarXl * 0.96,
+            petalColor: AppColors.green,
+            coreColor: AppColors.greenDeep,
+          ),
+          // Soft butter glow dot at the center (spec blurred lime dot).
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: AppColors.butter,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: AppColors.butter.withValues(alpha: 0.9),
+                  blurRadius: AppSizes.sm,
+                  spreadRadius: AppSizes.xs,
+                ),
+              ],
+            ),
+            child: const SizedBox(
+              width: AppSizes.sp12 * 1.4,
+              height: AppSizes.sp12 * 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Phase caption — faint uppercase "Loading" overlay inside the petal animation
+/// in the loading phase; bold "You all set!" body label below the animation in
+/// the success phase. Verbatim copy from the Figma frame (1290:10122).
+class _PhaseLabel extends StatelessWidget {
+  const _PhaseLabel({required this.phase});
+
+  final SubscriptionSuccessPhase phase;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    if (phase == SubscriptionSuccessPhase.loading) {
+      // "Loading" — Inter Regular 12.8 / 19.2 / tracking 4.33 / UPPERCASE,
+      // rendered low-contrast (cream on butter-soft) per spec.
+      return Positioned.fill(
+        child: Align(
+          alignment: const Alignment(0, 0.34),
+          child: Text(
+            'Loading'.toUpperCase(),
+            key: const Key('subscription_success_loading_label'),
+            textAlign: TextAlign.center,
+            style: textTheme.bodySmall?.copyWith(
+              color: AppColors.cream,
+              fontSize: 12.8,
+              height: 19.2 / 12.8,
+              letterSpacing: 4.33,
+              fontWeight: FontWeight.w400,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // success — "You all set!" body label below the animation.
+    return Positioned.fill(
+      child: Align(
+        alignment: const Alignment(0, 0.6),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.md + AppSizes.sp2,
+          ),
+          child: Text(
+            'You all set!',
+            key: const Key('subscription_success_done_label'),
+            textAlign: TextAlign.center,
+            style: textTheme.bodyLarge?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: AppColors.text,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/subscription/success/subscription_success_screen.dart
+++ b/lib/src/features/subscription/success/subscription_success_screen.dart
@@ -89,12 +89,17 @@ class _SubscriptionSuccessScreenState
       child: Scaffold(
         backgroundColor: AppColors.butterSoft,
         body: SafeArea(
-          child: Stack(
-            alignment: Alignment.center,
-            children: [
-              const _PetalBlob(key: Key('subscription_success_blob')),
-              _PhaseLabel(phase: phase),
-            ],
+          // SizedBox.expand forces the Stack to fill the SafeArea — without
+          // it the Stack collapses to its non-positioned child (_PetalBlob)
+          // and the whole cluster snaps to the upper-left.
+          child: SizedBox.expand(
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                const _PetalBlob(key: Key('subscription_success_blob')),
+                _PhaseLabel(phase: phase),
+              ],
+            ),
           ),
         ),
       ),
@@ -151,9 +156,12 @@ class _PetalBlob extends StatelessWidget {
   }
 }
 
-/// Phase caption — faint uppercase "Loading" overlay inside the petal animation
-/// in the loading phase; bold "You all set!" body label below the animation in
-/// the success phase. Verbatim copy from the Figma frame (1290:10122).
+/// Phase caption — faint uppercase "Loading" sits below the petal animation in
+/// both phases (matches the Figma frame 1290:10122 which renders LOADING
+/// faded above "You all set!" during the success state — a cross-fade where
+/// the slot is reserved so the layout never shifts). The "You all set!" label
+/// is rendered in both phases but invisible during loading so the vertical
+/// rhythm is preserved across the transition.
 class _PhaseLabel extends StatelessWidget {
   const _PhaseLabel({required this.phase});
 
@@ -162,47 +170,59 @@ class _PhaseLabel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final isSuccess = phase == SubscriptionSuccessPhase.success;
 
-    if (phase == SubscriptionSuccessPhase.loading) {
-      // "Loading" — Inter Regular 12.8 / 19.2 / tracking 4.33 / UPPERCASE,
-      // rendered low-contrast (cream on butter-soft) per spec.
-      return Positioned.fill(
-        child: Align(
-          alignment: const Alignment(0, 0.34),
-          child: Text(
-            'Loading'.toUpperCase(),
-            key: const Key('subscription_success_loading_label'),
-            textAlign: TextAlign.center,
-            style: textTheme.bodySmall?.copyWith(
-              color: AppColors.cream,
-              fontSize: 12.8,
-              height: 19.2 / 12.8,
-              letterSpacing: 4.33,
-              fontWeight: FontWeight.w400,
-            ),
-          ),
-        ),
-      );
-    }
-
-    // success — "You all set!" body label below the animation.
     return Positioned.fill(
-      child: Align(
-        alignment: const Alignment(0, 0.6),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.md + AppSizes.sp2,
-          ),
-          child: Text(
-            'You all set!',
-            key: const Key('subscription_success_done_label'),
-            textAlign: TextAlign.center,
-            style: textTheme.bodyLarge?.copyWith(
-              fontWeight: FontWeight.w600,
-              color: AppColors.text,
+      child: Stack(
+        children: [
+          // "Loading" — Inter Regular 12.8 / 19.2 / tracking 4.33 / UPPERCASE,
+          // rendered low-contrast (cream on butter-soft) per spec. Stays
+          // visible (faded) during the success phase to match Figma's
+          // cross-fade snapshot.
+          Align(
+            alignment: const Alignment(0, 0.34),
+            child: AnimatedOpacity(
+              duration: const Duration(milliseconds: 240),
+              opacity: isSuccess ? 0.55 : 1,
+              child: Text(
+                'Loading'.toUpperCase(),
+                key: const Key('subscription_success_loading_label'),
+                textAlign: TextAlign.center,
+                style: textTheme.bodySmall?.copyWith(
+                  color: AppColors.cream,
+                  fontSize: 12.8,
+                  height: 19.2 / 12.8,
+                  letterSpacing: 4.33,
+                  fontWeight: FontWeight.w400,
+                ),
+              ),
             ),
           ),
-        ),
+          // "You all set!" — body label below the animation. Always laid out
+          // so the slot is reserved during the loading phase too; opacity
+          // gates visibility so there's zero layout shift on transition.
+          Align(
+            alignment: const Alignment(0, 0.6),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.md + AppSizes.sp2,
+              ),
+              child: AnimatedOpacity(
+                duration: const Duration(milliseconds: 240),
+                opacity: isSuccess ? 1 : 0,
+                child: Text(
+                  'You all set!',
+                  key: const Key('subscription_success_done_label'),
+                  textAlign: TextAlign.center,
+                  style: textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.text,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/features/subscription/success/subscription_success_state.dart
+++ b/lib/src/features/subscription/success/subscription_success_state.dart
@@ -1,0 +1,9 @@
+/// Two-phase state for the post-purchase transition screen.
+///
+/// `loading` — petal animation + faint "Loading" label.
+/// `success` — petal animation + "You all set!" label, before auto-route to
+/// `/home`.
+enum SubscriptionSuccessPhase {
+  loading,
+  success,
+}

--- a/lib/src/routing/route_enums.dart
+++ b/lib/src/routing/route_enums.dart
@@ -24,6 +24,10 @@ enum AppRoute {
   forgotPassword(path: '/auth/forgot-password', name: 'forgot-password'),
   resetPassword(path: '/auth/reset-password', name: 'reset-password'),
   paywall(path: '/subscription/paywall', name: 'paywall'),
+  subscriptionSuccess(
+    path: '/subscription/success',
+    name: 'subscription-success',
+  ),
   home(path: '/home', name: 'home'),
   mealPlan(path: '/home/meal', name: 'meal-plan'),
   mealPlanMap(path: '/home/meal/map', name: 'meal-plan-map'),

--- a/lib/src/routing/routes.dart
+++ b/lib/src/routing/routes.dart
@@ -34,6 +34,7 @@ import 'package:nibbles/src/features/splash/splash_screen.dart';
 import 'package:nibbles/src/features/starting_guide/starting_guide_article_screen.dart';
 import 'package:nibbles/src/features/starting_guide/starting_guide_hub_screen.dart';
 import 'package:nibbles/src/features/subscription/paywall/paywall_screen.dart';
+import 'package:nibbles/src/features/subscription/success/subscription_success_screen.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -222,6 +223,14 @@ GoRouter goRouter(Ref ref) {
         path: AppRoute.paywall.path,
         name: AppRoute.paywall.name,
         builder: (context, state) => const PaywallScreen(),
+      ),
+      // NIB-130 — passive post-purchase transition. Kept off `gatedPaths` so a
+      // logged-in/onboarding-done user can reach it directly from the paywall
+      // (NIB-55) or the all-plans picker (NIB-61).
+      GoRoute(
+        path: AppRoute.subscriptionSuccess.path,
+        name: AppRoute.subscriptionSuccess.name,
+        builder: (context, state) => const SubscriptionSuccessScreen(),
       ),
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) =>

--- a/lib/src/routing/routes.g.dart
+++ b/lib/src/routing/routes.g.dart
@@ -6,7 +6,7 @@ part of 'routes.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'fdce46d093079b4f10f6661f9b74b2180691f13a';
+String _$goRouterHash() => r'26dfc3d3be386be0ee4f95ce6b9440001be29af3';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)

--- a/test/features/subscription/success/subscription_success_screen_test.dart
+++ b/test/features/subscription/success/subscription_success_screen_test.dart
@@ -1,0 +1,134 @@
+// NIB-130 — widget tests for the post-purchase transition screen.
+//
+// Covers:
+//   - Loading frame renders the petal blob + UPPERCASE "LOADING" label.
+//   - After the loading-min dwell, the screen flips to the success label.
+//   - After the success dwell, the screen auto-routes to /home (no back nav
+//     escape — PopScope.canPop is false until the route fires).
+//
+// `subscriptionServiceProvider` is overridden via Riverpod (no RC dependency)
+// and durations are advanced via `tester.pump` so the suite is deterministic.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/common/services/subscription_service.dart';
+import 'package:nibbles/src/features/subscription/success/subscription_success_controller.dart';
+import 'package:nibbles/src/features/subscription/success/subscription_success_screen.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+/// Always-active [SubscriptionService] so the controller's fast path fires
+/// and the suite doesn't have to wait the full loadingTimeout cap.
+class _ActiveSubscriptionService extends SubscriptionService {
+  @override
+  bool build() => true;
+}
+
+GoRouter _routerFor(Widget screen) => GoRouter(
+  initialLocation: AppRoute.subscriptionSuccess.path,
+  routes: [
+    GoRoute(
+      path: AppRoute.subscriptionSuccess.path,
+      name: AppRoute.subscriptionSuccess.name,
+      builder: (_, __) => screen,
+    ),
+    GoRoute(
+      path: AppRoute.home.path,
+      name: AppRoute.home.name,
+      builder: (_, __) => const Scaffold(body: Center(child: Text('HOME_STUB'))),
+    ),
+  ],
+);
+
+Widget _buildSut({required GoRouter router}) => ProviderScope(
+  overrides: [
+    subscriptionServiceProvider.overrideWith(_ActiveSubscriptionService.new),
+  ],
+  child: MaterialApp.router(routerConfig: router),
+);
+
+void main() {
+  testWidgets(
+    'loading frame renders the petal blob and UPPERCASE LOADING label',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildSut(router: _routerFor(const SubscriptionSuccessScreen())),
+      );
+      // One frame — controller is at `loading`, before the dwell elapses.
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('subscription_success_blob')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('subscription_success_loading_label')),
+        findsOneWidget,
+      );
+      // Verbatim copy from the Figma spec is rendered uppercased per CSS class.
+      expect(find.text('LOADING'), findsOneWidget);
+      expect(find.text('You all set!'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'flips to "You all set!" after loadingMinDwell when service is active',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildSut(router: _routerFor(const SubscriptionSuccessScreen())),
+      );
+      // Advance past the min-dwell so the controller settles to success.
+      await tester.pump(SubscriptionSuccessController.loadingMinDwell);
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('subscription_success_done_label')),
+        findsOneWidget,
+      );
+      expect(find.text('You all set!'), findsOneWidget);
+      // Loading caption is gone in the success phase.
+      expect(find.text('LOADING'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'after successDwell elapses the screen auto-routes to /home',
+    (tester) async {
+      final router = _routerFor(const SubscriptionSuccessScreen());
+      await tester.pumpWidget(_buildSut(router: router));
+
+      // Loading dwell + success dwell → screen schedules the /home push.
+      await tester.pump(SubscriptionSuccessController.loadingMinDwell);
+      await tester.pump();
+      await tester.pump(SubscriptionSuccessController.successDwell);
+      await tester.pumpAndSettle();
+
+      expect(find.text('HOME_STUB'), findsOneWidget);
+      expect(
+        router.routerDelegate.currentConfiguration.uri.path,
+        AppRoute.home.path,
+      );
+    },
+  );
+
+  testWidgets(
+    'PopScope blocks back navigation while provisioning is in flight',
+    (tester) async {
+      final router = _routerFor(const SubscriptionSuccessScreen());
+      await tester.pumpWidget(_buildSut(router: router));
+      await tester.pump();
+
+      // Attempt to pop from the GoRouter API — the wrapping PopScope sets
+      // canPop=false, so the screen stays on the success route.
+      router.routerDelegate.popRoute();
+      await tester.pump();
+
+      expect(
+        router.routerDelegate.currentConfiguration.uri.path,
+        AppRoute.subscriptionSuccess.path,
+      );
+      expect(find.text('HOME_STUB'), findsNothing);
+    },
+  );
+}

--- a/test/features/subscription/success/subscription_success_screen_test.dart
+++ b/test/features/subscription/success/subscription_success_screen_test.dart
@@ -48,6 +48,17 @@ Widget _buildSut({required GoRouter router}) => ProviderScope(
   child: MaterialApp.router(routerConfig: router),
 );
 
+/// Reads the *target* opacity of the [AnimatedOpacity] that wraps the widget
+/// keyed [key]. Target (not currently-tweened) opacity is what we assert
+/// against since it deterministically reflects the phase regardless of
+/// where the cross-fade animation sits at the moment of the assertion.
+double _opacityOf(WidgetTester tester, Key key) {
+  final ancestor = tester.widget<AnimatedOpacity>(
+    find.ancestor(of: find.byKey(key), matching: find.byType(AnimatedOpacity)),
+  );
+  return ancestor.opacity;
+}
+
 void main() {
   testWidgets(
     'loading frame renders the petal blob and UPPERCASE LOADING label',
@@ -68,7 +79,19 @@ void main() {
       );
       // Verbatim copy from the Figma spec is rendered uppercased per CSS class.
       expect(find.text('LOADING'), findsOneWidget);
-      expect(find.text('You all set!'), findsNothing);
+
+      // Both labels are always in the tree so the layout never shifts on
+      // transition — visibility is gated by AnimatedOpacity. During loading
+      // "You all set!" is laid out but fully transparent.
+      expect(find.text('You all set!'), findsOneWidget);
+      expect(
+        _opacityOf(tester, const Key('subscription_success_done_label')),
+        0.0,
+      );
+      expect(
+        _opacityOf(tester, const Key('subscription_success_loading_label')),
+        1.0,
+      );
     },
   );
 
@@ -87,8 +110,17 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('You all set!'), findsOneWidget);
-      // Loading caption is gone in the success phase.
-      expect(find.text('LOADING'), findsNothing);
+      // Loading caption stays mounted (matches the Figma cross-fade snapshot)
+      // but is rendered low-opacity in the success phase.
+      expect(find.text('LOADING'), findsOneWidget);
+      expect(
+        _opacityOf(tester, const Key('subscription_success_done_label')),
+        1.0,
+      );
+      expect(
+        _opacityOf(tester, const Key('subscription_success_loading_label')),
+        0.55,
+      );
     },
   );
 


### PR DESCRIPTION
## Summary
- Adds the passive post-purchase transition screen (NIB-130) at `/subscription/success` — petal-blob animation + faint `LOADING` caption flips to `You all set!` once provisioning settles, then auto-routes to `/home`.
- `SubscriptionSuccessController` listens on `subscription_service.isActive` with a min-dwell floor (1.2s) and a timeout cap (4s); failure handling is left to the upstream paywall/picker per the spec.
- Screen wraps in `PopScope(canPop: false)` to block back nav while provisioning is in flight.

## Acceptance criteria
- [x] Pixel-close to `/Users/adithyafp_/Projects/nibbles/.figma-audit/subscription-no-plan/babys-setup/screenshot.png` — layered Quatrefoil mark (butter outer + sage inner + butter glow dot) on butterSoft background.
- [x] Verbatim copy exact — `LOADING` uppercase with tracking 4.33, `You all set!` exact.
- [x] Auto-routes to `/home` after the success dwell elapses.
- [x] Back navigation guarded while provisioning is in flight (`PopScope.canPop=false`).
- [x] All tokens from the foundation (`AppColors.butterSoft`, `AppColors.butter`, `AppColors.green`, `AppColors.greenDeep`, `AppColors.cream`) — no raw hex.
- [x] `flutter analyze` clean (0 issues).
- [x] Widget tests cover loading frame, success flip, auto-route, back-nav guard — 488 tests pass.

## Figma frame
- `1290:10122` — "Baby's setup" (no plan / paywall section 1207:14606).

## Audit artifacts
- Report: `/Users/adithyafp_/Projects/nibbles/.figma-audit/subscription-no-plan/babys-setup/report.md`
- Screenshot: `/Users/adithyafp_/Projects/nibbles/.figma-audit/subscription-no-plan/babys-setup/screenshot.png`
- Tokens: `/Users/adithyafp_/Projects/nibbles/.figma-audit/subscription-no-plan/babys-setup/variables.json`

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 488 pass / 1 skip / 0 fail
- [ ] Manual: trigger from a future paywall purchase (blocked on NIB-55/NIB-61 — orphan-but-routable per scope)

## Open questions (deferred)
- Designer to confirm single combined state vs split states (defaulted to split per NIB-130 spec).
- Designer to confirm minimum success-state dwell (defaulted to 1.5s).