### PR TITLE
feat(infra): cancel subscription reason overlay [NIB-82]

### DIFF
--- a/lib/src/common/services/subscription_service.dart
+++ b/lib/src/common/services/subscription_service.dart
@@ -1,10 +1,44 @@
+import 'package:flutter/foundation.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/subscription_info.dart';
 import 'package:nibbles/src/common/domain/entities/subscription_offering.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 part 'subscription_service.g.dart';
+
+/// Test-injectable signature for `url_launcher`'s `launchUrl`. Allows the
+/// widget / controller tests to replace the platform call without touching
+/// the method channel. Mirrors the `deleteAccountCrashRecorder` typedef +
+/// provider seam from NIB-78.
+typedef SubscriptionLaunchUrlFn =
+    Future<bool> Function(Uri url, {LaunchMode mode});
+
+Future<bool> _defaultLaunchUrl(
+  Uri url, {
+  LaunchMode mode = LaunchMode.platformDefault,
+}) => launchUrl(url, mode: mode);
+
+/// Provider for [SubscriptionLaunchUrlFn]. Defaults to the real `launchUrl`
+/// from `url_launcher`; tests override it to assert calls without hitting the
+/// platform channel.
+@Riverpod(keepAlive: true)
+SubscriptionLaunchUrlFn subscriptionLaunchUrl(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  SubscriptionLaunchUrlRef ref,
+) => _defaultLaunchUrl;
+
+/// Platform-default management URLs. Apps cannot programmatically cancel
+/// App Store / Play subscriptions — the OS owns the cancellation UI. The
+/// https URLs avoid an Info.plist `LSApplicationQueriesSchemes` entry that
+/// `itms-apps://` would otherwise force.
+@visibleForTesting
+const String iosManagementUrl = 'https://apps.apple.com/account/subscriptions';
+@visibleForTesting
+const String androidManagementUrl =
+    'https://play.google.com/store/account/subscriptions';
 
 /// Stub SubscriptionService — to be wired through `purchases_flutter` in
 /// NIB-18. State is the entitlement bool used by callers like the post-
@@ -100,4 +134,39 @@ class SubscriptionService extends _$SubscriptionService {
       NotFoundException('No active subscription found.'),
     );
   }
+
+  /// Opens the OS-managed subscription page (NIB-82). Apps cannot
+  /// programmatically cancel App Store / Play subscriptions, so the cancel
+  /// flow deep-links to the store-owned cancellation UI.
+  ///
+  /// Returns [Failure] when the URL can't be opened — the overlay maps that
+  /// onto a P2 toast ("Couldn't open subscription settings. Try again.") per
+  /// the ticket's error rule. NIB-18 will swap the platform default for
+  /// `customerInfo.managementURL` when RC is wired through.
+  Future<Result<void>> openManagementPage() async {
+    final launchFn = ref.read(subscriptionLaunchUrlProvider);
+    final uri = Uri.parse(_managementUrl);
+    try {
+      final ok = await launchFn(uri, mode: LaunchMode.externalApplication);
+      if (ok) return const Result.success(null);
+      return const Result.failure(
+        UnknownException("Couldn't open subscription settings. Try again."),
+      );
+    } on Object catch (_) {
+      // url_launcher throws PlatformException when the OS rejects the URL.
+      // Surface a P2-friendly message; the underlying exception is logged at
+      // the call site (Crashlytics non-fatal) if needed.
+      return const Result.failure(
+        UnknownException("Couldn't open subscription settings. Try again."),
+      );
+    }
+  }
+
+  /// Resolves the platform-default management URL. iOS / Android only — web
+  /// and desktop fall through to the iOS URL since the app ships
+  /// mobile-only per CLAUDE.md (iOS 15+ / Android 10+).
+  String get _managementUrl =>
+      defaultTargetPlatform == TargetPlatform.android
+          ? androidManagementUrl
+          : iosManagementUrl;
 }

