### PR TITLE
feat(onboarding): DOB picker screen with computed age label [NIB-74]

### DIFF
--- a/lib/src/features/onboarding/dob/onboarding_dob_screen.dart
+++ b/lib/src/features/onboarding/dob/onboarding_dob_screen.dart
@@ -4,26 +4,30 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/components.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 import 'package:nibbles/src/utils/age_in_months.dart';
 
-/// OB DOB capture (Figma 971:10173). Reskin of NIB-51's stub.
+/// OB DOB capture — Figma 971:10173 (.figma-audit/onboarding/baby-birthdate).
 ///
-/// Composition (top → bottom):
-///   - butter quatrefoil illustration
-///   - title `When was [babyName.first] born?`
-///   - coral live age label (recomputed via [ageInMonths] on every wheel tick)
-///   - 3-wheel `CupertinoDatePicker` (date mode); bounds: today − 3y → today
-///   - primary `AppPillButton` "Next" — disabled until the wheel actually moves
+/// Layout matches the Figma composition exactly:
+///   - title `When was [firstName] born?` (first name in coral via TextSpan)
+///   - body subtitle ("We use this to suggest the right foods…")
+///   - quatrefoil illustration cluster + salmonGhost "X Month" age chip
+///   - 3-column wheel (Year / Month / Day) with lime selection pill per column
+///   - bottom row: butter back round button + forestDarkn "Next" pill
 ///
 /// State written to the hoisted [OnboardingController] via `updateDob`. Then
 /// the phase-A flag `onboarding_baby_setup_done` is flipped — the router's
