### PR TITLE
fix(auth): reset password initial + too-short + mismatch states [NIB-115]

### DIFF
--- a/lib/src/features/auth/reset_password/reset_password_controller.dart
+++ b/lib/src/features/auth/reset_password/reset_password_controller.dart
@@ -5,6 +5,11 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'reset_password_controller.g.dart';
 
+/// NIB-115 — Reset password / AU-03 controller.
+///
+/// Drives the three Figma states for forget-password 3/4/5:
+///   971:10136 (initial guidance), 971:10148 (too short),
+///   971:10160 (mismatch).
 @riverpod
 class ResetPasswordController extends _$ResetPasswordController {
   @override
@@ -26,12 +31,12 @@ class ResetPasswordController extends _$ResetPasswordController {
     if (password.isNotValid) {
       state = state.copyWith(
         password: password,
-        errorMessage: 'Password must be at least 8 characters.',
+        errorMessage: 'Password is too short',
       );
       return;
     }
     if (!state.passwordsMatch) {
-      state = state.copyWith(errorMessage: 'Passwords do not match.');
+      state = state.copyWith(errorMessage: "Password doesn't match");
       return;
     }
 

--- a/lib/src/features/auth/reset_password/reset_password_controller.g.dart
+++ b/lib/src/features/auth/reset_password/reset_password_controller.g.dart
@@ -7,9 +7,15 @@ part of 'reset_password_controller.dart';
 // **************************************************************************
 
 String _$resetPasswordControllerHash() =>
-    r'272b87c7b675fe94e674309f9449a10bd1c75b8f';
+    r'cbc677883b683d49dbd19df8dfd229fc4c3ecdf7';
 
-/// See also [ResetPasswordController].
+/// NIB-115 — Reset password / AU-03 controller.
+///
+/// Drives the three Figma states for forget-password 3/4/5:
+///   971:10136 (initial guidance), 971:10148 (too short),
+///   971:10160 (mismatch).
+///
+/// Copied from [ResetPasswordController].
 @ProviderFor(ResetPasswordController)
 final resetPasswordControllerProvider =
     AutoDisposeNotifierProvider<

--- a/lib/src/features/auth/reset_password/reset_password_screen.dart
+++ b/lib/src/features/auth/reset_password/reset_password_screen.dart
@@ -4,11 +4,26 @@ import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
 import 'package:nibbles/src/common/components/inputs/app_text_field.dart';
 import 'package:nibbles/src/features/auth/reset_password/reset_password_controller.dart';
 import 'package:nibbles/src/features/auth/reset_password/reset_password_state.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
+/// NIB-115 — Reset password / AU-03.
+///
+/// Figma frames 971:10136 (initial guidance), 971:10148 (too short),
+/// 971:10160 (mismatch). Background is the Grad-1 token
+/// (butterSoft → cream diagonal — same as the forgot-password sibling).
+/// Helper text under each field uses Nibble-primary-Forest (#5C7852 →
+/// [AppColors.green]) for ALL variants — including the validation
+/// failures — per the Figma spec's intentional "guidance tone" choice.
+///
+/// Verbatim copy (do not paraphrase):
+///   title "Forget Password"  (sic — spec mismatch with state-1 flagged)
+///   body  "Password must be at least 8 characters"
+///   field labels "Password" / "Retype Password"
+///   placeholders "Input password" / "Retype password"
 class ResetPasswordScreen extends ConsumerWidget {
   const ResetPasswordScreen({super.key});
 
@@ -28,85 +43,120 @@ class ResetPasswordScreen extends ConsumerWidget {
 
     final controller = ref.read(resetPasswordControllerProvider.notifier);
 
+    void goBack() => context.canPop()
+        ? context.pop()
+        : context.goNamed(AppRoute.login.name);
+
+    // Per-field helper text — derived from controller state to match the
+    // three Figma states. Falls back to the guidance copy when no error.
+    const guidance = 'Password must be at least 8 characters';
+    final passwordHelper =
+        state.passwordTooShort ? 'Password is too short' : guidance;
+    final String confirmHelper;
+    if (state.confirmTooShort) {
+      confirmHelper = 'Password is too short';
+    } else if (state.confirmMismatch) {
+      confirmHelper = "Password doesn't match";
+    } else {
+      confirmHelper = guidance;
+    }
+
     return Scaffold(
-      backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.background,
-        elevation: 0,
-        title: Text(
-          'Set New Password',
-          style: textTheme.titleMedium?.copyWith(color: AppColors.fgStrong),
-        ),
-      ),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
+      backgroundColor: Colors.transparent,
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.19, 0.5],
+            colors: [AppColors.butterSoft, AppColors.background],
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              const SizedBox(height: AppSizes.xxl),
-              Text(
-                'Create a new password',
-                style: textTheme.headlineLarge?.copyWith(
-                  color: AppColors.fgStrong,
+        ),
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSizes.pagePaddingH,
+              AppSizes.md,
+              AppSizes.pagePaddingH,
+              AppSizes.lg,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: AppRoundButton(
+                    icon: const Icon(Icons.arrow_back_rounded),
+                    onPressed: goBack,
+                    tone: AppRoundButtonTone.butter,
+                    semanticLabel: 'Back',
+                  ),
                 ),
-              ),
-              const SizedBox(height: AppSizes.sm),
-              Text(
-                'Your new password must be at least 8 characters.',
-                style: textTheme.bodyLarge?.copyWith(color: AppColors.fgMuted),
-              ),
-              const SizedBox(height: AppSizes.xl),
-              AppTextField(
-                key: const Key('reset_password_new_field'),
-                label: 'New password',
-                hintText: 'Enter new password',
-                obscureText: true,
-                onChanged: controller.updatePassword,
-                errorText:
-                    state.password.isNotValid &&
-                        state.password.value.isNotEmpty
-                    ? 'Password must be at least 8 characters.'
-                    : null,
-              ),
-              const SizedBox(height: AppSizes.md),
-              AppTextField(
-                key: const Key('reset_password_confirm_field'),
-                label: 'Confirm password',
-                hintText: 'Re-enter new password',
-                obscureText: true,
-                onChanged: controller.updateConfirmPassword,
-                errorText:
-                    state.confirmPassword.isNotEmpty && !state.passwordsMatch
-                    ? 'Passwords do not match.'
-                    : null,
-              ),
-              if (state.errorMessage != null) ...[
+                const SizedBox(height: AppSizes.lg),
+                Text(
+                  // Verbatim from Figma 971:10136 — "Forget Password" (sic).
+                  'Forget Password',
+                  style: textTheme.headlineSmall,
+                  textAlign: TextAlign.left,
+                ),
                 const SizedBox(height: AppSizes.sm),
                 Text(
-                  state.errorMessage!,
-                  style: textTheme.bodySmall?.copyWith(color: AppColors.error),
+                  guidance,
+                  style: textTheme.bodyLarge?.copyWith(color: AppColors.text),
+                  textAlign: TextAlign.left,
+                ),
+                const SizedBox(height: AppSizes.xl),
+                AppTextField(
+                  key: const Key('reset_password_new_field'),
+                  label: 'Password',
+                  hintText: 'Input password',
+                  obscureText: true,
+                  onChanged: controller.updatePassword,
+                  // Helper text is ALWAYS shown (guidance or error) — render
+                  // via errorText slot so the colour swap follows the field
+                  // border. Forest-green tone per Figma 971:10148 helper.
+                  errorText: passwordHelper,
+                  errorColor: AppColors.green,
+                ),
+                const SizedBox(height: AppSizes.md),
+                AppTextField(
+                  key: const Key('reset_password_confirm_field'),
+                  label: 'Retype Password',
+                  hintText: 'Retype password',
+                  obscureText: true,
+                  onChanged: controller.updateConfirmPassword,
+                  errorText: confirmHelper,
+                  errorColor: AppColors.green,
+                ),
+                if (state.errorMessage != null &&
+                    state.errorMessage != 'Password is too short' &&
+                    state.errorMessage != "Password doesn't match") ...[
+                  const SizedBox(height: AppSizes.sm),
+                  Text(
+                    state.errorMessage!,
+                    style: textTheme.bodySmall?.copyWith(
+                      color: AppColors.error,
+                    ),
+                  ),
+                ],
+                const Spacer(),
+                AppPillButton(
+                  key: const Key('reset_password_submit_button'),
+                  label: 'Confirm',
+                  onPressed: state.isLoading ? null : controller.submit,
+                  leading: state.isLoading
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: AppColors.cream,
+                          ),
+                        )
+                      : null,
                 ),
               ],
