### PR TITLE
fix(onboarding): rebuild intro carousel to Figma spec — verbatim copy, bottom back+Let's Go row, 10s auto-rotate [NIB-60]

### DIFF
--- a/lib/src/features/onboarding/intro/onboarding_intro_screen.dart
+++ b/lib/src/features/onboarding/intro/onboarding_intro_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -6,14 +8,26 @@ import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
+import 'package:nibbles/src/common/components/controls/app_checkbox.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Intro carousel — 3 butter-gradient slides with device-mockup illustrations.
+/// Pre-auth value-prop carousel — 3 device-mockup slides per NIB-60.
 ///
-/// Per NIB-60: butter-soft -> cream gradient bg, title2 heading, body sub,
-/// AppPillButton sage primary CTA, AppRoundButton butter back. Inline dot
-/// indicator (sage greenDeep widened pill on active). Last slide advances to
-/// /onboarding/name (route hoisted by NIB-51).
+/// Layout per Figma frames 971:10019 / 1242:10897 / 1242:11124:
+///   - shared eyebrow "We'll Help You with" + per-slide Parkinsans bold title
+///   - phone-mockup illustration placeholder (real SVGs pending NIB-138)
+///   - per-slide Figtree body copy (verbatim from spec; slide-3 duplicates
+///     slide-2 body per audit — PO open question, do not paraphrase)
+///   - bottom row: lime round back-arrow + forestDarkn "Let's Go" pill,
+///     always visible (back is no-op on slide 1).
+///
+/// Behavior:
+///   - PageView of 3 slides; auto-advance every 10s while no user interaction
+///   - dot indicator (active = greenDeep / forestDarkn widened pill) stays
+///     in sync with the live page index
+///   - "Let's Go" on slides 1/2 advances PageView; on slide 3 it flips
+///     app_has_launched and pushes /auth/login
 class OnboardingIntroScreen extends ConsumerStatefulWidget {
   const OnboardingIntroScreen({super.key});
 
@@ -23,53 +37,90 @@ class OnboardingIntroScreen extends ConsumerStatefulWidget {
 }
 
 class _OnboardingIntroScreenState extends ConsumerState<OnboardingIntroScreen> {
+  // Verbatim copy from .figma-audit/onboarding/{meal-prep-guidance,
+  // grocery-shopping,recipes-meal-planning}/report.md. Straight apostrophes
+  // intentional (ticket explicit). Slide-3 body duplicates slide-2 — flagged
+  // as PO open question on NIB-60.
   static const _slides = <_IntroSlideData>[
     _IntroSlideData(
       title: 'Meal Prep Guidance',
-      subtitle:
-          'Step-by-step guidance to plan, prep, and serve baby-safe meals '
-          'with confidence.',
+      body: "We'll help you plan, prepare, and stay consistent with "
+          'smarter daily meal choices.',
     ),
     _IntroSlideData(
       title: 'Grocery Shopping',
-      subtitle:
-          'Auto-generated shopping lists from your meal plan, organized by '
-          'aisle so nothing gets missed.',
+      body: "We'll help you organize your grocery shopping based on your "
+          'meal plan, preferences, and daily needs.',
     ),
     _IntroSlideData(
       title: 'Recipes & Meal Planning',
-      subtitle:
-          'A library of age-appropriate recipes, ready to drop into a weekly '
-          'plan tailored to your baby.',
+      body: "We'll help you organize your grocery shopping based on your "
+          'meal plan, preferences, and daily needs.',
     ),
   ];
 
+  static const Duration _autoAdvanceInterval = Duration(seconds: 10);
+  static const Duration _pageAnimDuration = Duration(milliseconds: 280);
+
   final _pageController = PageController();
   int _currentPage = 0;
+  Timer? _autoAdvanceTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleAutoAdvance();
+  }
 
   @override
   void dispose() {
+    _autoAdvanceTimer?.cancel();
     _pageController.dispose();
     super.dispose();
   }
 
   bool get _isLast => _currentPage == _slides.length - 1;
 
-  void _onPrimaryPressed() {
+  void _scheduleAutoAdvance() {
+    _autoAdvanceTimer?.cancel();
+    // Last slide does not auto-advance — never auto-navigate into auth.
+    if (_isLast) return;
+    _autoAdvanceTimer = Timer(_autoAdvanceInterval, _advanceFromTimer);
+  }
+
+  void _advanceFromTimer() {
+    if (!mounted || _isLast) return;
+    _pageController.nextPage(
+      duration: _pageAnimDuration,
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _onPageChanged(int page) {
+    setState(() => _currentPage = page);
+    _scheduleAutoAdvance();
+  }
+
+  Future<void> _onPrimaryPressed() async {
+    _autoAdvanceTimer?.cancel();
     if (_isLast) {
-      context.goNamed(AppRoute.onboardingName.name);
+      // Ensure GoRouter redirect step 1 doesn't bounce us back to intro.
+      ref.read(localFlagServiceProvider).setHasLaunched();
+      if (!mounted) return;
+      context.goNamed(AppRoute.login.name);
       return;
     }
-    _pageController.nextPage(
-      duration: const Duration(milliseconds: 280),
+    await _pageController.nextPage(
+      duration: _pageAnimDuration,
       curve: Curves.easeInOut,
     );
   }
 
   void _onBackPressed() {
     if (_currentPage == 0) return;
+    _autoAdvanceTimer?.cancel();
     _pageController.previousPage(
-      duration: const Duration(milliseconds: 280),
+      duration: _pageAnimDuration,
       curve: Curves.easeInOut,
     );
   }
@@ -79,6 +130,7 @@ class _OnboardingIntroScreenState extends ConsumerState<OnboardingIntroScreen> {
     return Scaffold(
       body: DecoratedBox(
         decoration: const BoxDecoration(
+          // Grad-1 ≈ butter-soft -> cream top->bottom per design_context.md.
           gradient: LinearGradient(
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
@@ -88,26 +140,31 @@ class _OnboardingIntroScreenState extends ConsumerState<OnboardingIntroScreen> {
         child: SafeArea(
           child: Column(
             children: [
-              _TopBar(
-                showBack: _currentPage > 0,
-                onBack: _onBackPressed,
-              ),
               Expanded(
-                child: PageView.builder(
-                  controller: _pageController,
-                  itemCount: _slides.length,
-                  onPageChanged: (page) => setState(() => _currentPage = page),
-                  itemBuilder: (context, index) => _IntroSlide(
-                    data: _slides[index],
-                    slideIndex: index,
+                child: NotificationListener<ScrollNotification>(
+                  onNotification: (n) {
+                    // Pause auto-advance while the user is dragging.
+                    if (n is ScrollStartNotification) {
+                      _autoAdvanceTimer?.cancel();
+                    }
+                    return false;
+                  },
+                  child: PageView.builder(
+                    controller: _pageController,
+                    itemCount: _slides.length,
+                    onPageChanged: _onPageChanged,
+                    itemBuilder: (context, index) => _IntroSlide(
+                      data: _slides[index],
+                      slideIndex: index,
+                    ),
                   ),
                 ),
               ),
               _BottomSection(
                 currentPage: _currentPage,
                 slideCount: _slides.length,
-                primaryLabel: _isLast ? "Let's Go" : 'Continue',
                 onPrimary: _onPrimaryPressed,
+                onBack: _onBackPressed,
               ),
             ],
           ),
@@ -118,46 +175,10 @@ class _OnboardingIntroScreenState extends ConsumerState<OnboardingIntroScreen> {
 }
 
 class _IntroSlideData {
-  const _IntroSlideData({required this.title, required this.subtitle});
+  const _IntroSlideData({required this.title, required this.body});
 
   final String title;
-  final String subtitle;
-}
-
-class _TopBar extends StatelessWidget {
-  const _TopBar({required this.showBack, required this.onBack});
-
-  final bool showBack;
-  final VoidCallback onBack;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSizes.pagePaddingH,
-        AppSizes.md,
-        AppSizes.pagePaddingH,
-        0,
-      ),
-      child: Row(
-        children: [
-          AnimatedOpacity(
-            duration: const Duration(milliseconds: 200),
-            opacity: showBack ? 1 : 0,
-            child: IgnorePointer(
-              ignoring: !showBack,
-              child: AppRoundButton(
-                icon: const Icon(Icons.arrow_back),
-                tone: AppRoundButtonTone.butter,
-                onPressed: onBack,
-                semanticLabel: 'Back',
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
+  final String body;
 }
 
 class _IntroSlide extends StatelessWidget {
@@ -166,36 +187,57 @@ class _IntroSlide extends StatelessWidget {
   final _IntroSlideData data;
   final int slideIndex;
 
+  static const _eyebrow = "We'll Help You with";
+
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    // Title 1/Bold per variables.json — Parkinsans 22/34 (height 1.5454…).
+    final titleStyle = textTheme.titleLarge?.copyWith(
+      color: AppColors.text,
+      height: 34 / 22,
+    );
+    // Body/Regular per variables.json — Figtree 15/22 (height 1.4666…).
+    final bodyStyle = textTheme.bodyLarge?.copyWith(
+      color: AppColors.text,
+      height: 22 / 15,
+    );
+
     return Padding(
       padding: const EdgeInsets.symmetric(
         horizontal: AppSizes.pagePaddingH,
         vertical: AppSizes.lg,
       ),
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
         children: [
+          // Headline block — eyebrow + per-slide title, centered, top of slide.
+          Text(
+            _eyebrow,
+            textAlign: TextAlign.center,
+            style: titleStyle,
+          ),
+          Text(
+            data.title,
+            textAlign: TextAlign.center,
+            style: titleStyle,
+          ),
+          if (slideIndex == 1) ...[
+            const SizedBox(height: AppSizes.xl),
+            const _AppleShoplistRow(),
+          ],
           Expanded(
             child: Center(
               child: _DeviceMockupPlaceholder(slideIndex: slideIndex),
             ),
           ),
-          const SizedBox(height: AppSizes.xl),
-          Text(
-            data.title,
-            textAlign: TextAlign.center,
-            style: textTheme.headlineSmall?.copyWith(
-              color: AppColors.greenDeep,
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.sm,
             ),
-          ),
-          const SizedBox(height: AppSizes.sp12),
-          Text(
-            data.subtitle,
-            textAlign: TextAlign.center,
-            style: textTheme.bodyLarge?.copyWith(
-              color: AppColors.fgDefault,
+            child: Text(
+              data.body,
+              textAlign: TextAlign.center,
+              style: bodyStyle,
             ),
           ),
           const SizedBox(height: AppSizes.md),
@@ -205,24 +247,68 @@ class _IntroSlide extends StatelessWidget {
   }
 }
 
-/// Styled placeholder for the device-frame illustration.
-// TODO(NIB-60): replace with device-frame illustration from Figma export
+/// Slide-2 animated shoplist demo row — checkbox + "Apple" + cancel chip on
+/// `#fffeea`. Spec source: grocery-shopping/report.md "Shoplist-animation".
+class _AppleShoplistRow extends StatelessWidget {
+  const _AppleShoplistRow();
+
+  // Spec literal — `bg #fffeea` per audit. No matching token in app_colors.
+  static const Color _bg = Color(0xFFFFFEEA);
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Container(
+      key: const Key('onboarding_intro_apple_row'),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md,
+        vertical: AppSizes.sp12,
+      ),
+      decoration: BoxDecoration(
+        color: _bg,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+      ),
+      child: Row(
+        children: [
+          AppCheckbox(value: false, onChanged: (_) {}),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Text(
+              'Apple',
+              style: textTheme.bodyLarge?.copyWith(color: AppColors.text),
+            ),
+          ),
+          const Icon(
+            Icons.cancel,
+            color: AppColors.destructive,
+            size: AppSizes.iconMd,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Styled placeholder for the phone-frame illustration. Real SVG export is
+/// tracked under NIB-138 (Backlog) — we ship the placeholder now so the
+/// carousel structure + copy match the spec, and swap visuals when the
+/// asset import lands.
 class _DeviceMockupPlaceholder extends StatelessWidget {
   const _DeviceMockupPlaceholder({required this.slideIndex});
 
   final int slideIndex;
 
   static const _accents = <Color>[
-    AppColors.coralSoft,
-    AppColors.greenTint,
     AppColors.butter,
+    AppColors.greenTint,
+    AppColors.coralSoft,
   ];
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        // Device-frame mockup proportions ~ iPhone 9:19.5.
+        // Device-frame proportions ~ iPhone 9:19.5.
         final maxWidth = constraints.maxWidth;
         final maxHeight = constraints.maxHeight;
         final widthFromHeight = maxHeight * 9 / 19.5;
@@ -267,14 +353,14 @@ class _BottomSection extends StatelessWidget {
   const _BottomSection({
     required this.currentPage,
     required this.slideCount,
-    required this.primaryLabel,
     required this.onPrimary,
+    required this.onBack,
   });
 
   final int currentPage;
   final int slideCount;
-  final String primaryLabel;
   final VoidCallback onPrimary;
+  final VoidCallback onBack;
 
   @override
   Widget build(BuildContext context) {
@@ -292,9 +378,24 @@ class _BottomSection extends StatelessWidget {
             currentIndex: currentPage,
           ),
           const SizedBox(height: AppSizes.lg),
-          AppPillButton(
-            label: primaryLabel,
-            onPressed: onPrimary,
+          Row(
+            children: [
+              AppRoundButton(
+                key: const Key('onboarding_intro_back'),
+                icon: const Icon(Icons.arrow_back),
+                tone: AppRoundButtonTone.butter,
+                onPressed: onBack,
+                semanticLabel: 'Back',
+              ),
+              const SizedBox(width: AppSizes.sp12),
+              Expanded(
+                child: AppPillButton(
+                  key: const Key('onboarding_intro_primary'),
+                  label: "Let's Go",
+                  onPressed: onPrimary,
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -302,7 +403,7 @@ class _BottomSection extends StatelessWidget {
   }
 }
 
-/// Inline animated dot indicator. Active dot widens into a sage pill.
+/// Inline animated dot indicator. Active dot widens into a forestDarkn pill.
 /// Spec forbids extracting this into a shared widget.
 class _DotIndicator extends StatelessWidget {
   const _DotIndicator({
@@ -320,6 +421,7 @@ class _DotIndicator extends StatelessWidget {
       children: List<Widget>.generate(count, (i) {
         final active = i == currentIndex;
         return AnimatedContainer(
+          key: Key('onboarding_intro_dot_$i'),
           duration: const Duration(milliseconds: 240),
           curve: Curves.easeOut,
           margin: const EdgeInsets.symmetric(horizontal: AppSizes.xs),

--- a/test/features/onboarding/intro/onboarding_intro_screen_test.dart
+++ b/test/features/onboarding/intro/onboarding_intro_screen_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/onboarding/intro/onboarding_intro_screen.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+class _MockLocalFlagService extends Mock implements LocalFlagService {}
+
+/// NIB-60 — widget tests for `OnboardingIntroScreen`.
+///
+/// Pins:
+///   - Verbatim slide copy (eyebrow + per-slide title/body) — protects against
+///     paraphrase drift on the audit-source-of-truth spec.
+///   - "Let's Go" is the CTA on ALL three slides (not "Continue").
+///   - Dot indicator stays in sync with the live PageView page.
+///   - Slide-1 back-arrow is a visible no-op (no nav happens).
+///   - Last-slide "Let's Go" calls `setHasLaunched()` AND routes to /auth/login.
+GoRouter _routerFor(Widget screen) => GoRouter(
+  initialLocation: AppRoute.onboardingIntro.path,
+  routes: [
+    GoRoute(
+      path: AppRoute.onboardingIntro.path,
+      name: AppRoute.onboardingIntro.name,
+      builder: (_, __) => screen,
+    ),
+    GoRoute(
+      path: AppRoute.login.path,
+      name: AppRoute.login.name,
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text('LOGIN_STUB'))),
+    ),
+  ],
+);
+
+Widget _wrap(Widget screen, List<Override> overrides) => ProviderScope(
+  overrides: overrides,
+  child: MaterialApp.router(routerConfig: _routerFor(screen)),
+);
+
+void main() {
+  late _MockLocalFlagService mockFlags;
+
+  setUp(() {
+    mockFlags = _MockLocalFlagService();
+    when(mockFlags.setHasLaunched).thenAnswer((_) {});
+  });
+
+  List<Override> overrides() => [
+    localFlagServiceProvider.overrideWithValue(mockFlags),
+  ];
+
+  Color dotColor(WidgetTester tester, int index) {
+    final box = tester.widget<AnimatedContainer>(
+      find.byKey(Key('onboarding_intro_dot_$index')),
+    );
+    final decoration = box.decoration! as BoxDecoration;
+    return decoration.color!;
+  }
+
+  testWidgets(
+    'renders eyebrow + slide-1 verbatim copy + "Let\'s Go" CTA on first paint',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(const OnboardingIntroScreen(), overrides()),
+      );
+      await tester.pumpAndSettle();
+
+      // Eyebrow text repeats on every slide — only one is mounted at a time.
+      expect(find.text("We'll Help You with"), findsOneWidget);
+      expect(find.text('Meal Prep Guidance'), findsOneWidget);
+      expect(
+        find.text(
+          "We'll help you plan, prepare, and stay consistent with smarter "
+          'daily meal choices.',
+        ),
+        findsOneWidget,
+      );
+
+      // CTA label is "Let's Go" — not "Continue".
+      final primary = tester.widget<AppPillButton>(
+        find.byKey(const Key('onboarding_intro_primary')),
+      );
+      expect(primary.label, "Let's Go");
+
+      // Back-arrow is always rendered (no-op on slide 1).
+      expect(find.byKey(const Key('onboarding_intro_back')), findsOneWidget);
+    },
+  );
+
+  testWidgets('tapping "Let\'s Go" on slide 1 advances to slide 2', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(const OnboardingIntroScreen(), overrides()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboarding_intro_primary')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Grocery Shopping'), findsOneWidget);
+    // Slide-2 "Apple" shoplist row is part of the verbatim spec.
+    expect(find.byKey(const Key('onboarding_intro_apple_row')), findsOneWidget);
+    expect(find.text('Apple'), findsOneWidget);
+
+    // CTA label stays "Let's Go" across slides.
+    final primary = tester.widget<AppPillButton>(
+      find.byKey(const Key('onboarding_intro_primary')),
+    );
+    expect(primary.label, "Let's Go");
+  });
+
+  testWidgets('dot indicator widens the active dot in sync with the page', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(const OnboardingIntroScreen(), overrides()));
+    await tester.pumpAndSettle();
+
+    // Page 0: dot 0 is the wide pill (greenDeep), 1 and 2 are muted dots.
+    expect(dotColor(tester, 0), AppColors.greenDeep);
+    expect(dotColor(tester, 1), AppColors.borderMuted);
+    expect(dotColor(tester, 2), AppColors.borderMuted);
+
+    // Advance to page 2 — dots shift, dot 2 becomes the active pill.
+    await tester.tap(find.byKey(const Key('onboarding_intro_primary')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboarding_intro_primary')));
+    await tester.pumpAndSettle();
+
+    expect(dotColor(tester, 0), AppColors.borderMuted);
+    expect(dotColor(tester, 1), AppColors.borderMuted);
+    expect(dotColor(tester, 2), AppColors.greenDeep);
+  });
+
+  testWidgets(
+    'back-arrow on slide 1 is a no-op (button rendered, page does not change)',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(const OnboardingIntroScreen(), overrides()),
+      );
+      await tester.pumpAndSettle();
+
+      // Sanity — slide 1 visible.
+      expect(find.text('Meal Prep Guidance'), findsOneWidget);
+
+      // Button exists and is hit-testable; tap.
+      final back = find.byKey(const Key('onboarding_intro_back'));
+      expect(back, findsOneWidget);
+      final btn = tester.widget<AppRoundButton>(back);
+      expect(btn.tone, AppRoundButtonTone.butter);
+      await tester.tap(back);
+      await tester.pumpAndSettle();
+
+      // Still on slide 1.
+      expect(find.text('Meal Prep Guidance'), findsOneWidget);
+      expect(find.text('Grocery Shopping'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'last-slide "Let\'s Go" flips app_has_launched and routes to /auth/login',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(const OnboardingIntroScreen(), overrides()),
+      );
+      await tester.pumpAndSettle();
+
+      // Advance twice to land on slide 3.
+      await tester.tap(find.byKey(const Key('onboarding_intro_primary')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('onboarding_intro_primary')));
+      await tester.pumpAndSettle();
+      expect(find.text('Recipes & Meal Planning'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('onboarding_intro_primary')));
+      await tester.pumpAndSettle();
+
+      verify(mockFlags.setHasLaunched).called(1);
+      expect(find.text('LOGIN_STUB'), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Rebuild the pre-auth `OnboardingIntroScreen` (NIB-60) to match the canonical Figma audit:

- Shared eyebrow "We'll Help You with" + per-slide Parkinsans Bold title (Meal Prep Guidance / Grocery Shopping / Recipes & Meal Planning).
- Verbatim Figtree body copy per slide (slide-3 deliberately duplicates slide-2 — flagged as PO open question on the ticket, NOT paraphrased here).
- "Let's Go" CTA on every slide (previously paraphrased to "Continue" on non-last).
- Bottom row: lime round back-arrow + forestDarkn pill, always visible (back is a no-op on slide 1).
- Slide-2 animated `Apple` shoplist row on `#fffeea` per audit.
- Heading color set to `AppColors.text` (charcoal) to match the screenshot — was `greenDeep`.
- 10s auto-advance timer; pauses on swipe; clamps at the last slide so it never auto-navigates into auth.
- Last-slide "Let's Go" calls `LocalFlagService.setHasLaunched()` then `context.goNamed(login)` — prevents the redirect from bouncing the user back into intro.

## Figma frames

- Slide 1 — Meal Prep Guidance: `971:10019`
- Slide 2 — Grocery Shopping: `1242:10897`
- Slide 3 — Recipes & Meal Planning: `1242:11124`

## Audit artifacts

- `.figma-audit/onboarding/meal-prep-guidance/`
- `.figma-audit/onboarding/grocery-shopping/`
- `.figma-audit/onboarding/recipes-meal-planning/`

## Acceptance criteria

- [x] Verbatim copy across all 3 slides (straight apostrophe in "We'll", duplicate slide-3 body left in place per PO open question)
- [x] "Let's Go" CTA wired (advance on slides 1/2, navigate to `/auth/login` on slide 3)
- [x] Back-arrow wired (no-op on slide 1)
- [x] Swipe wired (PageView)
- [x] Auto-rotate every 10s, pauses on user interaction, clamps at last slide
- [x] Dot indicator stays in sync with current slide (active = forestDarkn widened pill)
- [x] All colors/typography/spacing routed through `AppColors` / `AppSizes` / `AppTypography`; only the `#fffeea` Apple-row bg is a spec literal (no matching app token)
- [x] `flutter analyze` clean (0 issues)
- [x] Widget tests cover: verbatim copy, slide advance, dot sync, back no-op, last-slide nav + flag flip

## PO open questions surfaced by audit (carried over from ticket)

- Slide-3 body verbatim duplicates slide-2 body — flagged, not auto-fixed.
- Phone-mockup illustration SVGs are not yet exported (NIB-138 in Backlog). Shipping the existing styled placeholder; the "Apple" chip + all text + dots are real.

## Test plan

- [x] `make gen` clean (no unrelated regen)
- [x] `flutter analyze` clean
- [x] `flutter test` full suite green (524 passing, 1 pre-existing skip)
- [x] Targeted: `flutter test test/features/onboarding/intro/onboarding_intro_screen_test.dart` (5/5 pass)