### PR TITLE
feat(infra): paywall Try for $0 sheet [NIB-55]

### DIFF
--- a/lib/src/common/domain/entities/subscription_offering.dart
+++ b/lib/src/common/domain/entities/subscription_offering.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'subscription_offering.freezed.dart';
+
+/// Domain representation of a RevenueCat `StoreProduct` offering.
+///
+/// Only the fields the paywall needs are captured: a stable product identifier,
+/// the formatted price the StoreProduct surfaces (locale-aware, currency-
+/// symboled — never compose this in the UI) and a short cadence label
+/// (e.g. `yearly`). NIB-18 will wire this through `purchases_flutter` and
+/// replace the placeholder offering in `SubscriptionService`.
+@freezed
+class SubscriptionOffering with _$SubscriptionOffering {
+  const factory SubscriptionOffering({
+    required String productId,
+    required String priceString,
+    required String periodLabel,
+    required int trialDays,
+  }) = _SubscriptionOffering;
+}

--- a/lib/src/common/domain/entities/subscription_offering.freezed.dart
+++ b/lib/src/common/domain/entities/subscription_offering.freezed.dart
@@ -1,0 +1,232 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'subscription_offering.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$SubscriptionOffering {
+  String get productId => throw _privateConstructorUsedError;
+  String get priceString => throw _privateConstructorUsedError;
+  String get periodLabel => throw _privateConstructorUsedError;
+  int get trialDays => throw _privateConstructorUsedError;
+
+  /// Create a copy of SubscriptionOffering
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SubscriptionOfferingCopyWith<SubscriptionOffering> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SubscriptionOfferingCopyWith<$Res> {
+  factory $SubscriptionOfferingCopyWith(
+    SubscriptionOffering value,
+    $Res Function(SubscriptionOffering) then,
+  ) = _$SubscriptionOfferingCopyWithImpl<$Res, SubscriptionOffering>;
+  @useResult
+  $Res call({
+    String productId,
+    String priceString,
+    String periodLabel,
+    int trialDays,
+  });
+}
+
+/// @nodoc
+class _$SubscriptionOfferingCopyWithImpl<
+  $Res,
+  $Val extends SubscriptionOffering
+>
+    implements $SubscriptionOfferingCopyWith<$Res> {
+  _$SubscriptionOfferingCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SubscriptionOffering
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? productId = null,
+    Object? priceString = null,
+    Object? periodLabel = null,
+    Object? trialDays = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            productId: null == productId
+                ? _value.productId
+                : productId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            priceString: null == priceString
+                ? _value.priceString
+                : priceString // ignore: cast_nullable_to_non_nullable
+                      as String,
+            periodLabel: null == periodLabel
+                ? _value.periodLabel
+                : periodLabel // ignore: cast_nullable_to_non_nullable
+                      as String,
+            trialDays: null == trialDays
+                ? _value.trialDays
+                : trialDays // ignore: cast_nullable_to_non_nullable
+                      as int,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$SubscriptionOfferingImplCopyWith<$Res>
+    implements $SubscriptionOfferingCopyWith<$Res> {
+  factory _$$SubscriptionOfferingImplCopyWith(
+    _$SubscriptionOfferingImpl value,
+    $Res Function(_$SubscriptionOfferingImpl) then,
+  ) = __$$SubscriptionOfferingImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String productId,
+    String priceString,
+    String periodLabel,
+    int trialDays,
+  });
+}
+
+/// @nodoc
+class __$$SubscriptionOfferingImplCopyWithImpl<$Res>
+    extends _$SubscriptionOfferingCopyWithImpl<$Res, _$SubscriptionOfferingImpl>
+    implements _$$SubscriptionOfferingImplCopyWith<$Res> {
+  __$$SubscriptionOfferingImplCopyWithImpl(
+    _$SubscriptionOfferingImpl _value,
+    $Res Function(_$SubscriptionOfferingImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of SubscriptionOffering
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? productId = null,
+    Object? priceString = null,
+    Object? periodLabel = null,
+    Object? trialDays = null,
+  }) {
+    return _then(
+      _$SubscriptionOfferingImpl(
+        productId: null == productId
+            ? _value.productId
+            : productId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        priceString: null == priceString
+            ? _value.priceString
+            : priceString // ignore: cast_nullable_to_non_nullable
+                  as String,
+        periodLabel: null == periodLabel
+            ? _value.periodLabel
+            : periodLabel // ignore: cast_nullable_to_non_nullable
+                  as String,
+        trialDays: null == trialDays
+            ? _value.trialDays
+            : trialDays // ignore: cast_nullable_to_non_nullable
+                  as int,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$SubscriptionOfferingImpl implements _SubscriptionOffering {
+  const _$SubscriptionOfferingImpl({
+    required this.productId,
+    required this.priceString,
+    required this.periodLabel,
+    required this.trialDays,
+  });
+
+  @override
+  final String productId;
+  @override
+  final String priceString;
+  @override
+  final String periodLabel;
+  @override
+  final int trialDays;
+
+  @override
+  String toString() {
+    return 'SubscriptionOffering(productId: $productId, priceString: $priceString, periodLabel: $periodLabel, trialDays: $trialDays)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SubscriptionOfferingImpl &&
+            (identical(other.productId, productId) ||
+                other.productId == productId) &&
+            (identical(other.priceString, priceString) ||
+                other.priceString == priceString) &&
+            (identical(other.periodLabel, periodLabel) ||
+                other.periodLabel == periodLabel) &&
+            (identical(other.trialDays, trialDays) ||
+                other.trialDays == trialDays));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, productId, priceString, periodLabel, trialDays);
+
+  /// Create a copy of SubscriptionOffering
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SubscriptionOfferingImplCopyWith<_$SubscriptionOfferingImpl>
+  get copyWith =>
+      __$$SubscriptionOfferingImplCopyWithImpl<_$SubscriptionOfferingImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _SubscriptionOffering implements SubscriptionOffering {
+  const factory _SubscriptionOffering({
+    required final String productId,
+    required final String priceString,
+    required final String periodLabel,
+    required final int trialDays,
+  }) = _$SubscriptionOfferingImpl;
+
+  @override
+  String get productId;
+  @override
+  String get priceString;
+  @override
+  String get periodLabel;
+  @override
+  int get trialDays;
+
+  /// Create a copy of SubscriptionOffering
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SubscriptionOfferingImplCopyWith<_$SubscriptionOfferingImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/src/common/services/subscription_service.dart
+++ b/lib/src/common/services/subscription_service.dart
@@ -1,18 +1,44 @@
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/subscription_info.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_offering.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'subscription_service.g.dart';
 
-/// Stub SubscriptionService — will be wired in NIB-18.
-/// Returns false by default; redirect logic sends users to paywall.
+/// Stub SubscriptionService — to be wired through `purchases_flutter` in
+/// NIB-18. State is the entitlement bool used by callers like the post-
+/// purchase transition controller and the (currently deferred) router guard.
 ///
 /// NIB-73 expands the surface with [info] so the Manage Subscription screen
 /// can render plan / Started / Renewal from a single entitlement snapshot.
+/// NIB-55 adds [loadOfferings] / [purchaseDefault] / [restore] so the paywall
+/// reads its default trial offering and triggers purchase/restore at this
+/// seam. Until NIB-18 lands the stub returns a fixed placeholder offering so
+/// the UI never has to hardcode price strings, and the three P1 failure paths
+/// (`purchaseFail` / `restoreNoEntitlement` / `offeringsLoadFail`) are wired
+/// at the seam — tests override the provider to exercise them.
+///
 /// The shape mirrors what RevenueCat `customerInfo` will yield, so swapping
-/// the stub for the real implementation is a no-op for the screen.
+/// the stub for the real implementation is a no-op for callers.
 @riverpod
 class SubscriptionService extends _$SubscriptionService {
+  /// Hardcoded placeholder offering. The string is taken verbatim from the
+  /// Figma spec so the design renders correctly; NIB-18 replaces it with a
+  /// real `StoreProduct.priceString` read from RevenueCat.
+  ///
+  /// IMPORTANT: this constant only lives in the SERVICE layer (the seam where
+  /// RC will plug in). The paywall UI never references it directly — it reads
+  /// the price out of controller state, which sources it from [loadOfferings].
+  // TODO(NIB-18): replace with a real StoreProduct lookup via RC.
+  static const SubscriptionOffering placeholderTrialOffering =
+      SubscriptionOffering(
+        productId: 'nibbles_yearly_placeholder',
+        priceString: r'$29.99',
+        periodLabel: 'yearly',
+        trialDays: 3,
+      );
+
   @override
   bool build() => false;
 
@@ -43,6 +69,35 @@ class SubscriptionService extends _$SubscriptionService {
         renewsAt: renews,
         isTrial: true,
       ),
+    );
+  }
+
+  /// Loads the default trial offering. Stub returns the placeholder; NIB-18
+  /// will replace with `Purchases.getOfferings()`. Returns [Result] so the
+  /// controller can surface the `offeringsLoadFail` P1 state at the seam.
+  Future<Result<SubscriptionOffering>> loadOfferings() async {
+    // TODO(NIB-18): real `Purchases.getOfferings()` call.
+    return const Result.success(placeholderTrialOffering);
+  }
+
+  /// Purchases the default trial offering. Stub flips entitlement to active
+  /// and returns success; NIB-18 will wrap `Purchases.purchasePackage` and
+  /// map RC errors → [AppException]. Returns [Result] so the controller can
+  /// surface RC error messages verbatim (P1 modal).
+  Future<Result<void>> purchaseDefault() async {
+    // TODO(NIB-18): real `Purchases.purchasePackage` call.
+    state = true;
+    return const Result.success(null);
+  }
+
+  /// Restores entitlements. Stub returns `notFound` so callers can exercise
+  /// the "No active subscription found." P1 path; NIB-18 will wrap
+  /// `Purchases.restorePurchases` and flip [state] only when an active
+  /// entitlement is actually returned.
+  Future<Result<void>> restore() async {
+    // TODO(NIB-18): real `Purchases.restorePurchases` call.
+    return const Result.failure(
+      NotFoundException('No active subscription found.'),
     );
   }
 }

--- a/lib/src/common/services/subscription_service.g.dart
+++ b/lib/src/common/services/subscription_service.g.dart
@@ -7,15 +7,23 @@ part of 'subscription_service.dart';
 // **************************************************************************
 
 String _$subscriptionServiceHash() =>
-    r'0a5b4e13dd0c19f75cf8da447a27aa84b8a59922';
+    r'c5ece94fd553c4d270b8e630aaf272b43ab7b3cd';
 
-/// Stub SubscriptionService — will be wired in NIB-18.
-/// Returns false by default; redirect logic sends users to paywall.
+/// Stub SubscriptionService — to be wired through `purchases_flutter` in
+/// NIB-18. State is the entitlement bool used by callers like the post-
+/// purchase transition controller and the (currently deferred) router guard.
 ///
 /// NIB-73 expands the surface with [info] so the Manage Subscription screen
 /// can render plan / Started / Renewal from a single entitlement snapshot.
+/// NIB-55 adds [loadOfferings] / [purchaseDefault] / [restore] so the paywall
+/// reads its default trial offering and triggers purchase/restore at this
+/// seam. Until NIB-18 lands the stub returns a fixed placeholder offering so
+/// the UI never has to hardcode price strings, and the three P1 failure paths
+/// (`purchaseFail` / `restoreNoEntitlement` / `offeringsLoadFail`) are wired
+/// at the seam — tests override the provider to exercise them.
+///
 /// The shape mirrors what RevenueCat `customerInfo` will yield, so swapping
-/// the stub for the real implementation is a no-op for the screen.
+/// the stub for the real implementation is a no-op for callers.
 ///
 /// Copied from [SubscriptionService].
 @ProviderFor(SubscriptionService)

--- a/lib/src/features/subscription/manage/manage_subscription_controller.g.dart
+++ b/lib/src/features/subscription/manage/manage_subscription_controller.g.dart
@@ -7,7 +7,7 @@ part of 'manage_subscription_controller.dart';
 // **************************************************************************
 
 String _$manageSubscriptionControllerHash() =>
-    r'0f42bb5230031d98d837755303cfdf7dd731525d';
+    r'35fbe2622c6daacd3f6ab1a6f2e2cc211863e4fe';
 
 /// AsyncNotifier for the Manage Subscription screen (NIB-73).
 ///

--- a/lib/src/features/subscription/paywall/paywall_controller.dart
+++ b/lib/src/features/subscription/paywall/paywall_controller.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/subscription_service.dart';
+import 'package:nibbles/src/features/subscription/paywall/paywall_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'paywall_controller.g.dart';
+
+/// NIB-55 — paywall (Try for $0 sheet) controller.
+///
+/// Loads the default trial offering on build and exposes
+/// [purchaseDefault] / [restore] as the two CTA handlers. Results are
+/// returned to the UI so the screen owns the P1 modal surface (per
+/// error-handling.md the controller never throws and never decides UI).
+///
+/// Analytics fired here:
+/// * `paywall_viewed`            — on first build.
+/// * `subscription_started`      — on `purchaseDefault` success.
+/// * `subscription_restored`     — on `restore` success.
+@riverpod
+class PaywallController extends _$PaywallController {
+  @override
+  PaywallState build() {
+    unawaited(_logPaywallViewed());
+    // Defer the offerings fetch a microtask so the notifier is initialised
+    // before `_loadOfferings` reassigns `state` (Riverpod forbids writing
+    // `state` synchronously from inside `build`).
+    Future.microtask(_loadOfferings);
+    return PaywallState.initial();
+  }
+
+  Future<void> _logPaywallViewed() async {
+    try {
+      await ref.read(analyticsProvider).logPaywallViewed();
+    } on Object catch (_) {
+      // Best-effort; never block UI.
+    }
+  }
+
+  /// Re-runs the offerings fetch. Wired to the inline-error retry CTA so a
+  /// transient failure on first build is recoverable without rebuilding the
+  /// whole sheet.
+  Future<void> reloadOfferings() => _loadOfferings();
+
+  Future<void> _loadOfferings() async {
+    state = state.copyWith(
+      phase: PaywallPhase.loading,
+      errorMessage: null,
+    );
+    final result = await ref.read(subscriptionServiceProvider.notifier)
+        .loadOfferings();
+    result.fold(
+      onSuccess: (offering) {
+        state = state.copyWith(
+          phase: PaywallPhase.ready,
+          offering: offering,
+        );
+      },
+      onFailure: (error) {
+        state = state.copyWith(
+          phase: PaywallPhase.error,
+          errorMessage: error.message,
+        );
+      },
+    );
+  }
+
+  /// Triggers the default-package purchase. Returns the [Result] so the
+  /// screen can render the P1 modal with the RC message verbatim on
+  /// failure. Sets [PaywallAction.purchasing] for the duration.
+  Future<Result<void>> purchaseDefault() async {
+    if (state.action != PaywallAction.none) {
+      // Guard against double-tap while a prior action is still in flight.
+      return const Result.success(null);
+    }
+    state = state.copyWith(action: PaywallAction.purchasing);
+    final result = await ref.read(subscriptionServiceProvider.notifier)
+        .purchaseDefault();
+
+    final productId = state.offering?.productId ?? '';
+    result.whenOrNull(
+      success: (_) => unawaited(_logSubscriptionStarted(productId)),
+    );
+
+    state = state.copyWith(action: PaywallAction.none);
+    return result;
+  }
+
+  /// Restore CTA — re-checks RevenueCat for an existing entitlement. Returns
+  /// the [Result] so the screen can show the P1 "No active subscription
+  /// found." modal on `NotFoundException`, or fall through on success.
+  Future<Result<void>> restore() async {
+    if (state.action != PaywallAction.none) {
+      return const Result.success(null);
+    }
+    state = state.copyWith(action: PaywallAction.restoring);
+    final result = await ref.read(subscriptionServiceProvider.notifier)
+        .restore();
+
+    result.whenOrNull(
+      success: (_) => unawaited(_logSubscriptionRestored()),
+    );
+
+    state = state.copyWith(action: PaywallAction.none);
+    return result;
+  }
+
+  Future<void> _logSubscriptionStarted(String productId) async {
+    try {
+      await ref
+          .read(analyticsProvider)
+          .logSubscriptionStarted(productId: productId);
+    } on Object catch (_) {
+      // Best-effort; never block UI.
+    }
+  }
+
+  Future<void> _logSubscriptionRestored() async {
+    try {
+      await ref.read(analyticsProvider).logSubscriptionRestored();
+    } on Object catch (_) {
+      // Best-effort; never block UI.
+    }
+  }
+}

--- a/lib/src/features/subscription/paywall/paywall_controller.g.dart
+++ b/lib/src/features/subscription/paywall/paywall_controller.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'paywall_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$paywallControllerHash() => r'06a9028e6b66dd5ef1ed5cbb1551fe0597f51071';
+
+/// NIB-55 — paywall (Try for $0 sheet) controller.
+///
+/// Loads the default trial offering on build and exposes
+/// [purchaseDefault] / [restore] as the two CTA handlers. Results are
+/// returned to the UI so the screen owns the P1 modal surface (per
+/// error-handling.md the controller never throws and never decides UI).
+///
+/// Analytics fired here:
+/// * `paywall_viewed`            — on first build.
+/// * `subscription_started`      — on `purchaseDefault` success.
+/// * `subscription_restored`     — on `restore` success.
+///
+/// Copied from [PaywallController].
+@ProviderFor(PaywallController)
+final paywallControllerProvider =
+    AutoDisposeNotifierProvider<PaywallController, PaywallState>.internal(
+      PaywallController.new,
+      name: r'paywallControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$paywallControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$PaywallController = AutoDisposeNotifier<PaywallState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/subscription/paywall/paywall_screen.dart
+++ b/lib/src/features/subscription/paywall/paywall_screen.dart
@@ -1,9 +1,39 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/features/subscription/paywall/paywall_sheet.dart';
 
+/// NIB-55 — paywall screen.
+///
+/// The real entry point is [showPaywallSheet] (bottom sheet from "Go
+/// Premium"). This screen exists so the existing `/subscription/paywall`
+/// GoRoute still resolves to a widget; it hosts the same [PaywallSheet]
+/// body as a full-page Scaffold with the Figma sheet's rounded top corners
+/// drawn against a soft scrim so deep-link arrivals match the sheet aesthetic.
 class PaywallScreen extends ConsumerWidget {
   const PaywallScreen({super.key});
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) =>
-      const Scaffold(body: Center(child: Text('Paywall (SB-01)')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      // Soft scrim behind the sheet body so it reads as an overlay even when
+      // pushed full-screen via deep link (rather than animating up from a
+      // parent route).
+      backgroundColor: AppColors.text.withValues(alpha: 0.4),
+      body: const SafeArea(
+        child: Align(
+          alignment: Alignment.bottomCenter,
+          child: ClipRRect(
+            borderRadius: BorderRadius.vertical(
+              top: Radius.circular(30),
+            ),
+            child: Material(
+              color: AppColors.cream,
+              child: PaywallSheet(key: Key('paywall_screen_sheet')),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/src/features/subscription/paywall/paywall_sheet.dart
+++ b/lib/src/features/subscription/paywall/paywall_sheet.dart
@@ -1,0 +1,765 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/brand/brand_logo.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_offering.dart';
+import 'package:nibbles/src/features/subscription/paywall/paywall_controller.dart';
+import 'package:nibbles/src/features/subscription/paywall/paywall_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+/// Opens [PaywallSheet] as a modal bottom sheet (Figma "Overlay - subsplan",
+/// frame 1216:11727). Top corners are rounded 30 per spec; the sheet is
+/// `isScrollControlled` so the content can fill ~92% of screen height on
+/// short devices without clipping the trial card / CTAs.
+///
+/// Returns once the sheet is dismissed (Close X, scrim tap, or a successful
+/// purchase that pops the sheet from inside).
+Future<void> showPaywallSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: AppColors.cream,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(30)),
+    ),
+    builder: (_) => const PaywallSheet(),
+  );
+}
+
+/// Stateless sheet body. Hosted directly inside [showPaywallSheet] for the
+/// real entry-point flow (Go Premium → bottom sheet) and inside
+/// `PaywallScreen` as a full-page scaffold so the existing
+/// `/subscription/paywall` GoRoute still compiles. The two surfaces share
+/// state via the same [paywallControllerProvider] instance.
+class PaywallSheet extends ConsumerStatefulWidget {
+  const PaywallSheet({super.key});
+
+  @override
+  ConsumerState<PaywallSheet> createState() => _PaywallSheetState();
+}
+
+class _PaywallSheetState extends ConsumerState<PaywallSheet> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_logScreenView());
+    });
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await ref
+          .read(analyticsProvider)
+          .logScreenView(screenName: 'paywall');
+    } on Object catch (_) {
+      // Analytics is best-effort; never surface to the UI.
+    }
+  }
+
+  Future<void> _onPurchase() async {
+    final controller = ref.read(paywallControllerProvider.notifier);
+    final result = await controller.purchaseDefault();
+    if (!mounted) return;
+    result.whenOrNull(
+      success: (_) {
+        // Pop the sheet on success — the upstream `Go Premium` caller can
+        // route to the subscription success screen if it wants to (NIB-130).
+        Navigator.of(context).pop();
+      },
+      failure: (error) {
+        _showErrorDialog(
+          title: 'Purchase failed',
+          message: error.message,
+        );
+      },
+    );
+  }
+
+  Future<void> _onRestore() async {
+    final controller = ref.read(paywallControllerProvider.notifier);
+    final result = await controller.restore();
+    if (!mounted) return;
+    result.whenOrNull(
+      success: (_) {
+        Navigator.of(context).pop();
+      },
+      failure: (error) {
+        // Per error-handling.md, restore failure surfaces as P1 with the
+        // canonical "No active subscription found." copy when the seam
+        // returns NotFoundException; otherwise show the underlying message.
+        final message = error is NotFoundException
+            ? 'No active subscription found.'
+            : error.message;
+        _showErrorDialog(
+          title: 'Restore failed',
+          message: message,
+        );
+      },
+    );
+  }
+
+  void _onViewAllPlans() {
+    // TODO(NIB-61): push the All-plans picker sheet when it ships.
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        key: Key('paywall_view_all_plans_snackbar'),
+        content: Text('All plans coming soon.'),
+      ),
+    );
+  }
+
+  Future<void> _showErrorDialog({
+    required String title,
+    required String message,
+  }) async {
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        key: const Key('paywall_error_dialog'),
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(paywallControllerProvider);
+    final media = MediaQuery.of(context);
+
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: media.size.height * 0.92,
+        ),
+        // Sheet padding from Figma: px 24 / py 12.
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.lg,
+            vertical: AppSizes.sp12,
+          ),
+          child: _PaywallBody(
+            state: state,
+            onClose: state.action == PaywallAction.none
+                ? () => Navigator.of(context).pop()
+                : null,
+            onRestore: state.action == PaywallAction.none ? _onRestore : null,
+            onPurchase: state.action == PaywallAction.none && state.phase ==
+                    PaywallPhase.ready
+                ? _onPurchase
+                : null,
+            onViewAllPlans: state.action == PaywallAction.none
+                ? _onViewAllPlans
+                : null,
+            onRetry: state.action == PaywallAction.none
+                ? () => ref
+                    .read(paywallControllerProvider.notifier)
+                    .reloadOfferings()
+                : null,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Pure presentational body — no provider reads. Lets us drive every state
+/// variant from widget tests without spinning up a riverpod container.
+class _PaywallBody extends StatelessWidget {
+  const _PaywallBody({
+    required this.state,
+    required this.onClose,
+    required this.onRestore,
+    required this.onPurchase,
+    required this.onViewAllPlans,
+    required this.onRetry,
+  });
+
+  final PaywallState state;
+  final VoidCallback? onClose;
+  final VoidCallback? onRestore;
+  final VoidCallback? onPurchase;
+  final VoidCallback? onViewAllPlans;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _SheetHeader(
+          onClose: onClose,
+          onRestore: onRestore,
+          restoreSpinning: state.action == PaywallAction.restoring,
+        ),
+        Expanded(
+          child: SingleChildScrollView(
+            child: _ScrollContent(
+              state: state,
+              onRetry: onRetry,
+            ),
+          ),
+        ),
+        // Footer column gap to scroll content == 24 (Figma column gap).
+        const SizedBox(height: AppSizes.lg),
+        _Footer(
+          onPurchase: onPurchase,
+          onViewAllPlans: onViewAllPlans,
+          purchasing: state.action == PaywallAction.purchasing,
+        ),
+      ],
+    );
+  }
+}
+
+class _SheetHeader extends StatelessWidget {
+  const _SheetHeader({
+    required this.onClose,
+    required this.onRestore,
+    required this.restoreSpinning,
+  });
+
+  final VoidCallback? onClose;
+  final VoidCallback? onRestore;
+  final bool restoreSpinning;
+
+  @override
+  Widget build(BuildContext context) {
+    // Figma row: 34x33 close (radius 30) ↔ 148x42 Restore purchase pill.
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        SizedBox(
+          width: 34,
+          height: 33,
+          child: IconButton(
+            key: const Key('paywall_close_button'),
+            icon: const Icon(Icons.close, size: AppSizes.iconMd),
+            color: AppColors.text,
+            onPressed: onClose,
+            tooltip: 'Close',
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(
+              minWidth: 34,
+              minHeight: 33,
+            ),
+            style: IconButton.styleFrom(
+              shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(Radius.circular(30)),
+              ),
+            ),
+          ),
+        ),
+        SizedBox(
+          height: 42,
+          child: TextButton(
+            key: const Key('paywall_restore_purchase_button'),
+            onPressed: onRestore,
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: AppSizes.md),
+              shape: const StadiumBorder(),
+              minimumSize: const Size(148, 42),
+            ),
+            child: restoreSpinning
+                ? const SizedBox(
+                    width: AppSizes.iconSm,
+                    height: AppSizes.iconSm,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: AppColors.text,
+                    ),
+                  )
+                : Text(
+                    'Restore purchase',
+                    style: AppTypography.button.copyWith(
+                      fontFamily: FontFamily.parkinsans,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.text,
+                      height: 22 / 15,
+                    ),
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ScrollContent extends StatelessWidget {
+  const _ScrollContent({required this.state, required this.onRetry});
+
+  final PaywallState state;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Column gap from header to logo == 24 per spec.
+        const SizedBox(height: AppSizes.lg),
+        const _BrandRow(),
+        const SizedBox(height: AppSizes.lg),
+        const _Heading(),
+        const SizedBox(height: AppSizes.lg),
+        const _FeatureRows(),
+        const SizedBox(height: AppSizes.lg),
+        const _SocialProof(),
+        const SizedBox(height: AppSizes.lg),
+        switch (state.phase) {
+          PaywallPhase.loading => const _TrialCardLoading(),
+          PaywallPhase.error => _TrialCardError(
+            message: state.errorMessage ?? 'Could not load offering.',
+            onRetry: onRetry,
+          ),
+          PaywallPhase.ready => _TrialCard(
+            offering: state.offering ??
+                // Defensive — phase=ready always carries an offering.
+                const SubscriptionOffering(
+                  productId: '',
+                  priceString: '',
+                  periodLabel: '',
+                  trialDays: 0,
+                ),
+          ),
+        },
+      ],
+    );
+  }
+}
+
+class _BrandRow extends StatelessWidget {
+  const _BrandRow();
+
+  @override
+  Widget build(BuildContext context) {
+    // Figma: 173x42 wordmark + 12 gap + 42x42 Nibble-Icon-2 (crown/bee).
+    // SVG asset isn't in the repo yet — use the existing brand lockup + a
+    // butter circular placeholder for the mascot per precedent
+    // (delete_account_overlay). TODO(NIB-55): swap to real mascot SVG when
+    // assets/svgs/nibble_icon_2.svg lands.
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // BrandLogo at size 42 ≈ 162px wordmark, close to the 173 spec width
+        // without per-pixel hand-tuning.
+        const BrandLogo(size: 42),
+        const SizedBox(width: AppSizes.sp12),
+        Container(
+          key: const Key('paywall_mascot_placeholder'),
+          width: 42,
+          height: 42,
+          decoration: const BoxDecoration(
+            color: AppColors.butter,
+            shape: BoxShape.circle,
+          ),
+          child: const Icon(
+            // Crown stand-in for the Figma bee/crown mascot — closest
+            // material icon until the real SVG ships.
+            Icons.workspace_premium,
+            color: AppColors.greenDeep,
+            size: AppSizes.iconMd,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Heading extends StatelessWidget {
+  const _Heading();
+
+  @override
+  Widget build(BuildContext context) {
+    // Title 1 / Bold — Parkinsans 22/34 (matches theme `headlineSmall`/`titleLarge`
+    // height ratio 34/22 = 1.545; theme is 1.273 from a different ramp, so
+    // override the line-height explicitly to the Figma spec).
+    return Text(
+      'Everything you need for safe feeding',
+      style: AppTypography.textTheme.titleLarge?.copyWith(
+        fontSize: 22,
+        fontWeight: FontWeight.w700,
+        height: 34 / 22,
+        color: AppColors.text,
+      ),
+    );
+  }
+}
+
+class _FeatureRows extends StatelessWidget {
+  const _FeatureRows();
+
+  @override
+  Widget build(BuildContext context) {
+    // Per ticket: "All three feature rows currently share the sub-title …
+    // likely a copy placeholder per the audit. Wait for PO confirmation
+    // before substituting." — keep verbatim.
+    const subtitle = 'Clear guidance for the big 9';
+    const rows = [
+      ('Introduce allergens safely', subtitle, true),
+      ('Get 300+ recipe', subtitle, false),
+      ('Meal Planning', subtitle, false),
+    ];
+    return Column(
+      children: [
+        for (var i = 0; i < rows.length; i++) ...[
+          _FeatureRow(
+            title: rows[i].$1,
+            subtitle: rows[i].$2,
+            roundedThumb: rows[i].$3,
+          ),
+          if (i != rows.length - 1) const SizedBox(height: AppSizes.lg),
+        ],
+      ],
+    );
+  }
+}
+
+class _FeatureRow extends StatelessWidget {
+  const _FeatureRow({
+    required this.title,
+    required this.subtitle,
+    required this.roundedThumb,
+  });
+
+  final String title;
+  final String subtitle;
+
+  /// First-row thumbnail uses rounded corners (radius 10) per spec — the
+  /// other two rows are unclipped 68x68 tiles.
+  final bool roundedThumb;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          width: 68,
+          height: 68,
+          decoration: BoxDecoration(
+            color: AppColors.coralSoft,
+            borderRadius: roundedThumb
+                ? BorderRadius.circular(AppSizes.radiusMd)
+                : null,
+          ),
+          // TODO(NIB-55): replace with the Figma `Intersect` / nuts-table /
+          // meal-plan thumbnail PNGs when the assets land in
+          // assets/images/paywall/. Until then a neutral coral tile keeps
+          // the rhythm without shipping the wrong art.
+          child: const Icon(
+            Icons.restaurant_outlined,
+            color: AppColors.coralDeep,
+          ),
+        ),
+        const SizedBox(width: AppSizes.lg),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontFamily: FontFamily.parkinsans,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  height: 22 / 15,
+                  color: AppColors.text,
+                ),
+              ),
+              Text(
+                subtitle,
+                style: AppTypography.textTheme.bodyLarge?.copyWith(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w400,
+                  height: 22 / 15,
+                  color: AppColors.text,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SocialProof extends StatelessWidget {
+  const _SocialProof();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: List.generate(
+            5,
+            (_) => const Padding(
+              padding: EdgeInsets.symmetric(horizontal: AppSizes.xs + 2),
+              child: Icon(
+                Icons.star_rounded,
+                size: 22,
+                color: AppColors.coral,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSizes.xs),
+        const Text(
+          'Already help 150+ parents',
+          style: TextStyle(
+            fontFamily: FontFamily.parkinsans,
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            height: 22 / 15,
+            color: AppColors.text,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Trial card — ready state. Renders the real RC-sourced price out of
+/// [SubscriptionOffering] (no hardcoded `$29.99` literal — AC requirement).
+class _TrialCard extends StatelessWidget {
+  const _TrialCard({required this.offering});
+
+  final SubscriptionOffering offering;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('paywall_trial_card'),
+      padding: const EdgeInsets.all(AppSizes.sp12),
+      decoration: BoxDecoration(
+        color: AppColors.cream,
+        border: Border.all(color: AppColors.switchTrackOff),
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            // Verbatim copy: "3 Days Free" (capitalised exactly as Figma).
+            '${offering.trialDays} Days Free',
+            style: const TextStyle(
+              fontFamily: FontFamily.parkinsans,
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              height: 22 / 15,
+              color: AppColors.text,
+            ),
+          ),
+          const SizedBox(height: AppSizes.xs),
+          RichText(
+            text: TextSpan(
+              style: AppTypography.textTheme.bodyLarge?.copyWith(
+                fontSize: 15,
+                fontWeight: FontWeight.w400,
+                height: 22 / 15,
+                color: AppColors.text,
+              ),
+              children: [
+                const TextSpan(text: 'Then billed at '),
+                TextSpan(
+                  // Figma calls out Nunito Bold inline for the price token.
+                  text:
+                      '${offering.priceString} ${offering.periodLabel}',
+                  style: GoogleFonts.nunito(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    height: 22 / 15,
+                    color: AppColors.text,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrialCardLoading extends StatelessWidget {
+  const _TrialCardLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('paywall_trial_card_loading'),
+      padding: const EdgeInsets.all(AppSizes.sp12),
+      decoration: BoxDecoration(
+        color: AppColors.cream,
+        border: Border.all(color: AppColors.switchTrackOff),
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      ),
+      child: const Center(
+        child: SizedBox(
+          width: AppSizes.iconMd,
+          height: AppSizes.iconMd,
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            color: AppColors.greenDeep,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TrialCardError extends StatelessWidget {
+  const _TrialCardError({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('paywall_trial_card_error'),
+      padding: const EdgeInsets.all(AppSizes.sp12),
+      decoration: BoxDecoration(
+        color: AppColors.destructiveSoft,
+        border: Border.all(color: AppColors.destructive.withValues(alpha: 0.2)),
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      ),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.error_outline,
+            size: AppSizes.iconSm + 2,
+            color: AppColors.destructive,
+          ),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: Text(
+              message,
+              style: AppTypography.textTheme.bodyMedium?.copyWith(
+                color: AppColors.destructive,
+              ),
+            ),
+          ),
+          if (onRetry != null)
+            TextButton(
+              key: const Key('paywall_offerings_retry_button'),
+              onPressed: onRetry,
+              style: TextButton.styleFrom(
+                foregroundColor: AppColors.destructive,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.sm,
+                  vertical: AppSizes.xs,
+                ),
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              child: const Text('Retry'),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Footer extends StatelessWidget {
+  const _Footer({
+    required this.onPurchase,
+    required this.onViewAllPlans,
+    required this.purchasing,
+  });
+
+  final VoidCallback? onPurchase;
+  final VoidCallback? onViewAllPlans;
+  final bool purchasing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSizes.sp12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Primary CTA — h48 / radius 24 / Forest-dark fill.
+          SizedBox(
+            height: 48,
+            child: Material(
+              color: onPurchase == null
+                  ? AppColors.borderMuted
+                  : AppColors.greenDeep,
+              shape: const StadiumBorder(),
+              child: InkWell(
+                key: const Key('paywall_try_for_zero_button'),
+                onTap: onPurchase,
+                customBorder: const StadiumBorder(),
+                child: Center(
+                  child: purchasing
+                      ? const SizedBox(
+                          width: AppSizes.iconMd,
+                          height: AppSizes.iconMd,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: AppColors.cream,
+                          ),
+                        )
+                      : Text(
+                          r'Try for $0',
+                          style: AppTypography.button.copyWith(
+                            fontFamily: FontFamily.parkinsans,
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.cream,
+                            height: 22 / 15,
+                          ),
+                        ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSizes.sp12),
+          // Secondary CTA — transparent bg, Black text, h48.
+          SizedBox(
+            height: 48,
+            child: Material(
+              color: Colors.transparent,
+              shape: const StadiumBorder(),
+              child: InkWell(
+                key: const Key('paywall_view_all_plans_button'),
+                onTap: onViewAllPlans,
+                customBorder: const StadiumBorder(),
+                child: Center(
+                  child: Text(
+                    'View all plans',
+                    style: AppTypography.button.copyWith(
+                      fontFamily: FontFamily.parkinsans,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.text,
+                      height: 22 / 15,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/subscription/paywall/paywall_state.dart
+++ b/lib/src/features/subscription/paywall/paywall_state.dart
@@ -1,0 +1,33 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_offering.dart';
+
+part 'paywall_state.freezed.dart';
+
+/// Top-level phase the paywall is in.
+///
+/// * [loading] — initial offerings fetch in flight; renders the spinner
+///   placeholder per error-handling spec.
+/// * [ready] — offerings loaded; the populated sheet renders against
+///   [PaywallState.offering].
+/// * [error] — offerings load failed; renders the P3 fallback with retry.
+enum PaywallPhase { loading, ready, error }
+
+/// In-flight action initiated by the user. Mutually-exclusive so the two CTAs
+/// can't both spin at once and so the secondary surfaces of the sheet (close,
+/// view-all-plans) disable themselves while either is running.
+enum PaywallAction { none, purchasing, restoring }
+
+@freezed
+class PaywallState with _$PaywallState {
+  const factory PaywallState({
+    required PaywallPhase phase,
+    required PaywallAction action,
+    SubscriptionOffering? offering,
+    String? errorMessage,
+  }) = _PaywallState;
+
+  factory PaywallState.initial() => const PaywallState(
+    phase: PaywallPhase.loading,
+    action: PaywallAction.none,
+  );
+}

--- a/lib/src/features/subscription/paywall/paywall_state.freezed.dart
+++ b/lib/src/features/subscription/paywall/paywall_state.freezed.dart
@@ -1,0 +1,242 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'paywall_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$PaywallState {
+  PaywallPhase get phase => throw _privateConstructorUsedError;
+  PaywallAction get action => throw _privateConstructorUsedError;
+  SubscriptionOffering? get offering => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+
+  /// Create a copy of PaywallState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $PaywallStateCopyWith<PaywallState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PaywallStateCopyWith<$Res> {
+  factory $PaywallStateCopyWith(
+    PaywallState value,
+    $Res Function(PaywallState) then,
+  ) = _$PaywallStateCopyWithImpl<$Res, PaywallState>;
+  @useResult
+  $Res call({
+    PaywallPhase phase,
+    PaywallAction action,
+    SubscriptionOffering? offering,
+    String? errorMessage,
+  });
+
+  $SubscriptionOfferingCopyWith<$Res>? get offering;
+}
+
+/// @nodoc
+class _$PaywallStateCopyWithImpl<$Res, $Val extends PaywallState>
+    implements $PaywallStateCopyWith<$Res> {
+  _$PaywallStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of PaywallState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? phase = null,
+    Object? action = null,
+    Object? offering = freezed,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            phase: null == phase
+                ? _value.phase
+                : phase // ignore: cast_nullable_to_non_nullable
+                      as PaywallPhase,
+            action: null == action
+                ? _value.action
+                : action // ignore: cast_nullable_to_non_nullable
+                      as PaywallAction,
+            offering: freezed == offering
+                ? _value.offering
+                : offering // ignore: cast_nullable_to_non_nullable
+                      as SubscriptionOffering?,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+
+  /// Create a copy of PaywallState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $SubscriptionOfferingCopyWith<$Res>? get offering {
+    if (_value.offering == null) {
+      return null;
+    }
+
+    return $SubscriptionOfferingCopyWith<$Res>(_value.offering!, (value) {
+      return _then(_value.copyWith(offering: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$PaywallStateImplCopyWith<$Res>
+    implements $PaywallStateCopyWith<$Res> {
+  factory _$$PaywallStateImplCopyWith(
+    _$PaywallStateImpl value,
+    $Res Function(_$PaywallStateImpl) then,
+  ) = __$$PaywallStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    PaywallPhase phase,
+    PaywallAction action,
+    SubscriptionOffering? offering,
+    String? errorMessage,
+  });
+
+  @override
+  $SubscriptionOfferingCopyWith<$Res>? get offering;
+}
+
+/// @nodoc
+class __$$PaywallStateImplCopyWithImpl<$Res>
+    extends _$PaywallStateCopyWithImpl<$Res, _$PaywallStateImpl>
+    implements _$$PaywallStateImplCopyWith<$Res> {
+  __$$PaywallStateImplCopyWithImpl(
+    _$PaywallStateImpl _value,
+    $Res Function(_$PaywallStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of PaywallState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? phase = null,
+    Object? action = null,
+    Object? offering = freezed,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(
+      _$PaywallStateImpl(
+        phase: null == phase
+            ? _value.phase
+            : phase // ignore: cast_nullable_to_non_nullable
+                  as PaywallPhase,
+        action: null == action
+            ? _value.action
+            : action // ignore: cast_nullable_to_non_nullable
+                  as PaywallAction,
+        offering: freezed == offering
+            ? _value.offering
+            : offering // ignore: cast_nullable_to_non_nullable
+                  as SubscriptionOffering?,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$PaywallStateImpl implements _PaywallState {
+  const _$PaywallStateImpl({
+    required this.phase,
+    required this.action,
+    this.offering,
+    this.errorMessage,
+  });
+
+  @override
+  final PaywallPhase phase;
+  @override
+  final PaywallAction action;
+  @override
+  final SubscriptionOffering? offering;
+  @override
+  final String? errorMessage;
+
+  @override
+  String toString() {
+    return 'PaywallState(phase: $phase, action: $action, offering: $offering, errorMessage: $errorMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PaywallStateImpl &&
+            (identical(other.phase, phase) || other.phase == phase) &&
+            (identical(other.action, action) || other.action == action) &&
+            (identical(other.offering, offering) ||
+                other.offering == offering) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, phase, action, offering, errorMessage);
+
+  /// Create a copy of PaywallState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PaywallStateImplCopyWith<_$PaywallStateImpl> get copyWith =>
+      __$$PaywallStateImplCopyWithImpl<_$PaywallStateImpl>(this, _$identity);
+}
+
+abstract class _PaywallState implements PaywallState {
+  const factory _PaywallState({
+    required final PaywallPhase phase,
+    required final PaywallAction action,
+    final SubscriptionOffering? offering,
+    final String? errorMessage,
+  }) = _$PaywallStateImpl;
+
+  @override
+  PaywallPhase get phase;
+  @override
+  PaywallAction get action;
+  @override
+  SubscriptionOffering? get offering;
+  @override
+  String? get errorMessage;
+
+  /// Create a copy of PaywallState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PaywallStateImplCopyWith<_$PaywallStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/subscription/success/subscription_success_controller.g.dart
+++ b/lib/src/features/subscription/success/subscription_success_controller.g.dart
@@ -7,7 +7,7 @@ part of 'subscription_success_controller.dart';
 // **************************************************************************
 
 String _$subscriptionSuccessControllerHash() =>
-    r'ff342a52b9ddc3dca73544d4f53448aedad3dd81';
+    r'e12fe3c3ee4f743115c9397d927fa28ca8bb2b25';
 
 /// NIB-130 — passive two-phase transition shown after a successful purchase.
 ///

--- a/test/features/subscription/paywall/paywall_sheet_test.dart
+++ b/test/features/subscription/paywall/paywall_sheet_test.dart
@@ -1,0 +1,338 @@
+// NIB-55 — widget tests for the paywall (Try for $0 sheet).
+//
+// Coverage:
+//   * Populated/ready state renders the verbatim copy + price from the
+//     stub offering (no hardcoded "$29.99" literal in lib/**).
+//   * Loading frame renders the spinner placeholder (offerings fetch).
+//   * Error frame surfaces the inline error + retry CTA.
+//   * Purchase failure → P1 dialog with the RC message verbatim.
+//   * Restore-no-entitlement → P1 dialog with the canonical copy.
+//   * Restore success pops the sheet (entitlement flips active).
+//
+// Strategy:
+//   * Override `subscriptionServiceProvider` with a fake whose Result returns
+//     are scripted per-test. The paywall controller reads through this seam,
+//     so every state variant is reachable without RevenueCat in the loop.
+//   * Stub Firebase so `Analytics.instance.logScreenView` + the controller's
+//     `paywall_viewed` event are no-ops.
+
+// Firebase platform-interface packages are transitive deps; the public
+// barrels do not re-export FirebaseAnalyticsPlatform / setupFirebaseCoreMocks.
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:firebase_analytics_platform_interface/firebase_analytics_platform_interface.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_offering.dart';
+import 'package:nibbles/src/common/services/subscription_service.dart';
+import 'package:nibbles/src/features/subscription/paywall/paywall_sheet.dart';
+
+// ---------------------------------------------------------------------------
+// Firebase shim — replicates the home/recipe test pattern. The paywall
+// controller fires `paywall_viewed` on build and the sheet fires
+// `logScreenView` post-frame; both reach `FirebaseAnalytics.instance` which
+// must resolve to a no-op platform implementation in widget-test context.
+// ---------------------------------------------------------------------------
+
+class _NoopAnalyticsPlatform extends FirebaseAnalyticsPlatform {
+  _NoopAnalyticsPlatform() : super();
+
+  @override
+  FirebaseAnalyticsPlatform delegateFor({
+    required FirebaseApp app,
+    Map<String, dynamic>? webOptions,
+  }) => this;
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    Map<String, Object?>? parameters,
+    AnalyticsCallOptions? callOptions,
+  }) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Fake SubscriptionService — every call is scripted via the params below so
+// each test can drive the seam into the success / failure variant it needs.
+// ---------------------------------------------------------------------------
+
+class _FakeSubscriptionService extends SubscriptionService {
+  _FakeSubscriptionService({
+    required this.offeringsResult,
+    required this.purchaseResult,
+    required this.restoreResult,
+  });
+
+  final Result<SubscriptionOffering> offeringsResult;
+  final Result<void> purchaseResult;
+  final Result<void> restoreResult;
+
+  @override
+  bool build() => false;
+
+  @override
+  Future<Result<SubscriptionOffering>> loadOfferings() async => offeringsResult;
+
+  @override
+  Future<Result<void>> purchaseDefault() async {
+    purchaseResult.whenOrNull(success: (_) => state = true);
+    return purchaseResult;
+  }
+
+  @override
+  Future<Result<void>> restore() async {
+    restoreResult.whenOrNull(success: (_) => state = true);
+    return restoreResult;
+  }
+}
+
+const _kOffering = SubscriptionOffering(
+  productId: 'nibbles_yearly_test',
+  priceString: r'$12.34',
+  periodLabel: 'yearly',
+  trialDays: 3,
+);
+
+Widget _buildSut({required SubscriptionService Function() factory}) {
+  return ProviderScope(
+    overrides: [
+      subscriptionServiceProvider.overrideWith(factory),
+    ],
+    child: const MaterialApp(
+      home: Scaffold(body: PaywallSheet()),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() async {
+    setupFirebaseCoreMocks();
+    await Firebase.initializeApp();
+    FirebaseAnalyticsPlatform.instance = _NoopAnalyticsPlatform();
+  });
+
+  // -------------------------------------------------------------------------
+  // Populated / default state (AC: at minimum, ship the populated test).
+  // -------------------------------------------------------------------------
+
+  testWidgets('populated state renders Figma copy + price from service', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildSut(
+        factory: () => _FakeSubscriptionService(
+          offeringsResult: const Result.success(_kOffering),
+          purchaseResult: const Result.success(null),
+          restoreResult: const Result.failure(
+            NotFoundException('No active subscription found.'),
+          ),
+        ),
+      ),
+    );
+    // Settle the async offerings load.
+    await tester.pump();
+
+    // Verbatim copy from the Figma spec (kept exactly — including singular
+    // "recipe" and the placeholder "Clear guidance for the big 9" ×3 per AC).
+    expect(find.text('Restore purchase'), findsOneWidget);
+    expect(find.text('Everything you need for safe feeding'), findsOneWidget);
+    expect(find.text('Introduce allergens safely'), findsOneWidget);
+    expect(find.text('Get 300+ recipe'), findsOneWidget);
+    expect(find.text('Meal Planning'), findsOneWidget);
+    expect(find.text('Clear guidance for the big 9'), findsNWidgets(3));
+    expect(find.text('Already help 150+ parents'), findsOneWidget);
+    expect(find.text(r'Try for $0'), findsOneWidget);
+    expect(find.text('View all plans'), findsOneWidget);
+
+    // Trial card — pulls trialDays + priceString from the offering, not a
+    // hardcoded literal in the widget tree.
+    expect(find.text('3 Days Free'), findsOneWidget);
+    // RichText composes "Then billed at " + "$12.34 yearly" → assert against
+    // the rendered span text. `find.byType(RichText)` returns multiple matches
+    // because every `Text` widget renders as a RichText under the hood, so
+    // search the whole tree for the one whose plain text matches the trial
+    // line.
+    final richTexts = tester
+        .widgetList<RichText>(
+          find.descendant(
+            of: find.byKey(const Key('paywall_trial_card')),
+            matching: find.byType(RichText),
+          ),
+        )
+        .map((rt) => rt.text.toPlainText())
+        .toList();
+    expect(
+      richTexts.any(
+        (text) => text.contains(r'Then billed at $12.34 yearly'),
+      ),
+      isTrue,
+      reason: 'rendered trial card spans: $richTexts',
+    );
+
+    // All four CTA keys are wired.
+    expect(find.byKey(const Key('paywall_close_button')), findsOneWidget);
+    expect(
+      find.byKey(const Key('paywall_restore_purchase_button')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('paywall_try_for_zero_button')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('paywall_view_all_plans_button')),
+      findsOneWidget,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state — the spinner is rendered while offerings are in flight.
+  // -------------------------------------------------------------------------
+
+  testWidgets('loading frame renders spinner placeholder', (tester) async {
+    await tester.pumpWidget(
+      _buildSut(
+        factory: () => _FakeSubscriptionService(
+          offeringsResult: const Result.success(_kOffering),
+          purchaseResult: const Result.success(null),
+          restoreResult: const Result.failure(
+            NotFoundException('No active subscription found.'),
+          ),
+        ),
+      ),
+    );
+    // First pump — the controller has scheduled the offerings load but it
+    // hasn't resolved yet, so the loading card is visible.
+    expect(
+      find.byKey(const Key('paywall_trial_card_loading')),
+      findsOneWidget,
+    );
+    // Resolve so the test ends cleanly (no pending timers).
+    await tester.pump();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error state — inline error + retry CTA on offerings load failure.
+  // -------------------------------------------------------------------------
+
+  testWidgets('error frame renders inline error + retry', (tester) async {
+    await tester.pumpWidget(
+      _buildSut(
+        factory: () => _FakeSubscriptionService(
+          offeringsResult: const Result.failure(NetworkException()),
+          purchaseResult: const Result.success(null),
+          restoreResult: const Result.failure(
+            NotFoundException('No active subscription found.'),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('paywall_trial_card_error')), findsOneWidget);
+    expect(find.text('No internet connection.'), findsOneWidget);
+    expect(
+      find.byKey(const Key('paywall_offerings_retry_button')),
+      findsOneWidget,
+    );
+    // The primary CTA stays in its disabled-pill state while offerings are
+    // unavailable — guarded by `state.phase == ready` in the body.
+    expect(find.text(r'Try for $0'), findsOneWidget);
+  });
+
+  // -------------------------------------------------------------------------
+  // Purchase failure surfaces the P1 dialog with the RC message verbatim.
+  // -------------------------------------------------------------------------
+
+  testWidgets('purchase failure shows P1 dialog with RC message', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildSut(
+        factory: () => _FakeSubscriptionService(
+          offeringsResult: const Result.success(_kOffering),
+          purchaseResult: const Result.failure(
+            ServerException('Card declined.'),
+          ),
+          restoreResult: const Result.failure(
+            NotFoundException('No active subscription found.'),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('paywall_try_for_zero_button')));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const Key('paywall_error_dialog')), findsOneWidget);
+    expect(find.text('Purchase failed'), findsOneWidget);
+    expect(find.text('Card declined.'), findsOneWidget);
+  });
+
+  // -------------------------------------------------------------------------
+  // Restore-no-entitlement surfaces the canonical P1 copy.
+  // -------------------------------------------------------------------------
+
+  testWidgets('restore with no entitlement shows canonical P1 copy', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildSut(
+        factory: () => _FakeSubscriptionService(
+          offeringsResult: const Result.success(_kOffering),
+          purchaseResult: const Result.success(null),
+          restoreResult: const Result.failure(
+            NotFoundException('whatever the service says'),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('paywall_restore_purchase_button')));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const Key('paywall_error_dialog')), findsOneWidget);
+    expect(find.text('Restore failed'), findsOneWidget);
+    // Canonical copy from error-handling.md — overrides whatever the
+    // service message happens to be when the failure is `NotFoundException`.
+    expect(find.text('No active subscription found.'), findsOneWidget);
+  });
+
+  // -------------------------------------------------------------------------
+  // View all plans — TODO surface (NIB-61 not built) — shows snackbar.
+  // -------------------------------------------------------------------------
+
+  testWidgets('view all plans surfaces the placeholder snackbar', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildSut(
+        factory: () => _FakeSubscriptionService(
+          offeringsResult: const Result.success(_kOffering),
+          purchaseResult: const Result.success(null),
+          restoreResult: const Result.failure(
+            NotFoundException('No active subscription found.'),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('paywall_view_all_plans_button')));
+    await tester.pump();
+
+    expect(
+      find.byKey(const Key('paywall_view_all_plans_snackbar')),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Implements the Overlay - subsplan paywall (Figma 1216:11727) as a bottom sheet body + `showPaywallSheet` helper. Existing `/subscription/paywall` route hosts the same `PaywallSheet` widget so deep-link arrivals still resolve.
- Adds `SubscriptionOffering` entity + extends the `SubscriptionService` stub with `loadOfferings` / `purchaseDefault` / `restore` Result seams. Paywall reads the trial price out of controller state — never a hardcoded literal in the UI.
- All four CTAs wired: Try for \$0 (purchase), View all plans (TODO snackbar — NIB-61), Restore purchase (restore), Close X (dismiss). Purchase + restore + restore-no-entitlement surface P1 dialogs per error-handling.md.
- 6 widget tests cover populated default + loading + offerings-load failure + purchase-fail + restore-no-entitlement + view-all-plans.

## Acceptance criteria

- [x] Verbatim copy from the Figma spec — "Everything you need for safe feeding", three feature rows with the placeholder "Clear guidance for the big 9" subtitle, "Already help 150+ parents", "3 Days Free" + "Then billed at \$… yearly", "Try for \$0", "View all plans", "Restore purchase".
- [x] Primary CTA → `controller.purchaseDefault()` → success pops sheet + fires `subscription_started`; failure shows P1 dialog with the underlying message verbatim.
- [x] Restore → `controller.restore()` → success fires `subscription_restored`; `NotFoundException` shows the canonical "No active subscription found." P1 copy.
- [x] View all plans → TODO snackbar (no-op until NIB-61 ships the picker).
- [x] Close X → dismisses the sheet.
- [x] Tokens consumed from `AppColors` / `AppTypography` / `AppSizes`; no hardcoded hex outside the design-system foundation.
- [x] Price string sourced from `SubscriptionService.loadOfferings()` (placeholder until NIB-18 wires `purchases_flutter`).
- [x] `flutter analyze` — 0 issues in NIB-55-touched files. 2 pre-existing cosmetic lints in `subscription_success_screen_test.dart` (NIB-130 base drift) left untouched — out of scope.
- [x] `flutter test` — full suite passes (494 + 1 skipped).

## Out of scope / follow-ups

- **Pixel-close visual match (<3%)**: artwork assets (wordmark SVG, crown/bee mascot, allergen-tile / nuts / meal-plan thumbnails, star vector) aren't in the repo. Following the `delete_account_overlay` precedent: `BrandLogo` for the wordmark, `Icons.workspace_premium` (in butter circle) for the mascot, coral-tile + `Icons.restaurant_outlined` for the 3 feature thumbnails, `Icons.star_rounded` (coral) for the 5 stars. Visual diff against the Figma screenshot can be re-verified once the real PNGs land.
- **NIB-18 — RevenueCat wiring**: `SubscriptionService` is still a stub; the placeholder offering exposes a `$29.99 yearly` price purely so the layout renders. The seam is the only thing the UI talks to, so swapping in `purchases_flutter` is a service-internal change.
- **NIB-61 — All-plans picker sheet**: "View all plans" currently surfaces a placeholder snackbar. The picker pushes here once it ships.
- **NIB-73 — Go Premium entry wiring**: the paywall is not yet pushed from the Profile premium-teaser / Manage Subscription not-subscribed screen. Entry point lives in those tickets.

## Figma frames

- Section: Manage Subscription (no plan / paywall) — 1207:14606
- Overlay - subsplan — 1216:11727 (default / populated state)

## Audit artifacts

- `/Users/adithyafp_/Projects/nibbles/.figma-audit/subscription-no-plan/overlay-subsplan/report.md`
- `/Users/adithyafp_/Projects/nibbles/.figma-audit/subscription-no-plan/overlay-subsplan/screenshot.png`
- `/Users/adithyafp_/Projects/nibbles/.figma-audit/subscription-no-plan/overlay-subsplan/design_context.md`
- `/Users/adithyafp_/Projects/nibbles/.figma-audit/subscription-no-plan/overlay-subsplan/variables.json`

## Test plan

- [x] `flutter test test/features/subscription/` — 10/10 pass.
- [x] `flutter test` — full suite 494 + 1 skipped, no regressions.
- [x] `flutter analyze` — 0 issues introduced.