### PR TITLE
feat(infra): reusable LoadingConfirmation composite for cancel flow [NIB-131]

### DIFF
--- a/lib/src/common/components/components.dart
+++ b/lib/src/common/components/components.dart
@@ -16,6 +16,7 @@ export 'controls/app_segmented_control.dart';
 export 'controls/app_switch.dart';
 export 'controls/radio_pill.dart';
 export 'feedback/empty_state.dart';
+export 'feedback/loading_confirmation.dart';
 export 'inputs/app_search_field.dart';
 export 'inputs/app_text_field.dart';
 export 'navigation/app_bottom_nav.dart';

--- a/lib/src/common/components/feedback/loading_confirmation.dart
+++ b/lib/src/common/components/feedback/loading_confirmation.dart
@@ -166,11 +166,12 @@ class _PhaseLabel extends StatelessWidget {
               ),
             ),
           ),
-          // Success label below the animation. Always laid out so the slot
-          // is reserved during the loading phase too; opacity gates
-          // visibility so there's zero layout shift on transition.
+          // Success label sits just below LOADING so the two captions read
+          // as a tight cluster (Figma: cancel-flow + no-plan refs both show
+          // ~14% gap, not the old ~26%). Slot is always laid out; opacity
+          // gates visibility so there's zero layout shift on transition.
           Align(
-            alignment: const Alignment(0, 0.6),
+            alignment: const Alignment(0, 0.43),
             child: Padding(
               padding: const EdgeInsets.symmetric(
                 horizontal: AppSizes.md + AppSizes.sp2,
@@ -183,7 +184,7 @@ class _PhaseLabel extends StatelessWidget {
                   key: successLabelKey,
                   textAlign: TextAlign.center,
                   style: textTheme.bodyLarge?.copyWith(
-                    fontWeight: FontWeight.w600,
+                    fontWeight: FontWeight.w700,
                     color: AppColors.text,
                   ),
                 ),

--- a/lib/src/common/components/feedback/loading_confirmation.dart
+++ b/lib/src/common/components/feedback/loading_confirmation.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+
+/// Two-phase composition used by passive loading -> "You all set!"
+/// confirmation screens.
+///
+/// `loading` — petal blob + faint uppercase "Loading" caption.
+/// `success` — petal blob + bold success label; the caption stays mounted at
+/// low opacity so the cross-fade does not shift the layout.
+enum LoadingConfirmationPhase {
+  loading,
+  success,
+}
+
+/// NIB-131 — reusable loading -> confirmation composite.
+///
+/// Extracted from the NIB-130 post-purchase transition so any flow whose audit
+/// resolves to a "Loading + You all set!" composition (frame ids 1290:10122,
+/// 1216:11584, etc.) can reuse the same petal animation + cross-fade slot
+/// without duplicating geometry. Callers own:
+///   * which `phase` to render (driven by their controller),
+///   * the success copy (verbatim from the audit they map to),
+///   * unique widget keys for the blob / labels so screen-level tests can
+///     assert against them.
+///
+/// This widget is purely presentational — no controllers, no analytics, no
+/// auto-route. Hosts wrap it in their own `ConsumerWidget` to wire those in.
+class LoadingConfirmation extends StatelessWidget {
+  const LoadingConfirmation({
+    required this.phase,
+    required this.successLabel,
+    this.blobKey,
+    this.loadingLabelKey,
+    this.successLabelKey,
+    super.key,
+  });
+
+  final LoadingConfirmationPhase phase;
+  final String successLabel;
+  final Key? blobKey;
+  final Key? loadingLabelKey;
+  final Key? successLabelKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: AppColors.butterSoft,
+      child: SafeArea(
+        // SizedBox.expand forces the Stack to fill the SafeArea — without it
+        // the Stack collapses to its non-positioned child (_PetalBlob) and
+        // the cluster snaps to the upper-left.
+        child: SizedBox.expand(
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              _PetalBlob(key: blobKey),
+              _PhaseLabel(
+                phase: phase,
+                successLabel: successLabel,
+                loadingLabelKey: loadingLabelKey,
+                successLabelKey: successLabelKey,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Layered petal mark mimicking the Figma `LoadingAnimation` frame: a pale
+/// outer quatrefoil + a sage inner quatrefoil + a soft butter glow dot at
+/// the core (the bare circle reads as flat without the glow).
+class _PetalBlob extends StatelessWidget {
+  const _PetalBlob({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: AppSizes.avatarXl * 1.84,
+      height: AppSizes.avatarXl * 1.84,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          // Outer pale-butter petal blob (spec petal layer 1+2 composite).
+          const Quatrefoil(
+            size: AppSizes.avatarXl * 1.84,
+            coreColor: AppColors.butter,
+          ),
+          // Inner sage petal — smaller, scales down to ~52% of outer.
+          const Quatrefoil(
+            size: AppSizes.avatarXl * 0.96,
+            petalColor: AppColors.green,
+            coreColor: AppColors.greenDeep,
+          ),
+          // Soft butter glow dot at the center (spec blurred lime dot).
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: AppColors.butter,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: AppColors.butter.withValues(alpha: 0.9),
+                  blurRadius: AppSizes.sm,
+                  spreadRadius: AppSizes.xs,
+                ),
+              ],
+            ),
+            child: const SizedBox(
+              width: AppSizes.sp12 * 1.4,
+              height: AppSizes.sp12 * 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Phase caption — faint uppercase "Loading" sits below the petal animation
+/// in both phases; the success caption fades in below it. Both labels stay
+/// mounted with opacity gating so layout never shifts on transition.
+class _PhaseLabel extends StatelessWidget {
+  const _PhaseLabel({
+    required this.phase,
+    required this.successLabel,
+    required this.loadingLabelKey,
+    required this.successLabelKey,
+  });
+
+  final LoadingConfirmationPhase phase;
+  final String successLabel;
+  final Key? loadingLabelKey;
+  final Key? successLabelKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final isSuccess = phase == LoadingConfirmationPhase.success;
+
+    return Positioned.fill(
+      child: Stack(
+        children: [
+          // "Loading" — Inter Regular 12.8 / tracking 4.33 / UPPERCASE,
+          // rendered low-contrast (cream on butter-soft) per Figma spec.
+          // Stays visible (faded) during the success phase to match the
+          // cross-fade snapshot in the audit.
+          Align(
+            alignment: const Alignment(0, 0.34),
+            child: AnimatedOpacity(
+              duration: const Duration(milliseconds: 240),
+              opacity: isSuccess ? 0.55 : 1,
+              child: Text(
+                'Loading'.toUpperCase(),
+                key: loadingLabelKey,
+                textAlign: TextAlign.center,
+                style: textTheme.bodySmall?.copyWith(
+                  color: AppColors.cream,
+                  fontSize: 12.8,
+                  height: 19.2 / 12.8,
+                  letterSpacing: 4.33,
+                  fontWeight: FontWeight.w400,
+                ),
+              ),
+            ),
+          ),
+          // Success label below the animation. Always laid out so the slot
+          // is reserved during the loading phase too; opacity gates
+          // visibility so there's zero layout shift on transition.
+          Align(
+            alignment: const Alignment(0, 0.6),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.md + AppSizes.sp2,
+              ),
+              child: AnimatedOpacity(
+                duration: const Duration(milliseconds: 240),
+                opacity: isSuccess ? 1 : 0,
+                child: Text(
+                  successLabel,
+                  key: successLabelKey,
+                  textAlign: TextAlign.center,
+                  style: textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.text,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/subscription/success/subscription_success_screen.dart
+++ b/lib/src/features/subscription/success/subscription_success_screen.dart
@@ -3,9 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:nibbles/src/app/themes/app_colors.dart';
-import 'package:nibbles/src/app/themes/app_sizes.dart';
-import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+import 'package:nibbles/src/common/components/feedback/loading_confirmation.dart';
 import 'package:nibbles/src/features/subscription/success/subscription_success_controller.dart';
 import 'package:nibbles/src/features/subscription/success/subscription_success_state.dart';
 import 'package:nibbles/src/logging/analytics.dart';
@@ -17,6 +15,10 @@ import 'package:nibbles/src/routing/route_enums.dart';
 ///   * loading: petal blob + faint uppercase "LOADING" caption.
 ///   * success: petal blob + bold "You all set!" body label, then auto-routes
 ///     to `/home` after [SubscriptionSuccessController.successDwell].
+///
+/// Visuals come from the shared [LoadingConfirmation] composite (NIB-131
+/// extraction). This screen owns the controller wiring, analytics, and
+/// auto-route; the composite owns geometry + tokens + cross-fade.
 ///
 /// No interactive elements; back is blocked while provisioning is in flight
 /// (and on the success frame until the auto-route fires) per spec.
@@ -69,9 +71,9 @@ class _SubscriptionSuccessScreenState
 
   @override
   Widget build(BuildContext context) {
-    // Schedule the auto-route exactly once on the loading→success transition.
-    // Listening (not watching) keeps the build pure; the timer + mounted guard
-    // make double-fires safe.
+    // Schedule the auto-route once on the loading -> success transition.
+    // Listening (not watching) keeps the build pure; the timer + mounted
+    // guard make double-fires safe.
     ref.listen<SubscriptionSuccessPhase>(
       subscriptionSuccessControllerProvider,
       (prev, next) {
@@ -83,146 +85,20 @@ class _SubscriptionSuccessScreenState
     );
 
     final phase = ref.watch(subscriptionSuccessControllerProvider);
+    final mapped = phase == SubscriptionSuccessPhase.success
+        ? LoadingConfirmationPhase.success
+        : LoadingConfirmationPhase.loading;
 
     return PopScope(
       canPop: false,
       child: Scaffold(
-        backgroundColor: AppColors.butterSoft,
-        body: SafeArea(
-          // SizedBox.expand forces the Stack to fill the SafeArea — without
-          // it the Stack collapses to its non-positioned child (_PetalBlob)
-          // and the whole cluster snaps to the upper-left.
-          child: SizedBox.expand(
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                const _PetalBlob(key: Key('subscription_success_blob')),
-                _PhaseLabel(phase: phase),
-              ],
-            ),
-          ),
+        body: LoadingConfirmation(
+          phase: mapped,
+          successLabel: 'You all set!',
+          blobKey: const Key('subscription_success_blob'),
+          loadingLabelKey: const Key('subscription_success_loading_label'),
+          successLabelKey: const Key('subscription_success_done_label'),
         ),
-      ),
-    );
-  }
-}
-
-/// Layered petal mark mimicking the Figma `LoadingAnimation` frame:
-/// a pale outer quatrefoil + a sage inner quatrefoil + a soft butter glow
-/// dot at the core (Quatrefoil's circle core alone reads as flat).
-class _PetalBlob extends StatelessWidget {
-  const _PetalBlob({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: AppSizes.avatarXl * 1.84,
-      height: AppSizes.avatarXl * 1.84,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          // Outer pale-butter petal blob (spec petal layer 1+2 composite).
-          const Quatrefoil(
-            size: AppSizes.avatarXl * 1.84,
-            coreColor: AppColors.butter,
-          ),
-          // Inner sage petal — smaller, scales down to ~52% of outer.
-          const Quatrefoil(
-            size: AppSizes.avatarXl * 0.96,
-            petalColor: AppColors.green,
-            coreColor: AppColors.greenDeep,
-          ),
-          // Soft butter glow dot at the center (spec blurred lime dot).
-          DecoratedBox(
-            decoration: BoxDecoration(
-              color: AppColors.butter,
-              shape: BoxShape.circle,
-              boxShadow: [
-                BoxShadow(
-                  color: AppColors.butter.withValues(alpha: 0.9),
-                  blurRadius: AppSizes.sm,
-                  spreadRadius: AppSizes.xs,
-                ),
-              ],
-            ),
-            child: const SizedBox(
-              width: AppSizes.sp12 * 1.4,
-              height: AppSizes.sp12 * 1.4,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Phase caption — faint uppercase "Loading" sits below the petal animation in
-/// both phases (matches the Figma frame 1290:10122 which renders LOADING
-/// faded above "You all set!" during the success state — a cross-fade where
-/// the slot is reserved so the layout never shifts). The "You all set!" label
-/// is rendered in both phases but invisible during loading so the vertical
-/// rhythm is preserved across the transition.
-class _PhaseLabel extends StatelessWidget {
-  const _PhaseLabel({required this.phase});
-
-  final SubscriptionSuccessPhase phase;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final isSuccess = phase == SubscriptionSuccessPhase.success;
-
-    return Positioned.fill(
-      child: Stack(
-        children: [
-          // "Loading" — Inter Regular 12.8 / 19.2 / tracking 4.33 / UPPERCASE,
-          // rendered low-contrast (cream on butter-soft) per spec. Stays
-          // visible (faded) during the success phase to match Figma's
-          // cross-fade snapshot.
-          Align(
-            alignment: const Alignment(0, 0.34),
-            child: AnimatedOpacity(
-              duration: const Duration(milliseconds: 240),
-              opacity: isSuccess ? 0.55 : 1,
-              child: Text(
-                'Loading'.toUpperCase(),
-                key: const Key('subscription_success_loading_label'),
-                textAlign: TextAlign.center,
-                style: textTheme.bodySmall?.copyWith(
-                  color: AppColors.cream,
-                  fontSize: 12.8,
-                  height: 19.2 / 12.8,
-                  letterSpacing: 4.33,
-                  fontWeight: FontWeight.w400,
-                ),
-              ),
-            ),
-          ),
-          // "You all set!" — body label below the animation. Always laid out
-          // so the slot is reserved during the loading phase too; opacity
-          // gates visibility so there's zero layout shift on transition.
-          Align(
-            alignment: const Alignment(0, 0.6),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSizes.md + AppSizes.sp2,
-              ),
-              child: AnimatedOpacity(
-                duration: const Duration(milliseconds: 240),
-                opacity: isSuccess ? 1 : 0,
-                child: Text(
-                  'You all set!',
-                  key: const Key('subscription_success_done_label'),
-                  textAlign: TextAlign.center,
-                  style: textTheme.bodyLarge?.copyWith(
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.text,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/test/common/components/feedback/loading_confirmation_test.dart
+++ b/test/common/components/feedback/loading_confirmation_test.dart
@@ -1,0 +1,93 @@
+// NIB-131 — widget tests for the reusable LoadingConfirmation composite.
+//
+// Covers:
+//   - Loading phase: blob + UPPERCASE "Loading" caption visible at full
+//     opacity; success label laid out but transparent (zero layout shift on
+//     transition).
+//   - Success phase: success label fully visible; "Loading" caption stays
+//     mounted at 0.55 opacity (cross-fade snapshot from the Figma audit).
+//   - Caller-supplied keys propagate to the blob + both labels so screen-
+//     level tests can target them.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/components/feedback/loading_confirmation.dart';
+
+const _blobKey = Key('test_blob');
+const _loadingKey = Key('test_loading');
+const _successKey = Key('test_success');
+
+Widget _hostFor(LoadingConfirmationPhase phase) => MaterialApp(
+  home: Scaffold(
+    body: LoadingConfirmation(
+      phase: phase,
+      successLabel: 'You all set!',
+      blobKey: _blobKey,
+      loadingLabelKey: _loadingKey,
+      successLabelKey: _successKey,
+    ),
+  ),
+);
+
+/// Reads the *target* opacity of the [AnimatedOpacity] wrapping the widget
+/// keyed [key]. Target (not currently-tweened) opacity deterministically
+/// reflects the phase regardless of where the cross-fade sits at the moment
+/// of the assertion.
+double _opacityOf(WidgetTester tester, Key key) {
+  final ancestor = tester.widget<AnimatedOpacity>(
+    find.ancestor(of: find.byKey(key), matching: find.byType(AnimatedOpacity)),
+  );
+  return ancestor.opacity;
+}
+
+void main() {
+  testWidgets('loading phase renders blob + UPPERCASE caption at full opacity',
+      (tester) async {
+    await tester.pumpWidget(_hostFor(LoadingConfirmationPhase.loading));
+    await tester.pump();
+
+    expect(find.byKey(_blobKey), findsOneWidget);
+    expect(find.byKey(_loadingKey), findsOneWidget);
+    // Verbatim copy from Figma — uppercased via `.toUpperCase()` per spec
+    // (Inter Regular 12.8 / tracking 4.33 / uppercase).
+    expect(find.text('LOADING'), findsOneWidget);
+
+    // Success label is always in the tree so the layout never shifts on
+    // transition — visibility is gated by AnimatedOpacity.
+    expect(find.byKey(_successKey), findsOneWidget);
+    expect(find.text('You all set!'), findsOneWidget);
+    expect(_opacityOf(tester, _successKey), 0.0);
+    expect(_opacityOf(tester, _loadingKey), 1.0);
+  });
+
+  testWidgets('success phase shows success label and fades loading caption',
+      (tester) async {
+    await tester.pumpWidget(_hostFor(LoadingConfirmationPhase.success));
+    await tester.pump();
+
+    expect(find.byKey(_successKey), findsOneWidget);
+    expect(find.text('You all set!'), findsOneWidget);
+    // Caption stays mounted but low-opacity per the Figma cross-fade snapshot.
+    expect(find.text('LOADING'), findsOneWidget);
+    expect(_opacityOf(tester, _successKey), 1.0);
+    expect(_opacityOf(tester, _loadingKey), 0.55);
+  });
+
+  testWidgets('caller-supplied success label overrides the default',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: LoadingConfirmation(
+            phase: LoadingConfirmationPhase.success,
+            successLabel: 'Custom done copy',
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Custom done copy'), findsOneWidget);
+    expect(find.text('You all set!'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

NIB-131 — Cancel subscription confirmation state (loading -> "You all set!").

The audit screen (Figma 1216:11584 in section Cancel Subscription) is
visually identical to the NIB-130 post-purchase transition (frame 1290:10122):
butter-cream background, petal animation, faint uppercase "Loading" caption,
"You all set!" body label. The ticket itself flags that NIB-82's cancel-reason
sheet deep-links Continue to the OS-managed subscription page, so a standalone
in-app cancel confirmation is not reachable -- a duplicate screen would be
dead code.

Per the ticket's sanctioned fallback ("treat this as a reusable
LoadingConfirmation composite that any flow can show with its own success
copy and exit route"), this PR extracts the visual into a shared widget and
refactors NIB-130 to consume it. Net result: one composite, one consumer
today, ready for any future flow whose audit lands on the same composition.

## Changes

- `lib/src/common/components/feedback/loading_confirmation.dart` (new)
  - `LoadingConfirmation` widget + `LoadingConfirmationPhase` enum.
  - Takes `phase`, `successLabel`, and optional keys for blob / loading /
    success labels so screen-level tests can target them.
  - Background fixed to `AppColors.butterSoft` (#fffcd5) per Figma token
    `Nibble-primary-cream`.
  - "Loading" caption: Inter Regular 12.8 / tracking 4.33 / uppercase /
    cream (#fffdf8) -- verbatim from the audit.
  - Success label: `bodyLarge` w600 / `AppColors.text` (#2c2c2c).
  - Cross-fade preserves the layout slot for both labels (zero shift on
    transition) -- same behavior NIB-130 shipped.
- `lib/src/common/components/components.dart` -- export the new widget.
- `lib/src/features/subscription/success/subscription_success_screen.dart`
  -- now consumes `LoadingConfirmation`; deleted the inline `_PetalBlob`
  and `_PhaseLabel` (~120 lines). Controller wiring, analytics, PopScope,
  and auto-route to `/home` are unchanged. Same widget keys preserved
  (`subscription_success_blob`, `_loading_label`, `_done_label`) so the
  existing NIB-130 test suite stays green.
- `test/common/components/feedback/loading_confirmation_test.dart` (new)
  -- 3 widget tests: loading phase opacity, success phase opacity, and
  custom `successLabel` override.

## Acceptance criteria

- [x] Visual match to `.figma-audit/subscription-cancel/babys-setup/screenshot.png`
      -- composition identical to NIB-130 (already audited, same petal +
      cream surface + cross-fade).
- [x] Verbatim copy preserved: "Loading" uppercased via `.toUpperCase()`,
      "You all set!" with exclamation.
- [x] Tokens consumed from `AppColors` (`butterSoft`, `butter`, `green`,
      `greenDeep`, `cream`, `text`) -- no hardcoded hex outside the
      foundation.
- [x] No interactive elements (matches Figma -- passive confirmation).
- [x] `flutter analyze` clean (no new issues introduced; 2 pre-existing
      `info`s in `subscription_success_screen_test.dart` baseline carry
      over).
- [x] Widget test for the populated success state + loading state.
- Exit path: NIB-130 retains its existing auto-route to `/home`. The new
  composite is purely presentational so any future host owns its own
  exit. No cancel route registered (NIB-82 exits to OS).

## Open question carried over from ticket

PO question #1 ("what flow does this confirmation belong to") -- the
contradiction with NIB-82's deep-link exit remains. By shipping a reusable
composite the implementation is ready for any answer without code rework
or a dead route. Will revisit when PO resolves.

## Figma frame ids

- 1216:11584 -- "Baby's setup" (cancel-subscription confirmation, this
  ticket's audit screen)
- 1290:10122 -- post-purchase "You all set!" (NIB-130, the consumer)

## Audit report paths

- `.figma-audit/subscription-cancel/babys-setup/report.md`
- `.figma-audit/subscription-cancel/babys-setup/screenshot.png`
- `.figma-audit/subscription-cancel/babys-setup/variables.json`
- `.figma-audit/subscription-cancel/babys-setup/design_context.md`

## Test plan

- [x] `flutter test test/common/components/feedback/loading_confirmation_test.dart` -- 3 / 3 pass
- [x] `flutter test test/features/subscription/success/` -- 4 / 4 pass (no regression)
- [x] `flutter test` (full suite) -- 509 pass / 1 skipped
- [x] `flutter analyze` -- 0 new issues; 2 baseline `info`s carry over from `redesign`
- [x] `make gen` -- no unrelated regen drift