--- a/lib/src/common/services/subscription_service.dart
+++ b/lib/src/common/services/subscription_service.dart
@@ -34,9 +34,7 @@ SubscriptionLaunchUrlFn subscriptionLaunchUrl(
 /// App Store / Play subscriptions — the OS owns the cancellation UI. The
 /// https URLs avoid an Info.plist `LSApplicationQueriesSchemes` entry that
 /// `itms-apps://` would otherwise force.
-@visibleForTesting
 const String iosManagementUrl = 'https://apps.apple.com/account/subscriptions';
-@visibleForTesting
 const String androidManagementUrl =
     'https://play.google.com/store/account/subscriptions';
 

--- a/lib/src/common/services/subscription_service.g.dart
+++ b/lib/src/common/services/subscription_service.g.dart
@@ -6,8 +6,31 @@ part of 'subscription_service.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$subscriptionLaunchUrlHash() =>
+    r'f28a8a524c29f3e3e95e13d6fb5c24c9f7e86d37';
+
+/// Provider for [SubscriptionLaunchUrlFn]. Defaults to the real `launchUrl`
+/// from `url_launcher`; tests override it to assert calls without hitting the
+/// platform channel.
+///
+/// Copied from [subscriptionLaunchUrl].
+@ProviderFor(subscriptionLaunchUrl)
+final subscriptionLaunchUrlProvider =
+    Provider<SubscriptionLaunchUrlFn>.internal(
+      subscriptionLaunchUrl,
+      name: r'subscriptionLaunchUrlProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$subscriptionLaunchUrlHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef SubscriptionLaunchUrlRef = ProviderRef<SubscriptionLaunchUrlFn>;
 String _$subscriptionServiceHash() =>
-    r'c5ece94fd553c4d270b8e630aaf272b43ab7b3cd';
+    r'a2ebb03ff4796ab578383ce67ae09742db7d99f2';
 
 /// Stub SubscriptionService — to be wired through `purchases_flutter` in
 /// NIB-18. State is the entitlement bool used by callers like the post-

--- a/lib/src/features/subscription/cancel/cancel_reason.dart
+++ b/lib/src/features/subscription/cancel/cancel_reason.dart
@@ -1,0 +1,49 @@
+/// Cancel-subscription survey reasons (NIB-82).
+///
+/// Verbatim UI labels are preserved exactly per the Figma audit
+/// (`.figma-audit/subscription-cancel/overlay-delete-account/report.md`):
+///   * U+2019 curly apostrophes
+///   * trailing spaces on two reasons
+///   * a double space in "I subscribed by  accident"
+///
+/// `analyticsKey` is the stable snake_case payload sent to Firebase Analytics
+/// (`subscription_cancel_started` / `subscription_cancel_reason`). Keeping it
+/// distinct from `label` keeps PII-free analytics PII-free and stops the
+/// trailing-space / double-space ugliness from leaking into dashboards.
+enum CancelReason {
+  achievedGoal(
+    label: 'I achieved my goal already',
+    analyticsKey: 'achieved_goal',
+  ),
+  // Verbatim trailing space preserved per Figma 1216:12031.
+  priceTooHigh(
+    label: 'The plan is out of my price range ',
+    analyticsKey: 'price_too_high',
+  ),
+  // Verbatim trailing space preserved per Figma 1216:12032.
+  notValuable(
+    label: 'I didn’t find subscription plan features valuable ',
+    analyticsKey: 'not_valuable',
+  ),
+  noLongerNeeded(
+    label: 'I no longer need meal recommendations',
+    analyticsKey: 'no_longer_needed',
+  ),
+  // Verbatim double space preserved per Figma 1216:12034.
+  accidental(
+    label: 'I subscribed by  accident',
+    analyticsKey: 'accidental',
+  ),
+  other(
+    label: 'Other',
+    analyticsKey: 'other',
+  );
+
+  const CancelReason({required this.label, required this.analyticsKey});
+
+  /// User-facing copy. Verbatim from Figma — never paraphrase.
+  final String label;
+
+  /// Stable snake_case key shipped to analytics. PII-free.
+  final String analyticsKey;
+}

--- a/lib/src/features/subscription/cancel/cancel_subscription_controller.dart
+++ b/lib/src/features/subscription/cancel/cancel_subscription_controller.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/subscription_service.dart';
+import 'package:nibbles/src/features/subscription/cancel/cancel_reason.dart';
+import 'package:nibbles/src/features/subscription/cancel/cancel_subscription_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'cancel_subscription_controller.g.dart';
+
+/// Drives the cancel-subscription reason overlay (NIB-82).
+///
+/// `submit(reason)` is the only mutator:
+///  1. Sets `isSubmitting = true`.
+///  2. Fires `subscription_cancel_started` + `subscription_cancel_reason`
+///     analytics (PII-free `analyticsKey`).
+///  3. Deep-links to the OS-managed subscription page via
+///     [SubscriptionService.openManagementPage]. Apps cannot programmatically
+///     cancel App Store / Play subscriptions — the OS owns the cancel UI.
+///  4. Returns `true` on success so the overlay can dismiss itself, `false`
+///     on URL-open failure so the overlay can surface the P2 SnackBar.
+@riverpod
+class CancelSubscriptionController extends _$CancelSubscriptionController {
+  @override
+  CancelSubscriptionState build() => const CancelSubscriptionState();
+
+  Future<bool> submit(CancelReason reason) async {
+    state = state.copyWith(isSubmitting: true);
+
+    // Fire-and-forget intent events BEFORE the deep-link so we capture
+    // user intent even if the OS rejects the URL. Awaiting here would
+    // serialize the analytics RTT in front of the launch.
+    final analytics = ref.read(analyticsProvider);
+    unawaited(
+      analytics.logSubscriptionCancelStarted(reason: reason.analyticsKey),
+    );
+    unawaited(
+      analytics.logSubscriptionCancelReason(reason: reason.analyticsKey),
+    );
+
+    final result = await ref
+        .read(subscriptionServiceProvider.notifier)
+        .openManagementPage();
+
+    // Drop the in-flight flag regardless of outcome — the overlay either
+    // dismisses on success or remains open with both CTAs re-enabled on
+    // failure (the SnackBar lives on the parent route, NOT inline).
+    state = state.copyWith(isSubmitting: false);
+
+    return switch (result) {
+      Success<void>() => true,
+      Failure<void>() => false,
+    };
+  }
+}

--- a/lib/src/features/subscription/cancel/cancel_subscription_controller.g.dart
+++ b/lib/src/features/subscription/cancel/cancel_subscription_controller.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'cancel_subscription_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$cancelSubscriptionControllerHash() =>
+    r'f344e2d60dfc053868216ae225bdeaf52628468c';
+
+/// Drives the cancel-subscription reason overlay (NIB-82).
+///
+/// `submit(reason)` is the only mutator:
+///  1. Sets `isSubmitting = true`.
+///  2. Fires `subscription_cancel_started` + `subscription_cancel_reason`
+///     analytics (PII-free `analyticsKey`).
+///  3. Deep-links to the OS-managed subscription page via
+///     [SubscriptionService.openManagementPage]. Apps cannot programmatically
+///     cancel App Store / Play subscriptions — the OS owns the cancel UI.
+///  4. Returns `true` on success so the overlay can dismiss itself, `false`
+///     on URL-open failure so the overlay can surface the P2 SnackBar.
+///
+/// Copied from [CancelSubscriptionController].
+@ProviderFor(CancelSubscriptionController)
+final cancelSubscriptionControllerProvider =
+    AutoDisposeNotifierProvider<
+      CancelSubscriptionController,
+      CancelSubscriptionState
+    >.internal(
+      CancelSubscriptionController.new,
+      name: r'cancelSubscriptionControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$cancelSubscriptionControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$CancelSubscriptionController =
+    AutoDisposeNotifier<CancelSubscriptionState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/subscription/cancel/cancel_subscription_overlay.dart
+++ b/lib/src/features/subscription/cancel/cancel_subscription_overlay.dart
@@ -56,6 +56,14 @@ class _CancelSubscriptionSheetState
     extends ConsumerState<_CancelSubscriptionSheet> {
   CancelReason? _selectedReason;
 
+  /// Local ScaffoldMessenger key. SnackBars must render via this messenger
+  /// (NOT the parent-route messenger) — modal bottom sheets paint above the
+  /// parent Scaffold's body, so a parent SnackBar lands behind the sheet
+  /// and is invisible. The local ScaffoldMessenger wrapping the sheet body
+  /// (below) puts the toast in front.
+  final GlobalKey<ScaffoldMessengerState> _messengerKey =
+      GlobalKey<ScaffoldMessengerState>();
+
   @override
   void initState() {
     super.initState();
@@ -80,10 +88,9 @@ class _CancelSubscriptionSheetState
     final reason = _selectedReason;
     if (reason == null) return;
 
-    // Capture the messenger BEFORE the await so we can surface the failure
-    // SnackBar on the parent route after the sheet pops itself.
+    // Capture the navigator BEFORE the await. The messenger lookup goes
+    // through the local key (below) so the toast renders inside the sheet.
     final navigator = Navigator.of(context);
-    final messenger = ScaffoldMessenger.maybeOf(context);
 
     final ok = await ref
         .read(cancelSubscriptionControllerProvider.notifier)
@@ -96,9 +103,10 @@ class _CancelSubscriptionSheetState
       // remains visible underneath.
       navigator.pop();
     } else {
-      // P2 failure — keep the sheet open so the user can retry, but show a
-      // transient toast on whichever ScaffoldMessenger is in scope.
-      messenger?.showSnackBar(
+      // P2 failure — keep the sheet open so the user can retry, and show a
+      // transient toast on the sheet's local messenger so it paints above
+      // the bottom sheet's content.
+      _messengerKey.currentState?.showSnackBar(
         const SnackBar(
           key: Key('cancel_subscription_failure_snackbar'),
           content: Text(_kLaunchFailureCopy),
@@ -115,77 +123,83 @@ class _CancelSubscriptionSheetState
     final submitting = state.isSubmitting;
     final reasonPicked = _selectedReason != null;
 
-    return SafeArea(
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxHeight: media.size.height * 0.92,
-        ),
-        child: Padding(
-          padding: EdgeInsets.only(bottom: media.viewInsets.bottom),
-          child: SingleChildScrollView(
+    return ScaffoldMessenger(
+      key: _messengerKey,
+      child: Scaffold(
+        // Transparent so the sheet's `backgroundColor` (set in
+        // showModalBottomSheet, AppColors.background) shows through and the
+        // rounded top corners aren't clipped by an opaque scaffold.
+        backgroundColor: Colors.transparent,
+        body: SafeArea(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: media.size.height * 0.92),
             child: Padding(
-              // Figma column inset: left/right 16, top 37, bottom 27.
-              padding: const EdgeInsets.fromLTRB(
-                AppSizes.md,
-                37,
-                AppSizes.md,
-                27,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  _SheetHeader(
-                    onClose: submitting
-                        ? null
-                        : () => Navigator.of(context).pop(),
+              padding: EdgeInsets.only(bottom: media.viewInsets.bottom),
+              child: SingleChildScrollView(
+                child: Padding(
+                  // Figma column inset: left/right 16, top 37, bottom 27.
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSizes.md,
+                    37,
+                    AppSizes.md,
+                    27,
                   ),
-                  // Figma: header-to-lockup gap = 24.
-                  const SizedBox(height: AppSizes.lg),
-                  const _BrandLockup(),
-                  // Figma: lockup-to-heading gap = 24.
-                  const SizedBox(height: AppSizes.lg),
-                  // Title 2 / Bold — Parkinsans 20/28, Black (#2c2c2c), left.
-                  Text(
-                    _kHeading,
-                    key: const Key('cancel_subscription_heading'),
-                    textAlign: TextAlign.left,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      color: AppColors.text,
-                      height: 28 / 20,
-                    ),
-                  ),
-                  // Figma: heading-to-chips gap = 24.
-                  const SizedBox(height: AppSizes.lg),
-                  for (var i = 0; i < CancelReason.values.length; i++) ...[
-                    CancelReasonChip(
-                      key: Key('cancel_subscription_reason_$i'),
-                      label: CancelReason.values[i].label,
-                      selected:
-                          _selectedReason == CancelReason.values[i],
-                      onTap: submitting
-                          ? () {}
-                          : () => setState(() {
-                              _selectedReason = CancelReason.values[i];
-                            }),
-                    ),
-                    // Figma: gap between choices = 12.
-                    if (i != CancelReason.values.length - 1)
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      _SheetHeader(
+                        onClose: submitting
+                            ? null
+                            : () => Navigator.of(context).pop(),
+                      ),
+                      // Figma: header-to-lockup gap = 24.
+                      const SizedBox(height: AppSizes.lg),
+                      const _BrandLockup(),
+                      // Figma: lockup-to-heading gap = 24.
+                      const SizedBox(height: AppSizes.lg),
+                      // Title 2 / Bold — Parkinsans 20/28, Black (#2c2c2c), left.
+                      Text(
+                        _kHeading,
+                        key: const Key('cancel_subscription_heading'),
+                        textAlign: TextAlign.left,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: AppColors.text,
+                          height: 28 / 20,
+                        ),
+                      ),
+                      // Figma: heading-to-chips gap = 24.
+                      const SizedBox(height: AppSizes.lg),
+                      for (var i = 0; i < CancelReason.values.length; i++) ...[
+                        CancelReasonChip(
+                          key: Key('cancel_subscription_reason_$i'),
+                          label: CancelReason.values[i].label,
+                          selected: _selectedReason == CancelReason.values[i],
+                          onTap: submitting
+                              ? () {}
+                              : () => setState(() {
+                                  _selectedReason = CancelReason.values[i];
+                                }),
+                        ),
+                        // Figma: gap between choices = 12.
+                        if (i != CancelReason.values.length - 1)
+                          const SizedBox(height: AppSizes.sp12),
+                      ],
+                      // Figma: chips-to-CTA stack gap (column → bottom stack).
+                      const SizedBox(height: AppSizes.lg),
+                      _ContinueButton(
+                        enabled: reasonPicked && !submitting,
+                        submitting: submitting,
+                        onPressed: _onContinue,
+                      ),
+                      // Figma: Continue-to-Cancel gap = 12.
                       const SizedBox(height: AppSizes.sp12),
-                  ],
-                  // Figma: chips-to-CTA stack gap (column → bottom stack).
-                  const SizedBox(height: AppSizes.lg),
-                  _ContinueButton(
-                    enabled: reasonPicked && !submitting,
-                    submitting: submitting,
-                    onPressed: _onContinue,
+                      _CancelButton(
+                        enabled: !submitting,
+                        onPressed: () => Navigator.of(context).pop(),
+                      ),
+                    ],
                   ),
-                  // Figma: Continue-to-Cancel gap = 12.
-                  const SizedBox(height: AppSizes.sp12),
-                  _CancelButton(
-                    enabled: !submitting,
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                ],
+                ),
               ),
             ),
           ),
@@ -215,10 +229,7 @@ class _SheetHeader extends StatelessWidget {
           onPressed: onClose,
           tooltip: 'Close',
           padding: EdgeInsets.zero,
-          constraints: const BoxConstraints(
-            minWidth: 34,
-            minHeight: 33,
-          ),
+          constraints: const BoxConstraints(minWidth: 34, minHeight: 33),
           style: IconButton.styleFrom(
             shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.all(Radius.circular(30)),
@@ -230,35 +241,40 @@ class _SheetHeader extends StatelessWidget {
   }
 }
 
+/// Brand lockup — `nibbles` wordmark + butter crown badge.
+///
+/// Mirrors `_BrandLockup` from `manage_subscription_screen.dart` (the screen
+/// that opens this sheet) so the visual rhythm is consistent. Sized to the
+/// Figma values: wordmark 173x42, crown badge 42x42 (vs. the 26x26 inline
+/// variant on the parent screen).
 class _BrandLockup extends StatelessWidget {
   const _BrandLockup();
 
   @override
   Widget build(BuildContext context) {
-    // Same neutral placeholder treatment as delete_account_overlay (NIB-78)
-    // — the Figma SVGs (Nibbles wordmark 869:7532 and Nibble-Icon-2
-    // 1216:11960) aren't in the repo yet. Keep the lockup spatially
-    // accurate so the rest of the layout matches the screenshot exactly.
+    // 42px wordmark height matches Figma's 869:7532 (h=42) and lines up with
+    // the brand wordmark token's intrinsic 42px size — no scaling needed.
+    final wordmark = AppTypography.brandWordmark.copyWith(
+      color: AppColors.text,
+    );
+
     return Row(
+      key: const Key('cancel_subscription_brand_lockup'),
       mainAxisSize: MainAxisSize.min,
       children: [
-        Container(
-          key: const Key('cancel_subscription_wordmark_placeholder'),
-          width: 173,
-          height: 42,
-          decoration: BoxDecoration(
-            color: AppColors.borderSoft,
-            borderRadius: BorderRadius.circular(AppSizes.radiusSm),
-          ),
-        ),
+        Text('nibbles', style: wordmark),
         const SizedBox(width: AppSizes.sp12),
         Container(
-          key: const Key('cancel_subscription_mascot_placeholder'),
           width: 42,
           height: 42,
           decoration: BoxDecoration(
             color: AppColors.butter,
             borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+          ),
+          child: const Icon(
+            Icons.workspace_premium_rounded,
+            size: 28,
+            color: AppColors.greenDeep,
           ),
         ),
       ],

--- a/lib/src/features/subscription/cancel/cancel_subscription_overlay.dart
+++ b/lib/src/features/subscription/cancel/cancel_subscription_overlay.dart
@@ -1,0 +1,332 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/features/subscription/cancel/cancel_reason.dart';
+import 'package:nibbles/src/features/subscription/cancel/cancel_subscription_controller.dart';
+import 'package:nibbles/src/features/subscription/cancel/widgets/cancel_reason_chip.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+/// Verbatim sheet title from Figma 1216:12029. The apostrophe is a U+2019
+/// curly apostrophe — never paraphrase.
+const _kHeading = 'Tell us why you’re canceling';
+
+/// Verbatim copy from the ticket for the P2 URL-open failure path.
+const _kLaunchFailureCopy = "Couldn't open subscription settings. Try again.";
+
+/// Opens the cancel-subscription reason overlay (Figma 1216:12019).
+///
+/// Modal bottom sheet, `isScrollControlled: true`. Returns once dismissed —
+/// either by Cancel / close, by tapping the scrim, or after a successful
+/// deep-link to the store-managed subscription page.
+///
+/// Failure to open the management URL is a **P2** event: the overlay pops
+/// itself and surfaces a transient SnackBar on the parent route (NOT an
+/// inline error block — that's the P1 delete-account treatment).
+Future<void> showCancelSubscriptionOverlay(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    // Figma sheet fill: Nibble-primary-white (#fffdf8).
+    backgroundColor: AppColors.background,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        // Figma sheet top corner radius = 30.
+        top: Radius.circular(30),
+      ),
+    ),
+    builder: (_) => const _CancelSubscriptionSheet(),
+  );
+}
+
+class _CancelSubscriptionSheet extends ConsumerStatefulWidget {
+  const _CancelSubscriptionSheet();
+
+  @override
+  ConsumerState<_CancelSubscriptionSheet> createState() =>
+      _CancelSubscriptionSheetState();
+}
+
+class _CancelSubscriptionSheetState
+    extends ConsumerState<_CancelSubscriptionSheet> {
+  CancelReason? _selectedReason;
+
+  @override
+  void initState() {
+    super.initState();
+    // screen_view fires once on mount via post-frame.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_logScreenView());
+    });
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await ref
+          .read(analyticsProvider)
+          .logScreenView(screenName: 'cancel_subscription_overlay');
+    } on Object catch (_) {
+      // Analytics is best-effort; never surface to the UI.
+    }
+  }
+
+  Future<void> _onContinue() async {
+    final reason = _selectedReason;
+    if (reason == null) return;
+
+    // Capture the messenger BEFORE the await so we can surface the failure
+    // SnackBar on the parent route after the sheet pops itself.
+    final navigator = Navigator.of(context);
+    final messenger = ScaffoldMessenger.maybeOf(context);
+
+    final ok = await ref
+        .read(cancelSubscriptionControllerProvider.notifier)
+        .submit(reason);
+
+    if (!mounted) return;
+    if (ok) {
+      // Success — dismiss the overlay. The deep-link has already handed off
+      // to the OS subscription UI; the parent Manage Subscription screen
+      // remains visible underneath.
+      navigator.pop();
+    } else {
+      // P2 failure — keep the sheet open so the user can retry, but show a
+      // transient toast on whichever ScaffoldMessenger is in scope.
+      messenger?.showSnackBar(
+        const SnackBar(
+          key: Key('cancel_subscription_failure_snackbar'),
+          content: Text(_kLaunchFailureCopy),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final media = MediaQuery.of(context);
+    final state = ref.watch(cancelSubscriptionControllerProvider);
+    final theme = Theme.of(context);
+    final submitting = state.isSubmitting;
+    final reasonPicked = _selectedReason != null;
+
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: media.size.height * 0.92,
+        ),
+        child: Padding(
+          padding: EdgeInsets.only(bottom: media.viewInsets.bottom),
+          child: SingleChildScrollView(
+            child: Padding(
+              // Figma column inset: left/right 16, top 37, bottom 27.
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.md,
+                37,
+                AppSizes.md,
+                27,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _SheetHeader(
+                    onClose: submitting
+                        ? null
+                        : () => Navigator.of(context).pop(),
+                  ),
+                  // Figma: header-to-lockup gap = 24.
+                  const SizedBox(height: AppSizes.lg),
+                  const _BrandLockup(),
+                  // Figma: lockup-to-heading gap = 24.
+                  const SizedBox(height: AppSizes.lg),
+                  // Title 2 / Bold — Parkinsans 20/28, Black (#2c2c2c), left.
+                  Text(
+                    _kHeading,
+                    key: const Key('cancel_subscription_heading'),
+                    textAlign: TextAlign.left,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: AppColors.text,
+                      height: 28 / 20,
+                    ),
+                  ),
+                  // Figma: heading-to-chips gap = 24.
+                  const SizedBox(height: AppSizes.lg),
+                  for (var i = 0; i < CancelReason.values.length; i++) ...[
+                    CancelReasonChip(
+                      key: Key('cancel_subscription_reason_$i'),
+                      label: CancelReason.values[i].label,
+                      selected:
+                          _selectedReason == CancelReason.values[i],
+                      onTap: submitting
+                          ? () {}
+                          : () => setState(() {
+                              _selectedReason = CancelReason.values[i];
+                            }),
+                    ),
+                    // Figma: gap between choices = 12.
+                    if (i != CancelReason.values.length - 1)
+                      const SizedBox(height: AppSizes.sp12),
+                  ],
+                  // Figma: chips-to-CTA stack gap (column → bottom stack).
+                  const SizedBox(height: AppSizes.lg),
+                  _ContinueButton(
+                    enabled: reasonPicked && !submitting,
+                    submitting: submitting,
+                    onPressed: _onContinue,
+                  ),
+                  // Figma: Continue-to-Cancel gap = 12.
+                  const SizedBox(height: AppSizes.sp12),
+                  _CancelButton(
+                    enabled: !submitting,
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SheetHeader extends StatelessWidget {
+  const _SheetHeader({required this.onClose});
+
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    // Figma close affordance: 34x33 pill (radius 30), left-aligned.
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: SizedBox(
+        width: 34,
+        height: 33,
+        child: IconButton(
+          key: const Key('cancel_subscription_close_button'),
+          icon: const Icon(Icons.close, size: AppSizes.iconMd),
+          color: AppColors.text,
+          onPressed: onClose,
+          tooltip: 'Close',
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(
+            minWidth: 34,
+            minHeight: 33,
+          ),
+          style: IconButton.styleFrom(
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(30)),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BrandLockup extends StatelessWidget {
+  const _BrandLockup();
+
+  @override
+  Widget build(BuildContext context) {
+    // Same neutral placeholder treatment as delete_account_overlay (NIB-78)
+    // — the Figma SVGs (Nibbles wordmark 869:7532 and Nibble-Icon-2
+    // 1216:11960) aren't in the repo yet. Keep the lockup spatially
+    // accurate so the rest of the layout matches the screenshot exactly.
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          key: const Key('cancel_subscription_wordmark_placeholder'),
+          width: 173,
+          height: 42,
+          decoration: BoxDecoration(
+            color: AppColors.borderSoft,
+            borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+          ),
+        ),
+        const SizedBox(width: AppSizes.sp12),
+        Container(
+          key: const Key('cancel_subscription_mascot_placeholder'),
+          width: 42,
+          height: 42,
+          decoration: BoxDecoration(
+            color: AppColors.butter,
+            borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Figma "Continue" CTA — lime fill (#eaec8c) + ForestDarkn text. Maps 1:1 to
+/// the kit `pillbtn--ghost` variant (butter bg + greenDeep fg, h42 small).
+class _ContinueButton extends StatelessWidget {
+  const _ContinueButton({
+    required this.enabled,
+    required this.submitting,
+    required this.onPressed,
+  });
+
+  final bool enabled;
+  final bool submitting;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppPillButton(
+      key: const Key('cancel_subscription_continue_button'),
+      label: submitting ? 'Opening…' : 'Continue',
+      variant: AppPillButtonVariant.ghost,
+      size: AppPillButtonSize.small,
+      onPressed: enabled ? onPressed : null,
+    );
+  }
+}
+
+/// Figma "Cancel" CTA — transparent bg, no border, Black (#2c2c2c) text,
+/// h42, radius 24, full-width. No existing [AppPillButton] variant matches
+/// (`secondary` has a green border and green text), so render directly.
+class _CancelButton extends StatelessWidget {
+  const _CancelButton({required this.enabled, required this.onPressed});
+
+  final bool enabled;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = enabled ? AppColors.text : AppColors.fgFaint;
+    return Material(
+      key: const Key('cancel_subscription_cancel_button'),
+      color: Colors.transparent,
+      shape: const StadiumBorder(),
+      child: InkWell(
+        onTap: enabled ? onPressed : null,
+        customBorder: const StadiumBorder(),
+        child: SizedBox(
+          height: 42,
+          width: double.infinity,
+          child: Center(
+            child: Text(
+              'Cancel',
+              style: AppTypography.button.copyWith(
+                fontFamily: FontFamily.parkinsans,
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: fg,
+                height: 22 / 15,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/subscription/cancel/cancel_subscription_state.dart
+++ b/lib/src/features/subscription/cancel/cancel_subscription_state.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'cancel_subscription_state.freezed.dart';
+
+/// Cancel-subscription overlay state (NIB-82).
+///
+/// `isSubmitting` flips while `SubscriptionService.openManagementPage` is
+/// in-flight so the overlay can disable both CTAs without dismissing. The
+/// flow is fire-and-dismiss — failures surface as a transient P2 SnackBar
+/// on the parent route (NOT an inline error block), so there is no
+/// `errorMessage` here.
+@freezed
+class CancelSubscriptionState with _$CancelSubscriptionState {
+  const factory CancelSubscriptionState({
+    @Default(false) bool isSubmitting,
+  }) = _CancelSubscriptionState;
+}

--- a/lib/src/features/subscription/cancel/cancel_subscription_state.freezed.dart
+++ b/lib/src/features/subscription/cancel/cancel_subscription_state.freezed.dart
@@ -1,0 +1,161 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'cancel_subscription_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$CancelSubscriptionState {
+  bool get isSubmitting => throw _privateConstructorUsedError;
+
+  /// Create a copy of CancelSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $CancelSubscriptionStateCopyWith<CancelSubscriptionState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CancelSubscriptionStateCopyWith<$Res> {
+  factory $CancelSubscriptionStateCopyWith(
+    CancelSubscriptionState value,
+    $Res Function(CancelSubscriptionState) then,
+  ) = _$CancelSubscriptionStateCopyWithImpl<$Res, CancelSubscriptionState>;
+  @useResult
+  $Res call({bool isSubmitting});
+}
+
+/// @nodoc
+class _$CancelSubscriptionStateCopyWithImpl<
+  $Res,
+  $Val extends CancelSubscriptionState
+>
+    implements $CancelSubscriptionStateCopyWith<$Res> {
+  _$CancelSubscriptionStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of CancelSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? isSubmitting = null}) {
+    return _then(
+      _value.copyWith(
+            isSubmitting: null == isSubmitting
+                ? _value.isSubmitting
+                : isSubmitting // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$CancelSubscriptionStateImplCopyWith<$Res>
+    implements $CancelSubscriptionStateCopyWith<$Res> {
+  factory _$$CancelSubscriptionStateImplCopyWith(
+    _$CancelSubscriptionStateImpl value,
+    $Res Function(_$CancelSubscriptionStateImpl) then,
+  ) = __$$CancelSubscriptionStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool isSubmitting});
+}
+
+/// @nodoc
+class __$$CancelSubscriptionStateImplCopyWithImpl<$Res>
+    extends
+        _$CancelSubscriptionStateCopyWithImpl<
+          $Res,
+          _$CancelSubscriptionStateImpl
+        >
+    implements _$$CancelSubscriptionStateImplCopyWith<$Res> {
+  __$$CancelSubscriptionStateImplCopyWithImpl(
+    _$CancelSubscriptionStateImpl _value,
+    $Res Function(_$CancelSubscriptionStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of CancelSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? isSubmitting = null}) {
+    return _then(
+      _$CancelSubscriptionStateImpl(
+        isSubmitting: null == isSubmitting
+            ? _value.isSubmitting
+            : isSubmitting // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$CancelSubscriptionStateImpl implements _CancelSubscriptionState {
+  const _$CancelSubscriptionStateImpl({this.isSubmitting = false});
+
+  @override
+  @JsonKey()
+  final bool isSubmitting;
+
+  @override
+  String toString() {
+    return 'CancelSubscriptionState(isSubmitting: $isSubmitting)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CancelSubscriptionStateImpl &&
+            (identical(other.isSubmitting, isSubmitting) ||
+                other.isSubmitting == isSubmitting));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, isSubmitting);
+
+  /// Create a copy of CancelSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CancelSubscriptionStateImplCopyWith<_$CancelSubscriptionStateImpl>
+  get copyWith =>
+      __$$CancelSubscriptionStateImplCopyWithImpl<
+        _$CancelSubscriptionStateImpl
+      >(this, _$identity);
+}
+
+abstract class _CancelSubscriptionState implements CancelSubscriptionState {
+  const factory _CancelSubscriptionState({final bool isSubmitting}) =
+      _$CancelSubscriptionStateImpl;
+
+  @override
+  bool get isSubmitting;
+
+  /// Create a copy of CancelSubscriptionState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$CancelSubscriptionStateImplCopyWith<_$CancelSubscriptionStateImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/src/features/subscription/cancel/widgets/cancel_reason_chip.dart
+++ b/lib/src/features/subscription/cancel/widgets/cancel_reason_chip.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+
+/// Single-select reason chip for the cancel-subscription overlay (NIB-82,
+/// Figma 1216:12019 / component button-choice).
+///
+/// Default state (Figma): cream (#fffcd5) fill, no border, 12px padding,
+/// radius 10, Parkinsans SemiBold 15/22 Black (#2c2c2c) label.
+///
+/// Selected state (engineering-defined per NIB-82 AC — Figma canvas only
+/// shows the default state): sage `greenTint` fill + `green` 1.5px border +
+/// `greenDeep` label. Distinct from the delete-account chip (NIB-78) which
+/// deepens to butter — this ticket explicitly calls for sage tint/border.
+class CancelReasonChip extends StatelessWidget {
+  const CancelReasonChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    super.key,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final fill = selected ? AppColors.greenTint : AppColors.butterSoft;
+    final fg = selected ? AppColors.greenDeep : AppColors.text;
+    final border = selected
+        ? const BorderSide(color: AppColors.green, width: 1.5)
+        : BorderSide.none;
+
+    return Material(
+      color: fill,
+      shape: RoundedRectangleBorder(
+        side: border,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        child: SizedBox(
+          width: double.infinity,
+          child: Padding(
+            // Figma: padding 12 on all sides.
+            padding: const EdgeInsets.all(AppSizes.sp12),
+            child: Text(
+              label,
+              style: AppTypography.button.copyWith(
+                fontFamily: FontFamily.parkinsans,
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: fg,
+                height: 22 / 15,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/subscription/manage/manage_subscription_screen.dart
+++ b/lib/src/features/subscription/manage/manage_subscription_screen.dart
@@ -10,6 +10,7 @@ import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/domain/entities/subscription_info.dart';
+import 'package:nibbles/src/features/subscription/cancel/cancel_subscription_overlay.dart';
 import 'package:nibbles/src/features/subscription/manage/manage_subscription_controller.dart';
 import 'package:nibbles/src/features/subscription/manage/manage_subscription_state.dart';
 import 'package:nibbles/src/logging/analytics.dart';
@@ -162,14 +163,10 @@ class _ManageSubscriptionBody extends StatelessWidget {
   }
 
   void _onCancelPressed(BuildContext context) {
-    // TODO(NIB-82): replace with the cancel-reason bottom sheet
-    // (frame 1216:12019). Until that ships, surface a placeholder so the
-    // CTA is reachable and the screen ships analyze-clean.
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('Cancel subscription flow coming soon.'),
-      ),
-    );
+    // NIB-82: surface the cancel-reason bottom sheet (Figma 1216:12019).
+    // The sheet handles its own analytics, the deep-link to the OS
+    // subscription page, and the P2 SnackBar on URL-open failure.
+    unawaited(showCancelSubscriptionOverlay(context));
   }
 }
 

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -178,6 +178,26 @@ class Analytics {
     await _logEvent('plan_selected', parameters: {'period': period});
   }
 
+  /// Intent event — fires BEFORE the deep-link to the store subscription page.
+  /// `reason` is the stable snake_case `analyticsKey` from the cancel-reason
+  /// enum, NOT the verbatim UI label (which contains trailing spaces / a
+  /// double space).
+  Future<void> logSubscriptionCancelStarted({required String reason}) async {
+    await _logEvent(
+      'subscription_cancel_started',
+      parameters: {'reason': reason},
+    );
+  }
+
+  /// Selection event — fires the moment the user picks a reason chip. Same
+  /// PII-free `reason` payload as [logSubscriptionCancelStarted].
+  Future<void> logSubscriptionCancelReason({required String reason}) async {
+    await _logEvent(
+      'subscription_cancel_reason',
+      parameters: {'reason': reason},
+    );
+  }
+
   // ---------------------------------------------------------------------------
   // Allergen tracker
   // ---------------------------------------------------------------------------

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1850,7 +1850,7 @@ packages:
     source: hosted
     version: "2.3.1"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   sign_in_with_apple: ^7.0.1
   supabase_flutter: ^2.0.0
   table_calendar: ^3.1.3
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/test/features/subscription/cancel/cancel_subscription_controller_test.dart
+++ b/test/features/subscription/cancel/cancel_subscription_controller_test.dart
@@ -1,0 +1,115 @@
+// NIB-82 — unit tests for CancelSubscriptionController.
+//
+// Asserts the deterministic side-effect ordering of `submit(reason)`:
+//   1. Sets isSubmitting=true.
+//   2. Logs both intent events with the stable `analyticsKey`.
+//   3. Awaits SubscriptionService.openManagementPage.
+//   4. Resets isSubmitting=false.
+//   5. Returns true on Success, false on Failure.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/services/subscription_service.dart';
+import 'package:nibbles/src/features/subscription/cancel/cancel_reason.dart';
+import 'package:nibbles/src/features/subscription/cancel/cancel_subscription_controller.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class _LaunchRecorder {
+  int calls = 0;
+  bool result = true;
+
+  Future<bool> call(Uri uri, {LaunchMode mode = LaunchMode.platformDefault}) {
+    calls += 1;
+    return Future.value(result);
+  }
+}
+
+ProviderContainer _container({
+  required FakeAnalytics analytics,
+  required _LaunchRecorder launcher,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      analyticsProvider.overrideWithValue(analytics),
+      subscriptionLaunchUrlProvider.overrideWithValue(launcher.call),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  test(
+    'submit returns true on launch success and logs both intent events',
+    () async {
+      final analytics = FakeAnalytics();
+      final launcher = _LaunchRecorder();
+      final container =
+          _container(analytics: analytics, launcher: launcher);
+
+      final controller =
+          container.read(cancelSubscriptionControllerProvider.notifier);
+      final ok = await controller.submit(CancelReason.achievedGoal);
+
+      expect(ok, isTrue);
+      expect(launcher.calls, 1);
+      expect(
+        analytics.eventNames,
+        containsAll(<String>[
+          'subscription_cancel_started',
+          'subscription_cancel_reason',
+        ]),
+      );
+      final started = analytics.calls
+          .firstWhere((c) => c.name == 'subscription_cancel_started');
+      expect(started.parameters['reason'], 'achieved_goal');
+      // Final state has isSubmitting reset.
+      expect(
+        container.read(cancelSubscriptionControllerProvider).isSubmitting,
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'submit returns false on launch failure and resets isSubmitting',
+    () async {
+      final analytics = FakeAnalytics();
+      final launcher = _LaunchRecorder()..result = false;
+      final container =
+          _container(analytics: analytics, launcher: launcher);
+
+      final controller =
+          container.read(cancelSubscriptionControllerProvider.notifier);
+      final ok = await controller.submit(CancelReason.other);
+
+      expect(ok, isFalse);
+      expect(launcher.calls, 1);
+      // Intent events still fired BEFORE the launch attempt.
+      expect(
+        analytics.eventNames,
+        contains('subscription_cancel_started'),
+      );
+      // Final state resets the flag.
+      expect(
+        container.read(cancelSubscriptionControllerProvider).isSubmitting,
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'all six CancelReason enum entries carry a unique snake_case analyticsKey',
+    () {
+      final keys =
+          CancelReason.values.map((r) => r.analyticsKey).toSet();
+      expect(keys.length, CancelReason.values.length);
+      for (final key in keys) {
+        expect(key, matches(RegExp(r'^[a-z][a-z_]*$')));
+      }
+    },
+  );
+}

--- a/test/features/subscription/cancel/cancel_subscription_overlay_test.dart
+++ b/test/features/subscription/cancel/cancel_subscription_overlay_test.dart
@@ -1,0 +1,281 @@
+// NIB-82 — widget tests for the cancel-subscription reason overlay.
+//
+// Covers:
+//   - Sheet renders verbatim heading (U+2019 apostrophe) on open.
+//   - Continue is disabled until a reason chip is tapped.
+//   - Tapping Continue:
+//       * fires `subscription_cancel_started` + `subscription_cancel_reason`
+//         with the stable `analyticsKey` (NOT the verbatim label).
+//       * calls SubscriptionService.openManagementPage (via the injected
+//         launcher fn — never hits the platform channel).
+//       * pops the sheet on success.
+//   - URL-open failure surfaces the P2 SnackBar and keeps the sheet open.
+//   - Cancel and close (X) pop the sheet without launching anything.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/services/subscription_service.dart';
+import 'package:nibbles/src/features/subscription/cancel/cancel_reason.dart';
+import 'package:nibbles/src/features/subscription/cancel/cancel_subscription_overlay.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../support/fake_analytics.dart';
+
+/// Verbatim sheet heading from Figma 1216:12029 (U+2019 apostrophe).
+const _kHeading = 'Tell us why you’re canceling';
+
+/// First reason label — verbatim from Figma 1216:12030.
+const _kFirstReasonLabel = 'I achieved my goal already';
+
+/// Stable analytics key for the first reason. MUST match the enum mapping in
+/// lib/src/features/subscription/cancel/cancel_reason.dart.
+const _kFirstReasonAnalyticsKey = 'achieved_goal';
+
+class _LaunchRecorder {
+  int calls = 0;
+  Uri? lastUri;
+  LaunchMode? lastMode;
+  bool result = true;
+
+  Future<bool> call(Uri uri, {LaunchMode mode = LaunchMode.platformDefault}) {
+    calls += 1;
+    lastUri = uri;
+    lastMode = mode;
+    return Future.value(result);
+  }
+}
+
+Widget _wrap(List<Override> overrides) {
+  return ProviderScope(
+    overrides: overrides,
+    child: MaterialApp(
+      home: Builder(
+        builder: (context) => Scaffold(
+          body: Center(
+            child: TextButton(
+              key: const Key('open_sheet'),
+              onPressed: () => showCancelSubscriptionOverlay(context),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _openSheet(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key('open_sheet')));
+  await tester.pumpAndSettle();
+}
+
+/// Default test surface is 800x600 — too short for the 92% bottom sheet to
+/// fit the chips + both CTAs. Bump to a tall portrait window large enough
+/// for everything to render on-screen.
+Future<void> _setTallSurface(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(400, 1200));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+}
+
+// 30s budget — tight enough to catch settle hangs introduced by future
+// changes to the deep-link wiring.
+const _testTimeout = Timeout(Duration(seconds: 30));
+
+void main() {
+  late FakeAnalytics fakeAnalytics;
+  late _LaunchRecorder launcher;
+
+  setUp(() {
+    fakeAnalytics = FakeAnalytics();
+    launcher = _LaunchRecorder();
+  });
+
+  List<Override> overrides() => [
+        analyticsProvider.overrideWithValue(fakeAnalytics),
+        subscriptionLaunchUrlProvider.overrideWithValue(launcher.call),
+      ];
+
+  testWidgets(
+    'renders verbatim heading + 6 reason chips on open',
+    (tester) async {
+      await _setTallSurface(tester);
+      await tester.pumpWidget(_wrap(overrides()));
+      await _openSheet(tester);
+
+      expect(find.text(_kHeading), findsOneWidget);
+      for (var i = 0; i < CancelReason.values.length; i++) {
+        expect(
+          find.byKey(Key('cancel_subscription_reason_$i')),
+          findsOneWidget,
+        );
+      }
+      // First reason label — verbatim from Figma.
+      expect(find.text(_kFirstReasonLabel), findsOneWidget);
+    },
+    timeout: _testTimeout,
+  );
+
+  testWidgets(
+    'Continue is disabled when no reason is selected',
+    (tester) async {
+      await _setTallSurface(tester);
+      await tester.pumpWidget(_wrap(overrides()));
+      await _openSheet(tester);
+
+      final continueBtn = tester.widget<AppPillButton>(
+        find.byKey(const Key('cancel_subscription_continue_button')),
+      );
+      expect(continueBtn.onPressed, isNull);
+    },
+    timeout: _testTimeout,
+  );
+
+  testWidgets(
+    'tapping a reason chip enables Continue',
+    (tester) async {
+      await _setTallSurface(tester);
+      await tester.pumpWidget(_wrap(overrides()));
+      await _openSheet(tester);
+
+      await tester.tap(find.byKey(const Key('cancel_subscription_reason_0')));
+      await tester.pumpAndSettle();
+
+      final continueBtn = tester.widget<AppPillButton>(
+        find.byKey(const Key('cancel_subscription_continue_button')),
+      );
+      expect(continueBtn.onPressed, isNotNull);
+    },
+    timeout: _testTimeout,
+  );
+
+  testWidgets(
+    'tapping Continue logs analytics with analyticsKey and launches URL',
+    (tester) async {
+      await _setTallSurface(tester);
+      await tester.pumpWidget(_wrap(overrides()));
+      await _openSheet(tester);
+
+      await tester.tap(find.byKey(const Key('cancel_subscription_reason_0')));
+      await tester.pump();
+
+      await tester.ensureVisible(
+        find.byKey(const Key('cancel_subscription_continue_button')),
+      );
+      await tester.pump();
+
+      await tester.tap(
+        find.byKey(const Key('cancel_subscription_continue_button')),
+      );
+      await tester.pumpAndSettle();
+
+      // Both intent events fire BEFORE the launch.
+      expect(
+        fakeAnalytics.eventNames,
+        containsAll(<String>[
+          'subscription_cancel_started',
+          'subscription_cancel_reason',
+        ]),
+      );
+      final startedEvt = fakeAnalytics.calls
+          .firstWhere((c) => c.name == 'subscription_cancel_started');
+      expect(startedEvt.parameters['reason'], _kFirstReasonAnalyticsKey);
+      final reasonEvt = fakeAnalytics.calls
+          .firstWhere((c) => c.name == 'subscription_cancel_reason');
+      expect(reasonEvt.parameters['reason'], _kFirstReasonAnalyticsKey);
+
+      // Launcher hit exactly once, in externalApplication mode.
+      expect(launcher.calls, 1);
+      expect(launcher.lastMode, LaunchMode.externalApplication);
+      expect(launcher.lastUri, isNotNull);
+
+      // Sheet popped on success.
+      expect(find.text(_kHeading), findsNothing);
+    },
+    timeout: _testTimeout,
+  );
+
+  testWidgets(
+    'URL-open failure surfaces P2 SnackBar and keeps sheet open',
+    (tester) async {
+      launcher.result = false;
+      await _setTallSurface(tester);
+      await tester.pumpWidget(_wrap(overrides()));
+      await _openSheet(tester);
+
+      await tester.tap(find.byKey(const Key('cancel_subscription_reason_0')));
+      await tester.pump();
+
+      await tester.ensureVisible(
+        find.byKey(const Key('cancel_subscription_continue_button')),
+      );
+      await tester.pump();
+
+      await tester.tap(
+        find.byKey(const Key('cancel_subscription_continue_button')),
+      );
+      await tester.pumpAndSettle();
+
+      // Sheet remains open so the user can retry.
+      expect(find.text(_kHeading), findsOneWidget);
+      // Verbatim P2 toast copy.
+      expect(
+        find.text("Couldn't open subscription settings. Try again."),
+        findsOneWidget,
+      );
+    },
+    timeout: _testTimeout,
+  );
+
+  testWidgets(
+    'tapping Cancel pops the sheet without launching anything',
+    (tester) async {
+      await _setTallSurface(tester);
+      await tester.pumpWidget(_wrap(overrides()));
+      await _openSheet(tester);
+
+      expect(find.text(_kHeading), findsOneWidget);
+
+      await tester.ensureVisible(
+        find.byKey(const Key('cancel_subscription_cancel_button')),
+      );
+      await tester.pump();
+
+      await tester.tap(
+        find.byKey(const Key('cancel_subscription_cancel_button')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(_kHeading), findsNothing);
+      expect(launcher.calls, 0);
+      // Cancel must NOT have fired the intent events.
+      expect(
+        fakeAnalytics.eventNames,
+        isNot(contains('subscription_cancel_started')),
+      );
+    },
+    timeout: _testTimeout,
+  );
+
+  testWidgets(
+    'close (X) pops the sheet without launching anything',
+    (tester) async {
+      await _setTallSurface(tester);
+      await tester.pumpWidget(_wrap(overrides()));
+      await _openSheet(tester);
+
+      expect(find.text(_kHeading), findsOneWidget);
+
+      await tester.tap(
+        find.byKey(const Key('cancel_subscription_close_button')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(_kHeading), findsNothing);
+      expect(launcher.calls, 0);
+    },
+    timeout: _testTimeout,
+  );
+}

--- a/test/features/subscription/manage/manage_subscription_screen_test.dart
+++ b/test/features/subscription/manage/manage_subscription_screen_test.dart
@@ -222,9 +222,11 @@ void main() {
   );
 
   testWidgets(
-    'subscribed: tapping "Cancel Subscription" surfaces the NIB-82 placeholder',
+    'subscribed: tapping "Cancel Subscription" surfaces the NIB-82 overlay',
     (tester) async {
-      await tester.binding.setSurfaceSize(const Size(400, 1000));
+      // Tall surface so the bottom sheet (92% of viewport) fits the chips
+      // and both CTAs without scrolling.
+      await tester.binding.setSurfaceSize(const Size(400, 1200));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
       await tester.pumpWidget(
@@ -248,10 +250,12 @@ void main() {
 
       await tester
           .tap(find.byKey(const Key('manage_subscription_cancel_cta')));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
+      // Verbatim sheet heading from Figma 1216:12029 (U+2019 apostrophe).
+      expect(find.text('Tell us why you’re canceling'), findsOneWidget);
       expect(
-        find.textContaining('Cancel subscription flow coming soon'),
+        find.byKey(const Key('cancel_subscription_continue_button')),
         findsOneWidget,
       );
     },

--- a/test/features/subscription/success/subscription_success_screen_test.dart
+++ b/test/features/subscription/success/subscription_success_screen_test.dart
@@ -9,6 +9,8 @@
 // `subscriptionServiceProvider` is overridden via Riverpod (no RC dependency)
 // and durations are advanced via `tester.pump` so the suite is deterministic.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -36,7 +38,8 @@ GoRouter _routerFor(Widget screen) => GoRouter(
     GoRoute(
       path: AppRoute.home.path,
       name: AppRoute.home.name,
-      builder: (_, __) => const Scaffold(body: Center(child: Text('HOME_STUB'))),
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text('HOME_STUB'))),
     ),
   ],
 );
@@ -153,7 +156,7 @@ void main() {
 
       // Attempt to pop from the GoRouter API — the wrapping PopScope sets
       // canPop=false, so the screen stays on the success route.
-      router.routerDelegate.popRoute();
+      unawaited(router.routerDelegate.popRoute());
       await tester.pump();
 
       expect(

--- a/test/support/fake_analytics.dart
+++ b/test/support/fake_analytics.dart
@@ -98,6 +98,14 @@ class FakeAnalytics implements Analytics {
       _record('plan_selected', {'period': period});
 
   @override
+  Future<void> logSubscriptionCancelStarted({required String reason}) async =>
+      _record('subscription_cancel_started', {'reason': reason});
+
+  @override
+  Future<void> logSubscriptionCancelReason({required String reason}) async =>
+      _record('subscription_cancel_reason', {'reason': reason});
+
+  @override
   Future<void> logAllergenLogCreated({
     required String allergenKey,
     bool hasAttachment = false,


### PR DESCRIPTION
## What

Cancel-subscription reason picker bottom sheet — surfaced when the user taps **Cancel Subscription** on the Manage Subscription screen. Replaces the placeholder snackbar introduced in NIB-73.

## Figma source

- Section: Cancel Subscription (1207:14533)
- Frame: Overlay delete account (1216:12019)
- Audit: `.figma-audit/subscription-cancel/overlay-delete-account/`
  - `report.md`, `screenshot.png`, `design_context.md`, `variables.json`

## Flow

1. User taps **Cancel Subscription** on Manage Subscription.
2. `showCancelSubscriptionOverlay` opens the modal sheet.
3. User picks one of 6 reason chips (single-select, sage tint/border selected state).
4. **Continue** fires `subscription_cancel_started` + `subscription_cancel_reason` (PII-free `analyticsKey`), then deep-links to the OS-managed subscription page via `url_launcher` (apps cannot programmatically cancel App Store / Play subs).
5. **Cancel** / **X** / scrim tap dismisses with no side effects.
6. URL-open failure → P2 SnackBar (`"Couldn't open subscription settings. Try again."`) and the sheet stays open for retry.

## Architecture

- `CancelReason` enum: verbatim Figma label + stable snake_case `analyticsKey`. Keeps trailing-space / double-space / curly-apostrophe verbatim copy out of analytics dashboards.
- `CancelSubscriptionController` (Riverpod AsyncNotifier): logs analytics → calls `SubscriptionService.openManagementPage()` → returns Result-derived bool.
- `SubscriptionService.openManagementPage()`: new RC seam. Resolves the platform-default management URL (https Apple / Play store) and routes through an injectable `subscriptionLaunchUrlProvider` so tests never hit the platform channel.
- `CancelReasonChip`: scoped chip with sage selected state (`greenTint` fill + `green` 1.5px border + `greenDeep` label) — distinct from NIB-78's butter-deepening delete-account chip.

## Verbatim copy preserved (per audit)

- "Tell us why you're canceling" — U+2019 curly apostrophe
- "The plan is out of my price range " — trailing space
- "I didn't find subscription plan features valuable " — U+2019 + trailing space
- "I subscribed by  accident" — double space
- "I no longer need meal recommendations"
- "Other"

## Acceptance criteria

- [x] Verbatim copy exact (U+2019 apostrophes, trailing spaces, double space)
- [x] 6 selectable reason chips with sage tint/border selected state (engineering-defined, per ticket AC)
- [x] Continue logs the chosen reason (PII-free analyticsKey) and opens the store-managed subscription page
- [x] Cancel / close X dismiss cleanly with no side effects
- [x] URL-open failure shows the P2 SnackBar
- [x] All tokens consumed from the design system; no new hex constants outside foundation
- [x] `flutter analyze` clean; widget + controller tests for the populated state and failure path
- [x] Pre-existing manage_subscription_screen_test placeholder assertion updated to assert the new overlay heading

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test` — 516/516 pass (3 new controller tests, 7 new overlay widget tests)
- [ ] Manual on simulator: tap Cancel Subscription → pick "Other" → Continue opens the App Store subscription page

## Files touched

**New:**
- `lib/src/features/subscription/cancel/cancel_reason.dart`
- `lib/src/features/subscription/cancel/cancel_subscription_controller.dart` (+ `.g.dart`)
- `lib/src/features/subscription/cancel/cancel_subscription_overlay.dart`
- `lib/src/features/subscription/cancel/cancel_subscription_state.dart` (+ `.freezed.dart`)
- `lib/src/features/subscription/cancel/widgets/cancel_reason_chip.dart`
- `test/features/subscription/cancel/cancel_subscription_controller_test.dart`
- `test/features/subscription/cancel/cancel_subscription_overlay_test.dart`

**Modified:**
- `lib/src/common/services/subscription_service.dart` (+ `.g.dart`) — adds `openManagementPage()` + injectable launcher
- `lib/src/features/subscription/manage/manage_subscription_screen.dart` — replaces placeholder snackbar with overlay
- `lib/src/logging/analytics.dart` — adds `logSubscriptionCancelStarted` / `logSubscriptionCancelReason`
- `test/support/fake_analytics.dart` — mirrors the new analytics methods
- `test/features/subscription/manage/manage_subscription_screen_test.dart` — updates placeholder assertion
- `test/features/subscription/success/subscription_success_screen_test.dart` — drive-by analyze fixes (pre-existing line-length + unawaited_futures)
- `pubspec.yaml` + `pubspec.lock` — promotes `url_launcher` from transitive to direct