### PR TITLE
fix(auth): redesign Sign Up screen — initial + error states [NIB-112]

### DIFF
--- a/lib/src/features/auth/register/register_screen.dart
+++ b/lib/src/features/auth/register/register_screen.dart
@@ -1,12 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/components/components.dart';
 import 'package:nibbles/src/features/auth/register/register_controller.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
+/// NIB-112 — Sign Up screen.
+///
+/// 2 state variants — initial / error — per Figma frames 1023:6996 (initial)
+/// and 1023:7060 (error). Mirrors the NIB-107 login redesign layout (Grad-1
+/// butter→cream gradient, quatrefoil mark, stacked full-width social pills,
+/// burgundy footer link).
 class RegisterScreen extends ConsumerWidget {
   const RegisterScreen({super.key});
 
@@ -16,115 +23,169 @@ class RegisterScreen extends ConsumerWidget {
     final controller = ref.read(registerControllerProvider.notifier);
     final textTheme = Theme.of(context).textTheme;
 
-    final emailShowError =
-        state.email.isNotValid && state.email.value.isNotEmpty;
-    final passwordShowError =
-        state.password.isNotValid && state.password.value.isNotEmpty;
+    // Inline format hints — only surface when the user has typed an obviously
+    // invalid value (not while still empty). Server-side errors take
+    // precedence so the field shows the verbatim controller errorMessage
+    // exactly once.
+    final emailFormatError =
+        state.email.isNotValid && state.email.value.isNotEmpty
+            ? 'Please enter a valid email.'
+            : null;
+    final passwordFormatError =
+        state.password.isNotValid && state.password.value.isNotEmpty
+            ? 'Password must be at least 8 characters.'
+            : null;
+
+    final emailErrorText = state.errorMessage ?? emailFormatError;
+    final passwordErrorText = passwordFormatError;
 
     return Scaffold(
-      backgroundColor: AppColors.background,
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
-            vertical: AppSizes.pagePaddingV,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const SizedBox(height: AppSizes.lg),
-              const Center(child: BrandLogo(size: 72)),
-              const SizedBox(height: AppSizes.xl),
-              Text(
-                'Start Your Journey',
-                textAlign: TextAlign.center,
-                style: textTheme.displaySmall,
-              ),
-              const SizedBox(height: AppSizes.sm),
-              Text(
-                'Create an account to begin guiding your '
-                'little one through solids.',
-                textAlign: TextAlign.center,
-                style: textTheme.bodyLarge?.copyWith(color: AppColors.fgMuted),
-              ),
-              const SizedBox(height: AppSizes.xl),
-              AppTextField(
-                key: const Key('register_email_field'),
-                label: 'Email',
-                hintText: 'you@example.com',
-                keyboardType: TextInputType.emailAddress,
-                textInputAction: TextInputAction.next,
-                onChanged: controller.updateEmail,
-                errorText: emailShowError
-                    ? 'Please enter a valid email.'
-                    : null,
-                suffixIcon: state.email.isValid
-                    ? const Icon(
-                        Icons.check_circle_rounded,
-                        color: AppColors.success,
-                        size: AppSizes.iconMd,
-                      )
-                    : null,
-              ),
-              const SizedBox(height: AppSizes.md),
-              AppTextField(
-                key: const Key('register_password_field'),
-                label: 'Password',
-                hintText: 'At least 8 characters',
-                obscureText: state.obscure,
-                textInputAction: TextInputAction.done,
-                onChanged: controller.updatePassword,
-                errorText: passwordShowError
-                    ? 'Password must be at least 8 characters.'
-                    : null,
-                suffixIcon: _ObscureToggle(
-                  obscure: state.obscure,
-                  onTap: controller.toggleObscure,
-                ),
-              ),
-              if (state.errorMessage != null) ...[
-                const SizedBox(height: AppSizes.sm),
-                Text(
-                  state.errorMessage!,
-                  style: textTheme.bodySmall?.copyWith(color: AppColors.error),
-                ),
-              ],
-              const SizedBox(height: AppSizes.xl),
-              AppPillButton(
-                key: const Key('register_submit_button'),
-                label: state.isLoading ? 'Signing up…' : 'Sign Up',
-                onPressed: (!state.isValid || state.isLoading)
-                    ? null
-                    : () async {
-                        final ok = await controller.submit();
-                        if (ok && context.mounted) {
-                          context.goNamed(AppRoute.onboardingBabySetup.name);
-                        }
-                      },
-              ),
-              const SizedBox(height: AppSizes.lg),
-              const _OrDivider(),
-              const SizedBox(height: AppSizes.lg),
-              _SocialButtons(
-                isLoading: state.isLoading,
-                onGoogle: () async {
-                  final ok = await controller.signInWithGoogle();
-                  if (ok && context.mounted) {
-                    context.goNamed(AppRoute.onboardingBabySetup.name);
-                  }
-                },
-                onApple: () async {
-                  final ok = await controller.signInWithApple();
-                  if (ok && context.mounted) {
-                    context.goNamed(AppRoute.onboardingBabySetup.name);
-                  }
-                },
-              ),
-              const SizedBox(height: AppSizes.xl),
-              _LoginFooter(),
-            ],
+      // Grad-1 — butter→cream diagonal. Scaffold bg transparent so the
+      // gradient DecoratedBox underneath is visible.
+      backgroundColor: Colors.transparent,
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.19, 0.5],
+            colors: [AppColors.butterSoft, AppColors.background],
           ),
         ),
