### PR TITLE
feat(onboarding): readiness 6-screen questionnaire w/ color-progressing bar [NIB-83]

### DIFF
--- a/lib/src/features/onboarding/onboarding_controller.dart
+++ b/lib/src/features/onboarding/onboarding_controller.dart
@@ -30,6 +30,12 @@ class OnboardingController extends _$OnboardingController {
   // Readiness + result stages
   // ---------------------------------------------------------------------------
 
+  /// NIB-83 Q1 — pediatrician-approval gate. Captured separately from the
+  /// developmental-sign answers; not counted toward `signs_met`.
+  void setPediatricianApproved({required bool approved}) {
+    state = state.copyWith(pediatricianApproved: approved);
+  }
+
   void setReadinessAnswers(List<bool?> answers) {
     state = state.copyWith(
       readinessAnswers: List<bool?>.unmodifiable(answers),

--- a/lib/src/features/onboarding/onboarding_controller.g.dart
+++ b/lib/src/features/onboarding/onboarding_controller.g.dart
@@ -7,7 +7,7 @@ part of 'onboarding_controller.dart';
 // **************************************************************************
 
 String _$onboardingControllerHash() =>
-    r'60d0c444e4ae1e8efbbee4d702aa36143169b459';
+    r'121cd61b69c105a5fe4c78d79ba2ba2e165e8084';
 
 /// Single hoisted controller for the new onboarding flow.
 ///

--- a/lib/src/features/onboarding/onboarding_state.dart
+++ b/lib/src/features/onboarding/onboarding_state.dart
@@ -3,12 +3,18 @@ import 'package:nibbles/src/common/domain/formz/baby_name_input.dart';
 
 part 'onboarding_state.freezed.dart';
 
-/// Length of the readiness questionnaire. Lives next to [OnboardingState] so
-/// the screen and the seeded `readinessAnswers` default stay in lock-step.
+/// Length of the readiness *signs* questionnaire (Q2-Q6 in the Figma
+/// flow). Lives next to [OnboardingState] so the screen and the seeded
+/// `readinessAnswers` default stay in lock-step.
 ///
-/// NIB-83: redesign drops the pediatrician question — 5 developmental signs
-/// only (head control, sit upright, tongue-thrust, food interest, bring
-/// objects to mouth).
+/// NIB-83 redesign (Figma 971:10293..971:10363): the questionnaire is now
+/// SIX sequential screens — Q1 is a pediatrician-approval gate, captured
+/// separately on [OnboardingState.pediatricianApproved]. Q2-Q6 are the
+/// FIVE developmental signs (head control, sit upright, tongue-thrust,
+/// food interest, hand-to-mouth) tracked here. This keeps the downstream
+/// 3/5 majority gate (NIB-91 / NIB-120) and result-card sign labels
+/// unchanged — the gate flips the questionnaire entry point, not the
+/// score.
 const int readinessQuestionCount = 5;
 
 /// Hoisted state for the post-auth onboarding flow (name -> DOB -> readiness ->
@@ -19,6 +25,9 @@ class OnboardingState with _$OnboardingState {
   const factory OnboardingState({
     @Default(BabyNameInput.pure()) BabyNameInput babyName,
     DateTime? dob,
+    // NIB-83 Q1 gate. Null = not answered yet, true = pediatrician approved,
+    // false = unsure. Not counted toward `signs_met` — see the result screen.
+    bool? pediatricianApproved,
     // Seeded as a length-5 nullable list so the readiness screen can index
     // safely on first build; kept in sync with [readinessQuestionCount].
     @Default(<bool?>[null, null, null, null, null])

--- a/lib/src/features/onboarding/onboarding_state.freezed.dart
+++ b/lib/src/features/onboarding/onboarding_state.freezed.dart
@@ -19,6 +19,9 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$OnboardingState {
   BabyNameInput get babyName => throw _privateConstructorUsedError;
   DateTime? get dob =>
+      throw _privateConstructorUsedError; // NIB-83 Q1 gate. Null = not answered yet, true = pediatrician approved,
+  // false = unsure. Not counted toward `signs_met` — see the result screen.
+  bool? get pediatricianApproved =>
       throw _privateConstructorUsedError; // Seeded as a length-5 nullable list so the readiness screen can index
   // safely on first build; kept in sync with [readinessQuestionCount].
   List<bool?> get readinessAnswers => throw _privateConstructorUsedError;
@@ -44,6 +47,7 @@ abstract class $OnboardingStateCopyWith<$Res> {
   $Res call({
     BabyNameInput babyName,
     DateTime? dob,
+    bool? pediatricianApproved,
     List<bool?> readinessAnswers,
     bool readinessReady,
     bool consentAccepted,
@@ -69,6 +73,7 @@ class _$OnboardingStateCopyWithImpl<$Res, $Val extends OnboardingState>
   $Res call({
     Object? babyName = null,
     Object? dob = freezed,
+    Object? pediatricianApproved = freezed,
     Object? readinessAnswers = null,
     Object? readinessReady = null,
     Object? consentAccepted = null,
@@ -85,6 +90,10 @@ class _$OnboardingStateCopyWithImpl<$Res, $Val extends OnboardingState>
                 ? _value.dob
                 : dob // ignore: cast_nullable_to_non_nullable
                       as DateTime?,
+            pediatricianApproved: freezed == pediatricianApproved
+                ? _value.pediatricianApproved
+                : pediatricianApproved // ignore: cast_nullable_to_non_nullable
+                      as bool?,
             readinessAnswers: null == readinessAnswers
                 ? _value.readinessAnswers
                 : readinessAnswers // ignore: cast_nullable_to_non_nullable
@@ -123,6 +132,7 @@ abstract class _$$OnboardingStateImplCopyWith<$Res>
   $Res call({
     BabyNameInput babyName,
     DateTime? dob,
+    bool? pediatricianApproved,
     List<bool?> readinessAnswers,
     bool readinessReady,
     bool consentAccepted,
@@ -147,6 +157,7 @@ class __$$OnboardingStateImplCopyWithImpl<$Res>
   $Res call({
     Object? babyName = null,
     Object? dob = freezed,
+    Object? pediatricianApproved = freezed,
     Object? readinessAnswers = null,
     Object? readinessReady = null,
     Object? consentAccepted = null,
@@ -163,6 +174,10 @@ class __$$OnboardingStateImplCopyWithImpl<$Res>
             ? _value.dob
             : dob // ignore: cast_nullable_to_non_nullable
                   as DateTime?,
+        pediatricianApproved: freezed == pediatricianApproved
+            ? _value.pediatricianApproved
+            : pediatricianApproved // ignore: cast_nullable_to_non_nullable
+                  as bool?,
         readinessAnswers: null == readinessAnswers
             ? _value._readinessAnswers
             : readinessAnswers // ignore: cast_nullable_to_non_nullable
@@ -194,6 +209,7 @@ class _$OnboardingStateImpl implements _OnboardingState {
   const _$OnboardingStateImpl({
     this.babyName = const BabyNameInput.pure(),
     this.dob,
+    this.pediatricianApproved,
     final List<bool?> readinessAnswers = const <bool?>[
       null,
       null,
@@ -212,6 +228,10 @@ class _$OnboardingStateImpl implements _OnboardingState {
   final BabyNameInput babyName;
   @override
   final DateTime? dob;
+  // NIB-83 Q1 gate. Null = not answered yet, true = pediatrician approved,
+  // false = unsure. Not counted toward `signs_met` — see the result screen.
+  @override
+  final bool? pediatricianApproved;
   // Seeded as a length-5 nullable list so the readiness screen can index
   // safely on first build; kept in sync with [readinessQuestionCount].
   final List<bool?> _readinessAnswers;
@@ -240,7 +260,7 @@ class _$OnboardingStateImpl implements _OnboardingState {
 
   @override
   String toString() {
-    return 'OnboardingState(babyName: $babyName, dob: $dob, readinessAnswers: $readinessAnswers, readinessReady: $readinessReady, consentAccepted: $consentAccepted, isSubmitting: $isSubmitting, submitErrorMessage: $submitErrorMessage)';
+    return 'OnboardingState(babyName: $babyName, dob: $dob, pediatricianApproved: $pediatricianApproved, readinessAnswers: $readinessAnswers, readinessReady: $readinessReady, consentAccepted: $consentAccepted, isSubmitting: $isSubmitting, submitErrorMessage: $submitErrorMessage)';
   }
 
   @override
@@ -251,6 +271,8 @@ class _$OnboardingStateImpl implements _OnboardingState {
             (identical(other.babyName, babyName) ||
                 other.babyName == babyName) &&
             (identical(other.dob, dob) || other.dob == dob) &&
+            (identical(other.pediatricianApproved, pediatricianApproved) ||
+                other.pediatricianApproved == pediatricianApproved) &&
             const DeepCollectionEquality().equals(
               other._readinessAnswers,
               _readinessAnswers,
@@ -270,6 +292,7 @@ class _$OnboardingStateImpl implements _OnboardingState {
     runtimeType,
     babyName,
     dob,
+    pediatricianApproved,
     const DeepCollectionEquality().hash(_readinessAnswers),
     readinessReady,
     consentAccepted,
@@ -293,6 +316,7 @@ abstract class _OnboardingState implements OnboardingState {
   const factory _OnboardingState({
     final BabyNameInput babyName,
     final DateTime? dob,
+    final bool? pediatricianApproved,
     final List<bool?> readinessAnswers,
     final bool readinessReady,
     final bool consentAccepted,
@@ -303,7 +327,10 @@ abstract class _OnboardingState implements OnboardingState {
   @override
   BabyNameInput get babyName;
   @override
-  DateTime? get dob; // Seeded as a length-5 nullable list so the readiness screen can index
+  DateTime? get dob; // NIB-83 Q1 gate. Null = not answered yet, true = pediatrician approved,
+  // false = unsure. Not counted toward `signs_met` — see the result screen.
+  @override
+  bool? get pediatricianApproved; // Seeded as a length-5 nullable list so the readiness screen can index
   // safely on first build; kept in sync with [readinessQuestionCount].
   @override
   List<bool?> get readinessAnswers;

--- a/lib/src/features/onboarding/readiness/onboarding_readiness_screen.dart
+++ b/lib/src/features/onboarding/readiness/onboarding_readiness_screen.dart
@@ -11,42 +11,81 @@ import 'package:nibbles/src/features/onboarding/readiness/widgets/readiness_choi
 import 'package:nibbles/src/features/onboarding/readiness/widgets/readiness_progress_bar.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Single-question copy for each of the 5 developmental signs. Index aligns
-/// with `readinessAnswers` on [OnboardingState].
+/// Total step count for the 6-screen NIB-83 readiness questionnaire (Q1
+/// pediatrician gate + Q2-Q6 developmental signs).
+const int _readinessTotalSteps = 1 + readinessQuestionCount;
+
+/// Per-step copy / option labels. Step 0 is the Q1 pediatrician gate;
+/// steps 1..5 align with `readinessAnswers[0..4]`.
 ///
-/// `{name}` is interpolated at build with the first token of
-/// `state.babyName.value` (falls back to "your baby" when empty so we never
-/// render a dangling possessive apostrophe).
-const List<_ReadinessQuestion> _questions = [
-  _ReadinessQuestion(
+/// Verbatim from the Linear ticket and the Figma audit
+/// (.figma-audit/onboarding/readiness-check-{1..6}). Double-space typos
+/// flagged by audit are normalized to a single space per the PO open
+/// question; the literal "Asther Lee" / "[Baby Name]" placeholder is
+/// interpolated with the baby's first name.
+const List<_ReadinessStep> _steps = [
+  // Q1 — pediatrician gate.
+  _ReadinessStep(
+    title: 'Is {name} ready for solids?',
+    body: 'Most babies are ready around 6 months, but every child is '
+        "different. Let's check key signs of readiness",
+    yesLabel: 'Yes, our pediatrician approved it.',
+    noLabel: "I'm not sure yet",
+  ),
+  // Q2 — head/neck control.
+  _ReadinessStep(
     title: 'Can {name} hold their head steady?',
-    icon: Icons.face_retouching_natural,
+    body: 'Good head and neck control (can hold head steady)',
+    yesLabel: 'Yes!',
+    noLabel: 'Still figuring it out',
   ),
-  _ReadinessQuestion(
+  // Q3 — sitting.
+  _ReadinessStep(
     title: 'Can {name} sit upright with minimal support?',
-    icon: Icons.airline_seat_recline_extra_rounded,
+    body: 'Sits upright with minimal support',
+    yesLabel: 'Yes!',
+    noLabel: 'Still figuring it out',
   ),
-  _ReadinessQuestion(
-    title: "Has {name}'s tongue-thrust reflex gone?",
-    icon: Icons.emoji_emotions_outlined,
+  // Q4 — tongue-thrust reflex.
+  _ReadinessStep(
+    title:
+        'Does {name} no longer automatically push food out with their tongue?',
+    body:
+        "Loss of the tongue-thrust reflex (doesn't automatically push food "
+        'out).',
+    yesLabel: 'Yes!',
+    noLabel: 'Still figuring it out',
   ),
-  _ReadinessQuestion(
+  // Q5 — food interest.
+  _ReadinessStep(
     title: 'Does {name} show interest in food?',
-    icon: Icons.restaurant_rounded,
+    body: 'Shows interest in food (watching, reaching, opening mouth).',
+    yesLabel: 'Yes!',
+    noLabel: 'Still figuring it out',
   ),
-  _ReadinessQuestion(
+  // Q6 — hand-to-mouth.
+  _ReadinessStep(
     title: 'Can {name} bring objects to their mouth?',
-    icon: Icons.front_hand_outlined,
+    body: 'Can bring objects to their mouth.',
+    yesLabel: 'Yes!',
+    noLabel: 'Still figuring it out',
   ),
 ];
 
-/// NIB-83 — Readiness questionnaire rebuilt as a 5-step stepper.
+/// NIB-83 — 6-screen readiness questionnaire with color-progressing bar.
 ///
-/// Each step renders one developmental-sign question + two large square cards
-/// ('Yes!' / 'Still figuring it out'). Tapping a card records the answer on
-/// the hoisted [OnboardingController] (keepAlive — back-nav preserves state)
-/// and auto-advances. After step 4 we set the readiness-done local flag and
-/// navigate to `/onboarding/result`.
+/// Q1 captures pediatrician approval on `OnboardingState.pediatricianApproved`
+/// (separate gate field). Q2-Q6 capture the 5 developmental signs on
+/// `readinessAnswers[0..4]` — this is what the result screen
+/// (NIB-91 / NIB-120) counts for the 3/5 majority gate. Splitting Q1 out
+/// keeps the downstream score math unchanged.
+///
+/// Each step renders title + body + two answer cards. Tapping a card stores
+/// the answer on the hoisted [OnboardingController] (keepAlive — back-nav
+/// preserves state) and arms the bottom `Next` CTA. Next advances; on the
+/// last step we set the readiness-done local flag and navigate to
+/// `/onboarding/result`. Back inside the stepper rewinds one question;
+/// back from Q1 pops the route.
 class OnboardingReadinessScreen extends ConsumerStatefulWidget {
   const OnboardingReadinessScreen({super.key});
 
@@ -61,15 +100,17 @@ class _OnboardingReadinessScreenState
 
   @override
   Widget build(BuildContext context) {
-    // Defensive: the screen depends on a fixed-length answer list. The state
-    // default seeds 5 nulls (matches `readinessQuestionCount`) — assert in
-    // debug so a future spec change in either place fails loudly.
+    // Defensive: keep the stepper and the seeded answer list in lock-step
+    // with the readiness-signs count.
     assert(
-      _questions.length == readinessQuestionCount,
-      'Readiness question count drifted from OnboardingState seed',
+      _steps.length == _readinessTotalSteps,
+      'Readiness step count drifted from Q1 gate + readinessQuestionCount',
     );
 
-    final answers = ref.watch(
+    final pediatricianApproved = ref.watch(
+      onboardingControllerProvider.select((s) => s.pediatricianApproved),
+    );
+    final signAnswers = ref.watch(
       onboardingControllerProvider.select((s) => s.readinessAnswers),
     );
     final babyNameRaw = ref.watch(
@@ -77,76 +118,102 @@ class _OnboardingReadinessScreenState
     );
     final textTheme = Theme.of(context).textTheme;
 
-    final question = _questions[_currentIndex];
-    final currentAnswer = answers[_currentIndex];
+    final step = _steps[_currentIndex];
     final firstName = _firstToken(babyNameRaw);
-    final title = question.title.replaceAll('{name}', firstName);
+    final title = step.title.replaceAll('{name}', firstName);
+    final currentAnswer = _answerForIndex(
+      _currentIndex,
+      pediatricianApproved: pediatricianApproved,
+      signAnswers: signAnswers,
+    );
+    final isNextEnabled = currentAnswer != null;
 
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.background,
-        elevation: 0,
-        leadingWidth: AppSizes.roundButton + AppSizes.md,
-        leading: Padding(
-          padding: const EdgeInsets.only(left: AppSizes.md),
-          child: Center(
-            child: AppRoundButton(
-              icon: const Icon(Icons.arrow_back_rounded),
-              tone: AppRoundButtonTone.butter,
-              semanticLabel: 'Back',
-              onPressed: _onBack,
-            ),
-          ),
-        ),
-      ),
       body: SafeArea(
-        top: false,
         child: Padding(
           padding: const EdgeInsets.symmetric(
             horizontal: AppSizes.pagePaddingH,
           ),
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              ReadinessProgressBar(
-                stepCount: _questions.length,
-                currentIndex: _currentIndex,
+              const SizedBox(height: AppSizes.md),
+              Center(
+                child: Text(
+                  '${_currentIndex + 1} of $_readinessTotalSteps Questions',
+                  key: const Key('onboarding_readiness_counter'),
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: AppColors.fgStrong,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
               ),
               const SizedBox(height: AppSizes.sm),
-              Text(
-                '${_currentIndex + 1} of ${_questions.length} Questions',
-                style: textTheme.bodySmall?.copyWith(color: AppColors.fgMuted),
+              ReadinessProgressBar(
+                stepCount: _readinessTotalSteps,
+                currentIndex: _currentIndex,
               ),
               const SizedBox(height: AppSizes.xl),
-              Text(title, style: textTheme.displaySmall),
-              const SizedBox(height: AppSizes.xl),
+              Text(
+                title,
+                textAlign: TextAlign.center,
+                style: textTheme.titleLarge,
+              ),
+              const SizedBox(height: AppSizes.md),
+              Text(
+                step.body,
+                textAlign: TextAlign.center,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: AppColors.fgMuted,
+                ),
+              ),
+              const SizedBox(height: AppSizes.lg),
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Expanded(
                     child: ReadinessChoiceCard(
                       key: const Key('readiness_choice_yes'),
-                      label: 'Yes!',
-                      icon: Icons.check_rounded,
+                      label: step.yesLabel,
                       selected: currentAnswer ?? false,
-                      onTap: () => _onAnswer(isYes: true),
+                      onTap: () => _recordAnswer(isYes: true),
                     ),
                   ),
                   const SizedBox(width: AppSizes.md),
                   Expanded(
                     child: ReadinessChoiceCard(
                       key: const Key('readiness_choice_unsure'),
-                      label: 'Still figuring it out',
-                      icon: Icons.help_outline_rounded,
-                      selected: !(currentAnswer ?? true),
-                      onTap: () => _onAnswer(isYes: false),
+                      label: step.noLabel,
+                      selected: currentAnswer == false,
+                      onTap: () => _recordAnswer(isYes: false),
                     ),
                   ),
                 ],
               ),
               const Spacer(),
-              const SizedBox(height: AppSizes.pagePaddingV),
+              Padding(
+                padding: const EdgeInsets.only(bottom: AppSizes.pagePaddingV),
+                child: Row(
+                  children: [
+                    AppRoundButton(
+                      key: const Key('onboarding_readiness_back'),
+                      icon: const Icon(Icons.arrow_back_rounded),
+                      tone: AppRoundButtonTone.butter,
+                      semanticLabel: 'Back',
+                      onPressed: _onBack,
+                    ),
+                    const SizedBox(width: AppSizes.sm),
+                    Expanded(
+                      child: AppPillButton(
+                        key: const Key('onboarding_readiness_next'),
+                        label: 'Next',
+                        onPressed: isNextEnabled ? _onNext : null,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ],
           ),
         ),
@@ -155,8 +222,7 @@ class _OnboardingReadinessScreenState
   }
 
   /// First whitespace-separated token of [raw], or "your baby" fallback when
-  /// the name has not been captured yet. Prevents dangling possessives like
-  /// "'s tongue-thrust reflex".
+  /// the name has not been captured yet. Prevents dangling possessives.
   String _firstToken(String raw) {
     final trimmed = raw.trim();
     if (trimmed.isEmpty) return 'your baby';
@@ -164,9 +230,35 @@ class _OnboardingReadinessScreenState
     return idx < 0 ? trimmed : trimmed.substring(0, idx);
   }
 
+  /// Reads the currently-stored answer for [index] from the right slot:
+  /// index 0 = pediatricianApproved, index 1..5 = readinessAnswers[0..4].
+  bool? _answerForIndex(
+    int index, {
+    required bool? pediatricianApproved,
+    required List<bool?> signAnswers,
+  }) {
+    if (index == 0) return pediatricianApproved;
+    final signIndex = index - 1;
+    if (signIndex < 0 || signIndex >= signAnswers.length) return null;
+    return signAnswers[signIndex];
+  }
+
+  /// Stores the answer on the controller. Step 0 hits the pediatrician gate
+  /// field; steps 1..5 write into readinessAnswers[index-1]. Selection alone
+  /// does not auto-advance — Next handles navigation.
+  void _recordAnswer({required bool isYes}) {
+    final controller = ref.read(onboardingControllerProvider.notifier);
+    if (_currentIndex == 0) {
+      controller.setPediatricianApproved(approved: isYes);
+      return;
+    }
+    controller.answerReadinessQuestion(_currentIndex - 1, isYes: isYes);
+  }
+
   void _onBack() {
     if (_currentIndex == 0) {
-      // Pre-MVP: name -> dob -> readiness, so back must always pop to dob.
+      // Pre-MVP order is name -> dob -> readiness, so back from Q1 always
+      // pops to DOB.
       if (context.canPop()) {
         context.pop();
       }
@@ -175,12 +267,8 @@ class _OnboardingReadinessScreenState
     setState(() => _currentIndex--);
   }
 
-  void _onAnswer({required bool isYes}) {
-    ref
-        .read(onboardingControllerProvider.notifier)
-        .answerReadinessQuestion(_currentIndex, isYes: isYes);
-
-    if (_currentIndex < _questions.length - 1) {
+  void _onNext() {
+    if (_currentIndex < _steps.length - 1) {
       setState(() => _currentIndex++);
       return;
     }
@@ -189,9 +277,9 @@ class _OnboardingReadinessScreenState
 
   void _finish() {
     final controller = ref.read(onboardingControllerProvider.notifier);
-    // signs_met derivation: ready iff every answer is `true`. Stored on state
-    // so downstream screens (result/consent) can branch on it without
-    // recounting nullable bools.
+    // signs_met derivation: ready iff every sign answer is `true`. Pinned on
+    // state so the consent screen can branch without recounting. The result
+    // screen still applies the NIB-120 3/5 majority gate when rendering.
     final answers = ref.read(onboardingControllerProvider).readinessAnswers;
     final allMet = answers.every((a) => a ?? false);
     controller.setReadinessReady(ready: allMet);
@@ -202,9 +290,16 @@ class _OnboardingReadinessScreenState
   }
 }
 
-class _ReadinessQuestion {
-  const _ReadinessQuestion({required this.title, required this.icon});
+class _ReadinessStep {
+  const _ReadinessStep({
+    required this.title,
+    required this.body,
+    required this.yesLabel,
+    required this.noLabel,
+  });
 
   final String title;
-  final IconData icon;
+  final String body;
+  final String yesLabel;
+  final String noLabel;
 }

--- a/lib/src/features/onboarding/readiness/widgets/readiness_choice_card.dart
+++ b/lib/src/features/onboarding/readiness/widgets/readiness_choice_card.dart
@@ -1,73 +1,109 @@
 import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 
-/// Large square choice card used in the NIB-83 readiness stepper.
+/// Large square choice card used in the NIB-83 readiness questionnaire.
+///
+/// Composition matches the Figma frames
+/// (.figma-audit/onboarding/readiness-check-{1..6}/screenshot.png):
+/// a cream square with forest stroke, centered butter Quatrefoil with a
+/// cancel-X overlay glyph, and a centered label below.
 ///
 /// PRIVATE to the readiness feature — composes theme tokens only, NOT a
 /// shared DS component. See spec: do not promote to lib/src/common/components.
 class ReadinessChoiceCard extends StatelessWidget {
   const ReadinessChoiceCard({
     required this.label,
-    required this.icon,
     required this.selected,
     required this.onTap,
     super.key,
   });
 
+  /// CTA label.
   final String label;
-  final IconData icon;
+
+  /// Whether this card is the active answer. Selected paints the surface in
+  /// butter + thicker forest stroke; unselected uses cream surface + muted
+  /// stroke. (Figma does not capture selected state, kit-derived treatment.)
   final bool selected;
+
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final borderColor = selected ? AppColors.greenDeep : AppColors.green;
+    final borderWidth = selected ? 2.5 : 1.5;
+    final surface = selected ? AppColors.butterSoft : AppColors.cream;
 
-    return AspectRatio(
-      aspectRatio: 1,
-      child: Material(
-        color: selected ? AppColors.greenDeep : AppColors.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppSizes.radiusXl),
-          side: BorderSide(
-            color: selected ? AppColors.greenDeep : AppColors.borderMuted,
-            width: selected ? 2 : 1,
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: Material(
+          color: surface,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppSizes.radius2xl),
+            side: BorderSide(color: borderColor, width: borderWidth),
           ),
-        ),
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(AppSizes.radiusXl),
-          child: Padding(
-            padding: const EdgeInsets.all(AppSizes.md),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(
-                  width: AppSizes.sp40,
-                  height: AppSizes.sp40,
-                  decoration: BoxDecoration(
-                    color: selected ? AppColors.butter : AppColors.butterSoft,
-                    shape: BoxShape.circle,
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(AppSizes.radius2xl),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.sp12,
+                vertical: AppSizes.md,
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const _NibbleIcon(),
+                  const SizedBox(height: AppSizes.sm),
+                  Flexible(
+                    child: Text(
+                      label,
+                      textAlign: TextAlign.center,
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: AppColors.greenDeep,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
                   ),
-                  child: Icon(
-                    icon,
-                    color: AppColors.greenDeep,
-                    size: AppSizes.iconMd,
-                  ),
-                ),
-                Text(
-                  label,
-                  style: textTheme.titleMedium?.copyWith(
-                    color: selected ? AppColors.cream : AppColors.greenDeep,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Butter Quatrefoil with a small cancel-X overlay, per the Figma frames.
+class _NibbleIcon extends StatelessWidget {
+  const _NibbleIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      width: AppSizes.xxl,
+      height: AppSizes.xxl,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Quatrefoil(
+            size: AppSizes.xxl,
+            coreColor: AppColors.butter,
+          ),
+          Icon(
+            Icons.cancel_outlined,
+            size: AppSizes.iconMd,
+            color: AppColors.greenDeep,
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/features/onboarding/readiness/widgets/readiness_progress_bar.dart
+++ b/lib/src/features/onboarding/readiness/widgets/readiness_progress_bar.dart
@@ -2,9 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 
-/// Top progress bar for the 5-step readiness stepper. Each completed segment
-/// fills with a color interpolated along
-/// maroon -> coral -> butter -> sage as the current step advances.
+/// NIB-83 readiness stepper progress bar.
+///
+/// Single continuous pill bar: the fill widens AND shifts color as the
+/// active step advances through the 6-screen questionnaire. Per-step color
+/// stops mirror the Figma audit
+/// (.figma-audit/onboarding/readiness-check-{1..6}/screenshot.png):
+///
+///   step 0 (Q1)  -> coral peach   (gate / intro)
+///   step 1 (Q2)  -> destructive   (burgundy)
+///   step 2 (Q3)  -> destructive   (burgundy)
+///   step 3 (Q4)  -> coral         (salmon)
+///   step 4 (Q5)  -> butter        (lime)
+///   step 5 (Q6)  -> green         (forest)
+///
+/// Animated: both width (FractionallySizedBox factor) and fill color
+/// cross-fade on step change.
 ///
 /// PRIVATE to the readiness feature.
 class ReadinessProgressBar extends StatelessWidget {
@@ -14,59 +27,80 @@ class ReadinessProgressBar extends StatelessWidget {
     super.key,
   });
 
-  /// Total number of steps (= `readinessQuestionCount`).
+  /// Total number of steps (= 6 in the NIB-83 flow).
   final int stepCount;
 
-  /// 0-based index of the active step. Segments at or before this index are
-  /// considered "filled" — the fill color comes from the per-segment ramp.
+  /// 0-based index of the active step.
   final int currentIndex;
 
-  /// Anchor stops for the 4-color ramp.
-  static const List<Color> _stops = [
+  /// Per-step fill colors aligned with the Figma render. Length must match
+  /// the NIB-83 stepCount (6).
+  static const List<Color> _stepFillColors = <Color>[
+    AppColors.coral,
+    AppColors.destructive,
     AppColors.destructive,
     AppColors.coral,
     AppColors.butter,
-    AppColors.greenSoft,
+    AppColors.green,
   ];
 
-  /// Sample the [_stops] ramp at [t] in [0,1].
-  static Color _sample(double t) {
-    final clamped = t.clamp(0.0, 1.0);
-    if (_stops.length < 2) return _stops.first;
-    final segs = _stops.length - 1;
-    final scaled = clamped * segs;
-    final i = scaled.floor().clamp(0, segs - 1);
-    final local = scaled - i;
-    return Color.lerp(_stops[i], _stops[i + 1], local) ?? _stops[i];
+  /// Fraction of the track filled at [index]. Q1 reads as 0% to match the
+  /// Figma render of the first frame (empty grey track); subsequent steps
+  /// step linearly.
+  static double _fillForStep(int index, int stepCount) {
+    if (stepCount <= 1) return 1;
+    final span = stepCount - 1; // 5 increments for 6 steps
+    if (index <= 0) return 0;
+    if (index >= span) return 1;
+    return index / span;
+  }
+
+  Color _fillForCurrent() {
+    if (_stepFillColors.isEmpty) return AppColors.coral;
+    final clampedIdx = currentIndex.clamp(0, _stepFillColors.length - 1);
+    return _stepFillColors[clampedIdx];
   }
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: List.generate(stepCount, (i) {
-        final isLast = i == stepCount - 1;
-        final filled = i <= currentIndex;
-        final t = stepCount <= 1 ? 1.0 : i / (stepCount - 1);
-        final target = filled ? _sample(t) : AppColors.borderSoft;
+    final fraction = _fillForStep(currentIndex, stepCount);
+    final fillColor = _fillForCurrent();
+    const trackColor = AppColors.borderSoft;
+    const height = AppSizes.sm; // 8px track per Figma render.
 
-        return Expanded(
-          child: Padding(
-            padding: EdgeInsets.only(right: isLast ? 0 : AppSizes.xs),
-            child: TweenAnimationBuilder<Color?>(
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      child: SizedBox(
+        height: height,
+        width: double.infinity,
+        child: Stack(
+          children: [
+            const ColoredBox(
+              color: trackColor,
+              child: SizedBox.expand(),
+            ),
+            TweenAnimationBuilder<double>(
               duration: const Duration(milliseconds: 320),
               curve: Curves.easeOut,
-              tween: ColorTween(end: target),
-              builder: (context, color, _) => Container(
-                height: AppSizes.xs + 2,
-                decoration: BoxDecoration(
-                  color: color ?? target,
-                  borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              tween: Tween<double>(begin: fraction, end: fraction),
+              builder: (context, value, _) => FractionallySizedBox(
+                widthFactor: value.clamp(0.0, 1.0),
+                child: TweenAnimationBuilder<Color?>(
+                  duration: const Duration(milliseconds: 320),
+                  curve: Curves.easeOut,
+                  tween: ColorTween(end: fillColor),
+                  builder: (context, color, __) => Container(
+                    decoration: BoxDecoration(
+                      color: color ?? fillColor,
+                      borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+                    ),
+                  ),
                 ),
               ),
             ),
-          ),
-        );
-      }),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/test/features/onboarding/readiness/onboarding_readiness_screen_test.dart
+++ b/test/features/onboarding/readiness/onboarding_readiness_screen_test.dart
@@ -8,19 +8,23 @@ import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
 import 'package:nibbles/src/features/onboarding/readiness/onboarding_readiness_screen.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-/// NIB-105 — widget tests for `OnboardingReadinessScreen` (NIB-83).
+/// NIB-83 — widget tests for `OnboardingReadinessScreen`.
 ///
 /// Pins:
-///   - the 5-step stepper renders "1 of 5 Questions" through "5 of 5
-///     Questions" verbatim.
+///   - the 6-step questionnaire renders "1 of 6 Questions" through
+///     "6 of 6 Questions" verbatim.
+///   - tapping a card stores the answer but does NOT auto-advance; Next
+///     does.
+///   - Q1 (pediatrician gate) writes to a separate state field; Q2-Q6
+///     write to `readinessAnswers[0..4]` so downstream signs_met math
+///     keeps its length-5 contract.
 ///   - back-nav inside the stepper preserves answers captured at earlier
 ///     steps via the hoisted controller (keepAlive).
 ///
 /// The screen calls `localFlagServiceProvider.setOnboardingReadinessDone()`
-/// in `_finish` (after step 5). We don't tap step 5 in these tests — both
-/// scenarios stay within step 4 — so the local flag service isn't reached.
-/// Hive box init guards the test in case any future helper does flip the
-/// flag during back-nav (currently doesn't).
+/// in `_finish` (after step 6). We don't tap step 6 in these tests so the
+/// local flag service isn't reached. Hive box init guards the test in case
+/// any future helper does flip the flag during back-nav.
 GoRouter _routerFor(Widget screen) => GoRouter(
   initialLocation: AppRoute.onboardingReadiness.path,
   routes: [
@@ -73,23 +77,36 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  Future<void> tapYesAndAdvance(WidgetTester tester) async {
+    await tester.tap(find.byKey(const Key('readiness_choice_yes')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboarding_readiness_next')));
+    await tester.pumpAndSettle();
+  }
+
   testWidgets(
-    'renders the "1 of 5 Questions" counter on first paint',
+    'renders the "1 of 6 Questions" counter on first paint',
     (tester) async {
       final container = ProviderContainer();
       addTearDown(container.dispose);
-      // Seed a baby name so the question copy doesn't interpolate to the
+      // Seed a baby name so question copy doesn't interpolate to the
       // "your baby" fallback.
       container.read(onboardingControllerProvider.notifier).updateName('Lily');
 
       await pumpReadiness(tester, container: container);
 
-      expect(find.text('1 of 5 Questions'), findsOneWidget);
+      expect(find.text('1 of 6 Questions'), findsOneWidget);
+      // Q1 is the pediatrician-approval gate (Figma 971:10293).
+      expect(find.text('Is Lily ready for solids?'), findsOneWidget);
+      expect(
+        find.text('Yes, our pediatrician approved it.'),
+        findsOneWidget,
+      );
     },
   );
 
   testWidgets(
-    'tapping a card advances the counter 1/5 -> 2/5 -> 3/5 -> 4/5 -> 5/5',
+    'tapping a card alone does NOT advance; Next CTA advances 1/6 -> 2/6',
     (tester) async {
       final container = ProviderContainer();
       addTearDown(container.dispose);
@@ -97,12 +114,65 @@ void main() {
 
       await pumpReadiness(tester, container: container);
 
-      for (var i = 1; i <= 5; i++) {
-        expect(find.text('$i of 5 Questions'), findsOneWidget);
-        if (i == 5) break;
-        await tester.tap(find.byKey(const Key('readiness_choice_yes')));
-        await tester.pumpAndSettle();
-      }
+      // Tap the Yes card — selection is captured but counter stays put.
+      await tester.tap(find.byKey(const Key('readiness_choice_yes')));
+      await tester.pumpAndSettle();
+      expect(find.text('1 of 6 Questions'), findsOneWidget);
+
+      // Next CTA advances.
+      await tester.tap(find.byKey(const Key('onboarding_readiness_next')));
+      await tester.pumpAndSettle();
+      expect(find.text('2 of 6 Questions'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Next is disabled until the user picks an answer on the active step',
+    (tester) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(onboardingControllerProvider.notifier).updateName('Lily');
+
+      await pumpReadiness(tester, container: container);
+
+      // Tap Next without selecting — counter must stay at 1/6.
+      await tester.tap(find.byKey(const Key('onboarding_readiness_next')));
+      await tester.pumpAndSettle();
+      expect(find.text('1 of 6 Questions'), findsOneWidget);
+
+      // Now select + Next — counter advances.
+      await tester.tap(find.byKey(const Key('readiness_choice_yes')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('onboarding_readiness_next')));
+      await tester.pumpAndSettle();
+      expect(find.text('2 of 6 Questions'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Yes on Q1 writes to pediatricianApproved; Yes on Q2 writes to '
+    'readinessAnswers[0] (length-5 sign list preserved for NIB-91 downstream)',
+    (tester) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(onboardingControllerProvider.notifier).updateName('Lily');
+
+      await pumpReadiness(tester, container: container);
+
+      // Q1 -> Yes.
+      await tapYesAndAdvance(tester);
+
+      var state = container.read(onboardingControllerProvider);
+      expect(state.pediatricianApproved, isTrue);
+      // Sign list untouched.
+      expect(state.readinessAnswers, [null, null, null, null, null]);
+
+      // Q2 -> Yes (writes to readinessAnswers[0]).
+      await tapYesAndAdvance(tester);
+
+      state = container.read(onboardingControllerProvider);
+      expect(state.readinessAnswers[0], isTrue);
+      expect(state.readinessAnswers[1], isNull);
     },
   );
 
@@ -116,35 +186,33 @@ void main() {
 
       await pumpReadiness(tester, container: container);
 
-      // Step 1: tap Yes -> advances to step 2.
-      await tester.tap(find.byKey(const Key('readiness_choice_yes')));
-      await tester.pumpAndSettle();
-      expect(find.text('2 of 5 Questions'), findsOneWidget);
+      // Q1 (pediatrician): Yes -> Next.
+      await tapYesAndAdvance(tester);
+      expect(find.text('2 of 6 Questions'), findsOneWidget);
 
-      // Step 2: tap "Still figuring it out" -> advances to step 3.
+      // Q2 (head): "Still figuring it out" -> Next.
       await tester.tap(find.byKey(const Key('readiness_choice_unsure')));
       await tester.pumpAndSettle();
-      expect(find.text('3 of 5 Questions'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('onboarding_readiness_next')));
+      await tester.pumpAndSettle();
+      expect(find.text('3 of 6 Questions'), findsOneWidget);
 
-      // Back twice -> we're at step 1, and the controller still holds
-      // both earlier answers.
+      // Back twice -> back at Q1; both earlier answers still on state.
       await tester.tap(find.bySemanticsLabel('Back'));
       await tester.pumpAndSettle();
-      expect(find.text('2 of 5 Questions'), findsOneWidget);
+      expect(find.text('2 of 6 Questions'), findsOneWidget);
 
       await tester.tap(find.bySemanticsLabel('Back'));
       await tester.pumpAndSettle();
-      expect(find.text('1 of 5 Questions'), findsOneWidget);
+      expect(find.text('1 of 6 Questions'), findsOneWidget);
 
-      // Controller-level: answers list reflects both step taps, all later
-      // indices remain null.
-      final answers =
-          container.read(onboardingControllerProvider).readinessAnswers;
-      expect(answers[0], isTrue);
-      expect(answers[1], isFalse);
-      expect(answers[2], isNull);
-      expect(answers[3], isNull);
-      expect(answers[4], isNull);
+      final state = container.read(onboardingControllerProvider);
+      expect(state.pediatricianApproved, isTrue);
+      expect(state.readinessAnswers[0], isFalse);
+      expect(state.readinessAnswers[1], isNull);
+      expect(state.readinessAnswers[2], isNull);
+      expect(state.readinessAnswers[3], isNull);
+      expect(state.readinessAnswers[4], isNull);
     },
   );
 }


### PR DESCRIPTION
Rebuilds the readiness questionnaire to the 6-screen Figma spec (`971:10293..971:10363`). Q1 is a pediatrician-approval gate captured on a separate `OnboardingState.pediatricianApproved` field; Q2-Q6 keep using `readinessAnswers[0..4]` so the downstream NIB-91 / NIB-120 result card (3/5 majority gate) is untouched.

## Acceptance criteria

- [x] Six sequential question screens reachable in order (Q1-Q6)
- [x] Counter copy "X of 6 Questions" verbatim
- [x] Baby first-name interpolated into every Q title (falls back to "your baby" before name is captured)
- [x] Yes/No card selection records answer + arms Next; Next CTA disabled until an answer is picked
- [x] Back navigates step-by-step inside the stepper; Back from Q1 pops to DOB
- [x] Progress bar: single continuous pill, color steps per Figma stops (coral -> destructive -> destructive -> coral -> butter -> green) + width steps 0/20/40/60/80/100%
- [x] On Q6 Next: sets `signs_met`/`ready` on state, flips `onboarding_readiness_done` local flag, routes to `/onboarding/result`
- [x] `flutter analyze` clean (0 issues)
- [x] Widget tests cover counter render, no-auto-advance, Next-gated-on-selection, Q1 -> pediatrician field / Q2 -> signs[0] split, back-nav keepAlive

## Figma frames

- Readiness Check 1 -- `971:10293` (Q1 pediatrician)
- Readiness Check 2 -- `971:10307` (Q2 head/neck)
- Readiness Check 3 -- `971:10321` (Q3 sitting)
- Readiness Check 4 -- `971:10335` (Q4 tongue-thrust)
- Readiness Check 5 -- `971:10349` (Q5 food interest)
- Readiness Check 6 -- `971:10363` (Q6 hand-to-mouth)

## Audit artifacts

- `.figma-audit/onboarding/readiness-check-{1..6}/report.md`
- `.figma-audit/onboarding/readiness-check-{1..6}/screenshot.png`
- `.figma-audit/onboarding/readiness-check-{1..6}/design_context.md`
- `.figma-audit/onboarding/readiness-check-{1..6}/variables.json`

## Notes for review / PO

- **Pediatrician answer is captured but not yet consumed.** Per ticket Q1 is "gating, not a sign." The state field is in place so a downstream gate (NIB-90 result branching) can read it; this PR does not branch on it.
- **Audit-flagged copy normalisation applied** per the Linear PO open questions: double-space typos in Q4/Q5/Q6 titles normalised to single space; `[Baby Name]` / literal "Asther Lee" replaced with interpolated first name; counter advanced to "X of 6" (vs the stale "1 from 5" repeated on every Figma frame).
- **Progress color tokens.** Figma uses Burgundy `#77393b` and peach `#fc9f6d`; no exact tokens exist. Mapped to nearest DS tokens (`destructive` for burgundy, `coral` for peach) -- means Q1 and Q4 share a fill color. Add Burgundy/Peach tokens to the DS if exact match is required.
- **Pixel diff not measured.** Tests assert behavior + verbatim strings only; no golden snapshot was added. Visual diff against `screenshot.png` left for review pass.

## Test plan

- [x] `flutter analyze` -> 0 issues
- [x] `flutter test` -> 533 passing (full suite)
- [ ] Manual visual diff vs `.figma-audit/onboarding/readiness-check-{1..6}/screenshot.png` on iOS sim (Q1 / Q6 minimum)
- [ ] Walk through name -> DOB -> readiness -> result -> consent end-to-end on dev flavor