### PR TITLE
feat(onboarding): post-consent baby setup loading transition [NIB-137]

### DIFF
--- a/lib/src/features/onboarding/baby_setup_loading/baby_setup_loading_controller.dart
+++ b/lib/src/features/onboarding/baby_setup_loading/baby_setup_loading_controller.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:nibbles/src/features/onboarding/baby_setup_loading/baby_setup_loading_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'baby_setup_loading_controller.g.dart';
+
+/// NIB-137 — passive transition shown after the consent step submits
+/// successfully and before the user lands on /home.
+///
+/// The actual `createBaby` future is owned by `OnboardingController.submit`
+/// (NIB-100) — by the time this screen mounts, the baby already exists and
+/// `onboarding_done` is true. So this controller only owns the *dwell*:
+///
+///   1. Render [BabySetupLoadingPhase.loading] immediately.
+///   2. After [minDwell], flip to [BabySetupLoadingPhase.ready] so the screen
+///      schedules its auto-route to /home.
+///   3. [maxTimeout] is the safety belt — if some future preload were to be
+///      wired in here it would force-settle anyway. Today minDwell elapses
+///      first so the timeout is functionally a no-op, but the constant is
+///      kept so the screen's PopScope + timeout semantics stay clearly named.
+///
+/// Min dwell is sized so the petal animation never just flashes (per Figma
+/// audit rotating-icon cluster spec) and aligns with the NIB-130 subscription
+/// success screen's 1500ms floor.
+@riverpod
+class BabySetupLoadingController extends _$BabySetupLoadingController {
+  /// Floor on the loading frame so the petal animation reads as intentional
+  /// transition rather than a flash. Verbatim per ticket acceptance:
+  /// "Minimum 1.5s display".
+  static const Duration minDwell = Duration(milliseconds: 1600);
+
+  /// Hard timeout — surface the auto-route even if some future preload here
+  /// stalls. Verbatim per ticket acceptance: "Maximum display duration: hard
+  /// timeout (e.g. 8s)".
+  static const Duration maxTimeout = Duration(seconds: 8);
+
+  Timer? _dwellTimer;
+  Timer? _timeoutTimer;
+
+  @override
+  BabySetupLoadingPhase build() {
+    ref.onDispose(() {
+      _dwellTimer?.cancel();
+      _timeoutTimer?.cancel();
+    });
+    _scheduleSettle();
+    return BabySetupLoadingPhase.loading;
+  }
+
+  /// Schedules both the min-dwell and the safety-belt timeout. First to fire
+  /// flips the phase to [BabySetupLoadingPhase.ready]; the second fire is a
+  /// no-op courtesy of the idempotency check inside [_markReady].
+  void _scheduleSettle() {
+    _dwellTimer = Timer(minDwell, _markReady);
+    _timeoutTimer = Timer(maxTimeout, _markReady);
+  }
+
+  void _markReady() {
+    if (state == BabySetupLoadingPhase.ready) return;
+    state = BabySetupLoadingPhase.ready;
+  }
+}