-              const SizedBox(height: AppSizes.xl),
-              AppPillButton(
-                key: const Key('reset_password_submit_button'),
-                label: 'Confirm',
-                onPressed: state.isLoading ? null : controller.submit,
-                leading: state.isLoading
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: AppColors.cream,
-                        ),
-                      )
-                    : null,
-              ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/src/features/auth/reset_password/reset_password_state.dart
+++ b/lib/src/features/auth/reset_password/reset_password_state.dart
@@ -15,6 +15,26 @@ class ResetPasswordState with _$ResetPasswordState {
 
   const ResetPasswordState._();
 
+  /// True when the confirm field has any text AND matches password value.
   bool get passwordsMatch =>
       password.value == confirmPassword && confirmPassword.isNotEmpty;
+
+  /// True when the user has typed in the password field and it is too short
+  /// (formz [PasswordInput] minimum is 8 chars).
+  bool get passwordTooShort =>
+      password.value.isNotEmpty && password.isNotValid;
+
+  /// True when the confirm field has text and the password field is also
+  /// too short — mirrors the Figma "Password is too short" helper on the
+  /// retype field (state 4 / node 971:10148).
+  bool get confirmTooShort =>
+      confirmPassword.isNotEmpty && password.isNotValid;
+
+  /// True when the confirm field has text, the password field is valid
+  /// (≥8 chars), and the two values disagree — mirrors the Figma
+  /// "Password doesn't match" helper (state 5 / node 971:10160).
+  bool get confirmMismatch =>
+      confirmPassword.isNotEmpty &&
+      !password.isNotValid &&
+      password.value != confirmPassword;
 }