-/// phase-A whitelist (routes.dart) only contains `{name, dob}` while this
-/// flag is false, so without the flip a `goNamed(readiness)` immediately
-/// bounces back to `/onboarding/name`.
+/// phase-A whitelist (routes.dart) only contains `{name, dob}` while this flag
+/// is false, so without the flip a `goNamed(readiness)` immediately bounces
+/// back to `/onboarding/name`. This flag flip is load-bearing — do not drop.
+///
+/// Default DOB is 6 months ago (calendar-aware, clamped to today), so the
+/// initial age chip reads "6 Months" out of the box per the AC.
 class OnboardingDobScreen extends ConsumerStatefulWidget {
   const OnboardingDobScreen({super.key});
 
@@ -33,32 +37,95 @@ class OnboardingDobScreen extends ConsumerStatefulWidget {
 }
 
 class _OnboardingDobScreenState extends ConsumerState<OnboardingDobScreen> {
-  // CupertinoDatePicker always renders SOME date. We track an explicit
-  // "user touched the wheel" via [_selected]: null until the first
-  // [onDateTimeChanged] callback. Next stays disabled while null and the
-  // label reads from [_initialDate] for the first paint.
-  static const Duration _defaultOffset = Duration(days: 180);
   static const int _maxAgeYears = 3;
-  static const double _pickerHeight = 200;
+  static const double _wheelHeight = 156;
+  static const double _wheelItemExtent = 44;
+
+  // 3-letter month abbreviations. The Figma render mixes 'Feb'/'Apr' (3-letter)
+  // with 'March' (full) — we normalize to 3-letter uniformly. Noted in PR.
+  static const List<String> _monthAbbr = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
 
   late final DateTime _today;
-  late final DateTime _initialDate;
-  late final DateTime _minimumDate;
-  DateTime? _selected;
+  late final int _minYear;
+  late final int _maxYear;
+
+  late int _year;
+  late int _month; // 1..12
+  late int _day; // 1..31 (clamped to month length)
+
+  late FixedExtentScrollController _yearCtrl;
+  late FixedExtentScrollController _monthCtrl;
+  late FixedExtentScrollController _dayCtrl;
 
   @override
   void initState() {
     super.initState();
     final now = DateTime.now();
     _today = DateTime(now.year, now.month, now.day);
-    _initialDate = ref.read(onboardingControllerProvider).dob ??
-        _today.subtract(_defaultOffset);
-    _minimumDate = DateTime(now.year - _maxAgeYears, now.month, now.day);
-    // If the controller already had a DOB (back-nav), treat as selected so
-    // Next is enabled on re-entry — the visible wheel matches the stored value.
-    if (ref.read(onboardingControllerProvider).dob != null) {
-      _selected = _initialDate;
+    _maxYear = _today.year;
+    _minYear = _today.year - _maxAgeYears;
+
+    final stored = ref.read(onboardingControllerProvider).dob;
+    final initial = stored ?? _defaultDob(_today);
+    _year = initial.year;
+    _month = initial.month;
+    _day = initial.day;
+
+    _yearCtrl = FixedExtentScrollController(initialItem: _year - _minYear);
+    _monthCtrl = FixedExtentScrollController(initialItem: _month - 1);
+    _dayCtrl = FixedExtentScrollController(initialItem: _day - 1);
+  }
+
+  @override
+  void dispose() {
+    _yearCtrl.dispose();
+    _monthCtrl.dispose();
+    _dayCtrl.dispose();
+    super.dispose();
+  }
+
+  /// Calendar-aware "6 months ago" — drops calendar months, clamped to today.
+  static DateTime _defaultDob(DateTime today) {
+    var year = today.year;
+    var month = today.month - 6;
+    while (month <= 0) {
+      month += 12;
+      year -= 1;
     }
+    final day = _clampDay(year, month, today.day);
+    return DateTime(year, month, day);
+  }
+
+  static int _daysInMonth(int year, int month) {
+    // First of next month, minus 1 day. Handles leap years.
+    final firstNext = month == 12
+        ? DateTime(year + 1)
+        : DateTime(year, month + 1);
+    return firstNext.subtract(const Duration(days: 1)).day;
+  }
+
+  static int _clampDay(int year, int month, int day) {
+    final max = _daysInMonth(year, month);
+    return day > max ? max : (day < 1 ? 1 : day);
+  }
+
+  /// Selected DOB clamped to today's date (no future selection).
+  DateTime get _selected {
+    final picked = DateTime(_year, _month, _clampDay(_year, _month, _day));
+    return picked.isAfter(_today) ? _today : picked;
   }
 
   String _firstNameOrFallback(String stored) {
@@ -69,19 +136,56 @@ class _OnboardingDobScreenState extends ConsumerState<OnboardingDobScreen> {
 
   String _ageLabel(DateTime date) {
     final months = ageInMonths(date, now: _today);
-    if (months <= 0) return 'Less than a month old';
-    if (months == 1) return '1 month old';
-    return '$months months old';
+    if (months <= 0) return 'Less than a month';
+    if (months == 1) return '1 Month';
+    return '$months Months';
   }
 
-  void _onDateChanged(DateTime value) {
-    setState(() => _selected = value);
+  void _onYearChanged(int index) {
+    final next = _minYear + index;
+    setState(() {
+      _year = next;
+      // Re-clamp day if month-length changes (Feb 29 → Feb 28 across years).
+      _day = _clampDay(_year, _month, _day);
+      _clampToToday();
+    });
+  }
+
+  void _onMonthChanged(int index) {
+    final next = index + 1;
+    setState(() {
+      _month = next;
+      _day = _clampDay(_year, _month, _day);
+      _clampToToday();
+    });
+  }
+
+  void _onDayChanged(int index) {
+    setState(() {
+      _day = index + 1;
+      _clampToToday();
+    });
+  }
+
+  /// If wheels combine to land past today, snap each wheel back to today.
+  /// Wheel jumps are deferred to the next frame to avoid re-entering the
+  /// `onSelectedItemChanged` callback that triggered this clamp.
+  void _clampToToday() {
+    final picked = DateTime(_year, _month, _clampDay(_year, _month, _day));
+    if (!picked.isAfter(_today)) return;
+    _year = _today.year;
+    _month = _today.month;
+    _day = _today.day;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _yearCtrl.jumpToItem(_year - _minYear);
+      _monthCtrl.jumpToItem(_month - 1);
+      _dayCtrl.jumpToItem(_day - 1);
+    });
   }
 
   void _onNext() {
-    final picked = _selected;
-    if (picked == null) return;
-    ref.read(onboardingControllerProvider.notifier).updateDob(picked);
+    ref.read(onboardingControllerProvider.notifier).updateDob(_selected);
     ref.read(localFlagServiceProvider).setOnboardingBabySetupDone();
     context.goNamed(AppRoute.onboardingReadiness.name);
   }
@@ -93,21 +197,18 @@ class _OnboardingDobScreenState extends ConsumerState<OnboardingDobScreen> {
       onboardingControllerProvider.select((s) => s.babyName.value),
     );
     final firstName = _firstNameOrFallback(storedName);
-    final labelDate = _selected ?? _initialDate;
-    final canSubmit = _selected != null;
+
+    final years = List<int>.generate(
+      _maxYear - _minYear + 1,
+      (i) => _minYear + i,
+    );
+    final days = List<int>.generate(
+      _daysInMonth(_year, _month),
+      (i) => i + 1,
+    );
 
     return Scaffold(
-      backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.background,
-        elevation: 0,
-        leading: Navigator.of(context).canPop()
-            ? IconButton(
-                icon: const Icon(Icons.arrow_back_rounded),
-                onPressed: () => Navigator.of(context).pop(),
-              )
-            : null,
-      ),
+      backgroundColor: AppColors.cream,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(
@@ -117,43 +218,269 @@ class _OnboardingDobScreenState extends ConsumerState<OnboardingDobScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              const Center(child: Quatrefoil()),
-              const SizedBox(height: AppSizes.lg),
-              Text(
-                'When was $firstName born?',
-                style: textTheme.displaySmall,
+              Center(
+                child: Text.rich(
+                  TextSpan(
+                    style: textTheme.titleLarge,
+                    children: [
+                      const TextSpan(text: 'When was '),
+                      TextSpan(
+                        text: firstName,
+                        style: textTheme.titleLarge?.copyWith(
+                          color: AppColors.coral,
+                        ),
+                      ),
+                      const TextSpan(text: ' born?'),
+                    ],
+                  ),
+                  textAlign: TextAlign.center,
+                ),
               ),
               const SizedBox(height: AppSizes.sm),
               Text(
-                key: const Key('onboarding_dob_age_label'),
-                _ageLabel(labelDate),
-                style: textTheme.titleSmall?.copyWith(
-                  color: AppColors.coral,
-                  fontWeight: FontWeight.w700,
-                ),
+                'We use this to suggest the right foods at the right time.',
+                style: textTheme.bodyLarge?.copyWith(color: AppColors.fgMuted),
+                textAlign: TextAlign.center,
               ),
               const SizedBox(height: AppSizes.xl),
-              SizedBox(
-                height: _pickerHeight,
-                child: CupertinoDatePicker(
-                  key: const Key('onboarding_dob_picker'),
-                  mode: CupertinoDatePickerMode.date,
-                  initialDateTime: _initialDate,
-                  maximumDate: _today,
-                  minimumDate: _minimumDate,
-                  onDateTimeChanged: _onDateChanged,
+              const Center(child: Quatrefoil()),
+              const SizedBox(height: AppSizes.md),
+              Center(
+                child: _AgeChip(
+                  key: const Key('onboarding_dob_age_label'),
+                  label: _ageLabel(_selected),
                 ),
               ),
+              const SizedBox(height: AppSizes.lg),
+              _DateWheelRow(
+                yearCtrl: _yearCtrl,
+                monthCtrl: _monthCtrl,
+                dayCtrl: _dayCtrl,
+                years: years,
+                months: _monthAbbr,
+                days: days,
+                selectedYearIndex: _year - _minYear,
+                selectedMonthIndex: _month - 1,
+                selectedDayIndex: _day - 1,
+                wheelHeight: _wheelHeight,
+                itemExtent: _wheelItemExtent,
+                onYearChanged: _onYearChanged,
+                onMonthChanged: _onMonthChanged,
+                onDayChanged: _onDayChanged,
+              ),
               const Spacer(),
-              AppPillButton(
-                key: const Key('onboarding_dob_next'),
-                label: 'Next',
-                onPressed: canSubmit ? _onNext : null,
+              Row(
+                children: [
+                  AppRoundButton(
+                    key: const Key('onboarding_dob_back'),
+                    tone: AppRoundButtonTone.butter,
+                    icon: const Icon(Icons.arrow_back_rounded),
+                    semanticLabel: 'Back',
+                    onPressed: () {
+                      if (context.canPop()) {
+                        context.pop();
+                      } else {
+                        context.goNamed(AppRoute.onboardingName.name);
+                      }
+                    },
+                  ),
+                  const SizedBox(width: AppSizes.sm),
+                  Expanded(
+                    child: AppPillButton(
+                      key: const Key('onboarding_dob_next'),
+                      label: 'Next',
+                      onPressed: _onNext,
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Salmon-ghost age preview chip. Mirrors Figma "6 Month" pill.
+class _AgeChip extends StatelessWidget {
+  const _AgeChip({required this.label, super.key});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md,
+        vertical: AppSizes.xs,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.coralSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      child: Text(
+        label,
+        style: AppTypography.bodyBold.copyWith(color: AppColors.coralDeep),
+      ),
+    );
+  }
+}
+
+/// The 3-column Year/Month/Day wheel row with column headers and per-column
+/// lime selection pills. Composes three [_DateWheelColumn]s.
+class _DateWheelRow extends StatelessWidget {
+  const _DateWheelRow({
+    required this.yearCtrl,
+    required this.monthCtrl,
+    required this.dayCtrl,
+    required this.years,
+    required this.months,
+    required this.days,
+    required this.selectedYearIndex,
+    required this.selectedMonthIndex,
+    required this.selectedDayIndex,
+    required this.wheelHeight,
+    required this.itemExtent,
+    required this.onYearChanged,
+    required this.onMonthChanged,
+    required this.onDayChanged,
+  });
+
+  final FixedExtentScrollController yearCtrl;
+  final FixedExtentScrollController monthCtrl;
+  final FixedExtentScrollController dayCtrl;
+  final List<int> years;
+  final List<String> months;
+  final List<int> days;
+  final int selectedYearIndex;
+  final int selectedMonthIndex;
+  final int selectedDayIndex;
+  final double wheelHeight;
+  final double itemExtent;
+  final ValueChanged<int> onYearChanged;
+  final ValueChanged<int> onMonthChanged;
+  final ValueChanged<int> onDayChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: _DateWheelColumn(
+            key: const Key('onboarding_dob_year_wheel'),
+            header: 'Year',
+            height: wheelHeight,
+            itemExtent: itemExtent,
+            controller: yearCtrl,
+            itemCount: years.length,
+            selectedIndex: selectedYearIndex,
+            onSelectedItemChanged: onYearChanged,
+            itemBuilder: (i) => '${years[i]}',
+          ),
+        ),
+        Expanded(
+          child: _DateWheelColumn(
+            key: const Key('onboarding_dob_month_wheel'),
+            header: 'Month',
+            height: wheelHeight,
+            itemExtent: itemExtent,
+            controller: monthCtrl,
+            itemCount: months.length,
+            selectedIndex: selectedMonthIndex,
+            onSelectedItemChanged: onMonthChanged,
+            itemBuilder: (i) => months[i],
+          ),
+        ),
+        Expanded(
+          child: _DateWheelColumn(
+            key: const Key('onboarding_dob_day_wheel'),
+            header: 'Date',
+            height: wheelHeight,
+            itemExtent: itemExtent,
+            controller: dayCtrl,
+            itemCount: days.length,
+            selectedIndex: selectedDayIndex,
+            onSelectedItemChanged: onDayChanged,
+            itemBuilder: (i) => '${days[i]}',
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A single column: header label + CupertinoPicker with a lime rounded pill
+/// `selectionOverlay`. Selected row text rendered in forestDarkn; off-rows in
+/// muted neutral per the Figma render.
+class _DateWheelColumn extends StatelessWidget {
+  const _DateWheelColumn({
+    required this.header,
+    required this.height,
+    required this.itemExtent,
+    required this.controller,
+    required this.itemCount,
+    required this.selectedIndex,
+    required this.onSelectedItemChanged,
+    required this.itemBuilder,
+    super.key,
+  });
+
+  final String header;
+  final double height;
+  final double itemExtent;
+  final FixedExtentScrollController controller;
+  final int itemCount;
+  final int selectedIndex;
+  final ValueChanged<int> onSelectedItemChanged;
+  final String Function(int index) itemBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Column(
+      children: [
+        Text(
+          header,
+          style: textTheme.labelMedium?.copyWith(color: AppColors.fgStrong),
+        ),
+        const SizedBox(height: AppSizes.sm),
+        SizedBox(
+          height: height,
+          child: CupertinoPicker(
+            scrollController: controller,
+            itemExtent: itemExtent,
+            squeeze: 1.1,
+            backgroundColor: AppColors.cream,
+            selectionOverlay: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSizes.xs),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: AppColors.butter,
+                  borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+                ),
+              ),
+            ),
+            onSelectedItemChanged: onSelectedItemChanged,
+            children: List<Widget>.generate(itemCount, (i) {
+              final isSelected = i == selectedIndex;
+              return Center(
+                child: Text(
+                  itemBuilder(i),
+                  style: textTheme.labelLarge?.copyWith(
+                    color: isSelected
+                        ? AppColors.greenDeep
+                        : AppColors.fgFaint,
+                    fontWeight:
+                        isSelected ? FontWeight.w700 : FontWeight.w600,
+                  ),
+                ),
+              );
+            }),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/test/features/onboarding/dob/onboarding_dob_screen_test.dart
+++ b/test/features/onboarding/dob/onboarding_dob_screen_test.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/onboarding/dob/onboarding_dob_screen.dart';
+import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+class _MockLocalFlagService extends Mock implements LocalFlagService {}
+
+/// NIB-74 — widget tests for `OnboardingDobScreen`.
+///
+/// Pins:
+///   - Title interpolates the captured baby first name (not literal "Oliver").
+///   - Body subtitle copy is verbatim from Figma.
+///   - Default age preview reads "6 Months" out of the box (no stored DOB).
+///   - Age chip updates live as a wheel scrolls.
+///   - Tapping Next persists the picked DOB onto the hoisted controller,
+///     flips the phase-A `onboarding_baby_setup_done` flag, and navigates to
+///     `/onboarding/readiness`.
+GoRouter _routerFor(Widget screen) => GoRouter(
+  initialLocation: AppRoute.onboardingDob.path,
+  routes: [
+    GoRoute(
+      path: AppRoute.onboardingDob.path,
+      name: AppRoute.onboardingDob.name,
+      builder: (_, __) => screen,
+    ),
+    GoRoute(
+      path: AppRoute.onboardingReadiness.path,
+      name: AppRoute.onboardingReadiness.name,
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text('READINESS_STUB'))),
+    ),
+    GoRoute(
+      path: AppRoute.onboardingName.path,
+      name: AppRoute.onboardingName.name,
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text('NAME_STUB'))),
+    ),
+  ],
+);
+
+ProviderContainer _makeContainer({
+  required LocalFlagService flags,
+  String babyName = 'Lily',
+}) {
+  final container = ProviderContainer(
+    overrides: [localFlagServiceProvider.overrideWithValue(flags)],
+  );
+  addTearDown(container.dispose);
+  container.read(onboardingControllerProvider.notifier).updateName(babyName);
+  return container;
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester, {
+  required ProviderContainer container,
+}) async {
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(
+        routerConfig: _routerFor(const OnboardingDobScreen()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  late _MockLocalFlagService flags;
+
+  setUp(() {
+    flags = _MockLocalFlagService();
+    when(flags.setOnboardingBabySetupDone).thenAnswer((_) async {});
+  });
+
+  testWidgets(
+    'renders title with captured first name + verbatim body subtitle + '
+    'default "6 Months" age chip',
+    (tester) async {
+      final container = _makeContainer(flags: flags, babyName: 'Lily Putra');
+      await _pumpScreen(tester, container: container);
+
+      // Title is composed via Text.rich — assert each span verbatim.
+      expect(find.textContaining('When was '), findsOneWidget);
+      expect(find.textContaining('Lily'), findsOneWidget);
+      expect(find.textContaining(' born?'), findsOneWidget);
+
+      // Body subtitle (verbatim).
+      expect(
+        find.text('We use this to suggest the right foods at the right time.'),
+        findsOneWidget,
+      );
+
+      // Default DOB is 6 months ago → chip reads "6 Months".
+      final chip = tester.widget<Text>(
+        find.descendant(
+          of: find.byKey(const Key('onboarding_dob_age_label')),
+          matching: find.byType(Text),
+        ),
+      );
+      expect(chip.data, '6 Months');
+    },
+  );
+
+  testWidgets('age chip updates when the year wheel scrolls', (tester) async {
+    final container = _makeContainer(flags: flags);
+    await _pumpScreen(tester, container: container);
+
+    // Drag the YEAR wheel down so the centered item moves to an EARLIER year
+    // (older baby). Item extent is 44px; 88px ≈ 2 yrs back. We assert the
+    // chip moved off the default "6 Months", not the precise value (depends
+    // on today's date and clamp behavior).
+    await tester.drag(
+      find.byKey(const Key('onboarding_dob_year_wheel')),
+      const Offset(0, 88),
+    );
+    await tester.pumpAndSettle();
+
+    final chip = tester.widget<Text>(
+      find.descendant(
+        of: find.byKey(const Key('onboarding_dob_age_label')),
+        matching: find.byType(Text),
+      ),
+    );
+    expect(chip.data, isNot('6 Months'));
+    expect(chip.data, isNot('Less than a month'));
+  });
+
+  testWidgets(
+    'Next persists the picked DOB, flips onboarding_baby_setup_done, '
+    'navigates to /onboarding/readiness',
+    (tester) async {
+      final container = _makeContainer(flags: flags);
+      await _pumpScreen(tester, container: container);
+
+      // Tap Next without scrolling — default DOB (≈ 6 months ago) is valid.
+      await tester.tap(find.byKey(const Key('onboarding_dob_next')));
+      await tester.pumpAndSettle();
+
+      // Controller has a DOB stored.
+      final dob = container.read(onboardingControllerProvider).dob;
+      expect(dob, isNotNull);
+
+      // Flag flip fired exactly once.
+      verify(flags.setOnboardingBabySetupDone).called(1);
+
+      // Navigation landed on the readiness stub.
+      expect(find.text('READINESS_STUB'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Back button navigates to /onboarding/name when no pop target exists',
+    (tester) async {
+      final container = _makeContainer(flags: flags);
+      await _pumpScreen(tester, container: container);
+
+      await tester.tap(find.byKey(const Key('onboarding_dob_back')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('NAME_STUB'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'pre-seeded DOB from controller pre-positions the wheels to that date',
+    (tester) async {
+      // A DOB ~12 months ago should render "12 Months" on first paint.
+      final twelveMonthsAgo = () {
+        final now = DateTime.now();
+        var year = now.year;
+        var month = now.month - 12;
+        while (month <= 0) {
+          month += 12;
+          year -= 1;
+        }
+        return DateTime(year, month, now.day);
+      }();
+
+      final container = _makeContainer(flags: flags);
+      container
+          .read(onboardingControllerProvider.notifier)
+          .updateDob(twelveMonthsAgo);
+
+      await _pumpScreen(tester, container: container);
+
+      final chip = tester.widget<Text>(
+        find.descendant(
+          of: find.byKey(const Key('onboarding_dob_age_label')),
+          matching: find.byType(Text),
+        ),
+      );
+      expect(chip.data, '12 Months');
+    },
+  );
+
+  testWidgets('renders three column headers and three wheels', (tester) async {
+    final container = _makeContainer(flags: flags);
+    await _pumpScreen(tester, container: container);
+
+    expect(find.text('Year'), findsOneWidget);
+    expect(find.text('Month'), findsOneWidget);
+    expect(find.text('Date'), findsOneWidget);
+
+    expect(find.byType(CupertinoPicker), findsNWidgets(3));
+    expect(find.byKey(const Key('onboarding_dob_year_wheel')), findsOneWidget);
+    expect(find.byKey(const Key('onboarding_dob_month_wheel')), findsOneWidget);
+    expect(find.byKey(const Key('onboarding_dob_day_wheel')), findsOneWidget);
+
+    // Next CTA renders.
+    expect(
+      tester.widget<AppPillButton>(
+        find.byKey(const Key('onboarding_dob_next')),
+      ),
+      isNotNull,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Reskins the DOB capture screen to the Figma spec (frame 971:10173). Replaces the generic `CupertinoDatePicker` with a custom three-column wheel (Year / Month / Date), a salmon-ghost age preview chip, and a quatrefoil illustration cluster.

- Title via `Text.rich` interpolates the captured first name in coral (e.g. `When was [Lily] born?`); fallback `your baby` if name is empty.
- Body subtitle verbatim: "We use this to suggest the right foods at the right time."
- Default DOB = calendar-aware 6-months-ago so the chip reads "6 Months" on first paint.
- Three independent `CupertinoPicker` columns with per-column lime rounded-pill `selectionOverlay`. Centered (selected) row text rendered in forestDarkn / w700 via parent-driven `selectedIndex`.
- Day count clamps to the selected (year, month) so Feb 30 etc. are unreachable; impossible-future-date combos snap back to today, deferred to the next frame to avoid re-entering `onSelectedItemChanged`.
- Bottom row: butter `AppRoundButton` back + forestDarkn `AppPillButton` "Next".
- Next persists the picked DOB on the hoisted `OnboardingController`, flips `onboarding_baby_setup_done`, and navigates to `/onboarding/readiness`. Flag flip is load-bearing — the router's phase-A whitelist would otherwise bounce back to `/onboarding/name`.
- Back pops or falls back to `/onboarding/name` when the back stack is empty.

## Notes / minor deviations

- Figma's three visible month rows mix `Feb`/`Apr` (3-letter) with `March` (full word). Normalized to 3-letter abbreviations uniformly for consistency.
- Single-frame design — no error/loading state to wire.

## Acceptance criteria

- [x] Pixel-close to .figma-audit/onboarding/baby-birthdate/screenshot.png
- [x] Verbatim copy — title interpolates actual baby first name (not literal "Oliver")
- [x] Selected row renders with lime bg + forestDarkn text
- [x] Age chip updates live as the user scrolls each wheel
- [x] Next wired to advance to Readiness Check 1
- [x] Back wired to Name step
- [x] All tokens consumed from DS (`AppColors` / `AppSizes` / `AppTypography`); no hardcoded hex
- [x] analyze clean; widget tests cover age computation + wheel-selection updates

## Figma + audit

- Frame: 971:10173 ("When was Oliver born?")
- Audit report: .figma-audit/onboarding/baby-birthdate/report.md
- Screenshot: .figma-audit/onboarding/baby-birthdate/screenshot.png

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/features/onboarding/dob/onboarding_dob_screen_test.dart` — 6/6 pass
- [x] full `flutter test` — green