### PR TITLE
feat(auth): restyle Login to NIB-107 Figma — branded mark, filled inputs, stacked social buttons, inline burgundy errors [NIB-107]

### DIFF
--- a/lib/src/app/themes/app_colors.dart
+++ b/lib/src/app/themes/app_colors.dart
@@ -63,6 +63,11 @@ abstract final class AppColors {
   static const Color destructive = Color(0xFF851E1E);
   static const Color destructiveSoft = Color(0xFFFFE8E8);
 
+  // Brand burgundy — Nibble-primary-Burgundy.
+  // Used for the login error border + helper text and the Sign Up footer link
+  // (NIB-107 Figma node 971:10029 — token "Nibble-primary-Burgundy").
+  static const Color burgundy = Color(0xFF77393B);
+
   // ── Semantic tokens ───────────────────────────────────────────
   static const Color fgStrong = Color(0xFF2C2C2C);
   static const Color fgDefault = Color(0xFF2D1F17);

--- a/lib/src/features/auth/login/login_screen.dart
+++ b/lib/src/features/auth/login/login_screen.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/components/components.dart';
 import 'package:nibbles/src/features/auth/login/login_controller.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
+/// NIB-107 — Login screen.
+///
+/// 3 state variants — empty / filled / error — per Figma frames 971:10029,
+/// 1015:10854, 1023:6909. Background is the Grad-1 token (butter→cream).
 class LoginScreen extends ConsumerWidget {
   const LoginScreen({super.key});
 
@@ -18,94 +23,94 @@ class LoginScreen extends ConsumerWidget {
     final hasError = state.errorMessage != null;
 
     return Scaffold(
-      backgroundColor: AppColors.background,
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
-            vertical: AppSizes.pagePaddingV,
+      // Grad-1 — butter→cream diagonal. Frame backdrop applied via the
+      // scaffold body container; Scaffold's bg must be transparent.
+      backgroundColor: Colors.transparent,
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.19, 0.5],
+            colors: [AppColors.butterSoft, AppColors.background],
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const SizedBox(height: AppSizes.lg),
-              const Center(
-                child: FittedBox(
-                  fit: BoxFit.scaleDown,
-                  // BrandLogo defaults to size 120 (==AppSizes.avatarXl),
-                  // matching the NIB-107 spec; FittedBox prevents overflow
-                  // on narrow screens.
-                  child: BrandLogo(),
-                ),
-              ),
-              const SizedBox(height: AppSizes.xl),
-              Text(
-                'Hi, Welcome!',
-                textAlign: TextAlign.center,
-                style: textTheme.displaySmall,
-              ),
-              const SizedBox(height: AppSizes.sm),
-              Text(
-                'Log in to continue your journey.',
-                textAlign: TextAlign.center,
-                style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
-              ),
-              const SizedBox(height: AppSizes.xl),
-              AppTextField(
-                key: const Key('login_email_field'),
-                label: 'Email',
-                hintText: 'you@example.com',
-                keyboardType: TextInputType.emailAddress,
-                textInputAction: TextInputAction.next,
-                onChanged: controller.updateEmail,
-              ),
-              const SizedBox(height: AppSizes.md),
-              AppTextField(
-                key: const Key('login_password_field'),
-                label: 'Password',
-                hintText: 'Your password',
-                obscureText: state.obscure,
-                textInputAction: TextInputAction.done,
-                onChanged: controller.updatePassword,
-                suffixIcon: _ObscureToggle(
-                  obscure: state.obscure,
-                  onTap: controller.toggleObscure,
-                ),
-              ),
-              if (hasError) ...[
-                const SizedBox(height: AppSizes.xs),
+        ),
+        child: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.pagePaddingH,
+              vertical: AppSizes.pagePaddingV,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: AppSizes.lg),
+                const Center(child: _LoginLogoMark()),
+                const SizedBox(height: AppSizes.lg),
                 Text(
-                  state.errorMessage!,
-                  style: textTheme.bodySmall?.copyWith(
-                    color: AppColors.destructive,
+                  'Hi, Welcome!',
+                  textAlign: TextAlign.center,
+                  style: textTheme.headlineSmall,
+                ),
+                const SizedBox(height: AppSizes.sm),
+                Text(
+                  // Annotation: "split word like this", exactly 2 lines.
+                  // Smart apostrophe per Figma copy.
+                  'Login to continue tracking your\nbaby’s healthy growth.',
+                  textAlign: TextAlign.center,
+                  style: textTheme.bodyLarge?.copyWith(
+                    color: AppColors.text,
                   ),
                 ),
-              ],
-              Align(
-                alignment: Alignment.centerRight,
-                child: TextButton(
-                  onPressed: () =>
-                      context.goNamed(AppRoute.forgotPassword.name),
-                  child: const Text('Forgot your password?'),
+                const SizedBox(height: AppSizes.xl),
+                AppTextField(
+                  key: const Key('login_email_field'),
+                  label: 'Email address',
+                  hintText: 'Email address',
+                  keyboardType: TextInputType.emailAddress,
+                  textInputAction: TextInputAction.next,
+                  onChanged: controller.updateEmail,
+                  errorText: hasError ? state.errorMessage : null,
+                  errorColor: AppColors.burgundy,
                 ),
-              ),
-              const SizedBox(height: AppSizes.md),
-              AppPillButton(
-                key: const Key('login_submit_button'),
-                label: state.isLoading ? 'Logging in…' : 'Log In',
-                onPressed: state.isLoading ? null : controller.submit,
-              ),
-              const SizedBox(height: AppSizes.lg),
-              const _OrDivider(),
-              const SizedBox(height: AppSizes.lg),
-              _SocialButtons(
-                isLoading: state.isLoading,
-                onGoogle: controller.signInWithGoogle,
-                onApple: controller.signInWithApple,
-              ),
-              const SizedBox(height: AppSizes.xl),
-              _SignUpFooter(),
-            ],
+                const SizedBox(height: AppSizes.md),
+                AppTextField(
+                  key: const Key('login_password_field'),
+                  label: 'Password',
+                  hintText: 'Password',
+                  obscureText: state.obscure,
+                  textInputAction: TextInputAction.done,
+                  onChanged: controller.updatePassword,
+                  errorText: hasError ? state.errorMessage : null,
+                  errorColor: AppColors.burgundy,
+                  suffixIcon: _PasswordSuffixIcon(
+                    obscure: state.obscure,
+                    hasError: hasError,
+                    onToggle: controller.toggleObscure,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.lg),
+                AppPillButton(
+                  key: const Key('login_submit_button'),
+                  label: state.isLoading ? 'Logging in…' : 'Login',
+                  onPressed: state.isLoading ? null : controller.submit,
+                ),
+                const SizedBox(height: AppSizes.lg),
+                const _OrDivider(),
+                const SizedBox(height: AppSizes.md),
+                _GoogleLoginButton(
+                  isLoading: state.isLoading,
+                  onPressed: controller.signInWithGoogle,
+                ),
+                const SizedBox(height: AppSizes.md),
+                _AppleLoginButton(
+                  isLoading: state.isLoading,
+                  onPressed: controller.signInWithApple,
+                ),
+                const SizedBox(height: AppSizes.xl),
+                const _SignUpFooter(),
+              ],
+            ),
           ),
         ),
       ),
