### PR TITLE
fix(onboarding): match baby-name screen to figma spec [NIB-66]

### DIFF
--- a/lib/src/common/components/inputs/app_text_field.dart
+++ b/lib/src/common/components/inputs/app_text_field.dart
@@ -11,6 +11,7 @@ class AppTextField extends StatefulWidget {
     this.controller,
     this.hintText,
     this.errorText,
+    this.errorColor,
     this.obscureText = false,
     this.keyboardType,
     this.textInputAction,
@@ -28,6 +29,11 @@ class AppTextField extends StatefulWidget {
 
   /// When non-null the field renders its error state (red border + caption).
   final String? errorText;
+
+  /// Optional override for the error border + caption colour. Defaults to
+  /// [AppColors.error] (#E53E3E). Used by screens whose Figma spec calls for a
+  /// non-default tone (e.g. NIB-66 baby-name uses burgundy / destructive).
+  final Color? errorColor;
   final bool obscureText;
   final TextInputType? keyboardType;
   final TextInputAction? textInputAction;
@@ -74,9 +80,10 @@ class _AppTextFieldState extends State<AppTextField> {
     final theme = Theme.of(context);
     final hasError = widget.errorText != null;
     final focused = _focusNode.hasFocus;
+    final errorColor = widget.errorColor ?? AppColors.error;
 
     final borderColor = hasError
-        ? AppColors.error
+        ? errorColor
         : focused
             ? AppColors.greenDeep
             : AppColors.borderSoft;
@@ -153,7 +160,7 @@ class _AppTextFieldState extends State<AppTextField> {
           const SizedBox(height: AppSizes.xs),
           Text(
             widget.errorText!,
-            style: theme.textTheme.bodySmall?.copyWith(color: AppColors.error),
+            style: theme.textTheme.bodySmall?.copyWith(color: errorColor),
           ),
         ],
       ],

--- a/lib/src/features/onboarding/name/onboarding_name_screen.dart
+++ b/lib/src/features/onboarding/name/onboarding_name_screen.dart
@@ -97,19 +97,10 @@ class _OnboardingNameScreenState extends ConsumerState<OnboardingNameScreen> {
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final errorText = _firstErrorText;
+    final canPop = Navigator.of(context).canPop();
 
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.background,
-        elevation: 0,
-        leading: Navigator.of(context).canPop()
-            ? IconButton(
-                icon: const Icon(Icons.arrow_back_rounded),
-                onPressed: () => Navigator.of(context).pop(),
-              )
-            : null,
-      ),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(
@@ -119,48 +110,63 @@ class _OnboardingNameScreenState extends ConsumerState<OnboardingNameScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              const SizedBox(height: AppSizes.xxl),
               Text(
                 "What is your baby's name?",
-                style: textTheme.displaySmall,
+                style: textTheme.headlineSmall,
+                textAlign: TextAlign.center,
               ),
               const SizedBox(height: AppSizes.sm),
               Text(
-                "We'll use this to personalise your meal plans and progress.",
-                style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
+                "We'll use this to build their personalized 3-6 month guide.",
+                style: textTheme.bodyMedium?.copyWith(
+                  color: AppColors.fgStrong,
+                ),
+                textAlign: TextAlign.center,
               ),
               const SizedBox(height: AppSizes.xl),
               AppTextField(
                 key: const Key('onboarding_first_name_field'),
                 label: 'First Name',
-                hintText: 'Asther',
+                hintText: "Baby's First Name",
                 controller: _firstNameController,
                 textInputAction: TextInputAction.next,
                 onChanged: _onFirstChanged,
+                errorText: errorText,
+                // Figma state-2 token: Nibble-primary-Burgundy ≈ destructive.
+                errorColor: AppColors.destructive,
               ),
-              if (errorText != null) ...[
-                const SizedBox(height: AppSizes.xs),
-                Text(
-                  errorText,
-                  style: textTheme.bodySmall?.copyWith(
-                    color: AppColors.destructive,
-                  ),
-                ),
-              ],
               const SizedBox(height: AppSizes.md),
               AppTextField(
                 key: const Key('onboarding_last_name_field'),
                 label: 'Last Name (Optional)',
-                hintText: 'Putra',
+                hintText: "Baby's Last Name",
                 controller: _lastNameController,
                 textInputAction: TextInputAction.done,
                 onChanged: _onLastChanged,
                 onSubmitted: (_) => _onNext(),
               ),
               const Spacer(),
-              AppPillButton(
-                key: const Key('onboarding_name_next'),
-                label: 'Next',
-                onPressed: _canSubmit ? _onNext : null,
+              Row(
+                children: [
+                  if (canPop) ...[
+                    AppRoundButton(
+                      key: const Key('onboarding_name_back'),
+                      icon: const Icon(Icons.arrow_back_rounded),
+                      tone: AppRoundButtonTone.butter,
+                      semanticLabel: 'Back',
+                      onPressed: () => Navigator.of(context).pop(),
+                    ),
+                    const SizedBox(width: AppSizes.sm),
+                  ],
+                  Expanded(
+                    child: AppPillButton(
+                      key: const Key('onboarding_name_next'),
+                      label: 'Next',
+                      onPressed: _canSubmit ? _onNext : null,
+                    ),
+                  ),
+                ],
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
Reskin of the post-auth baby-name capture screen (first onboarding step) to match Figma frames 971:10266 / 971:10279 / 1025:7285.

## Acceptance criteria
- [x] Pixel-close match to Figma frames (centered title + subtitle, bottom-row back+Next CTA, burgundy error state)
- [x] Verbatim copy: title, subtitle "We'll use this to build their personalized 3-6 month guide.", labels, error helper "You must fill the name"
- [x] Placeholders swapped back per audit recommendation: First Name -> "Baby's First Name", Last Name -> "Baby's Last Name"
- [x] All 3 state variants reachable (empty / error / valid)
- [x] Back wired via Navigator.pop (lime/butter round button), Next wired to /onboarding/dob only when First Name valid
- [x] Burgundy border + helper via AppTextField.errorColor=AppColors.destructive (Nibble-primary-Burgundy token)
- [x] No hardcoded hex; all tokens via AppColors / textTheme
- [x] flutter analyze: 0 issues
- [x] All tests pass (524 +1 skipped)

## Figma frames
- baby-name-1 (empty / Next disabled): node 971:10266
- baby-name-2 (validation error): node 971:10279
- baby-name-3 (filled valid): node 1025:7285

## Audit artifacts
- .figma-audit/onboarding/baby-name-1/report.md
- .figma-audit/onboarding/baby-name-2/report.md
- .figma-audit/onboarding/baby-name-3/report.md

## Files changed
- lib/src/features/onboarding/name/onboarding_name_screen.dart (layout + copy + state surfaces)
- lib/src/common/components/inputs/app_text_field.dart (optional errorColor override)

## Test plan
- [x] Empty state: Next disabled, no error caption on first paint
- [x] Type-then-clear First Name: burgundy caption "You must fill the name" appears with AppColors.destructive
- [x] Filled valid: Next enabled, stores "First Last".trim() on OnboardingController, navigates to /onboarding/dob
- [x] Last name omitted: only first name persisted (no trailing space)