### PR TITLE
fix(onboarding): consent verbatim copy + bottom-row back button + shared PetalBlob [NIB-100]

### DIFF
--- a/lib/src/common/components/brand/petal_blob.dart
+++ b/lib/src/common/components/brand/petal_blob.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+
+/// Layered brand petal cluster — pale-butter outer quatrefoil, sage inner
+/// quatrefoil and a soft butter glow dot at the core. Mirrors the Figma
+/// `LoadingAnimation` frame shared across the baby-setup loading screen
+/// (NIB-131) and the consent / housekeeping screen (NIB-100).
+///
+/// Stateless and presentational — callers wrap it in their own layout.
+class PetalBlob extends StatelessWidget {
+  const PetalBlob({
+    this.size = AppSizes.avatarXl * 1.84,
+    super.key,
+  });
+
+  /// Outer diameter. Inner quatrefoil scales to ~52% (matches the audit
+  /// snapshot) and the glow dot scales relative to that.
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final innerSize = size * (96 / 184);
+    final glowSize = size * (16.8 / 184);
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          // Outer pale-butter petal blob (spec petal layer 1+2 composite).
+          Quatrefoil(
+            size: size,
+            coreColor: AppColors.butter,
+          ),
+          // Inner sage petal — smaller, scales down to ~52% of outer.
+          Quatrefoil(
+            size: innerSize,
+            petalColor: AppColors.green,
+            coreColor: AppColors.greenDeep,
+          ),
+          // Soft butter glow dot at the center (spec blurred lime dot).
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: AppColors.butter,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: AppColors.butter.withValues(alpha: 0.9),
+                  blurRadius: AppSizes.sm,
+                  spreadRadius: AppSizes.xs,
+                ),
+              ],
+            ),
+            child: SizedBox(width: glowSize, height: glowSize),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/common/components/brand/petal_blob.dart
+++ b/lib/src/common/components/brand/petal_blob.dart
@@ -21,8 +21,15 @@ class PetalBlob extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final innerSize = size * (96 / 184);
-    final glowSize = size * (16.8 / 184);
+    // Ratios are anchored to the original loading-screen geometry — outer
+    // 220.8 (avatarXl*1.84), inner 115.2 (avatarXl*0.96), glow 16.8 (sp12*1.4).
+    // Computed from the outer so other call sites that pass a custom [size]
+    // scale linearly without drifting against the NIB-131 baseline.
+    const baseOuter = AppSizes.avatarXl * 1.84;
+    const baseInner = AppSizes.avatarXl * 0.96;
+    const baseGlow = AppSizes.sp12 * 1.4;
+    final innerSize = size * (baseInner / baseOuter);
+    final glowSize = size * (baseGlow / baseOuter);
 
     return SizedBox(
       width: size,

--- a/lib/src/common/components/components.dart
+++ b/lib/src/common/components/components.dart
@@ -3,6 +3,7 @@
 library;
 
 export 'brand/brand_logo.dart';
+export 'brand/petal_blob.dart';
 export 'brand/quatrefoil.dart';
 export 'buttons/app_pill_button.dart';
 export 'buttons/app_round_button.dart';

--- a/lib/src/common/components/feedback/loading_confirmation.dart
+++ b/lib/src/common/components/feedback/loading_confirmation.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
-import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+import 'package:nibbles/src/common/components/brand/petal_blob.dart';
 
 /// Two-phase composition used by passive loading -> "You all set!"
 /// confirmation screens.
@@ -55,7 +55,7 @@ class LoadingConfirmation extends StatelessWidget {
           child: Stack(
             alignment: Alignment.center,
             children: [
-              _PetalBlob(key: blobKey),
+              PetalBlob(key: blobKey),
               _PhaseLabel(
                 phase: phase,
                 successLabel: successLabel,
@@ -65,55 +65,6 @@ class LoadingConfirmation extends StatelessWidget {
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-/// Layered petal mark mimicking the Figma `LoadingAnimation` frame: a pale
-/// outer quatrefoil + a sage inner quatrefoil + a soft butter glow dot at
-/// the core (the bare circle reads as flat without the glow).
-class _PetalBlob extends StatelessWidget {
-  const _PetalBlob({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: AppSizes.avatarXl * 1.84,
-      height: AppSizes.avatarXl * 1.84,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          // Outer pale-butter petal blob (spec petal layer 1+2 composite).
-          const Quatrefoil(
-            size: AppSizes.avatarXl * 1.84,
-            coreColor: AppColors.butter,
-          ),
-          // Inner sage petal — smaller, scales down to ~52% of outer.
-          const Quatrefoil(
-            size: AppSizes.avatarXl * 0.96,
-            petalColor: AppColors.green,
-            coreColor: AppColors.greenDeep,
-          ),
-          // Soft butter glow dot at the center (spec blurred lime dot).
-          DecoratedBox(
-            decoration: BoxDecoration(
-              color: AppColors.butter,
-              shape: BoxShape.circle,
-              boxShadow: [
-                BoxShadow(
-                  color: AppColors.butter.withValues(alpha: 0.9),
-                  blurRadius: AppSizes.sm,
-                  spreadRadius: AppSizes.xs,
-                ),
-              ],
-            ),
-            child: const SizedBox(
-              width: AppSizes.sp12 * 1.4,
-              height: AppSizes.sp12 * 1.4,
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/src/features/onboarding/consent/onboarding_consent_screen.dart
+++ b/lib/src/features/onboarding/consent/onboarding_consent_screen.dart
@@ -9,20 +9,28 @@ import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 import 'package:nibbles/src/utils/age_in_months.dart';
 
-/// Consent / housekeeping — final onboarding stage.
+/// Consent / housekeeping — final onboarding stage (NIB-100).
 ///
-/// Per NIB-100 (Figma 971:10184 / 971:10198): Quatrefoil + title1 +
-/// age-gated checkbox list (2 boxes if baby is >= 6 months old; 3 boxes if
-/// younger, with an extra "full responsibility" acknowledgement). CTA is
-/// disabled until every box is checked. Consent itself is EPHEMERAL per
-/// NIB-120 — checkbox state lives in this widget only, never persisted.
+/// Figma nodes: 971:10184 (>=6mo, empty) / 971:10215 (>=6mo, checked) /
+/// 971:10198 (<6mo, empty) / 971:10229 (<6mo, checked).
 ///
-/// Submit path: validates name/DOB via [OnboardingController.submit] which
-/// creates the baby via the baby-profile service. On success this screen
-/// sets `onboarding_done` + navigates to `/home` (the GoRouter redirect
-/// cannot fire without the flag and nothing else flips it). On failure the
-/// inline P1 error from `state.submitErrorMessage` is shown with a Retry
-/// button.
+/// Composition (top → bottom):
+///   - Title `Before we start, some housekeeping`
+///   - Brand `PetalBlob` (shared with baby-setup-loading)
+///   - Age-gated checkbox list (2 boxes when baby >= 6mo, 3 when younger —
+///     extra row carries the "full responsibility" early-solids clause)
+///   - Bottom row: butter `AppRoundButton` (back) + primary CTA
+///     `Check confirmation` (disabled) → `Yes, I Understand` (enabled)
+///
+/// All checkbox copy is verbatim from the Figma audit (no trailing periods,
+/// matches the spec strings byte-for-byte).
+///
+/// Consent itself is EPHEMERAL per NIB-120 — checkbox state lives in this
+/// widget only, never persisted. Submit path validates name/DOB via
+/// [OnboardingController.submit] which creates the baby via the baby-profile
+/// service. On success this screen sets `onboarding_done` + navigates to
+/// `/home`. On failure the inline P1 error from `state.submitErrorMessage`
+/// is shown with a Retry button.
 class OnboardingConsentScreen extends ConsumerStatefulWidget {
   const OnboardingConsentScreen({super.key});
 
@@ -65,6 +73,16 @@ class _OnboardingConsentScreenState
     context.goNamed(AppRoute.home.name);
   }
 
+  void _onBack() {
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
+    // Defensive fall-through: result is the previous stage in the new flow
+    // (NIB-51). The hoisted controller (keepAlive) preserves answers.
+    context.goNamed(AppRoute.onboardingResult.name);
+  }
+
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
@@ -80,18 +98,7 @@ class _OnboardingConsentScreenState
 
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.background,
-        elevation: 0,
-        leading: Navigator.of(context).canPop()
-            ? IconButton(
-                icon: const Icon(Icons.arrow_back_rounded),
-                onPressed: () => Navigator.of(context).pop(),
-              )
-            : null,
-      ),
       body: SafeArea(
-        top: false,
         child: Padding(
           padding: const EdgeInsets.symmetric(
             horizontal: AppSizes.pagePaddingH,
@@ -100,12 +107,13 @@ class _OnboardingConsentScreenState
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              const Center(child: Quatrefoil()),
-              const SizedBox(height: AppSizes.lg),
               Text(
                 'Before we start, some housekeeping',
+                textAlign: TextAlign.center,
                 style: textTheme.displaySmall,
               ),
+              const SizedBox(height: AppSizes.lg),
+              const Center(child: PetalBlob(size: 180)),
               const SizedBox(height: AppSizes.xl),
               Expanded(
                 child: SingleChildScrollView(
@@ -115,12 +123,12 @@ class _OnboardingConsentScreenState
                       for (var i = 0; i < _checks.length; i++) ...[
                         _ConsentCheckboxRow(
                           key: Key('onboarding_consent_checkbox_$i'),
-                          label: _labelFor(i, _checks.length),
+                          label: _labelFor(i),
                           value: _checks[i],
                           onChanged: (v) => _toggle(i, value: v),
                         ),
                         if (i < _checks.length - 1)
-                          const SizedBox(height: AppSizes.md),
+                          const SizedBox(height: AppSizes.sm),
                       ],
                       if (errorMessage != null) ...[
                         const SizedBox(height: AppSizes.md),
@@ -135,10 +143,24 @@ class _OnboardingConsentScreenState
                 ),
               ),
               const SizedBox(height: AppSizes.md),
-              AppPillButton(
-                key: const Key('onboarding_consent_submit'),
-                label: ctaLabel,
-                onPressed: canConfirm ? _onConfirm : null,
+              Row(
+                children: [
+                  AppRoundButton(
+                    key: const Key('onboarding_consent_back'),
+                    icon: const Icon(Icons.arrow_back_rounded),
+                    tone: AppRoundButtonTone.butter,
+                    semanticLabel: 'Back',
+                    onPressed: _onBack,
+                  ),
+                  const SizedBox(width: AppSizes.sp12),
+                  Expanded(
+                    child: AppPillButton(
+                      key: const Key('onboarding_consent_submit'),
+                      label: ctaLabel,
+                      onPressed: canConfirm ? _onConfirm : null,
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
@@ -147,27 +169,31 @@ class _OnboardingConsentScreenState
     );
   }
 
-  /// Copy for each checkbox row. Index 2 only renders when [count] == 3 (baby
-  /// younger than 6 months) and carries the early-solids acknowledgement.
-  String _labelFor(int index, int count) {
+  /// Verbatim copy for each checkbox row from the Figma audit
+  /// (.figma-audit/onboarding/baby-setup-{gt6mo,lt6mo}-1/report.md).
+  ///
+  /// Index 2 only renders when `_checks.length == 3` (baby younger than
+  /// 6 months) and carries the early-solids responsibility acknowledgement.
+  String _labelFor(int index) {
     switch (index) {
       case 0:
-        return 'I understand Nibbles is guidance, not medical advice.';
+        return 'I understand that Nibbles shares general educational '
+            'information, not medical advice, and that parents make the '
+            'final decisions for their baby';
       case 1:
-        return 'I will watch my baby closely during meals and stop if anything '
-            "doesn't feel right.";
+        return 'I confirm I have received medical clearance and understand '
+            'the above';
       case 2:
-        // Only shown when count == 3 — verbatim from the spec.
         return 'I accept full responsibility for my decision to start solids '
-            'before 6 months.';
+            'before 6 months';
       default:
         return '';
     }
   }
 }
 
-/// Row composed of [AppCheckbox] + label text. Tapping the label toggles the
-/// checkbox so the whole row is a hit target (kit pattern).
+/// Row composed of [AppCheckbox] + label text. Tapping the row toggles the
+/// checkbox so the whole label is a hit target (kit pattern).
 class _ConsentCheckboxRow extends StatelessWidget {
   const _ConsentCheckboxRow({
     required this.label,
@@ -193,7 +219,7 @@ class _ConsentCheckboxRow extends StatelessWidget {
           children: [
             Padding(
               // Nudge the checkbox down so it visually aligns with the first
-              // line of label text (label has a 22pt line-height; checkbox 24).
+              // line of label text.
               padding: const EdgeInsets.only(top: 2),
               child: AppCheckbox(
                 value: value,
@@ -204,7 +230,7 @@ class _ConsentCheckboxRow extends StatelessWidget {
             Expanded(
               child: Text(
                 label,
-                style: textTheme.bodyLarge?.copyWith(
+                style: textTheme.bodyMedium?.copyWith(
                   color: AppColors.fgDefault,
                 ),
               ),
@@ -217,7 +243,7 @@ class _ConsentCheckboxRow extends StatelessWidget {
 }
 
 /// P1 inline error surface — destructive-tinted panel with a Retry affordance.
-/// Retry is null while submit is in-flight or the boxes are unchecked, so the
+/// Retry is null while submit is in-flight or the boxes are unchecked so the
 /// user can't fire a duplicate submit mid-request.
 class _InlineError extends StatelessWidget {
   const _InlineError({

--- a/lib/src/features/onboarding/consent/onboarding_consent_screen.dart
+++ b/lib/src/features/onboarding/consent/onboarding_consent_screen.dart
@@ -113,6 +113,9 @@ class _OnboardingConsentScreenState
                 style: textTheme.displaySmall,
               ),
               const SizedBox(height: AppSizes.lg),
+              // Figma audit calls the cluster at 220x220; we render at 180
+              // so the 3-checkbox <6mo variant still fits without scrolling on
+              // ~5.5" devices (the cluster scales linearly via [PetalBlob]).
               const Center(child: PetalBlob(size: 180)),
               const SizedBox(height: AppSizes.xl),
               Expanded(
@@ -230,7 +233,8 @@ class _ConsentCheckboxRow extends StatelessWidget {
             Expanded(
               child: Text(
                 label,
-                style: textTheme.bodyMedium?.copyWith(
+                // Body/Regular per Figma audit (Figtree 15/22) → bodyLarge.
+                style: textTheme.bodyLarge?.copyWith(
                   color: AppColors.fgDefault,
                 ),
               ),

--- a/test/features/onboarding/consent/onboarding_consent_screen_test.dart
+++ b/test/features/onboarding/consent/onboarding_consent_screen_test.dart
@@ -165,11 +165,42 @@ void main() {
         findsOneWidget,
       );
 
-      // Verbatim copy from the spec for the 3rd box.
+      // Verbatim copy from the Figma audit for the 3rd box (no trailing
+      // period — matches baby-setup-lt6mo-1/report.md byte-for-byte).
       expect(
         find.text(
           'I accept full responsibility for my decision to start solids '
-          'before 6 months.',
+          'before 6 months',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'renders the verbatim Figma copy for boxes 0 and 1 (both age variants '
+    'share these two strings — pinned to guard against future paraphrase)',
+    (tester) async {
+      final dob = DateTime.now().subtract(const Duration(days: 30 * 18));
+      final container = _makeContainer(
+        babyProfile: babyProfile,
+        flags: flags,
+        dob: dob,
+      );
+      await _pumpConsent(tester, container: container);
+
+      expect(
+        find.text(
+          'I understand that Nibbles shares general educational '
+          'information, not medical advice, and that parents make the '
+          'final decisions for their baby',
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.text(
+          'I confirm I have received medical clearance and understand '
+          'the above',
         ),
         findsOneWidget,
       );


### PR DESCRIPTION
## Summary

Aligns the `OnboardingConsentScreen` (Figma nodes 971:10184 / 971:10215 / 971:10198 / 971:10229) with the Figma audit verbatim:

- Replaces paraphrased checkbox labels with the exact Figma copy (no trailing periods). Box 1 was substantively different (`"watch my baby closely..."` vs `"I confirm I have received medical clearance..."`).
- Moves the back button out of the AppBar into the bottom row alongside the primary CTA, per the audit (`Row [frame] bottom (back + CTA)`). Uses the butter-toned `AppRoundButton` (lime back per spec).
- Centers the title and places the brand petal cluster below it (matches screenshot layout).
- Extracts the layered petal mark from `loading_confirmation.dart` into a new public `PetalBlob` brand widget so the consent screen and the loading screen share a single source of truth — the audit calls out the asset is shared with `baby-setup-loading`.

CTA / state behavior unchanged:
- `Check confirmation` while one or more boxes are unchecked (disabled).
- `Yes, I Understand` once all boxes are checked (primary green CTA).
- Submit calls `OnboardingController.submit()` → `BabyProfileService.createBaby()` → sets `onboarding_done` → `go(/home)`.
- Failures surface as an inline P1 destructive panel with a Retry pill.

## Acceptance criteria

- [x] >= 6mo DOB renders 2 checkboxes; the 3rd (`full responsibility`) row is absent.
- [x] < 6mo DOB renders the 3-checkbox variant with the verbatim early-solids clause.
- [x] Missing DOB falls back to the safer 2-checkbox variant.
- [x] CTA disabled until every required box is ticked; label flips `Check confirmation` -> `Yes, I Understand` once enabled.
- [x] CTA stays disabled while submit is in-flight (widget-layer double-submit guard).
- [x] On confirm: `createBaby` runs, `setOnboardingDone` flips, nav lands on `/home`.
- [x] On failure: inline error renders verbatim, `setOnboardingDone` NOT called, nav NOT performed.
- [x] All 3 box labels render the Figma verbatim copy (pinned via widget tests).
- [x] `flutter analyze` 0 issues; `flutter test` 525 passed.

## Figma frame ids

- `971:10184` — gt6mo state 1 (empty / `Check confirmation` disabled)
- `971:10215` — gt6mo state 2 (checked / `Yes, I Understand` enabled)
- `971:10198` — lt6mo state 1 (empty)
- `971:10229` — lt6mo state 2 (checked)

## Audit report paths

- `.figma-audit/onboarding/baby-setup-gt6mo-1/report.md`
- `.figma-audit/onboarding/baby-setup-gt6mo-2/report.md`
- `.figma-audit/onboarding/baby-setup-lt6mo-1/report.md`
- `.figma-audit/onboarding/baby-setup-lt6mo-2/report.md`

## Files touched

- `lib/src/common/components/brand/petal_blob.dart` (new) - extracted brand petal cluster.
- `lib/src/common/components/components.dart` - export new widget.
- `lib/src/common/components/feedback/loading_confirmation.dart` - reuse `PetalBlob`.
- `lib/src/features/onboarding/consent/onboarding_consent_screen.dart` - verbatim copy + layout.
- `test/features/onboarding/consent/onboarding_consent_screen_test.dart` - drop stale period, pin boxes 0/1.

## Test plan

- [x] `flutter analyze` 0 issues
- [x] `flutter test` 525/525 pass
- [x] `flutter test test/features/onboarding/consent/` 7/7 pass
- [x] `flutter test test/common/components/feedback/loading_confirmation_test.dart` 3/3 pass (regression check on shared `PetalBlob` swap)