--- a/lib/src/features/onboarding/baby_setup_loading/baby_setup_loading_controller.g.dart
+++ b/lib/src/features/onboarding/baby_setup_loading/baby_setup_loading_controller.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'baby_setup_loading_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$babySetupLoadingControllerHash() =>
+    r'6f190638946c66e1b0f9afb10a33e1176b06c233';
+
+/// NIB-137 — passive transition shown after the consent step submits
+/// successfully and before the user lands on /home.
+///
+/// The actual `createBaby` future is owned by [OnboardingController.submit]
+/// (NIB-100) — by the time this screen mounts, the baby already exists and
+/// `onboarding_done` is true. So this controller only owns the *dwell*:
+///
+///   1. Render [BabySetupLoadingPhase.loading] immediately.
+///   2. After [minDwell], flip to [BabySetupLoadingPhase.ready] so the screen
+///      schedules its auto-route to /home.
+///   3. [maxTimeout] is the safety belt — if some future preload were to be
+///      wired in here it would force-settle anyway. Today minDwell elapses
+///      first so the timeout is functionally a no-op, but the constant is
+///      kept so the screen's PopScope + timeout semantics stay clearly named.
+///
+/// Min dwell is sized so the petal animation never just flashes (per Figma
+/// audit rotating-icon cluster spec) and aligns with the NIB-130 subscription
+/// success screen's 1500ms floor.
+///
+/// Copied from [BabySetupLoadingController].
+@ProviderFor(BabySetupLoadingController)
+final babySetupLoadingControllerProvider =
+    AutoDisposeNotifierProvider<
+      BabySetupLoadingController,
+      BabySetupLoadingPhase
+    >.internal(
+      BabySetupLoadingController.new,
+      name: r'babySetupLoadingControllerProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$babySetupLoadingControllerHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$BabySetupLoadingController =
+    AutoDisposeNotifier<BabySetupLoadingPhase>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/onboarding/baby_setup_loading/baby_setup_loading_state.dart
+++ b/lib/src/features/onboarding/baby_setup_loading/baby_setup_loading_state.dart
@@ -1,0 +1,10 @@
+/// NIB-137 — phase enum for the post-consent baby-setup loading transition.
+///
+/// `loading` — petal animation visible, dwell timer running.
+/// `ready` — min dwell elapsed; the screen will schedule its auto-route to
+/// `/home`. Visually identical to `loading` (single Figma frame); the split
+/// exists purely as the notification edge the screen listens on.
+enum BabySetupLoadingPhase {
+  loading,
+  ready,
+}

--- a/lib/src/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen.dart
+++ b/lib/src/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen.dart
@@ -1,0 +1,165 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/brand/petal_blob.dart';
+import 'package:nibbles/src/features/onboarding/baby_setup_loading/baby_setup_loading_controller.dart';
+import 'package:nibbles/src/features/onboarding/baby_setup_loading/baby_setup_loading_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+/// NIB-137 — passive post-consent loading transition.
+///
+/// Reached from `OnboardingConsentScreen` after `createBaby` resolves and
+/// `onboarding_done` is set true. The screen owns no data calls: it renders
+/// a static petal-blob frame for [BabySetupLoadingController.minDwell] and
+/// then auto-pushes /home.
+///
+/// Visuals (Figma node 971:10246 — `.figma-audit/onboarding/baby-setup-loading`):
+///   - Solid cream (#FFFCD5 — `AppColors.butterSoft`) background.
+///   - [PetalBlob] cluster center-screen with faint uppercase "LOADING"
+///     caption layered inside (cream-on-cream, low contrast per spec).
+///   - Footer tagline ("We need several data to know more about your babys")
+///     anchored ~70% down screen, Figtree SemiBold 15/22, black.
+///
+/// Back-nav is blocked while the screen is mounted so kill-and-resume after
+/// a consent submit does not let the user re-enter the consent form with the
+/// baby already created. Once the auto-route fires the GoRouter redirect
+/// gates this path anyway (onboarding_done is true).
+class OnboardingBabySetupLoadingScreen extends ConsumerStatefulWidget {
+  const OnboardingBabySetupLoadingScreen({super.key});
+
+  @override
+  ConsumerState<OnboardingBabySetupLoadingScreen> createState() =>
+      _OnboardingBabySetupLoadingScreenState();
+}
+
+class _OnboardingBabySetupLoadingScreenState
+    extends ConsumerState<OnboardingBabySetupLoadingScreen> {
+  /// Footer copy — verbatim from the Figma audit (incl. the flagged grammar
+  /// issue: "several data" treated singular + missing apostrophe on "babys").
+  /// PO has the rewrite "We need some data to learn more about your baby." on
+  /// the open-questions list; until that lands here this stays byte-for-byte
+  /// to keep the visual diff clean.
+  static const String footerCopy =
+      'We need several data to know more about your babys';
+
+  /// Caption inside the petal cluster — Figma renders the word "Loading" in
+  /// title case but at a tracking/contrast where the eye reads it as caps;
+  /// uppercased here to match the LoadingConfirmation convention (NIB-130).
+  static const String loadingCaption = 'LOADING';
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_logScreenView());
+    });
+  }
+
+  Future<void> _logScreenView() async {
+    try {
+      await Analytics.instance.logScreenView(
+        screenName: 'onboarding_baby_setup_loading',
+      );
+    } on Object catch (_) {
+      // Best-effort — never surface to the UI.
+    }
+  }
+
+  void _goHome() {
+    if (!mounted) return;
+    context.goNamed(AppRoute.home.name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    // Listen (not watch) so the auto-route side-effect fires exactly on the
+    // loading -> ready edge. Watching would re-fire on every rebuild after
+    // the phase has already flipped. No `ref.watch` is needed: both phases
+    // render identically, and the `ref.listen` registration itself is what
+    // mounts the controller on first build.
+    ref.listen<BabySetupLoadingPhase>(
+      babySetupLoadingControllerProvider,
+      (prev, next) {
+        if (next == BabySetupLoadingPhase.ready &&
+            prev != BabySetupLoadingPhase.ready) {
+          _goHome();
+        }
+      },
+    );
+
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        backgroundColor: AppColors.butterSoft,
+        body: SafeArea(
+          child: SizedBox.expand(
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                // Centered cluster: petal blob + faint "LOADING" caption
+                // overlay. The caption sits inside the blob's footprint per
+                // the Figma snapshot (audit screenshot).
+                Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    const PetalBlob(
+                      key: Key('onboarding_baby_setup_loading_blob'),
+                    ),
+                    Padding(
+                      // Nudge the caption slightly below the blob's optical
+                      // center so it reads under the inner sage quatrefoil
+                      // (matches the audit snapshot).
+                      padding: const EdgeInsets.only(top: AppSizes.xxl),
+                      child: Text(
+                        loadingCaption,
+                        key: const Key(
+                          'onboarding_baby_setup_loading_caption',
+                        ),
+                        textAlign: TextAlign.center,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: AppColors.cream,
+                          fontSize: 12.8,
+                          height: 19.2 / 12.8,
+                          letterSpacing: 4.33,
+                          fontWeight: FontWeight.w400,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                // Footer tagline anchored ~70% down screen — Figma footer at
+                // bottom 611 of an 874 height (≈30% from the bottom = 0.40
+                // on the y axis once expressed as Alignment(0, y)).
+                Align(
+                  alignment: const Alignment(0, 0.40),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSizes.pagePaddingH,
+                    ),
+                    child: Text(
+                      footerCopy,
+                      key: const Key('onboarding_baby_setup_loading_footer'),
+                      textAlign: TextAlign.center,
+                      // Body/SemiBold (Figtree 15/22 w600) per audit token map.
+                      style: textTheme.bodyLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.text,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/onboarding/consent/onboarding_consent_screen.dart
+++ b/lib/src/features/onboarding/consent/onboarding_consent_screen.dart
@@ -70,7 +70,10 @@ class _OnboardingConsentScreenState
     if (!ok || !mounted) return;
     ref.read(localFlagServiceProvider).setOnboardingDone();
     if (!mounted) return;
-    context.goNamed(AppRoute.home.name);
+    // NIB-137 — drop the user on the post-consent loading transition; the
+    // loading screen auto-routes to /home after a short min dwell. createBaby
+    // has already resolved at this point so this screen is purely visual.
+    context.goNamed(AppRoute.onboardingBabySetupLoading.name);
   }
 
   void _onBack() {

--- a/lib/src/routing/route_enums.dart
+++ b/lib/src/routing/route_enums.dart
@@ -19,6 +19,10 @@ enum AppRoute {
     path: '/onboarding/baby-setup',
     name: 'onboarding-baby-setup',
   ),
+  onboardingBabySetupLoading(
+    path: '/onboarding/baby-setup-loading',
+    name: 'onboarding-baby-setup-loading',
+  ),
   register(path: '/auth/register', name: 'register'),
   login(path: '/auth/login', name: 'login'),
   forgotPassword(path: '/auth/forgot-password', name: 'forgot-password'),

--- a/lib/src/routing/routes.dart
+++ b/lib/src/routing/routes.dart
@@ -18,6 +18,7 @@ import 'package:nibbles/src/features/meal_plan/map/map_meals_screen.dart';
 import 'package:nibbles/src/features/meal_plan/map/map_meals_state.dart';
 import 'package:nibbles/src/features/meal_plan/meal_plan_screen.dart';
 import 'package:nibbles/src/features/onboarding/baby_setup/onboarding_baby_setup_screen.dart';
+import 'package:nibbles/src/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen.dart';
 import 'package:nibbles/src/features/onboarding/consent/onboarding_consent_screen.dart';
 import 'package:nibbles/src/features/onboarding/dob/onboarding_dob_screen.dart';
 import 'package:nibbles/src/features/onboarding/intro/onboarding_intro_screen.dart';
@@ -199,6 +200,16 @@ GoRouter goRouter(Ref ref) {
         path: AppRoute.onboardingBabySetup.path,
         name: AppRoute.onboardingBabySetup.name,
         builder: (context, state) => const OnboardingBabySetupScreen(),
+      ),
+      // NIB-137 — passive post-consent transition. Kept OFF `gatedPaths` so a
+      // user whose `onboarding_done` flag has just flipped (set by the consent
+      // screen before pushing here) is not bounced straight to /home by the
+      // redirect. The screen auto-routes to /home after a short min dwell.
+      GoRoute(
+        path: AppRoute.onboardingBabySetupLoading.path,
+        name: AppRoute.onboardingBabySetupLoading.name,
+        builder: (context, state) =>
+            const OnboardingBabySetupLoadingScreen(),
       ),
       GoRoute(
         path: AppRoute.register.path,

--- a/lib/src/routing/routes.g.dart
+++ b/lib/src/routing/routes.g.dart
@@ -6,7 +6,7 @@ part of 'routes.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'd5bab8f67774cfb4432ec333d2dd166a07d5d658';
+String _$goRouterHash() => r'4a5c05f07ace54e5e39198f72fc0a2979cda15c5';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)

--- a/test/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen_test.dart
+++ b/test/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen_test.dart
@@ -1,0 +1,131 @@
+// NIB-137 — widget tests for the post-consent baby-setup loading transition.
+//
+// Covers:
+//   - Loading frame renders the petal blob + faint "LOADING" caption + the
+//     verbatim footer copy.
+//   - PopScope blocks back navigation while the dwell is running.
+//   - After [BabySetupLoadingController.minDwell] elapses the screen auto-
+//     routes to /home (single edge — no double-fire on subsequent rebuilds).
+//
+// Durations are advanced via `tester.pump` so the suite is deterministic.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/features/onboarding/baby_setup_loading/baby_setup_loading_controller.dart';
+import 'package:nibbles/src/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+GoRouter _routerFor(Widget screen) => GoRouter(
+  initialLocation: AppRoute.onboardingBabySetupLoading.path,
+  routes: [
+    GoRoute(
+      path: AppRoute.onboardingBabySetupLoading.path,
+      name: AppRoute.onboardingBabySetupLoading.name,
+      builder: (_, __) => screen,
+    ),
+    GoRoute(
+      path: AppRoute.home.path,
+      name: AppRoute.home.name,
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text('HOME_STUB'))),
+    ),
+  ],
+);
+
+Widget _buildSut({required GoRouter router}) => ProviderScope(
+  child: MaterialApp.router(routerConfig: router),
+);
+
+void main() {
+  testWidgets(
+    'loading frame renders the petal blob, LOADING caption and footer copy',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildSut(
+          router: _routerFor(const OnboardingBabySetupLoadingScreen()),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('onboarding_baby_setup_loading_blob')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('onboarding_baby_setup_loading_caption')),
+        findsOneWidget,
+      );
+      expect(find.text('LOADING'), findsOneWidget);
+      // Verbatim copy from the Figma audit (grammar issue preserved).
+      expect(
+        find.text('We need several data to know more about your babys'),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'after minDwell elapses the screen auto-routes to /home',
+    (tester) async {
+      final router = _routerFor(const OnboardingBabySetupLoadingScreen());
+      await tester.pumpWidget(_buildSut(router: router));
+      await tester.pump();
+
+      // Advance past the min-dwell so the controller flips to `ready` and
+      // the screen schedules its push to /home.
+      await tester.pump(BabySetupLoadingController.minDwell);
+      await tester.pumpAndSettle();
+
+      expect(find.text('HOME_STUB'), findsOneWidget);
+      expect(
+        router.routerDelegate.currentConfiguration.uri.path,
+        AppRoute.home.path,
+      );
+    },
+  );
+
+  testWidgets(
+    'PopScope blocks back navigation while the dwell is running',
+    (tester) async {
+      final router = _routerFor(const OnboardingBabySetupLoadingScreen());
+      await tester.pumpWidget(_buildSut(router: router));
+      await tester.pump();
+
+      // Attempt to pop from the GoRouter API — PopScope.canPop is false so
+      // the screen stays on the loading route until the auto-route fires.
+      unawaited(router.routerDelegate.popRoute());
+      await tester.pump();
+
+      expect(
+        router.routerDelegate.currentConfiguration.uri.path,
+        AppRoute.onboardingBabySetupLoading.path,
+      );
+      expect(find.text('HOME_STUB'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'within maxTimeout window the screen still ends up on /home',
+    (tester) async {
+      // Sanity: even under the safety-belt cap, the screen still resolves.
+      // Today minDwell elapses first (so this is functionally the same as the
+      // happy-path test) but the assertion guards a future where the dwell
+      // is replaced by a real preload.
+      final router = _routerFor(const OnboardingBabySetupLoadingScreen());
+      await tester.pumpWidget(_buildSut(router: router));
+      await tester.pump();
+
+      await tester.pump(BabySetupLoadingController.maxTimeout);
+      await tester.pumpAndSettle();
+
+      expect(
+        router.routerDelegate.currentConfiguration.uri.path,
+        AppRoute.home.path,
+      );
+    },
+  );
+}

--- a/test/features/onboarding/consent/onboarding_consent_screen_test.dart
+++ b/test/features/onboarding/consent/onboarding_consent_screen_test.dart
@@ -48,6 +48,15 @@ GoRouter _routerFor(Widget screen) => GoRouter(
       name: AppRoute.onboardingConsent.name,
       builder: (_, __) => screen,
     ),
+    // NIB-137 — consent now pushes through the post-consent loading
+    // transition instead of going straight to /home. Stub it so the
+    // success-path test can land on a deterministic route.
+    GoRoute(
+      path: AppRoute.onboardingBabySetupLoading.path,
+      name: AppRoute.onboardingBabySetupLoading.name,
+      builder: (_, __) =>
+          const Scaffold(body: Center(child: Text('LOADING_STUB'))),
+    ),
     GoRoute(
       path: AppRoute.home.path,
       name: AppRoute.home.name,
@@ -257,7 +266,7 @@ void main() {
 
   testWidgets(
     'on confirm: calls baby_profile_service.createBaby, flips '
-    'onboarding_done, navigates to /home',
+    'onboarding_done, navigates to the post-consent loading transition',
     (tester) async {
       when(
         () => babyProfile.createBaby(any(), any()),
@@ -280,7 +289,10 @@ void main() {
 
       verify(() => babyProfile.createBaby('Lily', dob)).called(1);
       verify(flags.setOnboardingDone).called(1);
-      expect(find.text('HOME_STUB'), findsOneWidget);
+      // NIB-137 — consent now pushes through the loading transition; that
+      // screen owns the auto-route to /home and is tested in isolation.
+      expect(find.text('LOADING_STUB'), findsOneWidget);
+      expect(find.text('HOME_STUB'), findsNothing);
     },
   );
 


### PR DESCRIPTION
## NIB-137 — Design+Flow: post-consent baby setup loading transition

Adds a passive single-phase loading transition between the consent submit (NIB-100) and the home screen. The petal-blob cluster + faint "LOADING" caption + footer tagline render for a min dwell then auto-routes to /home.

createBaby is owned by `OnboardingController.submit` (NIB-100) and has already resolved before this screen mounts; this screen owns no data calls.

### Acceptance criteria

- [x] Pixel-close match to `.figma-audit/onboarding/baby-setup-loading/screenshot.png`
- [x] Verbatim copy: "Loading" + "We need several data to know more about your babys" (grammar issue preserved per PO open question)
- [x] Solid cream background (`AppColors.butterSoft` = `#FFFCD5`, the Figma `Nibble-primary-cream` token) — NOT the butter gradient
- [x] Min 1.6s dwell + 8s safety-belt timeout
- [x] Routes to `/home` on settle; PopScope blocks back-nav while dwell runs
- [x] All tokens consumed from DS (`AppColors`, `AppSizes`, `textTheme`); no hardcoded hex
- [x] `flutter analyze` clean (0 issues)
- [x] Widget tests for blob + caption + footer copy, min-dwell auto-route, PopScope, and max-timeout safety belt

### Files

- `lib/src/features/onboarding/baby_setup_loading/baby_setup_loading_state.dart` — single-phase enum
- `lib/src/features/onboarding/baby_setup_loading/baby_setup_loading_controller.dart` — min-dwell + max-timeout Notifier
- `lib/src/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen.dart` — screen + auto-route side-effect
- `lib/src/routing/route_enums.dart` — new `onboardingBabySetupLoading` route
- `lib/src/routing/routes.dart` — registers the new GoRoute (kept OFF `gatedPaths` so a just-flipped-onboarding-done user is not bounced)
- `lib/src/features/onboarding/consent/onboarding_consent_screen.dart` — pushes through the loading screen instead of going straight to `/home`
- `test/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen_test.dart` — 4 widget tests
- `test/features/onboarding/consent/onboarding_consent_screen_test.dart` — updated success-path expectation

### Figma frame ids

- `971:10246` — Baby's setup - Loading
- Audit report: `.figma-audit/onboarding/baby-setup-loading/report.md`
- Audit screenshot: `.figma-audit/onboarding/baby-setup-loading/screenshot.png`
- Audit token map: `.figma-audit/onboarding/baby-setup-loading/variables.json`

### PO open questions still outstanding

- Footer copy has flagged grammar issues — kept verbatim until PO resolution lands.
- Rotation/easing for the petal cluster is left static (Figma snapshot is static); a rotating SVG layer can be wired in once PO confirms speed + direction.