### PR TITLE
feat(infra): all-plans picker bottom sheet [NIB-61]

### DIFF
--- a/lib/src/common/domain/entities/subscription_plan.dart
+++ b/lib/src/common/domain/entities/subscription_plan.dart
@@ -1,0 +1,43 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'subscription_plan.freezed.dart';
+
+/// Domain entity for a purchasable subscription plan (NIB-61).
+///
+/// Source of truth for the all-plans picker bottom sheet. Repositories map
+/// RevenueCat `Package` / `StoreProduct` DTOs into this entity; the widget
+/// layer never touches RevenueCat types directly (architecture rule).
+///
+/// Fields:
+///   * [id] — opaque package identifier (e.g. RevenueCat `Package.identifier`).
+///     Passed back to the purchase pipeline; never rendered.
+///   * [title] — verbatim display title ("Annual" / "Monthly").
+///   * [priceLabel] — pre-formatted localized price + period
+///     (e.g. "$29.99 yearly").
+///   * [period] — coarse cadence used for analytics + selection-default logic.
+///   * [isRecommended] — true for the package that should be selected by
+///     default and decorated with the "Recomended" badge.
+@freezed
+class SubscriptionPlan with _$SubscriptionPlan {
+  const factory SubscriptionPlan({
+    required String id,
+    required String title,
+    required String priceLabel,
+    required SubscriptionPlanPeriod period,
+    @Default(false) bool isRecommended,
+  }) = _SubscriptionPlan;
+}
+
+/// Coarse plan cadence — used for `plan_selected` analytics + the "annual is
+/// recommended" default selection rule. Maps RevenueCat `PackageType` once
+/// NIB-18 wires the real provider.
+enum SubscriptionPlanPeriod {
+  monthly,
+  annual;
+
+  /// Snake-case value emitted to analytics (`plan_selected{period}`).
+  String get analyticsValue => switch (this) {
+    SubscriptionPlanPeriod.monthly => 'monthly',
+    SubscriptionPlanPeriod.annual => 'annual',
+  };
+}

