### PR TITLE
fix(auth): forgot-password screen tokens + verbatim copy [NIB-114]

### DIFF
--- a/lib/src/features/auth/forgot_password/forgot_password_screen.dart
+++ b/lib/src/features/auth/forgot_password/forgot_password_screen.dart
@@ -10,8 +10,18 @@ import 'package:nibbles/src/features/auth/forgot_password/forgot_password_contro
 import 'package:nibbles/src/features/auth/forgot_password/forgot_password_state.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Generic, enumeration-safe error caption shown for any submit failure.
-/// Never leaks whether the email exists.
+/// NIB-114 — Forgot password entry + error.
+///
+/// Figma frames 971:10119 (entry) and 971:10128 (error). Background is the
+/// Grad-1 token (butterSoft→cream diagonal — same as login). The error frame
+/// adds burgundy inline helper text; we map this onto AppTextField's burgundy
+/// errorColor.
+///
+/// Enumeration safety: Supabase `resetPasswordForEmail` returns success even
+/// for unregistered emails (anti-enumeration, by design). We therefore never
+/// render a literal "Email doesn't exist" caption (would mislead users and
+/// would require a separate existence query — the exact vector this app
+/// rejects). Any submit failure collapses to a generic caption.
 const String _genericErrorMessage =
     "Couldn't send the reset link. Please try again.";
 