@@ -113,16 +118,65 @@ class LoginScreen extends ConsumerWidget {
   }
 }
 
-class _ObscureToggle extends StatelessWidget {
-  const _ObscureToggle({required this.obscure, required this.onTap});
+/// Branded mark: butter quatrefoil with the green sage "n" glyph centered.
+/// No wordmark (Figma node 1015:13496 — `imgVector`).
+class _LoginLogoMark extends StatelessWidget {
+  const _LoginLogoMark();
 
-  final bool obscure;
-  final VoidCallback onTap;
+  static const double _size = 119;
 
   @override
   Widget build(BuildContext context) {
+    return const SizedBox(
+      width: _size,
+      height: _size,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Quatrefoil(
+            size: _size,
+            coreColor: AppColors.butter,
+          ),
+          Text(
+            'n',
+            style: TextStyle(
+              fontFamily: FontFamily.parkinsans,
+              fontSize: 70,
+              fontWeight: FontWeight.w800,
+              height: 1,
+              color: AppColors.greenDeep,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PasswordSuffixIcon extends StatelessWidget {
+  const _PasswordSuffixIcon({
+    required this.obscure,
+    required this.hasError,
+    required this.onToggle,
+  });
+
+  final bool obscure;
+  final bool hasError;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    // Error variant (Figma login-3) shows a check glyph in the password
+    // suffix instead of the eye toggle — odd, but per spec.
+    if (hasError) {
+      return const Icon(
+        Icons.check_rounded,
+        color: AppColors.burgundy,
+        size: AppSizes.iconMd,
+      );
+    }
     return InkResponse(
-      onTap: onTap,
+      onTap: onToggle,
       radius: AppSizes.iconMd,
       child: Icon(
         obscure ? Icons.visibility_off_outlined : Icons.visibility_outlined,
@@ -146,7 +200,7 @@ class _OrDivider extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: AppSizes.md),
           child: Text(
             'Or login with',
-            style: textTheme.bodySmall?.copyWith(color: AppColors.fgFaint),
+            style: textTheme.bodyLarge?.copyWith(color: AppColors.fgFaint),
           ),
         ),
         const Expanded(child: Divider(color: AppColors.borderSoft)),
@@ -155,50 +209,135 @@ class _OrDivider extends StatelessWidget {
   }
 }
 
-class _SocialButtons extends StatelessWidget {
-  const _SocialButtons({
-    required this.isLoading,
-    required this.onGoogle,
-    required this.onApple,
-  });
+/// White pill with the Google "G" mark + black "Login with Google" label.
+class _GoogleLoginButton extends StatelessWidget {
+  const _GoogleLoginButton({required this.isLoading, required this.onPressed});
 
   final bool isLoading;
-  final VoidCallback onGoogle;
-  final VoidCallback onApple;
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Expanded(
-          child: AppPillButton(
-            key: const Key('login_google_button'),
-            label: 'Google',
-            variant: AppPillButtonVariant.secondary,
-            onPressed: isLoading ? null : onGoogle,
-            // TODO(infra): swap Material icon for brand Google glyph when
-            // design/assets/google.svg ships.
-            leading: const Icon(Icons.g_mobiledata_rounded),
+    final disabled = isLoading;
+    return Material(
+      key: const Key('login_google_button'),
+      color: AppColors.surface,
+      shape: const StadiumBorder(
+        side: BorderSide(color: AppColors.borderSoft),
+      ),
+      child: InkWell(
+        onTap: disabled ? null : onPressed,
+        customBorder: const StadiumBorder(),
+        child: SizedBox(
+          height: AppSizes.buttonHeight,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const _GoogleGlyph(size: 24),
+              const SizedBox(width: AppSizes.sm),
+              Text(
+                'Login with Google',
+                style: TextStyle(
+                  fontFamily: FontFamily.parkinsans,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  height: 20 / 13,
+                  color: disabled ? AppColors.fgMuted : AppColors.text,
+                ),
+              ),
+            ],
           ),
         ),
-        const SizedBox(width: AppSizes.md),
-        Expanded(
-          child: AppPillButton(
-            key: const Key('login_apple_button'),
-            label: 'Apple',
-            variant: AppPillButtonVariant.secondary,
-            onPressed: isLoading ? null : onApple,
-            // TODO(infra): swap Material icon for brand Apple glyph when
-            // design/assets/apple.svg ships.
-            leading: const Icon(Icons.apple_rounded),
+      ),
+    );
+  }
+}
+
+/// Stylized Google "G" mark — single-color blue brand glyph rendered as a
+/// circular badge with the "G" letterform centered. Used in lieu of bundling a
+/// brand SVG; the social sign-in row only needs an unmistakable recognition
+/// cue.
+class _GoogleGlyph extends StatelessWidget {
+  const _GoogleGlyph({required this.size});
+
+  // Google Brand "Mountain View" blue — recognised brand primary.
+  static const Color _googleBlue = Color(0xFF4285F4);
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: const BoxDecoration(
+        color: _googleBlue,
+        shape: BoxShape.circle,
+      ),
+      child: Text(
+        'G',
+        style: TextStyle(
+          fontFamily: FontFamily.parkinsans,
+          fontSize: size * 0.66,
+          fontWeight: FontWeight.w700,
+          height: 1,
+          color: AppColors.surface,
+        ),
+      ),
+    );
+  }
+}
+
+/// Black pill with the Apple glyph + white "Login with Apple Account" label.
+class _AppleLoginButton extends StatelessWidget {
+  const _AppleLoginButton({required this.isLoading, required this.onPressed});
+
+  final bool isLoading;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final disabled = isLoading;
+    return Material(
+      key: const Key('login_apple_button'),
+      color: AppColors.text,
+      shape: const StadiumBorder(),
+      child: InkWell(
+        onTap: disabled ? null : onPressed,
+        customBorder: const StadiumBorder(),
+        child: SizedBox(
+          height: AppSizes.buttonHeight,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(
+                Icons.apple_rounded,
+                color: AppColors.surface,
+                size: AppSizes.iconMd,
+              ),
+              const SizedBox(width: AppSizes.sm),
+              Text(
+                'Login with Apple Account',
+                style: TextStyle(
+                  fontFamily: FontFamily.parkinsans,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  height: 20 / 13,
+                  color: disabled ? AppColors.fgFaint : AppColors.surface,
+                ),
+              ),
+            ],
           ),
         ),
-      ],
+      ),
     );
   }
 }
 
 class _SignUpFooter extends StatelessWidget {
+  const _SignUpFooter();
+
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
@@ -206,12 +345,30 @@ class _SignUpFooter extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Text(
-          "Don't have an account?",
-          style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
+          // Smart apostrophe per Figma copy.
+          'Don’t have an account?',
+          style: textTheme.bodyLarge?.copyWith(color: AppColors.text),
         ),
-        TextButton(
-          onPressed: () => context.goNamed(AppRoute.register.name),
-          child: const Text('Sign Up'),
+        const SizedBox(width: AppSizes.xs),
+        InkWell(
+          key: const Key('login_signup_link'),
+          onTap: () => context.goNamed(AppRoute.register.name),
+          child: const Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: AppSizes.xs,
+              vertical: AppSizes.xs,
+            ),
+            child: Text(
+              'Sign Up',
+              style: TextStyle(
+                fontFamily: FontFamily.parkinsans,
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                height: 22 / 15,
+                color: AppColors.burgundy,
+              ),
+            ),
+          ),
         ),
       ],
     );