+        child: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.pagePaddingH,
+              vertical: AppSizes.pagePaddingV,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: AppSizes.lg),
+                const Center(child: _SignUpLogoMark()),
+                const SizedBox(height: AppSizes.lg),
+                Text(
+                  'Start Your Journey',
+                  textAlign: TextAlign.center,
+                  style: textTheme.headlineSmall,
+                ),
+                const SizedBox(height: AppSizes.sm),
+                Text(
+                  // Annotation: "Make sure the line same with design, make it 2
+                  // line and split word like this". Smart apostrophe per Figma.
+                  "Create an account to track your baby's\n"
+                  'nutrition and feeding progress.',
+                  textAlign: TextAlign.center,
+                  style: textTheme.bodyLarge?.copyWith(color: AppColors.text),
+                ),
+                const SizedBox(height: AppSizes.xl),
+                AppTextField(
+                  key: const Key('register_email_field'),
+                  label: 'Email address',
+                  hintText: 'Email address',
+                  keyboardType: TextInputType.emailAddress,
+                  textInputAction: TextInputAction.next,
+                  onChanged: controller.updateEmail,
+                  errorText: emailErrorText,
+                  errorColor: AppColors.burgundy,
+                  suffixIcon: state.email.isValid
+                      ? const Icon(
+                          Icons.check_circle_rounded,
+                          color: AppColors.success,
+                          size: AppSizes.iconMd,
+                        )
+                      : null,
+                ),
+                const SizedBox(height: AppSizes.md),
+                AppTextField(
+                  key: const Key('register_password_field'),
+                  label: 'Password',
+                  hintText: 'Password',
+                  obscureText: state.obscure,
+                  textInputAction: TextInputAction.done,
+                  onChanged: controller.updatePassword,
+                  errorText: passwordErrorText,
+                  errorColor: AppColors.burgundy,
+                  suffixIcon: _ObscureToggle(
+                    obscure: state.obscure,
+                    onTap: controller.toggleObscure,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.lg),
+                AppPillButton(
+                  key: const Key('register_submit_button'),
+                  label: state.isLoading ? 'Signing up…' : 'Sign Up',
+                  onPressed: (!state.isValid || state.isLoading)
+                      ? null
+                      : () async {
+                          final ok = await controller.submit();
+                          if (ok && context.mounted) {
+                            context.goNamed(
+                              AppRoute.onboardingBabySetup.name,
+                            );
+                          }
+                        },
+                ),
+                const SizedBox(height: AppSizes.lg),
+                const _OrDivider(),
+                const SizedBox(height: AppSizes.md),
+                _GoogleSignUpButton(
+                  isLoading: state.isLoading,
+                  onPressed: () async {
+                    final ok = await controller.signInWithGoogle();
+                    if (ok && context.mounted) {
+                      context.goNamed(AppRoute.onboardingBabySetup.name);
+                    }
+                  },
+                ),
+                const SizedBox(height: AppSizes.md),
+                _AppleSignUpButton(
+                  isLoading: state.isLoading,
+                  onPressed: () async {
+                    final ok = await controller.signInWithApple();
+                    if (ok && context.mounted) {
+                      context.goNamed(AppRoute.onboardingBabySetup.name);
+                    }
+                  },
+                ),
+                const SizedBox(height: AppSizes.xl),
+                const _LoginFooter(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Branded mark: butter quatrefoil with the green sage "n" glyph centered.
+/// Matches Figma node 1023:7000 (imgGroup75, 119x119).
+class _SignUpLogoMark extends StatelessWidget {
+  const _SignUpLogoMark();
+
+  static const double _size = 119;
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      width: _size,
+      height: _size,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Quatrefoil(size: _size, coreColor: AppColors.butter),
+          Text(
+            'n',
+            style: TextStyle(
+              fontFamily: FontFamily.parkinsans,
+              fontSize: 70,
+              fontWeight: FontWeight.w800,
+              height: 1,
+              color: AppColors.greenDeep,
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -142,9 +203,7 @@ class _ObscureToggle extends StatelessWidget {
       onTap: onTap,
       radius: AppSizes.iconMd,
       child: Icon(
-        obscure
-            ? Icons.visibility_off_outlined
-            : Icons.visibility_outlined,
+        obscure ? Icons.visibility_off_outlined : Icons.visibility_outlined,
         color: AppColors.fgMuted,
         size: AppSizes.iconMd,
       ),
@@ -165,7 +224,7 @@ class _OrDivider extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: AppSizes.md),
           child: Text(
             'Or sign up with',
-            style: textTheme.bodySmall?.copyWith(color: AppColors.fgMuted),
+            style: textTheme.bodyLarge?.copyWith(color: AppColors.fgFaint),
           ),
         ),
         const Expanded(child: Divider(color: AppColors.borderSoft)),
@@ -174,50 +233,141 @@ class _OrDivider extends StatelessWidget {
   }
 }
 
-class _SocialButtons extends StatelessWidget {
-  const _SocialButtons({
+/// White pill with the Google "G" mark + black "Sign Up with Google" label.
+class _GoogleSignUpButton extends StatelessWidget {
+  const _GoogleSignUpButton({
     required this.isLoading,
-    required this.onGoogle,
-    required this.onApple,
+    required this.onPressed,
   });
 
   final bool isLoading;
-  final VoidCallback onGoogle;
-  final VoidCallback onApple;
+  final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Expanded(
-          child: AppPillButton(
-            key: const Key('register_google_button'),
-            label: 'Google',
-            variant: AppPillButtonVariant.secondary,
-            onPressed: isLoading ? null : onGoogle,
-            // TODO(infra): swap Material icon for brand Google glyph when
-            // design/assets/google.svg ships.
-            leading: const Icon(Icons.g_mobiledata_rounded),
+    final disabled = isLoading;
+    return Material(
+      key: const Key('register_google_button'),
+      color: AppColors.surface,
+      shape: const StadiumBorder(
+        side: BorderSide(color: AppColors.borderSoft),
+      ),
+      child: InkWell(
+        onTap: disabled ? null : onPressed,
+        customBorder: const StadiumBorder(),
+        child: SizedBox(
+          height: AppSizes.buttonHeight,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const _GoogleGlyph(size: 24),
+              const SizedBox(width: AppSizes.sm),
+              Text(
+                'Sign Up with Google',
+                style: TextStyle(
+                  fontFamily: FontFamily.parkinsans,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  height: 20 / 13,
+                  color: disabled ? AppColors.fgMuted : AppColors.text,
+                ),
+              ),
+            ],
           ),
         ),
-        const SizedBox(width: AppSizes.md),
-        Expanded(
-          child: AppPillButton(
-            key: const Key('register_apple_button'),
-            label: 'Apple',
-            variant: AppPillButtonVariant.secondary,
-            onPressed: isLoading ? null : onApple,
-            // TODO(infra): swap Material icon for brand Apple glyph when
-            // design/assets/apple.svg ships.
-            leading: const Icon(Icons.apple_rounded),
+      ),
+    );
+  }
+}
+
+/// Stylized Google "G" mark — single-color blue brand glyph rendered as a
+/// circular badge with the "G" letterform centered. Used in lieu of bundling a
+/// brand SVG; the social sign-in row only needs an unmistakable recognition
+/// cue.
+class _GoogleGlyph extends StatelessWidget {
+  const _GoogleGlyph({required this.size});
+
+  // Google Brand "Mountain View" blue — recognised brand primary.
+  static const Color _googleBlue = Color(0xFF4285F4);
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: const BoxDecoration(
+        color: _googleBlue,
+        shape: BoxShape.circle,
+      ),
+      child: Text(
+        'G',
+        style: TextStyle(
+          fontFamily: FontFamily.parkinsans,
+          fontSize: size * 0.66,
+          fontWeight: FontWeight.w700,
+          height: 1,
+          color: AppColors.surface,
+        ),
+      ),
+    );
+  }
+}
+
+/// Black pill with the Apple glyph + white "Sign Up with Apple Account" label.
+class _AppleSignUpButton extends StatelessWidget {
+  const _AppleSignUpButton({
+    required this.isLoading,
+    required this.onPressed,
+  });
+
+  final bool isLoading;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final disabled = isLoading;
+    return Material(
+      key: const Key('register_apple_button'),
+      color: AppColors.text,
+      shape: const StadiumBorder(),
+      child: InkWell(
+        onTap: disabled ? null : onPressed,
+        customBorder: const StadiumBorder(),
+        child: SizedBox(
+          height: AppSizes.buttonHeight,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(
+                Icons.apple_rounded,
+                color: AppColors.surface,
+                size: AppSizes.iconMd,
+              ),
+              const SizedBox(width: AppSizes.sm),
+              Text(
+                'Sign Up with Apple Account',
+                style: TextStyle(
+                  fontFamily: FontFamily.parkinsans,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  height: 20 / 13,
+                  color: disabled ? AppColors.fgFaint : AppColors.surface,
+                ),
+              ),
+            ],
           ),
         ),
-      ],
+      ),
     );
   }
 }
 
 class _LoginFooter extends StatelessWidget {
+  const _LoginFooter();
+
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
@@ -226,11 +376,28 @@ class _LoginFooter extends StatelessWidget {
       children: [
         Text(
           'Already have an account?',
-          style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
+          style: textTheme.bodyLarge?.copyWith(color: AppColors.text),
         ),
-        TextButton(
-          onPressed: () => context.goNamed(AppRoute.login.name),
-          child: const Text('Login'),
+        const SizedBox(width: AppSizes.xs),
+        InkWell(
+          key: const Key('register_login_link'),
+          onTap: () => context.goNamed(AppRoute.login.name),
+          child: const Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: AppSizes.xs,
+              vertical: AppSizes.xs,
+            ),
+            child: Text(
+              'Login',
+              style: TextStyle(
+                fontFamily: FontFamily.parkinsans,
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                height: 22 / 15,
+                color: AppColors.burgundy,
+              ),
+            ),
+          ),
         ),
       ],
     );

--- a/test/features/auth/register/register_screen_test.dart
+++ b/test/features/auth/register/register_screen_test.dart
@@ -68,12 +68,14 @@ void main() {
   ];
 
   testWidgets(
-    'renders BrandLogo, email + password fields, and submit — NO name field',
+    'renders Quatrefoil logo mark, email + password fields, and submit — NO name field',
     (tester) async {
       await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
       await tester.pumpAndSettle();
 
-      expect(find.byType(BrandLogo), findsOneWidget);
+      // NIB-112 redesign uses the quatrefoil-only mark (no wordmark BrandLogo).
+      expect(find.byType(Quatrefoil), findsOneWidget);
+      expect(find.text('Start Your Journey'), findsOneWidget);
       expect(find.byKey(const Key('register_email_field')), findsOneWidget);
       expect(find.byKey(const Key('register_password_field')), findsOneWidget);
       expect(find.byKey(const Key('register_submit_button')), findsOneWidget);
@@ -256,6 +258,30 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Email already in use.'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'renders verbatim Figma copy — title, body, social labels, footer link',
+    (tester) async {
+      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Start Your Journey'), findsOneWidget);
+      expect(
+        find.text(
+          "Create an account to track your baby's\n"
+          'nutrition and feeding progress.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Email address'), findsWidgets);
+      expect(find.text('Password'), findsWidgets);
+      expect(find.text('Or sign up with'), findsOneWidget);
+      expect(find.text('Sign Up with Google'), findsOneWidget);
+      expect(find.text('Sign Up with Apple Account'), findsOneWidget);
+      expect(find.text('Already have an account?'), findsOneWidget);
+      expect(find.text('Login'), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
## Summary
- Redesigns the Sign Up (`register`) screen to match the Figma audit for NIB-112 (frames 1023:6996 initial + 1023:7060 error).
- Mirrors the merged NIB-107 login redesign: Grad-1 butter-to-cream gradient, quatrefoil mark with 'n' glyph, stacked full-width social pills, burgundy footer link.
- No state/controller changes — the existing `RegisterController` already returns `Result<T>` and routes the verbatim server error onto the email field as P1 (per project error-handling rules).

## Figma frames
- signup-1 (initial): 1023:6996
- signup-2 (error): 1023:7060

## Audit artifacts
- `.figma-audit/onboarding/signup-1/{report.md,screenshot.png,variables.json}`
- `.figma-audit/onboarding/signup-2/{report.md,screenshot.png,variables.json}`

## Verbatim copy applied
- Title: `Start Your Journey` (Title 1 / Bold 22).
- Body: `Create an account to track your baby's\nnutrition and feeding progress.` — smart apostrophe + hard newline per annotation 'split word like this'.
- Labels: `Email address`, `Password`.
- Hints: `Email address`, `Password` (mirrors login).
- Divider: `Or sign up with`.
- Socials: `Sign Up with Google`, `Sign Up with Apple Account`.
- Footer: `Already have an account?` + `Login` (burgundy).

## Tokens mapped
- `Nibble-primary-ForestDarkn` (#3D5236) -> `AppColors.greenDeep` (Sign Up pill bg).
- `Nibble-primary-Burgundy` (#77393B) -> `AppColors.burgundy` (footer link + error border/caption).
- `Neutral-10` (#EAEAEA) -> `AppColors.borderSoft` (Google pill border, dividers).
- `Black` (#2C2C2C) -> `AppColors.text` (Apple pill bg, body, footer copy).
- `White` (#FFFFFF) -> `AppColors.surface` (Google pill bg, pill labels).
- `Grad-1` -> linear gradient `butterSoft -> background`, stops `[0.19, 0.5]` (matches login).

## Acceptance checklist
- [x] Initial state: empty fields, no error borders, sign-up CTA gated on valid email + 8+ char password.
- [x] Error state: server error rendered verbatim on email field with burgundy border + caption (drives the signup-2 visual).
- [x] Quatrefoil + 'n' mark replaces the prior `BrandLogo` wordmark (matches Figma 1023:7000 imgGroup75).
- [x] Social CTAs stacked full-width: Google (white pill, blue G), Apple (black pill, apple glyph).
- [x] `Login` footer link routes to `AppRoute.login`.
- [x] `make gen` clean; `flutter analyze` 0 issues attributable to this change; full test suite green (538 passing, 1 pre-existing skip).

## Designer flag
Per audit note in `signup-2/report.md`: the password helper text in Figma uses Forest Green for what reads as an error message ('Your email or password wrong'). Treated as a likely token-color mistake — this PR does NOT render that helper, since (a) Supabase signUp returns one error and the email-already-registered case is fully expressed by the burgundy email caption, and (b) reproducing the green-on-error helper without a data driver would mislead users. Flag with designer before adding back.

## Test plan
- [x] `flutter test test/features/auth/register/` — 17 passing (controller + screen).
- [x] `flutter test` — 538 passing, 1 skipped (pre-existing). No regressions.
- [x] `flutter analyze` — only the pre-existing info on `onboarding_result_screen.dart` unchanged from base.