@@ -27,42 +37,54 @@ class ForgotPasswordScreen extends ConsumerWidget {
         : context.goNamed(AppRoute.login.name);
 
     return Scaffold(
-      backgroundColor: AppColors.background,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(
-            AppSizes.pagePaddingH,
-            AppSizes.md,
-            AppSizes.pagePaddingH,
-            AppSizes.lg,
+      // Grad-1 — butterSoft→cream diagonal. Scaffold transparent so the
+      // gradient covers behind SafeArea.
+      backgroundColor: Colors.transparent,
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.19, 0.5],
+            colors: [AppColors.butterSoft, AppColors.background],
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Align(
-                alignment: Alignment.centerLeft,
-                child: AppRoundButton(
-                  icon: const Icon(Icons.arrow_back_rounded),
-                  onPressed: goBack,
-                  tone: AppRoundButtonTone.butter,
-                  semanticLabel: 'Back',
+        ),
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSizes.pagePaddingH,
+              AppSizes.md,
+              AppSizes.pagePaddingH,
+              AppSizes.lg,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: AppRoundButton(
+                    icon: const Icon(Icons.arrow_back_rounded),
+                    onPressed: goBack,
+                    tone: AppRoundButtonTone.butter,
+                    semanticLabel: 'Back',
+                  ),
                 ),
-              ),
-              const SizedBox(height: AppSizes.lg),
-              Expanded(
-                child: state.sent
-                    ? _ConfirmationView(onBackToLogin: goBack)
-                    : _InputView(
-                        state: state,
-                        onEmailChanged: ref
-                            .read(forgotPasswordControllerProvider.notifier)
-                            .updateEmail,
-                        onSubmit: ref
-                            .read(forgotPasswordControllerProvider.notifier)
-                            .submit,
-                      ),
-              ),
-            ],
+                const SizedBox(height: AppSizes.lg),
+                Expanded(
+                  child: state.sent
+                      ? _ConfirmationView(onBackToLogin: goBack)
+                      : _InputView(
+                          state: state,
+                          onEmailChanged: ref
+                              .read(forgotPasswordControllerProvider.notifier)
+                              .updateEmail,
+                          onSubmit: ref
+                              .read(forgotPasswordControllerProvider.notifier)
+                              .submit,
+                        ),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -96,25 +118,30 @@ class _InputView extends StatelessWidget {
       children: [
         Text(
           'Forgot your password?',
-          style: textTheme.headlineLarge,
+          style: textTheme.headlineSmall,
           textAlign: TextAlign.left,
         ),
         const SizedBox(height: AppSizes.sm),
         Text(
-          "Enter your email and we'll send you a reset link.",
-          style: textTheme.bodyLarge?.copyWith(color: AppColors.subtext),
+          // Verbatim copy from Figma node 971:10119.
+          // Smart apostrophe per Figma render.
+          'Please enter the email address you’d like your password reset '
+          'information sent to',
+          style: textTheme.bodyLarge?.copyWith(color: AppColors.text),
           textAlign: TextAlign.left,
         ),
         const SizedBox(height: AppSizes.xl),
         AppTextField(
           key: const Key('forgot_email_field'),
-          label: 'Email',
-          hintText: 'you@example.com',
+          hintText: 'Email address',
           keyboardType: TextInputType.emailAddress,
           textInputAction: TextInputAction.done,
           onChanged: onEmailChanged,
           onSubmitted: (_) => state.isLoading ? null : onSubmit(),
           errorText: inlineError,
+          // Figma error frame 971:10128 — Nibble-primary-Burgundy border +
+          // caption.
+          errorColor: AppColors.burgundy,
         ),
         const Spacer(),
         AppPillButton(
@@ -155,7 +182,7 @@ class _ConfirmationView extends StatelessWidget {
         const SizedBox(height: AppSizes.lg),
         Text(
           'Check your email',
-          style: textTheme.headlineLarge,
+          style: textTheme.headlineSmall,
           textAlign: TextAlign.left,
         ),
         const SizedBox(height: AppSizes.sm),


### PR DESCRIPTION
## Summary
- Matches Figma frames `971:10119` (entry) and `971:10128` (error) for the forgot-password entry screen.
- Background switched to Grad-1 (butterSoft -> cream diagonal), mirroring the login redesign.
- Body copy is now verbatim from Figma with smart apostrophe; placeholder is `Email address`; title uses `headlineSmall` (22/700).
- Error treatment for the input now uses `AppColors.burgundy` (Nibble-primary-Burgundy) to match the Figma error frame.
- Kept the enumeration-safe generic caption + the existing post-submit confirmation view (`Check your email` -> `Back to login`).

## Acceptance criteria
- [x] Renders butter back pill, title `Forgot your password?`, verbatim body copy, `Email address` placeholder, bottom-anchored `Confirm` CTA.
- [x] Grad-1 background applied.
- [x] Error state reachable: invalid email shows `Please enter a valid email.` in burgundy; backend failure shows generic caption in burgundy.
- [x] Success transitions to confirmation sub-view.
- [x] Back button pops if possible, otherwise navigates to `/auth/login`.
- [x] All 7 existing widget tests pass.
- [x] `flutter analyze` shows 0 issues for this file.

## Known deviation — literal "Email doesn't exist" not implemented
The Figma error frame (`971:10128`) shows the inline caption `Email doesn't exist`. We deliberately do **not** render this string:

- Supabase `resetPasswordForEmail` returns success even for unregistered emails (anti-enumeration, by design).
- A literal `Email doesn't exist` caption would either (a) be misleading (the API may have actually sent mail) or (b) require a separate existence query — the exact enumeration vector this codebase rejects.
- The existing `forgot_password_screen_test` explicitly asserts no `doesn't exist` / `not found` leak.
- The error frame's real delta — Nibble-primary-Burgundy border + caption tone — is implemented via `AppTextField.errorColor: AppColors.burgundy`.

Flagging this for human reviewer to make the final call.

## Figma frames
- Entry: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-10119
- Error: https://www.figma.com/design/ASB9HZLodbzJCo5bjkqjy6/Baby-s-Nutrition-App?node-id=971-10128

## Audit reports
- `.figma-audit/onboarding/forget-password-1/report.md`
- `.figma-audit/onboarding/forget-password-error/report.md`

## Test plan
- [x] `flutter test test/features/auth/forgot_password/` — all 7 tests pass
- [x] `flutter test test/features/auth/` — all 45 auth tests pass
- [x] `flutter analyze` — 0 issues in changed file