--- a/test/features/auth/login/login_screen_test.dart
+++ b/test/features/auth/login/login_screen_test.dart
@@ -31,11 +31,6 @@ GoRouter _routerFor(Widget screen) => GoRouter(
       name: AppRoute.register.name,
       builder: (_, __) => const Scaffold(body: Text('Register stub')),
     ),
-    GoRoute(
-      path: AppRoute.forgotPassword.path,
-      name: AppRoute.forgotPassword.name,
-      builder: (_, __) => const Scaffold(body: Text('Forgot stub')),
-    ),
   ],
 );
 
@@ -66,36 +61,66 @@ void main() {
     analyticsProvider.overrideWithValue(fakeAnalytics),
   ];
 
-  testWidgets('renders BrandLogo, email + password fields, and submit', (
-    tester,
-  ) async {
-    await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
-    await tester.pumpAndSettle();
-
-    expect(find.byType(BrandLogo), findsOneWidget);
-    expect(find.byKey(const Key('login_email_field')), findsOneWidget);
-    expect(find.byKey(const Key('login_password_field')), findsOneWidget);
-    expect(find.byKey(const Key('login_submit_button')), findsOneWidget);
-    // Greeting copy locks the NIB-107 redesign.
-    expect(find.text('Hi, Welcome!'), findsOneWidget);
-  });
-
-  testWidgets('social buttons (Google + Apple) are present', (tester) async {
-    await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('login_google_button')), findsOneWidget);
-    expect(find.byKey(const Key('login_apple_button')), findsOneWidget);
-  });
+  // -------------------------------------------------------------------------
+  // State 1 — empty
+  // -------------------------------------------------------------------------
 
   testWidgets(
-    'password toggle flips obscureText (eye -> eye-off icon swap)',
+    'empty state — brand mark, verbatim copy, both input fields, primary CTA',
     (tester) async {
       await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
       await tester.pumpAndSettle();
 
-      // Initial state: obscured -> visibility_off shown inside the password
-      // field's suffix slot. Scope by ancestor to ignore unrelated icons.
+      // Brand mark is the Quatrefoil (NIB-107 swapped the lockup for the
+      // bare butter mark per Figma node 1015:13496).
+      expect(find.byType(Quatrefoil), findsOneWidget);
+
+      // Verbatim copy per Figma — smart apostrophes intentional.
+      expect(find.text('Hi, Welcome!'), findsOneWidget);
+      expect(
+        find.text('Login to continue tracking your\nbaby’s healthy growth.'),
+        findsOneWidget,
+      );
+      expect(find.text('Email address'), findsWidgets);
+      expect(find.text('Password'), findsWidgets);
+      expect(find.text('Login'), findsOneWidget);
+      expect(find.text('Or login with'), findsOneWidget);
+      expect(find.text('Login with Google'), findsOneWidget);
+      expect(find.text('Login with Apple Account'), findsOneWidget);
+      expect(find.text('Don’t have an account?'), findsOneWidget);
+      expect(find.text('Sign Up'), findsOneWidget);
+
+      // Keys for downstream wiring.
+      expect(find.byKey(const Key('login_email_field')), findsOneWidget);
+      expect(find.byKey(const Key('login_password_field')), findsOneWidget);
+      expect(find.byKey(const Key('login_submit_button')), findsOneWidget);
+      expect(find.byKey(const Key('login_google_button')), findsOneWidget);
+      expect(find.byKey(const Key('login_apple_button')), findsOneWidget);
+      expect(find.byKey(const Key('login_signup_link')), findsOneWidget);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // State 2 — filled / focus
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'filled state — typing in both inputs keeps the eye toggle visible '
+    'and flips obscureText on tap',
+    (tester) async {
+      await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('login_email_field')),
+        'tuffahati128@gmail.com',
+      );
+      await tester.enterText(
+        find.byKey(const Key('login_password_field')),
+        'supersecret',
+      );
+      await tester.pump();
+
       Finder iconInPasswordField(IconData icon) => find.descendant(
         of: find.byKey(const Key('login_password_field')),
         matching: find.byIcon(icon),
@@ -118,8 +143,14 @@ void main() {
     },
   );
 
+  // -------------------------------------------------------------------------
+  // State 3 — auth error
+  // -------------------------------------------------------------------------
+
   testWidgets(
-    'submit failure renders destructive caption (not red field borders)',
+    'error state — submit failure renders the Supabase error verbatim '
+    'under each input (NIB-107 deviation: hardcoded copy is replaced by '
+    'the live backend message per project P1 rule)',
     (tester) async {
       when(() => mockRepo.signIn(any(), any())).thenAnswer(
         (_) async =>
@@ -140,14 +171,24 @@ void main() {
       await tester.tap(find.byKey(const Key('login_submit_button')));
       await tester.pumpAndSettle();
 
-      // Caption text rendered verbatim — NIB-107 deviation: caption, not
-      // a red border on the field itself.
-      expect(find.text('Invalid login credentials.'), findsOneWidget);
-      // Fields themselves carry no errorText, so 'Please enter a valid email.'
-      // (the AppTextField helper text) must NOT be present.
-      expect(find.text('Please enter a valid email.'), findsNothing);
+      // Per-field helper rows render the Supabase error verbatim — one row
+      // under email, one under password.
+      expect(find.text('Invalid login credentials.'), findsNWidgets(2));
+
+      // Password suffix swaps to the check glyph in the error variant.
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('login_password_field')),
+          matching: find.byIcon(Icons.check_rounded),
+        ),
+        findsOneWidget,
+      );
     },
   );