--- a/lib/src/common/domain/entities/subscription_plan.freezed.dart
+++ b/lib/src/common/domain/entities/subscription_plan.freezed.dart
@@ -1,0 +1,247 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'subscription_plan.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$SubscriptionPlan {
+  String get id => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String get priceLabel => throw _privateConstructorUsedError;
+  SubscriptionPlanPeriod get period => throw _privateConstructorUsedError;
+  bool get isRecommended => throw _privateConstructorUsedError;
+
+  /// Create a copy of SubscriptionPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SubscriptionPlanCopyWith<SubscriptionPlan> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SubscriptionPlanCopyWith<$Res> {
+  factory $SubscriptionPlanCopyWith(
+    SubscriptionPlan value,
+    $Res Function(SubscriptionPlan) then,
+  ) = _$SubscriptionPlanCopyWithImpl<$Res, SubscriptionPlan>;
+  @useResult
+  $Res call({
+    String id,
+    String title,
+    String priceLabel,
+    SubscriptionPlanPeriod period,
+    bool isRecommended,
+  });
+}
+
+/// @nodoc
+class _$SubscriptionPlanCopyWithImpl<$Res, $Val extends SubscriptionPlan>
+    implements $SubscriptionPlanCopyWith<$Res> {
+  _$SubscriptionPlanCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SubscriptionPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? priceLabel = null,
+    Object? period = null,
+    Object? isRecommended = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            title: null == title
+                ? _value.title
+                : title // ignore: cast_nullable_to_non_nullable
+                      as String,
+            priceLabel: null == priceLabel
+                ? _value.priceLabel
+                : priceLabel // ignore: cast_nullable_to_non_nullable
+                      as String,
+            period: null == period
+                ? _value.period
+                : period // ignore: cast_nullable_to_non_nullable
+                      as SubscriptionPlanPeriod,
+            isRecommended: null == isRecommended
+                ? _value.isRecommended
+                : isRecommended // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$SubscriptionPlanImplCopyWith<$Res>
+    implements $SubscriptionPlanCopyWith<$Res> {
+  factory _$$SubscriptionPlanImplCopyWith(
+    _$SubscriptionPlanImpl value,
+    $Res Function(_$SubscriptionPlanImpl) then,
+  ) = __$$SubscriptionPlanImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String title,
+    String priceLabel,
+    SubscriptionPlanPeriod period,
+    bool isRecommended,
+  });
+}
+
+/// @nodoc
+class __$$SubscriptionPlanImplCopyWithImpl<$Res>
+    extends _$SubscriptionPlanCopyWithImpl<$Res, _$SubscriptionPlanImpl>
+    implements _$$SubscriptionPlanImplCopyWith<$Res> {
+  __$$SubscriptionPlanImplCopyWithImpl(
+    _$SubscriptionPlanImpl _value,
+    $Res Function(_$SubscriptionPlanImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of SubscriptionPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? priceLabel = null,
+    Object? period = null,
+    Object? isRecommended = null,
+  }) {
+    return _then(
+      _$SubscriptionPlanImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        title: null == title
+            ? _value.title
+            : title // ignore: cast_nullable_to_non_nullable
+                  as String,
+        priceLabel: null == priceLabel
+            ? _value.priceLabel
+            : priceLabel // ignore: cast_nullable_to_non_nullable
+                  as String,
+        period: null == period
+            ? _value.period
+            : period // ignore: cast_nullable_to_non_nullable
+                  as SubscriptionPlanPeriod,
+        isRecommended: null == isRecommended
+            ? _value.isRecommended
+            : isRecommended // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$SubscriptionPlanImpl implements _SubscriptionPlan {
+  const _$SubscriptionPlanImpl({
+    required this.id,
+    required this.title,
+    required this.priceLabel,
+    required this.period,
+    this.isRecommended = false,
+  });
+
+  @override
+  final String id;
+  @override
+  final String title;
+  @override
+  final String priceLabel;
+  @override
+  final SubscriptionPlanPeriod period;
+  @override
+  @JsonKey()
+  final bool isRecommended;
+
+  @override
+  String toString() {
+    return 'SubscriptionPlan(id: $id, title: $title, priceLabel: $priceLabel, period: $period, isRecommended: $isRecommended)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SubscriptionPlanImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.priceLabel, priceLabel) ||
+                other.priceLabel == priceLabel) &&
+            (identical(other.period, period) || other.period == period) &&
+            (identical(other.isRecommended, isRecommended) ||
+                other.isRecommended == isRecommended));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, title, priceLabel, period, isRecommended);
+
+  /// Create a copy of SubscriptionPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SubscriptionPlanImplCopyWith<_$SubscriptionPlanImpl> get copyWith =>
+      __$$SubscriptionPlanImplCopyWithImpl<_$SubscriptionPlanImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _SubscriptionPlan implements SubscriptionPlan {
+  const factory _SubscriptionPlan({
+    required final String id,
+    required final String title,
+    required final String priceLabel,
+    required final SubscriptionPlanPeriod period,
+    final bool isRecommended,
+  }) = _$SubscriptionPlanImpl;
+
+  @override
+  String get id;
+  @override
+  String get title;
+  @override
+  String get priceLabel;
+  @override
+  SubscriptionPlanPeriod get period;
+  @override
+  bool get isRecommended;
+
+  /// Create a copy of SubscriptionPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SubscriptionPlanImplCopyWith<_$SubscriptionPlanImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/subscription/paywall/widgets/all_plans_sheet.dart
+++ b/lib/src/features/subscription/paywall/widgets/all_plans_sheet.dart
@@ -1,0 +1,376 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_plan.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+/// Pixel constants pulled verbatim from the Figma audit (frame 1216:11891 —
+/// see /Users/adithyafp_/Projects/nibbles/.figma-audit/subscription-no-plan/
+/// overlay-all-plans/report.md). Kept private — these are spec-locked
+/// non-token values (sheet corner radius, card radius, badge offset, etc.)
+/// not currently in `AppSizes` and not reused elsewhere yet.
+const double _kSheetTopRadius = 30;
+const double _kColumnGap = 24;
+const double _kPlanCardRadius = 10;
+const double _kPlanCardPadding = 12;
+const double _kPlanCardGap = 4;
+const double _kBadgePaddingH = 12;
+const double _kBadgePaddingV = 4;
+const double _kBadgeRadius = 30;
+const double _kContinueHeight = 42;
+const double _kContinueRadius = 24;
+const double _kCloseButtonSize = 34;
+
+/// Plan name + price text styles per the Figma `Headline/SemiBold` (Parkinsans
+/// 15/22 600) + `Body/Regular` (Figtree 15/22 400) tokens. Defined inline so
+/// the sheet matches the variables.json mapping exactly without rerouting
+/// through the broader `AppTypography` ramp.
+const TextStyle _kPlanTitleStyle = TextStyle(
+  fontFamily: 'Parkinsans',
+  fontSize: 15,
+  fontWeight: FontWeight.w600,
+  height: 22 / 15,
+  color: AppColors.text,
+);
+
+/// Shows the "View all plans" bottom sheet (NIB-61). Returns the selected
+/// plan when the user confirms via "Continue", or `null` on dismiss (close X,
+/// scrim tap, system back).
+///
+/// The caller is responsible for handing the returned plan to the purchase
+/// pipeline (NIB-55 paywall controller / NIB-18 subscription service). This
+/// widget is intentionally purchase-agnostic so its data source stays domain
+/// (`SubscriptionPlan`) and never references RevenueCat types directly.
+///
+/// `initialPlanId` lets the caller restore a prior selection across opens;
+/// when null, the recommended plan is selected (falling back to the first
+/// plan in [plans]).
+Future<SubscriptionPlan?> showAllPlansSheet(
+  BuildContext context, {
+  required List<SubscriptionPlan> plans,
+  String? initialPlanId,
+}) {
+  assert(plans.isNotEmpty, 'showAllPlansSheet requires at least one plan');
+  return showModalBottomSheet<SubscriptionPlan>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(_kSheetTopRadius),
+      ),
+    ),
+    builder: (_) => AllPlansSheet(
+      plans: plans,
+      initialPlanId: initialPlanId,
+    ),
+  );
+}
+
+/// The bottom sheet body. Exposed (not private) so widget tests can mount it
+/// without a parent overlay/route.
+@visibleForTesting
+class AllPlansSheet extends StatefulWidget {
+  const AllPlansSheet({
+    required this.plans,
+    this.initialPlanId,
+    super.key,
+  });
+
+  final List<SubscriptionPlan> plans;
+  final String? initialPlanId;
+
+  @override
+  State<AllPlansSheet> createState() => _AllPlansSheetState();
+}
+
+class _AllPlansSheetState extends State<AllPlansSheet> {
+  late String _selectedId;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedId = _resolveInitialSelection();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_logViewed());
+    });
+  }
+
+  String _resolveInitialSelection() {
+    final initial = widget.initialPlanId;
+    if (initial != null &&
+        widget.plans.any((SubscriptionPlan p) => p.id == initial)) {
+      return initial;
+    }
+    final recommended = widget.plans
+        .where((SubscriptionPlan p) => p.isRecommended)
+        .map((SubscriptionPlan p) => p.id);
+    if (recommended.isNotEmpty) return recommended.first;
+    return widget.plans.first.id;
+  }
+
+  Future<void> _logViewed() async {
+    try {
+      await Analytics.instance.logAllPlansViewed();
+    } on Object catch (_) {
+      // Analytics is best-effort; never surface to the UI.
+    }
+  }
+
+  Future<void> _logPlanSelected(SubscriptionPlan plan) async {
+    try {
+      await Analytics.instance.logPlanSelected(
+        period: plan.period.analyticsValue,
+      );
+    } on Object catch (_) {
+      // Best-effort.
+    }
+  }
+
+  void _onSelect(SubscriptionPlan plan) {
+    if (_selectedId == plan.id) return;
+    setState(() => _selectedId = plan.id);
+    unawaited(_logPlanSelected(plan));
+  }
+
+  void _onContinue() {
+    final plan = widget.plans.firstWhere(
+      (SubscriptionPlan p) => p.id == _selectedId,
+      orElse: () => widget.plans.first,
+    );
+    Navigator.of(context).pop(plan);
+  }
+
+  void _onClose() {
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isSingle = widget.plans.length == 1;
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.md,
+          vertical: AppSizes.lg,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            _CloseButton(onTap: _onClose),
+            const SizedBox(height: _kColumnGap),
+            // Per spec edge case — single configured package hides the
+            // selection chrome (no card border treatment, no "Recomended"
+            // badge) and shows only the Continue CTA. We still render the
+            // single plan as a borderless title/price stack so the sheet
+            // doesn't collapse to a bare button.
+            if (isSingle)
+              _SinglePlanRow(plan: widget.plans.first)
+            else
+              ..._buildPlanList(),
+            const SizedBox(height: _kColumnGap),
+            _ContinueButton(onPressed: _onContinue),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildPlanList() {
+    final widgets = <Widget>[];
+    for (var i = 0; i < widget.plans.length; i++) {
+      if (i > 0) widgets.add(const SizedBox(height: _kColumnGap));
+      final plan = widget.plans[i];
+      widgets.add(
+        _PlanCard(
+          plan: plan,
+          isSelected: plan.id == _selectedId,
+          onTap: () => _onSelect(plan),
+        ),
+      );
+    }
+    return widgets;
+  }
+}
+
+class _CloseButton extends StatelessWidget {
+  const _CloseButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Close',
+      button: true,
+      child: SizedBox(
+        width: _kCloseButtonSize,
+        height: _kCloseButtonSize,
+        child: Material(
+          color: Colors.transparent,
+          shape: const CircleBorder(),
+          child: InkWell(
+            onTap: onTap,
+            customBorder: const CircleBorder(),
+            child: const Center(
+              child: Icon(
+                Icons.close,
+                size: AppSizes.iconMd,
+                color: AppColors.text,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Single-plan layout (edge case) — no border, no badge, no tap target since
+/// there is nothing else to switch to. Just the title + price stack so the
+/// user can still see what they are about to purchase.
+class _SinglePlanRow extends StatelessWidget {
+  const _SinglePlanRow({required this.plan});
+
+  final SubscriptionPlan plan;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(plan.title, style: _kPlanTitleStyle),
+          const SizedBox(height: _kPlanCardGap),
+          Text(
+            plan.priceLabel,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: AppColors.text,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlanCard extends StatelessWidget {
+  const _PlanCard({
+    required this.plan,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final SubscriptionPlan plan;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderColor =
+        isSelected ? AppColors.greenDeep : AppColors.borderMuted;
+    final priceStyle = Theme.of(context).textTheme.bodyLarge?.copyWith(
+          color: AppColors.text,
+        );
+    // The "Recomended" badge overlaps the top edge of the Annual card; using
+    // Stack + clipBehavior:none lets it spill ~22px above the card boundary
+    // without altering layout flow (matches Figma absolute positioning).
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Material(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(_kPlanCardRadius),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(_kPlanCardRadius),
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(_kPlanCardPadding),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(_kPlanCardRadius),
+                border: Border.all(color: borderColor),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(plan.title, style: _kPlanTitleStyle),
+                  const SizedBox(height: _kPlanCardGap),
+                  Text(plan.priceLabel, style: priceStyle),
+                ],
+              ),
+            ),
+          ),
+        ),
+        if (plan.isRecommended)
+          const Positioned(
+            right: AppSizes.md,
+            top: -AppSizes.sp20,
+            child: _RecommendedBadge(),
+          ),
+      ],
+    );
+  }
+}
+
+class _RecommendedBadge extends StatelessWidget {
+  const _RecommendedBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.coral,
+        borderRadius: BorderRadius.circular(_kBadgeRadius),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: _kBadgePaddingH,
+          vertical: _kBadgePaddingV,
+        ),
+        // "Recomended" is intentionally misspelled — verbatim per Figma spec
+        // (frame 1216:11898). Pending PO confirmation before fixing.
+        child: Text(
+          'Recomended',
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: AppColors.surface,
+                fontWeight: FontWeight.w400,
+              ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ContinueButton extends StatelessWidget {
+  const _ContinueButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: _kContinueHeight,
+      child: Material(
+        color: AppColors.greenDeep,
+        borderRadius: BorderRadius.circular(_kContinueRadius),
+        child: InkWell(
+          onTap: onPressed,
+          borderRadius: BorderRadius.circular(_kContinueRadius),
+          child: Center(
+            child: Text(
+              'Continue',
+              style: _kPlanTitleStyle.copyWith(color: AppColors.surface),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -170,6 +170,14 @@ class Analytics {
     await _logEvent('subscription_restored');
   }
 
+  Future<void> logAllPlansViewed() async {
+    await _logEvent('all_plans_viewed');
+  }
+
+  Future<void> logPlanSelected({required String period}) async {
+    await _logEvent('plan_selected', parameters: {'period': period});
+  }
+
   // ---------------------------------------------------------------------------
   // Allergen tracker
   // ---------------------------------------------------------------------------

--- a/test/features/subscription/paywall/widgets/all_plans_sheet_test.dart
+++ b/test/features/subscription/paywall/widgets/all_plans_sheet_test.dart
@@ -1,0 +1,211 @@
+// Widget tests for the "View all plans" bottom sheet (NIB-61).
+//
+// Drives `showAllPlansSheet(context, plans: ...)` and asserts:
+//   * default populated state — Annual selected, "Recomended" badge present,
+//     plan titles + price labels rendered verbatim from the SubscriptionPlan
+//     domain entity.
+//   * selection inversion — tapping Monthly inverts the border treatment;
+//     the badge stays on Annual.
+//   * Continue pops with the selected plan; close X pops with null.
+//   * single-plan edge case — no badge, no second card, Continue still works.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_plan.dart';
+import 'package:nibbles/src/features/subscription/paywall/widgets/all_plans_sheet.dart';
+
+const _annual = SubscriptionPlan(
+  id: 'annual_29_99',
+  title: 'Annual',
+  priceLabel: r'$29.99 yearly',
+  period: SubscriptionPlanPeriod.annual,
+  isRecommended: true,
+);
+
+const _monthly = SubscriptionPlan(
+  id: 'monthly_4_99',
+  title: 'Monthly',
+  priceLabel: r'$4.99 monthly',
+  period: SubscriptionPlanPeriod.monthly,
+);
+
+Future<void> _setupViewport(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(1080, 2400);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+/// Mounts the sheet directly (not through `showModalBottomSheet`) so the
+/// test can inspect its internals without dealing with route animations.
+Future<void> _pumpSheet(
+  WidgetTester tester, {
+  required List<SubscriptionPlan> plans,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: AllPlansSheet(plans: plans),
+      ),
+    ),
+  );
+}
+
+/// Returns the border color of the plan card whose title equals [title].
+/// The card is `Container > BoxDecoration > Border.all(...)` — we walk up
+/// from the title text to find the nearest decorated container.
+Color _borderColorOf(WidgetTester tester, String title) {
+  final container = tester
+      .widgetList<Container>(
+        find.ancestor(of: find.text(title), matching: find.byType(Container)),
+      )
+      .firstWhere((c) {
+        final decoration = c.decoration;
+        return decoration is BoxDecoration && decoration.border != null;
+      });
+  final border = (container.decoration! as BoxDecoration).border! as Border;
+  return border.top.color;
+}
+
+void main() {
+  group('AllPlansSheet — populated default state', () {
+    testWidgets(
+      'renders both plan titles, both price labels, and the badge',
+      (tester) async {
+        await _setupViewport(tester);
+        await _pumpSheet(tester, plans: const [_annual, _monthly]);
+
+        expect(find.text('Annual'), findsOneWidget);
+        expect(find.text(r'$29.99 yearly'), findsOneWidget);
+        expect(find.text('Monthly'), findsOneWidget);
+        expect(find.text(r'$4.99 monthly'), findsOneWidget);
+        expect(find.text('Recomended'), findsOneWidget);
+        expect(find.text('Continue'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'recommended plan (Annual) is selected by default — forest border, '
+      'Monthly has muted border',
+      (tester) async {
+        await _setupViewport(tester);
+        await _pumpSheet(tester, plans: const [_annual, _monthly]);
+
+        expect(_borderColorOf(tester, 'Annual'), AppColors.greenDeep);
+        expect(_borderColorOf(tester, 'Monthly'), AppColors.borderMuted);
+      },
+    );
+  });
+
+  group('AllPlansSheet — selection inversion', () {
+    testWidgets(
+      'tapping Monthly inverts the border; Recomended badge stays on Annual',
+      (tester) async {
+        await _setupViewport(tester);
+        await _pumpSheet(tester, plans: const [_annual, _monthly]);
+
+        await tester.tap(find.text('Monthly'));
+        await tester.pump();
+
+        expect(_borderColorOf(tester, 'Monthly'), AppColors.greenDeep);
+        expect(_borderColorOf(tester, 'Annual'), AppColors.borderMuted);
+        // Badge stays on Annual — never migrates to Monthly.
+        expect(find.text('Recomended'), findsOneWidget);
+      },
+    );
+  });
+
+  group('AllPlansSheet — Continue / Close flow', () {
+    testWidgets(
+      'Continue pops the sheet with the selected plan',
+      (tester) async {
+        await _setupViewport(tester);
+        SubscriptionPlan? picked;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      picked = await showAllPlansSheet(
+                        context,
+                        plans: const [_annual, _monthly],
+                      );
+                    },
+                    child: const Text('Open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.tap(find.text('Open'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+
+        await tester.tap(find.text('Continue'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+
+        expect(picked, isNotNull);
+        expect(picked!.id, _annual.id);
+      },
+    );
+
+    testWidgets(
+      'close X pops with null',
+      (tester) async {
+        await _setupViewport(tester);
+        SubscriptionPlan? picked = _annual; // sentinel — must become null
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      picked = await showAllPlansSheet(
+                        context,
+                        plans: const [_annual, _monthly],
+                      );
+                    },
+                    child: const Text('Open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.tap(find.text('Open'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+
+        await tester.tap(find.byIcon(Icons.close));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+
+        expect(picked, isNull);
+      },
+    );
+  });
+
+  group('AllPlansSheet — single-plan edge case', () {
+    testWidgets(
+      'single plan hides the badge and still allows Continue',
+      (tester) async {
+        await _setupViewport(tester);
+        await _pumpSheet(tester, plans: const [_annual]);
+
+        expect(find.text('Annual'), findsOneWidget);
+        expect(find.text(r'$29.99 yearly'), findsOneWidget);
+        // No selection chrome → badge is hidden even though the plan is
+        // marked recommended.
+        expect(find.text('Recomended'), findsNothing);
+        expect(find.text('Monthly'), findsNothing);
+        expect(find.text('Continue'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/test/support/fake_analytics.dart
+++ b/test/support/fake_analytics.dart
@@ -91,6 +91,13 @@ class FakeAnalytics implements Analytics {
       _record('subscription_restored');
 
   @override
+  Future<void> logAllPlansViewed() async => _record('all_plans_viewed');
+
+  @override
+  Future<void> logPlanSelected({required String period}) async =>
+      _record('plan_selected', {'period': period});
+
+  @override
   Future<void> logAllergenLogCreated({
     required String allergenKey,
     bool hasAttachment = false,


### PR DESCRIPTION
## Summary

Implements the "View all plans" bottom sheet (Figma frame 1216:11891) used by the paywall to let the user pick between Annual (recommended) and Monthly before confirming via "Continue".

- New `SubscriptionPlan` domain entity + `SubscriptionPlanPeriod` enum so the widget consumes domain data and never touches RevenueCat `Package` / `StoreProduct` types directly (architecture rule: DTOs never above the repository).
- `showAllPlansSheet(context, plans, initialPlanId)` entry function returns the picked plan (or null on close X / scrim dismiss). Selection state lives in a local `StatefulWidget` so no new Riverpod surface is introduced; the caller (NIB-55 paywall) hands the result to its own purchase pipeline.
- Verbatim copy preserved: "Annual", "$29.99 yearly", "Recomended" (one m, per spec), "Monthly", "Continue".
- Tokens: `AppColors.greenDeep` for the selected card border + Continue fill, `AppColors.borderMuted` for the unselected card (replaces the hardcoded `#d2d2d2` from Figma; no raw hex in the widget), `AppColors.coral` for the badge background, `AppColors.surface` / `AppColors.text` per the variables.json mapping. Parkinsans 15/22 600 for titles; Figtree 15/22 400 for prices and the badge text.
- Selection inversion is reachable — tapping Monthly inverts the border treatment; the "Recomended" badge stays on Annual in both states (per AC).
- Edge case: a single configured plan hides the selection chrome (no border decoration, no badge) and shows only the title/price stack + Continue.
- Analytics: `all_plans_viewed` on open, `plan_selected{period}` on selection change. Added to `Analytics` + `FakeAnalytics`.

## Out of scope (deferred to NIB-18 / NIB-55)

- RevenueCat package loading + purchase pipeline. The sheet is purchase-agnostic; AC items "Continue purchases the selected package and updates entitlement state" and "Purchase failure shows verbatim RevenueCat error (P1)" cannot be satisfied without the wired `SubscriptionService` (NIB-18 stub) and the paywall controller (NIB-55, not yet implemented). Continue currently pops the sheet with the chosen `SubscriptionPlan`; the caller will route to `/subscription/success` on success and surface the verbatim RevenueCat error in a P1 modal on failure once those tickets land.

## Figma frames

- `1216:11891` — Overlay - all plans (default — Annual selected, Monthly unselected)

## Audit artifacts

- Report: `.figma-audit/subscription-no-plan/overlay-all-plans/report.md`
- Screenshot: `.figma-audit/subscription-no-plan/overlay-all-plans/screenshot.png`
- Raw Figma context: `.figma-audit/subscription-no-plan/overlay-all-plans/design_context.md`
- Token map: `.figma-audit/subscription-no-plan/overlay-all-plans/variables.json`

## Acceptance criteria

- [x] Pixel-close match to `screenshot.png` (sheet padding 16/24, plan card radius 10 / pad 12, badge radius 30, Continue height 42 / radius 24, close button 34x33)
- [x] Verbatim copy exact — "Recomended" misspelling preserved per spec note
- [x] Annual selected by default; tapping Monthly inverts border; badge stays on Annual
- [ ] Continue purchases the selected package and updates entitlement state — deferred to NIB-18 / NIB-55 (sheet returns the selected plan; pipeline wires up downstream)
- [ ] Purchase failure shows verbatim RevenueCat error (P1) — deferred to NIB-18 / NIB-55
- [x] No hardcoded prices/periods in the widget — data sourced from `SubscriptionPlan`
- [x] All tokens consumed from the design system; `#d2d2d2` → `AppColors.borderMuted`
- [x] `flutter analyze` clean (only 2 pre-existing infos in `subscription_success_screen_test.dart`)
- [x] Widget test for populated default state + selection inversion + Continue/Close flow + single-plan edge case

## Test plan

- [x] `flutter analyze` — 0 issues introduced (2 pre-existing infos on the base)
- [x] `flutter test test/features/subscription/paywall/widgets/all_plans_sheet_test.dart` — 6/6 pass
- [x] `flutter test` (full suite) — 494 pass, 1 skipped, 0 fail