### PR TITLE
feat(subscription): manage screen — not-subscribed + subscribed/trial [NIB-73]

### DIFF
--- a/lib/src/common/domain/entities/subscription_info.dart
+++ b/lib/src/common/domain/entities/subscription_info.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'subscription_info.freezed.dart';
+
+/// Subscription entitlement snapshot consumed by the Manage Subscription
+/// screen (NIB-73). Sourced from RevenueCat `customerInfo` once the real
+/// SubscriptionService lands — currently synthesized from the stub bool.
+///
+/// `planLabel` is the user-facing plan name ("Free Trial", "Premium", or a
+/// product display name). When [isActive] is false the other fields are null.
+@freezed
+class SubscriptionInfo with _$SubscriptionInfo {
+  const factory SubscriptionInfo({
+    required bool isActive,
+    String? planLabel,
+    DateTime? startedAt,
+    DateTime? renewsAt,
+    @Default(false) bool isTrial,
+  }) = _SubscriptionInfo;
+}

--- a/lib/src/common/domain/entities/subscription_info.freezed.dart
+++ b/lib/src/common/domain/entities/subscription_info.freezed.dart
@@ -1,0 +1,255 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'subscription_info.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$SubscriptionInfo {
+  bool get isActive => throw _privateConstructorUsedError;
+  String? get planLabel => throw _privateConstructorUsedError;
+  DateTime? get startedAt => throw _privateConstructorUsedError;
+  DateTime? get renewsAt => throw _privateConstructorUsedError;
+  bool get isTrial => throw _privateConstructorUsedError;
+
+  /// Create a copy of SubscriptionInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SubscriptionInfoCopyWith<SubscriptionInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SubscriptionInfoCopyWith<$Res> {
+  factory $SubscriptionInfoCopyWith(
+    SubscriptionInfo value,
+    $Res Function(SubscriptionInfo) then,
+  ) = _$SubscriptionInfoCopyWithImpl<$Res, SubscriptionInfo>;
+  @useResult
+  $Res call({
+    bool isActive,
+    String? planLabel,
+    DateTime? startedAt,
+    DateTime? renewsAt,
+    bool isTrial,
+  });
+}
+
+/// @nodoc
+class _$SubscriptionInfoCopyWithImpl<$Res, $Val extends SubscriptionInfo>
+    implements $SubscriptionInfoCopyWith<$Res> {
+  _$SubscriptionInfoCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SubscriptionInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isActive = null,
+    Object? planLabel = freezed,
+    Object? startedAt = freezed,
+    Object? renewsAt = freezed,
+    Object? isTrial = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            isActive: null == isActive
+                ? _value.isActive
+                : isActive // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            planLabel: freezed == planLabel
+                ? _value.planLabel
+                : planLabel // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            startedAt: freezed == startedAt
+                ? _value.startedAt
+                : startedAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            renewsAt: freezed == renewsAt
+                ? _value.renewsAt
+                : renewsAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            isTrial: null == isTrial
+                ? _value.isTrial
+                : isTrial // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$SubscriptionInfoImplCopyWith<$Res>
+    implements $SubscriptionInfoCopyWith<$Res> {
+  factory _$$SubscriptionInfoImplCopyWith(
+    _$SubscriptionInfoImpl value,
+    $Res Function(_$SubscriptionInfoImpl) then,
+  ) = __$$SubscriptionInfoImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    bool isActive,
+    String? planLabel,
+    DateTime? startedAt,
+    DateTime? renewsAt,
+    bool isTrial,
+  });
+}
+
+/// @nodoc
+class __$$SubscriptionInfoImplCopyWithImpl<$Res>
+    extends _$SubscriptionInfoCopyWithImpl<$Res, _$SubscriptionInfoImpl>
+    implements _$$SubscriptionInfoImplCopyWith<$Res> {
+  __$$SubscriptionInfoImplCopyWithImpl(
+    _$SubscriptionInfoImpl _value,
+    $Res Function(_$SubscriptionInfoImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of SubscriptionInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isActive = null,
+    Object? planLabel = freezed,
+    Object? startedAt = freezed,
+    Object? renewsAt = freezed,
+    Object? isTrial = null,
+  }) {
+    return _then(
+      _$SubscriptionInfoImpl(
+        isActive: null == isActive
+            ? _value.isActive
+            : isActive // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        planLabel: freezed == planLabel
+            ? _value.planLabel
+            : planLabel // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        startedAt: freezed == startedAt
+            ? _value.startedAt
+            : startedAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        renewsAt: freezed == renewsAt
+            ? _value.renewsAt
+            : renewsAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        isTrial: null == isTrial
+            ? _value.isTrial
+            : isTrial // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$SubscriptionInfoImpl implements _SubscriptionInfo {
+  const _$SubscriptionInfoImpl({
+    required this.isActive,
+    this.planLabel,
+    this.startedAt,
+    this.renewsAt,
+    this.isTrial = false,
+  });
+
+  @override
+  final bool isActive;
+  @override
+  final String? planLabel;
+  @override
+  final DateTime? startedAt;
+  @override
+  final DateTime? renewsAt;
+  @override
+  @JsonKey()
+  final bool isTrial;
+
+  @override
+  String toString() {
+    return 'SubscriptionInfo(isActive: $isActive, planLabel: $planLabel, startedAt: $startedAt, renewsAt: $renewsAt, isTrial: $isTrial)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SubscriptionInfoImpl &&
+            (identical(other.isActive, isActive) ||
+                other.isActive == isActive) &&
+            (identical(other.planLabel, planLabel) ||
+                other.planLabel == planLabel) &&
+            (identical(other.startedAt, startedAt) ||
+                other.startedAt == startedAt) &&
+            (identical(other.renewsAt, renewsAt) ||
+                other.renewsAt == renewsAt) &&
+            (identical(other.isTrial, isTrial) || other.isTrial == isTrial));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    isActive,
+    planLabel,
+    startedAt,
+    renewsAt,
+    isTrial,
+  );
+
+  /// Create a copy of SubscriptionInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SubscriptionInfoImplCopyWith<_$SubscriptionInfoImpl> get copyWith =>
+      __$$SubscriptionInfoImplCopyWithImpl<_$SubscriptionInfoImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _SubscriptionInfo implements SubscriptionInfo {
+  const factory _SubscriptionInfo({
+    required final bool isActive,
+    final String? planLabel,
+    final DateTime? startedAt,
+    final DateTime? renewsAt,
+    final bool isTrial,
+  }) = _$SubscriptionInfoImpl;
+
+  @override
+  bool get isActive;
+  @override
+  String? get planLabel;
+  @override
+  DateTime? get startedAt;
+  @override
+  DateTime? get renewsAt;
+  @override
+  bool get isTrial;
+
+  /// Create a copy of SubscriptionInfo
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SubscriptionInfoImplCopyWith<_$SubscriptionInfoImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/common/services/subscription_service.dart
+++ b/lib/src/common/services/subscription_service.dart
@@ -1,9 +1,16 @@
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_info.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'subscription_service.g.dart';
 
 /// Stub SubscriptionService — will be wired in NIB-18.
 /// Returns false by default; redirect logic sends users to paywall.
+///
+/// NIB-73 expands the surface with [info] so the Manage Subscription screen
+/// can render plan / Started / Renewal from a single entitlement snapshot.
+/// The shape mirrors what RevenueCat `customerInfo` will yield, so swapping
+/// the stub for the real implementation is a no-op for the screen.
 @riverpod
 class SubscriptionService extends _$SubscriptionService {
   @override
@@ -13,4 +20,29 @@ class SubscriptionService extends _$SubscriptionService {
   // setter syntax is not valid here.
   // ignore: use_setters_to_change_properties
   void setActive({required bool value}) => state = value;
+
+  /// Returns the current entitlement snapshot.
+  ///
+  /// Stub-only: synthesises a deterministic [SubscriptionInfo] from the
+  /// notifier's bool state. When active, surfaces a 30-day Free Trial
+  /// window so the subscribed branch has plausible dates to render — the
+  /// real RC-backed implementation (NIB-18) will replace this verbatim.
+  Future<Result<SubscriptionInfo>> info() async {
+    final active = state;
+    if (!active) {
+      return const Result.success(SubscriptionInfo(isActive: false));
+    }
+    final now = DateTime.now();
+    final started = DateTime(now.year, now.month, now.day);
+    final renews = started.add(const Duration(days: 30));
+    return Result.success(
+      SubscriptionInfo(
+        isActive: true,
+        planLabel: 'Free Trial',
+        startedAt: started,
+        renewsAt: renews,
+        isTrial: true,
+      ),
+    );
+  }
 }

--- a/lib/src/common/services/subscription_service.g.dart
+++ b/lib/src/common/services/subscription_service.g.dart
@@ -7,10 +7,15 @@ part of 'subscription_service.dart';
 // **************************************************************************
 
 String _$subscriptionServiceHash() =>
-    r'a19ffaac6571296239894948843a8e744d000c54';
+    r'0a5b4e13dd0c19f75cf8da447a27aa84b8a59922';
 
 /// Stub SubscriptionService — will be wired in NIB-18.
 /// Returns false by default; redirect logic sends users to paywall.
+///
+/// NIB-73 expands the surface with [info] so the Manage Subscription screen
+/// can render plan / Started / Renewal from a single entitlement snapshot.
+/// The shape mirrors what RevenueCat `customerInfo` will yield, so swapping
+/// the stub for the real implementation is a no-op for the screen.
 ///
 /// Copied from [SubscriptionService].
 @ProviderFor(SubscriptionService)

--- a/lib/src/features/profile/profile_screen.dart
+++ b/lib/src/features/profile/profile_screen.dart
@@ -153,10 +153,9 @@ class _ProfileContent extends ConsumerWidget {
                         key: const Key('profile_manage_subscription_row'),
                         title: 'Manage Subscription',
                         subtitle: state.subscriptionLabel ?? 'No Subscription',
-                        // TODO(NIB-73): push paywall when ticket ships.
-                        onTap: () => _showComingSoon(
-                          context,
-                          'Subscription management coming soon.',
+                        // NIB-73 — push the Manage Subscription screen.
+                        onTap: () => context.pushNamed(
+                          AppRoute.manageSubscription.name,
                         ),
                       ),
                       const SizedBox(height: AppSizes.sp12),
@@ -200,12 +199,6 @@ class _ProfileContent extends ConsumerWidget {
     final days = now.difference(monthStart).inDays;
     final clampedDays = days < 0 ? 0 : days;
     return '$months month $clampedDays days';
-  }
-
-  void _showComingSoon(BuildContext context, String message) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   Future<void> _confirmSignOut(BuildContext context, WidgetRef ref) async {

--- a/lib/src/features/subscription/manage/manage_subscription_controller.dart
+++ b/lib/src/features/subscription/manage/manage_subscription_controller.dart
@@ -1,0 +1,25 @@
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/subscription_service.dart';
+import 'package:nibbles/src/features/subscription/manage/manage_subscription_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'manage_subscription_controller.g.dart';
+
+/// AsyncNotifier for the Manage Subscription screen (NIB-73).
+///
+/// Reads the entitlement snapshot from [SubscriptionService.info]. Surfaces
+/// repository failures as an `AsyncError` so the screen can render the P1
+/// error placeholder + retry (mirrors the Profile screen error UI).
+@riverpod
+class ManageSubscriptionController extends _$ManageSubscriptionController {
+  @override
+  Future<ManageSubscriptionState> build() async {
+    final result = await ref.read(subscriptionServiceProvider.notifier).info();
+    return switch (result) {
+      Success(:final data) => ManageSubscriptionState(info: data),
+      // Re-throw the typed AppException so AsyncValue.error preserves the
+      // domain error and the screen's error placeholder can read .message.
+      Failure(:final error) => throw error,
+    };
+  }
+}

--- a/lib/src/features/subscription/manage/manage_subscription_controller.g.dart
+++ b/lib/src/features/subscription/manage/manage_subscription_controller.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'manage_subscription_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$manageSubscriptionControllerHash() =>
+    r'0f42bb5230031d98d837755303cfdf7dd731525d';
+
+/// AsyncNotifier for the Manage Subscription screen (NIB-73).
+///
+/// Reads the entitlement snapshot from [SubscriptionService.info]. Surfaces
+/// repository failures as an `AsyncError` so the screen can render the P1
+/// error placeholder + retry (mirrors the Profile screen error UI).
+///
+/// Copied from [ManageSubscriptionController].
+@ProviderFor(ManageSubscriptionController)
+final manageSubscriptionControllerProvider =
+    AutoDisposeAsyncNotifierProvider<
+      ManageSubscriptionController,
+      ManageSubscriptionState
+    >.internal(
+      ManageSubscriptionController.new,
+      name: r'manageSubscriptionControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$manageSubscriptionControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$ManageSubscriptionController =
+    AutoDisposeAsyncNotifier<ManageSubscriptionState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/subscription/manage/manage_subscription_screen.dart
+++ b/lib/src/features/subscription/manage/manage_subscription_screen.dart
@@ -1,0 +1,545 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_info.dart';
+import 'package:nibbles/src/features/subscription/manage/manage_subscription_controller.dart';
+import 'package:nibbles/src/features/subscription/manage/manage_subscription_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+/// NIB-73 — Manage Subscription screen.
+///
+/// Two render branches keyed on `SubscriptionInfo.isActive`:
+///   * not-subscribed (Figma 1207:11462): butter info card + "Go Premium" pill.
+///   * subscribed/trial (Figma 1207:11737): butter plan card + Started/Renewal
+///     timeline + "Cancel Subscription" pill.
+///
+/// Reachable from Profile via `/subscription/manage`. Route is intentionally
+/// kept off `gatedPaths` (routes.dart) so onboarded users can land here.
+class ManageSubscriptionScreen extends ConsumerStatefulWidget {
+  const ManageSubscriptionScreen({super.key});
+
+  @override
+  ConsumerState<ManageSubscriptionScreen> createState() =>
+      _ManageSubscriptionScreenState();
+}
+
+class _ManageSubscriptionScreenState
+    extends ConsumerState<ManageSubscriptionScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_logScreenView());
+    });
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await ref
+          .read(analyticsProvider)
+          .logScreenView(screenName: 'manage_subscription');
+    } on Object catch (_) {
+      // Analytics is best-effort; never surface to the UI.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asyncState = ref.watch(manageSubscriptionControllerProvider);
+
+    return asyncState.when(
+      loading: () => const _ManageSubscriptionScaffold(
+        child: Center(
+          key: Key('manage_subscription_loading'),
+          child: CircularProgressIndicator(),
+        ),
+      ),
+      error: (err, _) => _ManageSubscriptionError(
+        message: err is AppException
+            ? err.message
+            : 'Couldn’t load your subscription. Please try again.',
+        onRetry: () =>
+            ref.invalidate(manageSubscriptionControllerProvider),
+      ),
+      data: (state) => _ManageSubscriptionBody(state: state),
+    );
+  }
+}
+
+/// Shared scaffold — butter-soft → grey gradient background that mirrors the
+/// `Grad-1` token from variables.json (`linear-gradient(154.372deg, #FFFCD5
+/// 19.168%, #F5F5F5 50%)`). All branches sit on this same canvas.
+class _ManageSubscriptionScaffold extends StatelessWidget {
+  const _ManageSubscriptionScaffold({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            // 154.372deg in CSS — same convention as profile_screen.dart.
+            // sin(154.372°) ≈ 0.433, cos(154.372°) ≈ -0.901.
+            begin: Alignment(-0.433, 0.901),
+            end: Alignment(0.433, -0.901),
+            stops: [0.19168, 0.5],
+            colors: [AppColors.butterSoft, Color(0xFFF5F5F5)],
+          ),
+        ),
+        child: SafeArea(bottom: false, child: child),
+      ),
+    );
+  }
+}
+
+class _ManageSubscriptionBody extends StatelessWidget {
+  const _ManageSubscriptionBody({required this.state});
+
+  final ManageSubscriptionState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final info = state.info;
+
+    void goBack() => context.canPop() ? context.pop() : context.go('/home');
+
+    return _ManageSubscriptionScaffold(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _ManageSubscriptionHeader(onBack: goBack),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.md,
+                0,
+                AppSizes.md,
+                AppSizes.pagePaddingV,
+              ),
+              child: info.isActive
+                  ? _SubscribedSection(info: info)
+                  : const _NotSubscribedSection(),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSizes.md,
+              0,
+              AppSizes.md,
+              AppSizes.pagePaddingV,
+            ),
+            child: info.isActive
+                ? AppPillButton(
+                    key: const Key('manage_subscription_cancel_cta'),
+                    label: 'Cancel Subscription',
+                    variant: AppPillButtonVariant.ghost,
+                    onPressed: () => _onCancelPressed(context),
+                  )
+                : AppPillButton(
+                    key: const Key('manage_subscription_go_premium_cta'),
+                    label: 'Go Premium',
+                    variant: AppPillButtonVariant.ghost,
+                    onPressed: () =>
+                        context.pushNamed(AppRoute.paywall.name),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _onCancelPressed(BuildContext context) {
+    // TODO(NIB-82): replace with the cancel-reason bottom sheet
+    // (frame 1216:12019). Until that ships, surface a placeholder so the
+    // CTA is reachable and the screen ships analyze-clean.
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Cancel subscription flow coming soon.'),
+      ),
+    );
+  }
+}
+
+/// Header row — back chip + "Manage Subscription" title (Title 3/Bold).
+/// Mirrors the structure of `ProfileHeader` but uses the verbatim screen
+/// title from the Figma spec.
+class _ManageSubscriptionHeader extends StatelessWidget {
+  const _ManageSubscriptionHeader({required this.onBack});
+
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.sp12,
+        AppSizes.sm - 2,
+        AppSizes.sp12,
+        AppSizes.lg,
+      ),
+      child: Row(
+        children: [
+          AppRoundButton(
+            key: const Key('manage_subscription_back_button'),
+            icon: const Icon(Icons.arrow_back_ios_new_rounded),
+            onPressed: onBack,
+            tone: AppRoundButtonTone.ghost,
+            size: AppRoundButtonSize.small,
+            semanticLabel: 'Back',
+          ),
+          const SizedBox(width: AppSizes.sp2),
+          Text(
+            'Manage Subscription',
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: AppColors.fgStrong,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Not-subscribed branch (Figma 1207:11462). Single butter-soft card with the
+/// `nibbles` wordmark + crown badge + status copy.
+class _NotSubscribedSection extends StatelessWidget {
+  const _NotSubscribedSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final body = theme.textTheme.bodyLarge?.copyWith(
+      color: AppColors.text,
+      fontSize: 15,
+      height: 22 / 15,
+    );
+
+    return _BrandCard(
+      key: const Key('manage_subscription_not_subscribed_card'),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const _BrandLockup(),
+          const SizedBox(height: AppSizes.sp12),
+          Text('You are not subscribed', style: body),
+          const SizedBox(height: AppSizes.sp12),
+          Text(
+            'You have a free Nibbles account. You can purchase a Premium '
+            'subscription to access our full recipe, content and features.',
+            style: body,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Subscribed/trial branch (Figma 1207:11737). "You are subscribed to :"
+/// intro + butter card (wordmark + plan label) + Started/Renewal timeline +
+/// reassurance paragraph.
+class _SubscribedSection extends StatelessWidget {
+  const _SubscribedSection({required this.info});
+
+  final SubscriptionInfo info;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final body = theme.textTheme.bodyLarge?.copyWith(
+      color: AppColors.text,
+      fontSize: 15,
+      height: 22 / 15,
+    );
+    final planLabel = info.planLabel ?? 'Premium';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Verbatim copy — leading space before the colon is intentional
+        // ("You are subscribed to :"). Preserved per ticket AC.
+        Text('You are subscribed to :', style: body),
+        const SizedBox(height: AppSizes.sp12),
+        _BrandCard(
+          key: const Key('manage_subscription_plan_card'),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const _BrandLockup(),
+              const SizedBox(height: AppSizes.xs),
+              Text(
+                planLabel,
+                key: const Key('manage_subscription_plan_label'),
+                style: body,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSizes.md),
+        _Timeline(
+          startedAt: info.startedAt,
+          renewsAt: info.renewsAt,
+        ),
+        const SizedBox(height: AppSizes.md),
+        Text(
+          'You can cancel your subscription plan. If you cancel, you can '
+          'keep using the subscription until the next billing date.',
+          style: body,
+        ),
+      ],
+    );
+  }
+}
+
+/// Butter-soft surface with a 1px butter border + radius 10. Used by both the
+/// not-subscribed info card and the subscribed plan card. Mirrors the
+/// construction of `PremiumTeaserCard` so the visual rhythm matches Profile.
+class _BrandCard extends StatelessWidget {
+  const _BrandCard({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.butterSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        border: Border.all(color: AppColors.butter),
+      ),
+      padding: const EdgeInsets.all(AppSizes.sp12),
+      child: child,
+    );
+  }
+}
+
+/// `nibbles` wordmark scaled to ~22px next to the crown badge (26x26 butter
+/// square). Identical to `PremiumTeaserCard`'s inline lockup.
+class _BrandLockup extends StatelessWidget {
+  const _BrandLockup();
+
+  @override
+  Widget build(BuildContext context) {
+    final wordmark = AppTypography.brandWordmark.copyWith(
+      fontSize: 22,
+      letterSpacing: 22 * -0.02,
+    );
+
+    return Row(
+      children: [
+        Text('nibbles', style: wordmark),
+        const SizedBox(width: AppSizes.sp12),
+        Container(
+          width: 26,
+          height: 26,
+          decoration: BoxDecoration(
+            color: AppColors.butter,
+            borderRadius: BorderRadius.circular(AppSizes.sm),
+          ),
+          child: const Icon(
+            Icons.workspace_premium_rounded,
+            size: 18,
+            color: AppColors.greenDeep,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Two-row vertical timeline: Started (lime + check, completed) above Renewal
+/// (neutral + radio_button_unchecked, future). A 1px sage stem connects the
+/// two dots. Mirrors Figma 1207:11737 timeline composition.
+class _Timeline extends StatelessWidget {
+  const _Timeline({required this.startedAt, required this.renewsAt});
+
+  final DateTime? startedAt;
+  final DateTime? renewsAt;
+
+  static String _formatDdMmYyyy(DateTime? date) {
+    if (date == null) return '';
+    String two(int v) => v.toString().padLeft(2, '0');
+    return '${two(date.day)}/${two(date.month)}/${date.year}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final labelStyle = theme.textTheme.bodyLarge?.copyWith(
+      color: AppColors.text,
+      fontSize: 15,
+      height: 22 / 15,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _TimelineRow(
+          dot: const _TimelineDot(
+            key: Key('manage_subscription_timeline_started_dot'),
+            completed: true,
+          ),
+          // Verbatim copy preserves the trailing space before the value
+          // ("Started : "). Per ticket AC.
+          label: 'Started : ',
+          value: _formatDdMmYyyy(startedAt),
+          valueKey: const Key('manage_subscription_started_value'),
+          labelStyle: labelStyle,
+        ),
+        // Vertical sage connector between the two dots.
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: AppSizes.xs),
+          child: Row(
+            children: [
+              SizedBox(
+                width: _TimelineDot._size,
+                child: Center(
+                  child: SizedBox(
+                    width: 1,
+                    height: AppSizes.sp12,
+                    child: ColoredBox(color: AppColors.green),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        _TimelineRow(
+          dot: const _TimelineDot(
+            key: Key('manage_subscription_timeline_renewal_dot'),
+            completed: false,
+          ),
+          // Verbatim copy preserves the trailing space ("Renewal : ").
+          label: 'Renewal : ',
+          value: _formatDdMmYyyy(renewsAt),
+          valueKey: const Key('manage_subscription_renewal_value'),
+          labelStyle: labelStyle,
+        ),
+      ],
+    );
+  }
+}
+
+class _TimelineRow extends StatelessWidget {
+  const _TimelineRow({
+    required this.dot,
+    required this.label,
+    required this.value,
+    required this.valueKey,
+    required this.labelStyle,
+  });
+
+  final Widget dot;
+  final String label;
+  final String value;
+  final Key valueKey;
+  final TextStyle? labelStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        dot,
+        const SizedBox(width: AppSizes.sp12),
+        Text(label, style: labelStyle),
+        const SizedBox(width: AppSizes.lg),
+        Flexible(
+          child: Text(value, key: valueKey, style: labelStyle),
+        ),
+      ],
+    );
+  }
+}
+
+/// 31x31 circle dot. Completed state = lime fill + dark check; future state =
+/// neutral fill + outlined radio. Matches Figma chips 1207:11844 / 1207:11848.
+class _TimelineDot extends StatelessWidget {
+  const _TimelineDot({required this.completed, super.key});
+
+  final bool completed;
+
+  static const double _size = 31;
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = completed ? AppColors.butter : AppColors.switchTrackOff;
+    const fg = AppColors.greenDeep;
+
+    return Container(
+      width: _size,
+      height: _size,
+      decoration: BoxDecoration(color: bg, shape: BoxShape.circle),
+      child: Icon(
+        completed
+            ? Icons.check_rounded
+            : Icons.radio_button_unchecked_rounded,
+        size: 18,
+        color: fg,
+      ),
+    );
+  }
+}
+
+/// Error placeholder — mirrors `_ProfileError` (profile_screen.dart) so the
+/// Manage Subscription screen has the same retry affordance under P1.
+class _ManageSubscriptionError extends StatelessWidget {
+  const _ManageSubscriptionError({required this.message, this.onRetry});
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return _ManageSubscriptionScaffold(
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSizes.pagePaddingH),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.error_outline,
+                size: AppSizes.iconXl,
+                color: AppColors.destructive,
+              ),
+              const SizedBox(height: AppSizes.md),
+              Text(
+                message,
+                key: const Key('manage_subscription_error_message'),
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: AppColors.fgMuted,
+                ),
+              ),
+              if (onRetry != null) ...[
+                const SizedBox(height: AppSizes.lg),
+                FilledButton(
+                  key: const Key('manage_subscription_retry_button'),
+                  onPressed: onRetry,
+                  child: const Text('Try Again'),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/subscription/manage/manage_subscription_state.dart
+++ b/lib/src/features/subscription/manage/manage_subscription_state.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_info.dart';
+
+part 'manage_subscription_state.freezed.dart';
+
+/// State for the Manage Subscription screen (NIB-73).
+///
+/// `info` is hydrated from `SubscriptionService.info()` — the screen branches
+/// on `info.isActive` to render the not-subscribed (Go Premium CTA) vs the
+/// subscribed/trial (plan card + timeline + Cancel CTA) layout.
+@freezed
+class ManageSubscriptionState with _$ManageSubscriptionState {
+  const factory ManageSubscriptionState({
+    required SubscriptionInfo info,
+  }) = _ManageSubscriptionState;
+}

--- a/lib/src/features/subscription/manage/manage_subscription_state.freezed.dart
+++ b/lib/src/features/subscription/manage/manage_subscription_state.freezed.dart
@@ -1,0 +1,175 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'manage_subscription_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$ManageSubscriptionState {
+  SubscriptionInfo get info => throw _privateConstructorUsedError;
+
+  /// Create a copy of ManageSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ManageSubscriptionStateCopyWith<ManageSubscriptionState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ManageSubscriptionStateCopyWith<$Res> {
+  factory $ManageSubscriptionStateCopyWith(
+    ManageSubscriptionState value,
+    $Res Function(ManageSubscriptionState) then,
+  ) = _$ManageSubscriptionStateCopyWithImpl<$Res, ManageSubscriptionState>;
+  @useResult
+  $Res call({SubscriptionInfo info});
+
+  $SubscriptionInfoCopyWith<$Res> get info;
+}
+
+/// @nodoc
+class _$ManageSubscriptionStateCopyWithImpl<
+  $Res,
+  $Val extends ManageSubscriptionState
+>
+    implements $ManageSubscriptionStateCopyWith<$Res> {
+  _$ManageSubscriptionStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ManageSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? info = null}) {
+    return _then(
+      _value.copyWith(
+            info: null == info
+                ? _value.info
+                : info // ignore: cast_nullable_to_non_nullable
+                      as SubscriptionInfo,
+          )
+          as $Val,
+    );
+  }
+
+  /// Create a copy of ManageSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $SubscriptionInfoCopyWith<$Res> get info {
+    return $SubscriptionInfoCopyWith<$Res>(_value.info, (value) {
+      return _then(_value.copyWith(info: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ManageSubscriptionStateImplCopyWith<$Res>
+    implements $ManageSubscriptionStateCopyWith<$Res> {
+  factory _$$ManageSubscriptionStateImplCopyWith(
+    _$ManageSubscriptionStateImpl value,
+    $Res Function(_$ManageSubscriptionStateImpl) then,
+  ) = __$$ManageSubscriptionStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({SubscriptionInfo info});
+
+  @override
+  $SubscriptionInfoCopyWith<$Res> get info;
+}
+
+/// @nodoc
+class __$$ManageSubscriptionStateImplCopyWithImpl<$Res>
+    extends
+        _$ManageSubscriptionStateCopyWithImpl<
+          $Res,
+          _$ManageSubscriptionStateImpl
+        >
+    implements _$$ManageSubscriptionStateImplCopyWith<$Res> {
+  __$$ManageSubscriptionStateImplCopyWithImpl(
+    _$ManageSubscriptionStateImpl _value,
+    $Res Function(_$ManageSubscriptionStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of ManageSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? info = null}) {
+    return _then(
+      _$ManageSubscriptionStateImpl(
+        info: null == info
+            ? _value.info
+            : info // ignore: cast_nullable_to_non_nullable
+                  as SubscriptionInfo,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ManageSubscriptionStateImpl implements _ManageSubscriptionState {
+  const _$ManageSubscriptionStateImpl({required this.info});
+
+  @override
+  final SubscriptionInfo info;
+
+  @override
+  String toString() {
+    return 'ManageSubscriptionState(info: $info)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ManageSubscriptionStateImpl &&
+            (identical(other.info, info) || other.info == info));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, info);
+
+  /// Create a copy of ManageSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ManageSubscriptionStateImplCopyWith<_$ManageSubscriptionStateImpl>
+  get copyWith =>
+      __$$ManageSubscriptionStateImplCopyWithImpl<
+        _$ManageSubscriptionStateImpl
+      >(this, _$identity);
+}
+
+abstract class _ManageSubscriptionState implements ManageSubscriptionState {
+  const factory _ManageSubscriptionState({
+    required final SubscriptionInfo info,
+  }) = _$ManageSubscriptionStateImpl;
+
+  @override
+  SubscriptionInfo get info;
+
+  /// Create a copy of ManageSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ManageSubscriptionStateImplCopyWith<_$ManageSubscriptionStateImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/src/routing/route_enums.dart
+++ b/lib/src/routing/route_enums.dart
@@ -28,6 +28,10 @@ enum AppRoute {
     path: '/subscription/success',
     name: 'subscription-success',
   ),
+  manageSubscription(
+    path: '/subscription/manage',
+    name: 'manage-subscription',
+  ),
   home(path: '/home', name: 'home'),
   mealPlan(path: '/home/meal', name: 'meal-plan'),
   mealPlanMap(path: '/home/meal/map', name: 'meal-plan-map'),

--- a/lib/src/routing/routes.dart
+++ b/lib/src/routing/routes.dart
@@ -33,6 +33,7 @@ import 'package:nibbles/src/features/shopping_list/shopping_list_screen.dart';
 import 'package:nibbles/src/features/splash/splash_screen.dart';
 import 'package:nibbles/src/features/starting_guide/starting_guide_article_screen.dart';
 import 'package:nibbles/src/features/starting_guide/starting_guide_hub_screen.dart';
+import 'package:nibbles/src/features/subscription/manage/manage_subscription_screen.dart';
 import 'package:nibbles/src/features/subscription/paywall/paywall_screen.dart';
 import 'package:nibbles/src/features/subscription/success/subscription_success_screen.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
@@ -231,6 +232,16 @@ GoRouter goRouter(Ref ref) {
         path: AppRoute.subscriptionSuccess.path,
         name: AppRoute.subscriptionSuccess.name,
         builder: (context, state) => const SubscriptionSuccessScreen(),
+      ),
+      // NIB-73 — Manage Subscription. Two render branches (not-subscribed /
+      // subscribed-trial) keyed on `SubscriptionService.info()`. Kept OFF
+      // `gatedPaths` so onboarded users can reach it from Profile while M2
+      // is deferred — see NIB-73 acceptance: "reachable, not redirected to
+      // /home".
+      GoRoute(
+        path: AppRoute.manageSubscription.path,
+        name: AppRoute.manageSubscription.name,
+        builder: (context, state) => const ManageSubscriptionScreen(),
       ),
       StatefulShellRoute.indexedStack(
         builder: (context, state, navigationShell) =>

--- a/lib/src/routing/routes.g.dart
+++ b/lib/src/routing/routes.g.dart
@@ -6,7 +6,7 @@ part of 'routes.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'26dfc3d3be386be0ee4f95ce6b9440001be29af3';
+String _$goRouterHash() => r'd5bab8f67774cfb4432ec333d2dd166a07d5d658';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -116,6 +116,7 @@ class _FakeProfileController extends ProfileController {
 
 const _editStubKey = Key('stub_profile_edit');
 const _feedbackStubKey = Key('stub_profile_feedback');
+const _manageSubscriptionStubKey = Key('stub_manage_subscription');
 
 GoRouter _router() => GoRouter(
       initialLocation: '/home/profile',
@@ -126,8 +127,8 @@ GoRouter _router() => GoRouter(
           builder: (_, __) => const ProfileScreen(),
         ),
         // Stub destinations: keep nav assertable without booting the real
-        // ProfileEdit / Feedback subtrees (which would try to read providers
-        // we don't mock here).
+        // ProfileEdit / Feedback / ManageSubscription subtrees (which would
+        // try to read providers we don't mock here).
         GoRoute(
           path: '/home/profile/edit',
           name: AppRoute.profileEdit.name,
@@ -142,6 +143,14 @@ GoRouter _router() => GoRouter(
           builder: (_, __) => const Scaffold(
             key: _feedbackStubKey,
             body: Center(child: Text('FEEDBACK STUB')),
+          ),
+        ),
+        GoRoute(
+          path: '/subscription/manage',
+          name: AppRoute.manageSubscription.name,
+          builder: (_, __) => const Scaffold(
+            key: _manageSubscriptionStubKey,
+            body: Center(child: Text('MANAGE SUBSCRIPTION STUB')),
           ),
         ),
       ],
@@ -281,7 +290,7 @@ void main() {
   // -------------------------------------------------------------------------
 
   testWidgets(
-    "tapping 'Manage Subscription' surfaces the 'coming soon' SnackBar",
+    "tapping 'Manage Subscription' pushes /subscription/manage",
     (tester) async {
       await tester.binding.setSurfaceSize(const Size(400, 1200));
       addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -293,9 +302,10 @@ void main() {
 
       await tester
           .tap(find.byKey(const Key('profile_manage_subscription_row')));
-      await tester.pump(); // SnackBar transition starts on the next frame.
+      await tester.pumpAndSettle();
 
-      expect(find.textContaining('coming soon'), findsOneWidget);
+      expect(find.byKey(_manageSubscriptionStubKey), findsOneWidget);
+      expect(find.text('MANAGE SUBSCRIPTION STUB'), findsOneWidget);
     },
   );
 

--- a/test/features/subscription/manage/manage_subscription_screen_test.dart
+++ b/test/features/subscription/manage/manage_subscription_screen_test.dart
@@ -1,0 +1,309 @@
+// NIB-73 — widget tests for the Manage Subscription screen.
+//
+// Covers:
+//   - Not-subscribed branch renders the info card + "Go Premium" CTA.
+//   - "Go Premium" pushes /subscription/paywall.
+//   - Subscribed/trial branch renders plan label + Started/Renewal timeline
+//     dates pulled from SubscriptionInfo (no hardcoded 15/08/2026).
+//   - "Cancel Subscription" surfaces the placeholder until NIB-82 ships.
+//   - Loading branch renders the spinner; error branch renders the retry CTA.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_info.dart';
+import 'package:nibbles/src/features/subscription/manage/manage_subscription_controller.dart';
+import 'package:nibbles/src/features/subscription/manage/manage_subscription_screen.dart';
+import 'package:nibbles/src/features/subscription/manage/manage_subscription_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class _FakeManageSubscriptionController extends ManageSubscriptionController {
+  _FakeManageSubscriptionController(this._initial);
+
+  final AsyncValue<ManageSubscriptionState> _initial;
+
+  @override
+  Future<ManageSubscriptionState> build() async {
+    return _initial.when(
+      data: (state) => state,
+      loading: () => Completer<ManageSubscriptionState>().future,
+      error: Future<ManageSubscriptionState>.error,
+    );
+  }
+}
+
+const _paywallStubKey = Key('stub_paywall');
+const _profileStubKey = Key('stub_profile');
+
+GoRouter _router() => GoRouter(
+      initialLocation: AppRoute.manageSubscription.path,
+      routes: [
+        GoRoute(
+          path: AppRoute.manageSubscription.path,
+          name: AppRoute.manageSubscription.name,
+          builder: (_, __) => const ManageSubscriptionScreen(),
+        ),
+        GoRoute(
+          path: AppRoute.paywall.path,
+          name: AppRoute.paywall.name,
+          builder: (_, __) => const Scaffold(
+            key: _paywallStubKey,
+            body: Center(child: Text('PAYWALL STUB')),
+          ),
+        ),
+        GoRoute(
+          path: AppRoute.profile.path,
+          name: AppRoute.profile.name,
+          builder: (_, __) => const Scaffold(
+            key: _profileStubKey,
+            body: Center(child: Text('PROFILE STUB')),
+          ),
+        ),
+      ],
+    );
+
+Widget _wrap(List<Override> overrides) => ProviderScope(
+      overrides: overrides,
+      child: MaterialApp.router(routerConfig: _router()),
+    );
+
+List<Override> _overrides(AsyncValue<ManageSubscriptionState> state) => [
+      analyticsProvider.overrideWithValue(FakeAnalytics()),
+      manageSubscriptionControllerProvider
+          .overrideWith(() => _FakeManageSubscriptionController(state)),
+    ];
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // Not-subscribed branch
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'not-subscribed: renders verbatim copy + "Go Premium" CTA',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        _wrap(
+          _overrides(
+            const AsyncData(
+              ManageSubscriptionState(
+                info: SubscriptionInfo(isActive: false),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Manage Subscription'), findsOneWidget);
+      expect(find.text('You are not subscribed'), findsOneWidget);
+      expect(
+        find.text(
+          'You have a free Nibbles account. You can purchase a Premium '
+          'subscription to access our full recipe, content and features.',
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('manage_subscription_go_premium_cta')),
+        findsOneWidget,
+      );
+      expect(find.text('Go Premium'), findsOneWidget);
+      // Cancel CTA is hidden in the not-subscribed branch.
+      expect(
+        find.byKey(const Key('manage_subscription_cancel_cta')),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'not-subscribed: tapping "Go Premium" pushes /subscription/paywall',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        _wrap(
+          _overrides(
+            const AsyncData(
+              ManageSubscriptionState(
+                info: SubscriptionInfo(isActive: false),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester
+          .tap(find.byKey(const Key('manage_subscription_go_premium_cta')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(_paywallStubKey), findsOneWidget);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Subscribed / trial branch
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'subscribed: renders plan label, dd/MM/yyyy timeline dates, and copy',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 1000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // Distinct started/renewal dates so we know they bind separately and
+      // are NOT hardcoded to the Figma placeholder 15/08/2026.
+      final started = DateTime(2026, 7, 3);
+      final renews = DateTime(2026, 8, 15);
+
+      await tester.pumpWidget(
+        _wrap(
+          _overrides(
+            AsyncData(
+              ManageSubscriptionState(
+                info: SubscriptionInfo(
+                  isActive: true,
+                  planLabel: 'Free Trial',
+                  startedAt: started,
+                  renewsAt: renews,
+                  isTrial: true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Manage Subscription'), findsOneWidget);
+      // Verbatim intro copy — leading space before the colon is preserved.
+      expect(find.text('You are subscribed to :'), findsOneWidget);
+      expect(find.text('Free Trial'), findsOneWidget);
+      // Verbatim timeline labels — trailing space after the colon preserved.
+      expect(find.text('Started : '), findsOneWidget);
+      expect(find.text('Renewal : '), findsOneWidget);
+      expect(
+        find.byKey(const Key('manage_subscription_started_value')),
+        findsOneWidget,
+      );
+      expect(find.text('03/07/2026'), findsOneWidget);
+      expect(find.text('15/08/2026'), findsOneWidget);
+      expect(
+        find.text(
+          'You can cancel your subscription plan. If you cancel, you can '
+          'keep using the subscription until the next billing date.',
+        ),
+        findsOneWidget,
+      );
+      // Cancel CTA is the primary action on the subscribed branch.
+      expect(
+        find.byKey(const Key('manage_subscription_cancel_cta')),
+        findsOneWidget,
+      );
+      expect(find.text('Cancel Subscription'), findsOneWidget);
+      // Go Premium CTA is hidden in the subscribed branch.
+      expect(
+        find.byKey(const Key('manage_subscription_go_premium_cta')),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'subscribed: tapping "Cancel Subscription" surfaces the NIB-82 placeholder',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 1000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        _wrap(
+          _overrides(
+            AsyncData(
+              ManageSubscriptionState(
+                info: SubscriptionInfo(
+                  isActive: true,
+                  planLabel: 'Free Trial',
+                  startedAt: DateTime(2026, 7, 3),
+                  renewsAt: DateTime(2026, 8, 15),
+                  isTrial: true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester
+          .tap(find.byKey(const Key('manage_subscription_cancel_cta')));
+      await tester.pump();
+
+      expect(
+        find.textContaining('Cancel subscription flow coming soon'),
+        findsOneWidget,
+      );
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Loading + error branches
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'loading: renders the spinner placeholder',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(_overrides(const AsyncLoading())),
+      );
+      // Single pump — spinner animates indefinitely so pumpAndSettle would
+      // block.
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('manage_subscription_loading')),
+        findsOneWidget,
+      );
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'error: renders error message + retry CTA',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          _overrides(
+            const AsyncError<ManageSubscriptionState>(
+              ServerException('boom'),
+              StackTrace.empty,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('manage_subscription_error_message')),
+        findsOneWidget,
+      );
+      expect(find.text('boom'), findsOneWidget);
+      expect(
+        find.byKey(const Key('manage_subscription_retry_button')),
+        findsOneWidget,
+      );
+      expect(find.text('Try Again'), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Implements the Manage Subscription screen (NIB-73) with two render branches keyed on `SubscriptionInfo.isActive`:

- **Not-subscribed** (Figma `1207:11462`): butter-soft info card with `nibbles` wordmark + crown badge + status copy, bottom butter pill `Go Premium` -> pushes Paywall.
- **Subscribed / trial** (Figma `1207:11737`): butter plan card with dynamic plan label, two-row vertical timeline (Started lime+check, Renewal neutral+radio), reassurance paragraph, bottom butter pill `Cancel Subscription` -> opens cancel-sheet placeholder (NIB-82 owns the real sheet).

Wires the Profile `Manage Subscription` row to push the new screen, replacing the previous coming-soon SnackBar.

`SubscriptionService` gains an `info()` method returning a `SubscriptionInfo` domain entity that mirrors the RevenueCat `customerInfo` shape — swapping the stub for the real implementation (NIB-18) is a no-op for the screen.

## Acceptance criteria

- [x] Profile has a working entry to Manage Subscription; route is reachable (not in `gatedPaths`).
- [x] Not-subscribed state matches `1207:11462`; `Go Premium` pushes Paywall (M2 gate behaviour intentional — gate stays off `gatedPaths`).
- [x] Subscribed state matches `1207:11737` with real Started/Renewal dates and plan label from `SubscriptionInfo` (no hardcoded `15/08/2026`).
- [x] Verbatim copy preserved exactly (trailing space after `Started : ` / `Renewal : `, leading space colon in `You are subscribed to :`).
- [x] All tokens from `lib/src/app/themes/` — no new hex outside the foundation.
- [x] Loading -> spinner; error -> P1 message + Try Again retry.
- [x] `Cancel Subscription` placeholder reachable (NIB-82 will replace with the cancel-reason sheet).
- [x] `flutter analyze` clean for the changed files (2 pre-existing infos in `subscription_success_screen_test.dart` unchanged from `redesign`).
- [x] Widget tests cover both branches + loading + error + Profile -> Manage push.

## Figma frames

- [`1207:11462`](https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1207-11462) — not-subscribed
- [`1207:11737`](https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=1207-11737) — subscribed/trial

## Audit artifacts

- `.figma-audit/subscription-no-plan/subscription-plan/report.md`
- `.figma-audit/subscription-cancel/subscription-plan-if-subscrip/report.md`

## Test plan

- [x] `make gen` succeeds
- [x] `flutter analyze` reports zero new issues
- [x] `flutter test` passes (494 passing, 1 pre-existing skipped)
- [ ] Smoke on simulator: Profile -> Manage Subscription -> Go Premium / Cancel Subscription paths

## Out of scope

- Real RevenueCat-backed `SubscriptionService` (NIB-18)
- Cancel-reason bottom sheet (NIB-82) — placeholder SnackBar shipped, TODO comment in screen
- `manage_subscription_viewed` analytics event (NIB-90 owns subscription events) — using `logScreenView('manage_subscription')` for now