+
+  // -------------------------------------------------------------------------
+  // Social auth paths
+  // -------------------------------------------------------------------------
 
   testWidgets(
     'Google tap calls controller.signInWithGoogle and logs analytics',
@@ -226,4 +267,21 @@ void main() {
       );
     },
   );
+
+  // -------------------------------------------------------------------------
+  // Sign Up footer navigation
+  // -------------------------------------------------------------------------
+
+  testWidgets('Sign Up link navigates to the register route', (tester) async {
+    await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
+
+    final signUp = find.byKey(const Key('login_signup_link'));
+    await tester.ensureVisible(signUp);
+    await tester.pumpAndSettle();
+    await tester.tap(signUp);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Register stub'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## NIB-107 — Login screen (3 state variants)

Restyles the Login screen to match the redesign Figma. Implements all three state variants — empty (971:10029), filled (1015:10854), and error (1023:6909) — with verbatim copy, the new branded butter quatrefoil + "n" mark, label-above filled inputs, password visibility toggle, vertically-stacked Google/Apple social CTAs, and a burgundy Sign Up footer link.

## Figma frames

- Login (state 1, empty): 971:10029
- Login (state 2, filled): 1015:10854
- Login (state 3, error): 1023:6909

## Audit artifacts

- .figma-audit/onboarding/login-1/report.md
- .figma-audit/onboarding/login-2/report.md
- .figma-audit/onboarding/login-3/report.md

## Acceptance criteria

- [x] Pixel-close to .figma-audit/onboarding/login-{1,2,3}/screenshot.png
- [x] Verbatim copy across all 3 states (smart apostrophes preserved)
- [x] All 3 state variants reachable (empty / filled-focus / error)
- [x] Email/password Login wired through `LoginController.submit`
- [x] Google + Apple OAuth wired through `signInWithGoogle` / `signInWithApple`
- [x] Sign Up footer link navigates to `/auth/register`
- [x] Password visibility toggle wired
- [x] Error state shows Supabase error verbatim (per project P1 rule — hardcoded "Your email or password wrong" deviation called out by audit was rejected in favour of CLAUDE.md "Auth login fails | P1 | Show Supabase error message")
- [x] All tokens consumed from DS; new `AppColors.burgundy` (#77393B) token added for the Nibble-primary-Burgundy variable
- [x] `flutter analyze` clean (no new issues; one pre-existing `prefer_adjacent_string_concatenation` info in `onboarding_result_screen.dart` is unrelated)
- [x] Widget tests cover all 3 states + each auth path + Sign Up footer nav

## Notable deltas vs current `redesign`

- **Logo**: dropped the `BrandLogo` mark+wordmark lockup in favour of an inline `_LoginLogoMark` — butter `Quatrefoil` with a green sage "n" Parkinsans glyph centered. Matches Figma node 1015:13496.
- **Background**: new Grad-1 butter-soft → cream diagonal gradient.
- **Social buttons**: replaced the side-by-side `secondary` `AppPillButton` row with two stacked full-width pills: white-bg / black-text Google with a blue "G" badge, and a black-bg / white-text Apple pill. Material `AppPillButton` variants don't model "Apple black pill" or "Google white-with-color-G", so both are inline custom widgets keyed `login_google_button` / `login_apple_button`.
- **Errors**: per-field burgundy borders + helper rows (driven by the existing `AppTextField` `errorText` + new `errorColor` arg already shipped on `redesign`). Password suffix swaps to a burgundy check glyph in the error variant per Figma (visual oddity flagged in audit, kept per spec).
- **Forgot password link**: removed — not in any of the three Figma states. The `/auth/forgot-password` route still exists but currently has no in-screen entry point on login. Flagging for follow-up; if desired, add a tertiary link above the social section, or wire from elsewhere.
- **Burgundy token**: added `AppColors.burgundy = #77393B` for the Nibble-primary-Burgundy variable used by the Sign Up link and error treatments.