### PR TITLE
fix(onboarding): align readiness result with figma layout + verbatim signs [NIB-91]

### DIFF
--- a/lib/src/features/onboarding/result/onboarding_result_screen.dart
+++ b/lib/src/features/onboarding/result/onboarding_result_screen.dart
@@ -15,11 +15,14 @@ import 'package:nibbles/src/routing/route_enums.dart';
 ///
 /// The audit's item 1 string concatenates two distinct signs ("Can sit upright
 /// with minimal support. Good head and neck control (can hold head steady)") —
-/// flagged as a copy-paste defect in both frames. We render the head-control
-/// half on row 0 to match index 0 of `readinessAnswers` (head control), and
-/// keep the remaining four strings verbatim.
+/// flagged as a copy-paste defect in both frames. Visual gate confirmed Figma
+/// renders the COMBINED two-sentence string as a single first item, so we
+/// keep it verbatim. The audit-flagged duplicate "Sits upright with minimal
+/// support" remains on row 1 pending PO cleanup.
 const List<String> _signLabels = [
-  'Good head and neck control (can hold head steady)',
+  // ignore: no_adjacent_strings_in_list — verbatim Figma copy spans two phrases
+  'Can sit upright with minimal support. ' +
+      'Good head and neck control (can hold head steady)',
   'Sits upright with minimal support',
   "Loss of the tongue-thrust reflex (doesn't automatically push food out).",
   'Shows interest in food (watching, reaching, opening mouth).',

--- a/lib/src/features/onboarding/result/onboarding_result_screen.dart
+++ b/lib/src/features/onboarding/result/onboarding_result_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
-import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
@@ -11,17 +10,24 @@ import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
 import 'package:nibbles/src/features/onboarding/onboarding_state.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Short labels for the 5 developmental signs surfaced on the result card.
-/// Index aligns with `readinessAnswers` on [OnboardingState] (set by the
-/// readiness screen). Kept terse — the question form lives on the readiness
-/// step; this screen summarizes.
+/// Verbatim sign labels lifted from the Figma audit
+/// (.figma-audit/onboarding/readiness-{ready,not-ready}/report.md).
+///
+/// The audit's item 1 string concatenates two distinct signs ("Can sit upright
+/// with minimal support. Good head and neck control (can hold head steady)") —
+/// flagged as a copy-paste defect in both frames. We render the head-control
+/// half on row 0 to match index 0 of `readinessAnswers` (head control), and
+/// keep the remaining four strings verbatim.
 const List<String> _signLabels = [
-  'Holds head steady',
+  'Good head and neck control (can hold head steady)',
   'Sits upright with minimal support',
-  'Tongue-thrust reflex gone',
-  'Shows interest in food',
-  'Brings objects to mouth',
+  "Loss of the tongue-thrust reflex (doesn't automatically push food out).",
+  'Shows interest in food (watching, reaching, opening mouth).',
+  'Can bring objects to their mouth.',
 ];
+
+/// Majority gate per NIB-120: ready iff at least this many signs are met.
+const int readinessReadyThreshold = 3;
 
 /// NIB-91 — Readiness RESULT screen.
 ///
@@ -29,10 +35,13 @@ const List<String> _signLabels = [
 /// and renders one of two variants based on `signsMet >= 3` (NIB-120 majority
 /// gate). Soft-warn UX: Next routes to `/onboarding/consent` in BOTH variants.
 ///
-/// * READY (signs_met >= 3): butter card, all 5 signs rendered with a green
-///   check, "New Journey Unlock!" headline.
-/// * NOT-READY (signs_met < 3): sage card, each sign rendered with the
-///   per-answer check or cross, "not ready" headline.
+/// Layout matches Figma 1255:11893 / 1029:8508:
+/// * Title (+ eyebrow on ready) at the top above the hero.
+/// * Hero quatrefoil cluster overlaps the top of the lime card.
+/// * Card carries the "Readiness Signs" header row + salmon X/5 chip and the
+///   5 sign rows with per-answer check/cross icons (ready variant renders all
+///   rows as passed regardless of per-answer values).
+/// * Bottom row: butter `AppRoundButton` (back) + primary `AppPillButton` Next.
 ///
 /// Back routes to `/onboarding/readiness` — the readiness screen `go`s here so
 /// the navigator stack typically can't pop; `goNamed` preserves the hoisted
@@ -61,52 +70,72 @@ class OnboardingResultScreen extends ConsumerWidget {
     final signsMet = answers.where((a) => a ?? false).length;
     final ready = signsMet >= readinessReadyThreshold;
 
+    final textTheme = Theme.of(context).textTheme;
+
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.background,
-        elevation: 0,
-        leadingWidth: AppSizes.roundButton + AppSizes.md,
-        leading: Padding(
-          padding: const EdgeInsets.only(left: AppSizes.md),
-          child: Center(
-            child: AppRoundButton(
-              icon: const Icon(Icons.arrow_back_rounded),
-              tone: AppRoundButtonTone.butter,
-              semanticLabel: 'Back',
-              onPressed: () => _onBack(context),
-            ),
-          ),
-        ),
-      ),
       body: SafeArea(
-        top: false,
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(
-            AppSizes.pagePaddingH,
-            AppSizes.sm,
-            AppSizes.pagePaddingH,
-            AppSizes.pagePaddingV,
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.pagePaddingH,
+            vertical: AppSizes.pagePaddingV,
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Expanded(
                 child: SingleChildScrollView(
-                  child: _ResultCard(
-                    firstName: firstName,
-                    answers: answers,
-                    signsMet: signsMet,
-                    ready: ready,
+                  child: Column(
+                    children: [
+                      if (ready) ...[
+                        Text(
+                          'New Journey Unlock!',
+                          textAlign: TextAlign.center,
+                          style: textTheme.titleSmall?.copyWith(
+                            color: AppColors.fgStrong,
+                          ),
+                        ),
+                        const SizedBox(height: AppSizes.sm),
+                      ],
+                      Text(
+                        ready
+                            ? '$firstName is ready for solids at this time'
+                            : '$firstName is not ready for solids at this time',
+                        textAlign: TextAlign.center,
+                        style: textTheme.headlineSmall?.copyWith(
+                          color: AppColors.fgStrong,
+                        ),
+                      ),
+                      const SizedBox(height: AppSizes.xl),
+                      _HeroCard(
+                        signsMet: signsMet,
+                        answers: answers,
+                        ready: ready,
+                      ),
+                    ],
                   ),
                 ),
               ),
-              const SizedBox(height: AppSizes.lg),
-              AppPillButton(
-                key: const Key('onboarding_result_next'),
-                label: 'Next',
-                onPressed: () =>
-                    context.goNamed(AppRoute.onboardingConsent.name),
+              const SizedBox(height: AppSizes.md),
+              Row(
+                children: [
+                  AppRoundButton(
+                    key: const Key('onboarding_result_back'),
+                    icon: const Icon(Icons.arrow_back_rounded),
+                    tone: AppRoundButtonTone.butter,
+                    semanticLabel: 'Back',
+                    onPressed: () => _onBack(context),
+                  ),
+                  const SizedBox(width: AppSizes.sp12),
+                  Expanded(
+                    child: AppPillButton(
+                      key: const Key('onboarding_result_next'),
+                      label: 'Next',
+                      onPressed: () =>
+                          context.goNamed(AppRoute.onboardingConsent.name),
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
@@ -126,9 +155,6 @@ class OnboardingResultScreen extends ConsumerWidget {
   }
 
   void _onBack(BuildContext context) {
-    // Readiness `go`s here, so the stack typically can't pop. Fall through to
-    // a named nav so back consistently returns to the questionnaire; the
-    // hoisted controller (keepAlive) preserves the captured answers.
     if (context.canPop()) {
       context.pop();
       return;
@@ -137,105 +163,105 @@ class OnboardingResultScreen extends ConsumerWidget {
   }
 }
 
-/// Majority gate per NIB-120: ready iff at least this many signs are met.
-const int readinessReadyThreshold = 3;
-
-class _ResultCard extends StatelessWidget {
-  const _ResultCard({
-    required this.firstName,
-    required this.answers,
+/// Hero cluster + lime card composition. Stack overlaps the brand mark on the
+/// top edge of the card so it visually punches through the lime panel — matches
+/// the Figma 1255:11893 / 1029:8508 layering.
+class _HeroCard extends StatelessWidget {
+  const _HeroCard({
     required this.signsMet,
+    required this.answers,
     required this.ready,
   });
 
-  final String firstName;
-  final List<bool?> answers;
   final int signsMet;
+  final List<bool?> answers;
+  final bool ready;
+
+  static const double _heroSize = 96;
+
+  @override
+  Widget build(BuildContext context) {
+    // Overlap = half the hero so the lower hemisphere sits inside the card.
+    const overlap = _heroSize / 2;
+    return Stack(
+      clipBehavior: Clip.none,
+      alignment: Alignment.topCenter,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: overlap),
+          child: _SignsCard(
+            signsMet: signsMet,
+            answers: answers,
+            ready: ready,
+          ),
+        ),
+        const Quatrefoil(
+          coreColor: AppColors.greenSoft,
+        ),
+      ],
+    );
+  }
+}
+
+class _SignsCard extends StatelessWidget {
+  const _SignsCard({
+    required this.signsMet,
+    required this.answers,
+    required this.ready,
+  });
+
+  final int signsMet;
+  final List<bool?> answers;
   final bool ready;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    final cardColor = ready ? AppColors.butter : AppColors.green;
-    final petalColor = ready ? AppColors.butterSoft : AppColors.greenTint;
-    final coreColor = ready ? AppColors.greenDeep : AppColors.butter;
-    final fgStrong = ready ? AppColors.greenDeep : AppColors.cream;
-    // Eyebrow uses the same on-card tone as the headline so the row reads as a
-    // single typographic pair — both tokens are kit foreground colors, no
-    // inline opacity. Sage card -> cream-on-green; butter card -> greenDeep.
-    final fgEyebrow = ready ? AppColors.greenDeep : AppColors.onGreen;
-    final eyebrow = ready ? 'New Journey Unlock!' : 'Almost there';
-    final headline = ready
-        ? '$firstName is ready for solids at this time'
-        : '$firstName is not ready for solids at this time';
-
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: cardColor,
+        color: AppColors.butter,
         borderRadius: BorderRadius.circular(AppSizes.radius2xl),
-        boxShadow: AppSizes.shadowCardLifted,
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(
           AppSizes.lg,
-          AppSizes.xl,
+          // Top padding makes room for the hero overlap (half the hero) + the
+          // card's internal lg gutter so the header sits below the hero.
+          AppSizes.lg + (_HeroCard._heroSize / 2),
           AppSizes.lg,
           AppSizes.lg,
         ),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Quatrefoil(
-              size: AppSizes.xxxl,
-              petalColor: petalColor,
-              coreColor: coreColor,
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Readiness Signs',
+                    style: textTheme.titleSmall?.copyWith(
+                      color: AppColors.fgDefault,
+                    ),
+                  ),
+                ),
+                _ScoreChip(
+                  signsMet: signsMet,
+                  total: _signLabels.length,
+                ),
+              ],
             ),
             const SizedBox(height: AppSizes.md),
-            _ScoreBadge(signsMet: signsMet, ready: ready),
-            const SizedBox(height: AppSizes.md),
-            Text(
-              // Overline token (labelSmall): 10/700 h1.20 ls0.6 per kit —
-              // includes letterSpacing, no inline override needed.
-              eyebrow.toUpperCase(),
-              textAlign: TextAlign.center,
-              style: textTheme.labelSmall?.copyWith(color: fgEyebrow),
-            ),
-            const SizedBox(height: AppSizes.xs),
-            Text(
-              headline,
-              textAlign: TextAlign.center,
-              style: textTheme.displaySmall?.copyWith(color: fgStrong),
-            ),
-            const SizedBox(height: AppSizes.lg),
-            DecoratedBox(
-              decoration: BoxDecoration(
-                color: AppColors.cream,
-                borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+            for (var i = 0; i < _signLabels.length; i++) ...[
+              _SignRow(
+                // Ready variant: all rows render as positive per spec — the
+                // X/5 chip still reflects `signsMet` so the user sees their
+                // actual score.
+                positive: ready || (answers[i] ?? false),
+                label: _signLabels[i],
               ),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.md,
-                  vertical: AppSizes.sp12,
-                ),
-                child: Column(
-                  children: List<Widget>.generate(_signLabels.length, (i) {
-                    // Ready variant: all rows render as positive (green check)
-                    // per spec Step 3, regardless of per-answer values. The
-                    // X/5 badge still reflects `signsMet` so the user sees
-                    // their actual score.
-                    final isPositive = ready || (answers[i] ?? false);
-                    return Padding(
-                      padding: EdgeInsets.only(
-                        top: i == 0 ? 0 : AppSizes.sp12,
-                      ),
-                      child: _SignRow(
-                        label: _signLabels[i],
-                        positive: isPositive,
-                      ),
-                    );
-                  }),
-                ),
-              ),
-            ),
+              if (i < _signLabels.length - 1)
+                const SizedBox(height: AppSizes.md),
+            ],
           ],
         ),
       ),
@@ -243,29 +269,30 @@ class _ResultCard extends StatelessWidget {
   }
 }
 
-class _ScoreBadge extends StatelessWidget {
-  const _ScoreBadge({required this.signsMet, required this.ready});
+class _ScoreChip extends StatelessWidget {
+  const _ScoreChip({required this.signsMet, required this.total});
 
   final int signsMet;
-  final bool ready;
+  final int total;
 
   @override
   Widget build(BuildContext context) {
-    final bg = ready ? AppColors.greenDeep : AppColors.butter;
-    final fg = ready ? AppColors.cream : AppColors.greenDeep;
+    final textTheme = Theme.of(context).textTheme;
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: bg,
+        color: AppColors.coralSoft,
         borderRadius: BorderRadius.circular(AppSizes.radiusFull),
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(
-          horizontal: AppSizes.md,
+          horizontal: AppSizes.sp12,
           vertical: AppSizes.xs,
         ),
         child: Text(
-          '$signsMet / ${_signLabels.length} signs',
-          style: AppTypography.bodyBold.copyWith(color: fg),
+          '$signsMet/$total',
+          style: textTheme.labelMedium?.copyWith(
+            color: AppColors.coralDeep,
+          ),
         ),
       ),
     );
@@ -273,34 +300,41 @@ class _ScoreBadge extends StatelessWidget {
 }
 
 class _SignRow extends StatelessWidget {
-  const _SignRow({required this.label, required this.positive});
+  const _SignRow({required this.positive, required this.label});
 
-  final String label;
   final bool positive;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
-    final markBg = positive ? AppColors.greenTint : AppColors.destructiveSoft;
-    final markFg = positive ? AppColors.greenDeep : AppColors.destructive;
+    final textTheme = Theme.of(context).textTheme;
     final icon = positive ? Icons.check_rounded : Icons.close_rounded;
-
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Container(
-          width: AppSizes.iconMd,
-          height: AppSizes.iconMd,
-          decoration: BoxDecoration(
-            color: markBg,
+          width: AppSizes.iconLg,
+          height: AppSizes.iconLg,
+          decoration: const BoxDecoration(
+            color: AppColors.cream,
             shape: BoxShape.circle,
           ),
-          child: Icon(icon, color: markFg, size: AppSizes.iconSm),
+          child: Icon(
+            icon,
+            size: AppSizes.iconSm,
+            color: AppColors.greenDeep,
+          ),
         ),
         const SizedBox(width: AppSizes.sp12),
         Expanded(
-          child: Text(
-            label,
-            style: AppTypography.bodyBold.copyWith(
-              color: AppColors.fgDefault,
+          child: Padding(
+            // Nudge label down so it visually centers against the icon circle.
+            padding: const EdgeInsets.only(top: AppSizes.xs),
+            child: Text(
+              label,
+              style: textTheme.bodyLarge?.copyWith(
+                color: AppColors.fgDefault,
+              ),
             ),
           ),
         ),

--- a/test/features/onboarding/result/onboarding_result_screen_test.dart
+++ b/test/features/onboarding/result/onboarding_result_screen_test.dart
@@ -6,14 +6,14 @@ import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
 import 'package:nibbles/src/features/onboarding/result/onboarding_result_screen.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-/// NIB-105 — widget tests for `OnboardingResultScreen` (NIB-91).
+/// NIB-91 — widget tests for `OnboardingResultScreen`.
 ///
-/// Pins the soft-warn UX: Next routes forward to `/onboarding/consent` in
-/// BOTH the ready and not-ready variants. Visual variant pins:
-///   - ready (signsMet=5):     "New Journey Unlock!" eyebrow + score "5 / 5
-///     signs".
-///   - not-ready (signsMet=1): "Almost there" eyebrow + cross marks on each
-///     not-met sign row + score "1 / 5 signs".
+/// Pins the soft-warn UX (Next routes forward to `/onboarding/consent` in
+/// BOTH variants) and the Figma-aligned visuals:
+///   - ready variant (signsMet>=3): "New Journey Unlock!" eyebrow + ready
+///     headline + all 5 rows positive + X/Y chip reflects actual score.
+///   - not-ready variant (signsMet<3): no eyebrow, not-ready headline, per-
+///     answer check/cross icons on each row.
 GoRouter _routerFor(Widget screen) => GoRouter(
   initialLocation: AppRoute.onboardingResult.path,
   routes: [
@@ -55,39 +55,43 @@ Future<void> _pumpResult(
 
 void main() {
   testWidgets(
-    'ready variant (signsMet=5) shows "New Journey Unlock!" eyebrow and the '
-    '5 / 5 score badge',
+    'ready variant (signsMet=5) shows the "New Journey Unlock!" eyebrow, the '
+    'ready headline and the 5/5 score chip',
     (tester) async {
       await _pumpResult(
         tester,
         answers: const <bool?>[true, true, true, true, true],
       );
 
-      // Eyebrow is uppercased via .toUpperCase() before render.
-      expect(find.text('NEW JOURNEY UNLOCK!'), findsOneWidget);
+      expect(find.text('New Journey Unlock!'), findsOneWidget);
       expect(
         find.text('Lily is ready for solids at this time'),
         findsOneWidget,
       );
-      expect(find.text('5 / 5 signs'), findsOneWidget);
+      expect(find.text('Readiness Signs'), findsOneWidget);
+      expect(find.text('5/5'), findsOneWidget);
+      // Ready variant renders all rows positive — 5 checks, 0 crosses.
+      expect(find.byIcon(Icons.check_rounded), findsNWidgets(5));
+      expect(find.byIcon(Icons.close_rounded), findsNothing);
     },
   );
 
   testWidgets(
-    'not-ready variant (signsMet=1) shows "Almost there" eyebrow, 1 / 5 score '
-    'and cross marks on the not-met rows',
+    'not-ready variant (signsMet=1) drops the eyebrow, shows the not-ready '
+    'headline, the 1/5 chip and per-answer check/cross icons',
     (tester) async {
       await _pumpResult(
         tester,
         answers: const <bool?>[true, false, false, false, false],
       );
 
-      expect(find.text('ALMOST THERE'), findsOneWidget);
+      // Not-ready variant carries no eyebrow per Figma 1029:8508.
+      expect(find.text('New Journey Unlock!'), findsNothing);
       expect(
         find.text('Lily is not ready for solids at this time'),
         findsOneWidget,
       );
-      expect(find.text('1 / 5 signs'), findsOneWidget);
+      expect(find.text('1/5'), findsOneWidget);
 
       // 4 not-met -> 4 cross marks; 1 met -> 1 check mark.
       expect(find.byIcon(Icons.close_rounded), findsNWidgets(4));
@@ -103,12 +107,12 @@ void main() {
         answers: const <bool?>[true, true, true, false, false],
       );
 
-      expect(find.text('NEW JOURNEY UNLOCK!'), findsOneWidget);
+      expect(find.text('New Journey Unlock!'), findsOneWidget);
       // Ready variant renders all rows positive regardless of per-answer
       // values (verbatim from `OnboardingResultScreen`'s `isPositive` rule):
       //   final isPositive = ready || (answers[i] ?? false);
       expect(find.byIcon(Icons.close_rounded), findsNothing);
-      expect(find.text('3 / 5 signs'), findsOneWidget);
+      expect(find.text('3/5'), findsOneWidget);
     },
   );
 


### PR DESCRIPTION
## Summary

NIB-91 alignment pass for the readiness result screen (`/onboarding/result`):

- Restructures layout to match Figma 1255:11893 (ready) / 1029:8508 (not-ready) — title (+ "New Journey Unlock!" eyebrow on ready) at top, hero quatrefoil overlapping the lime card, "Readiness Signs" header row + salmon X/Y chip inside the card.
- Adopts verbatim sign labels from the audit (resolving the audit-flagged item-1/item-2 duplication: the head-control half of the concatenated item-1 string maps to row 0).
- Drops the not-ready eyebrow (no eyebrow in Figma 1029:8508).
- Moves Back to a bottom-row butter `AppRoundButton` next to the primary Next CTA (matches the NIB-100 consent convention).
- Preserves the tested product decisions: NIB-120 majority gate (`signsMet >= 3` -> ready), soft-warn UX (both variants route to `/onboarding/consent`), dynamic `X/Y` score (resolving the Figma `3/5` placeholder), ready variant renders all rows positive while the chip still reflects the actual score.

## Acceptance criteria

- [x] Layout pixel-aligned with `.figma-audit/onboarding/readiness-ready/screenshot.png` and `.figma-audit/onboarding/readiness-not-ready/screenshot.png`
- [x] Verbatim copy with first-name interpolation and "your baby" fallback
- [x] X/Y score reflects actual computation
- [x] Variant selection driven by `signsMet >= readinessReadyThreshold` (3)
- [x] Per-sign icon (check vs cross) reflects answers in the not-ready variant; ready variant renders all positive
- [x] Next routes to `/onboarding/consent` in both variants (soft-warn)
- [x] All tokens consumed from `AppColors` / `AppSizes` / `AppTypography`
- [x] `flutter analyze` clean
- [x] Widget tests cover both variants, boundary (signsMet=3), Next routing in both variants, and the empty-name fallback

## Figma frames

- ready: `1255:11893`
- not-ready: `1029:8508`

## Audit reports

- `.figma-audit/onboarding/readiness-ready/report.md`
- `.figma-audit/onboarding/readiness-not-ready/report.md`