--- a/test/features/auth/reset_password/reset_password_screen_test.dart
+++ b/test/features/auth/reset_password/reset_password_screen_test.dart
@@ -98,7 +98,47 @@ void main() {
   );
 
   testWidgets(
-    'confirm-mismatch shows inline error preserved from the redesign',
+    'shows guidance helper under both fields in the initial state '
+    '(Figma 971:10136)',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(const ResetPasswordScreen(), buildOverrides()),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Password must be at least 8 characters'),
+        findsNWidgets(3),
+      );
+    },
+  );
+
+  testWidgets(
+    'shows "Password is too short" under both fields when password is short '
+    '(Figma 971:10148)',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(const ResetPasswordScreen(), buildOverrides()),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('reset_password_new_field')),
+        'short',
+      );
+      await tester.enterText(
+        find.byKey(const Key('reset_password_confirm_field')),
+        'short',
+      );
+      await tester.pump();
+
+      expect(find.text('Password is too short'), findsNWidgets(2));
+    },
+  );
+
+  testWidgets(
+    "shows \"Password doesn't match\" helper on retype when values differ "
+    '(Figma 971:10160)',
     (tester) async {
       await tester.pumpWidget(
         _wrap(const ResetPasswordScreen(), buildOverrides()),
@@ -115,7 +155,7 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text('Passwords do not match.'), findsOneWidget);
+      expect(find.text("Password doesn't match"), findsOneWidget);
     },
   );
 


### PR DESCRIPTION
## Summary

Redesigns the reset-password screen (AU-03 / route `/auth/reset-password`) to match the three Figma forget-password 3/4/5 states. Per-field helper text now drives the three reachable variants:

- **Initial guidance** (Figma 971:10136) — "Password must be at least 8 characters" under both fields
- **Too short** (Figma 971:10148) — "Password is too short" under both fields when the password is under 8 chars
- **Mismatch** (Figma 971:10160) — "Password doesn't match" under the retype field when values disagree and password is valid

Visual changes:
- Title now reads "Forget Password" (verbatim spec — sic, mismatched with state-1 "Forgot your password?" — flagged in audit; design owns the inconsistency)
- Body "Password must be at least 8 characters"
- Field labels "Password" / "Retype Password"; placeholders "Input password" / "Retype password"
- Lime back button (butter tone) + `Grad-1` butterSoft → cream background — matches the forgot-password sibling
- Helper-text tone is forest green (`AppColors.green` / `Nibble-primary-Forest`) for ALL three variants per Figma's intentional "guidance tone" choice; not the destructive red

Behaviour preserved:
- Confirm CTA still calls `AuthService.updatePassword(value)`
- Success snackbar + redirect to `AppRoute.login` unchanged
- Result<T> contract preserved end-to-end (no raw throws)

## Acceptance criteria

- [x] Title "Forget Password" verbatim
- [x] Body "Password must be at least 8 characters" verbatim
- [x] Both fields obscured
- [x] Initial state shows guidance helper on both fields
- [x] Too-short state shows "Password is too short" on both fields when password length < 8
- [x] Mismatch state shows "Password doesn't match" on retype field when values disagree
- [x] Confirm CTA wired to `AuthService.updatePassword`
- [x] `flutter analyze` clean (only 2 pre-existing infos in unrelated files)
- [x] `flutter test` green (540 pass / 1 skipped)

## Figma frames

- forget-password-3 (initial): `971:10136`
- forget-password-4 (too short): `971:10148`
- forget-password-5 (mismatch): `971:10160`

## Audit reports

- `.figma-audit/onboarding/forget-password-3/report.md`
- `.figma-audit/onboarding/forget-password-4/report.md`
- `.figma-audit/onboarding/forget-password-5/report.md`

## Test plan

- [x] `flutter test test/features/auth/reset_password/` — all 5 widget tests pass
- [x] Full suite green
- [ ] Manual: trigger reset link from forgot-password → land on this screen → verify three helper-text variants visually