### PR TITLE
fix(allergen): reskin reaction log detail + verbatim banners [NIB-93]

### DIFF
--- a/lib/src/features/allergen/detail/widgets/detail_contextual_banner.dart
+++ b/lib/src/features/allergen/detail/widgets/detail_contextual_banner.dart
@@ -24,16 +24,21 @@ class DetailContextualBanner extends StatelessWidget {
         );
       case AllergenStatus.safe:
         return (
-          text: "You've already introduced this allergen",
+          text:
+              "You've already introduced this allergen! Don't forget to "
+              "include it regularly in your baby's meal prep to help "
+              'maintain exposure.',
           bg: AppColors.butterSoft,
           fg: AppColors.greenDeep,
         );
       case AllergenStatus.flagged:
         return (
-          text: 'You already tried this allergen. '
-              'Please consult a medical professional.',
+          text:
+              'You already tried this allergen, but it appears to be '
+              'unsafe. Please consult a medical professional for further '
+              'guidance.',
           bg: AppColors.destructiveSoft,
-          fg: AppColors.flagFg,
+          fg: AppColors.burgundy,
         );
     }
   }

--- a/lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart
+++ b/lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart
@@ -3,14 +3,14 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/components/components.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
-import 'package:nibbles/src/common/domain/entities/allergen.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
-import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/features/allergen/detail/allergen_detail_controller.dart';
 import 'package:nibbles/src/features/allergen/log_detail/allergen_log_detail_controller.dart';
@@ -19,13 +19,20 @@ import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_controlle
 import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Read-only Allergen Log Detail screen (NIB-127).
+/// Read-only Reaction Log Detail screen (NIB-93).
 ///
-/// Route — `/home/allergen/:allergenKey/log/:logId`. Shows the captured log
-/// fields (header + status badge, log date, optional taste, optional notes,
-/// optional attachment title/description/photo). The overflow menu in the
-/// app bar exposes Edit (pushes the EDIT route) and Delete (confirmation
-/// dialog → [AllergenService.deleteAllergenLog] → pops back).
+/// Route — `/home/allergen/:allergenKey/log/:logId`. Figma frames:
+///  • 1525:28920 — Tried Safe + No Attachment
+///  • 1525:28776 — Tried Safe + Attachment
+///  • 1525:28946 — Tried Unsafe + No Attachment
+///  • 1525:28856 — Tried Unsafe + Attachment
+///
+/// Layout (verbatim copy):
+/// AppBar "Reaction Log" + overflow (Edit Reactions / Delete Log).
+/// Body: "Log N" + Safe/Unsafe pill, "Date" field, "Notes" field, and an
+/// optional "Attachment (Optional)" block (photo + Change Picture CTA +
+/// title/description + download chip). The Reaction (taste) field is not
+/// shown in the Figma audit and is intentionally omitted from this screen.
 class AllergenLogDetailScreen extends ConsumerWidget {
   const AllergenLogDetailScreen({
     required this.allergenKey,
@@ -122,12 +129,6 @@ class _LogDetailView extends ConsumerWidget {
   String _formatDate(DateTime d) =>
       '${_months[d.month - 1]} ${d.day}, ${d.year}';
 
-  String _tasteLabel(EmojiTaste taste) => switch (taste) {
-    EmojiTaste.love => '😍 Loved it',
-    EmojiTaste.neutral => '😐 Neutral',
-    EmojiTaste.dislike => '😣 Disliked',
-  };
-
   Future<void> _onMenuSelected(
     BuildContext context,
     WidgetRef ref,
@@ -139,13 +140,12 @@ class _LogDetailView extends ConsumerWidget {
           AppRoute.allergenLogEdit.name,
           pathParameters: {'allergenKey': allergenKey, 'logId': logId},
         );
-        // Refresh the detail view in case the edit updated fields.
-        ref.invalidate(
-          allergenLogDetailControllerProvider(allergenKey, logId),
-        );
-        // Refresh both upstream lists so a pop to either reflects the edit.
-        ref.invalidate(allergenDetailControllerProvider(allergenKey));
-        ref.invalidate(allergenTrackerControllerProvider(state.babyId));
+        ref
+          ..invalidate(
+            allergenLogDetailControllerProvider(allergenKey, logId),
+          )
+          ..invalidate(allergenDetailControllerProvider(allergenKey))
+          ..invalidate(allergenTrackerControllerProvider(state.babyId));
       case 'delete':
         await _confirmAndDelete(context, ref);
     }
@@ -218,25 +218,50 @@ class _LogDetailView extends ConsumerWidget {
       Analytics.instance.logAllergenLogDeleted(allergenKey: allergenKey),
     );
 
-    // Invalidate both upstream lists so a pop to either reflects the delete.
     ref
       ..invalidate(allergenDetailControllerProvider(allergenKey))
       ..invalidate(allergenTrackerControllerProvider(state.babyId));
     context.pop();
   }
 
+  Future<void> _onChangePicturePressed(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    await context.pushNamed(
+      AppRoute.allergenLogEdit.name,
+      pathParameters: {'allergenKey': allergenKey, 'logId': logId},
+    );
+    ref
+      ..invalidate(allergenLogDetailControllerProvider(allergenKey, logId))
+      ..invalidate(allergenDetailControllerProvider(allergenKey))
+      ..invalidate(allergenTrackerControllerProvider(state.babyId));
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final textTheme = Theme.of(context).textTheme;
     final log = state.log;
-    final allergen = state.allergen;
+    final notes = log.notes?.trim();
 
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
         backgroundColor: AppColors.background,
         elevation: 0,
-        title: Text('Log ${state.logNumber}', style: textTheme.titleMedium),
+        leading: IconButton(
+          icon: const Icon(
+            Icons.arrow_back_rounded,
+            color: AppColors.fgStrong,
+          ),
+          onPressed: () => context.pop(),
+        ),
+        title: Text(
+          'Reaction Log',
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+            color: AppColors.fgStrong,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
         actions: [
           PopupMenuButton<String>(
             key: const Key('log_detail_menu'),
@@ -248,11 +273,11 @@ class _LogDetailView extends ConsumerWidget {
             itemBuilder: (_) => const [
               PopupMenuItem<String>(
                 value: 'edit',
-                child: Text('Edit'),
+                child: Text('Edit Reactions'),
               ),
               PopupMenuItem<String>(
                 value: 'delete',
-                child: Text('Delete'),
+                child: Text('Delete Log'),
               ),
             ],
           ),
@@ -264,28 +289,29 @@ class _LogDetailView extends ConsumerWidget {
           vertical: AppSizes.pagePaddingV,
         ),
         children: [
-          _LogHeaderCard(
-            allergen: allergen,
+          _LogTitleRow(
+            logNumber: state.logNumber,
             hadReaction: log.hadReaction,
-            logDate: _formatDate(log.logDate),
           ),
-          if (log.emojiTaste != null) ...[
-            const SizedBox(height: AppSizes.lg),
-            const _SectionLabel('Reaction'),
-            const SizedBox(height: AppSizes.sm),
-            _ReadOnlyRow(value: _tasteLabel(log.emojiTaste!)),
-          ],
-          if (log.notes != null && log.notes!.trim().isNotEmpty) ...[
-            const SizedBox(height: AppSizes.lg),
-            const _SectionLabel('Notes'),
-            const SizedBox(height: AppSizes.sm),
-            _ReadOnlyRow(value: log.notes!.trim()),
-          ],
+          const SizedBox(height: AppSizes.md),
+          const _FieldLabel('Date'),
+          const SizedBox(height: AppSizes.xs),
+          _ReadOnlyField(value: _formatDate(log.logDate)),
+          const SizedBox(height: AppSizes.md),
+          const _FieldLabel('Notes'),
+          const SizedBox(height: AppSizes.xs),
+          _ReadOnlyField(
+            value: notes == null || notes.isEmpty ? '—' : notes,
+          ),
           if (_hasAttachment(log)) ...[
-            const SizedBox(height: AppSizes.lg),
-            const _SectionLabel('Attachment'),
+            const SizedBox(height: AppSizes.md),
+            const _FieldLabel('Attachment (Optional)'),
             const SizedBox(height: AppSizes.sm),
-            _AttachmentCard(log: log),
+            _AttachmentBlock(
+              log: log,
+              onChangePicturePressed: () =>
+                  _onChangePicturePressed(context, ref),
+            ),
           ],
           const SizedBox(height: AppSizes.xxl),
         ],
@@ -310,129 +336,159 @@ class _LogDetailView extends ConsumerWidget {
 // Local widgets — private to log_detail per spec build-rule 3.
 // ---------------------------------------------------------------------------
 
-class _SectionLabel extends StatelessWidget {
-  const _SectionLabel(this.text);
+/// Header row: bold "Log N" + Safe/Unsafe status pill.
+class _LogTitleRow extends StatelessWidget {
+  const _LogTitleRow({required this.logNumber, required this.hadReaction});
+
+  final int logNumber;
+  final bool hadReaction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            'Log $logNumber',
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+              color: AppColors.fgStrong,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+        AppChip(
+          label: hadReaction ? 'Unsafe' : 'Safe',
+          tone: hadReaction ? AppChipTone.flag : AppChipTone.safe,
+        ),
+      ],
+    );
+  }
+}
+
+/// Field label — Parkinsans SemiBold 15 per Headline/SemiBold token.
+class _FieldLabel extends StatelessWidget {
+  const _FieldLabel(this.text);
   final String text;
 
   @override
   Widget build(BuildContext context) {
     return Text(
       text,
-      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+      style: const TextStyle(
+        fontFamily: FontFamily.parkinsans,
+        fontSize: 15,
+        height: 22 / 15,
+        fontWeight: FontWeight.w600,
         color: AppColors.fgStrong,
       ),
     );
   }
 }
 
-class _LogHeaderCard extends StatelessWidget {
-  const _LogHeaderCard({
-    required this.allergen,
-    required this.hadReaction,
-    required this.logDate,
-  });
-
-  final Allergen allergen;
-  final bool hadReaction;
-  final String logDate;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return AppCard(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.md,
-        vertical: AppSizes.md,
-      ),
-      child: Row(
-        children: [
-          Container(
-            width: 56,
-            height: 56,
-            decoration: const BoxDecoration(
-              color: AppColors.coralSoft,
-              shape: BoxShape.circle,
-            ),
-            alignment: Alignment.center,
-            child: Text(allergen.emoji, style: const TextStyle(fontSize: 26)),
-          ),
-          const SizedBox(width: AppSizes.sp12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(allergen.name, style: textTheme.titleMedium),
-                const SizedBox(height: 2),
-                Text(
-                  logDate,
-                  style: textTheme.bodySmall?.copyWith(
-                    color: AppColors.fgFaint,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: AppSizes.sm),
-          AppChip(
-            label: hadReaction ? 'Unsafe' : 'Safe',
-            tone: hadReaction ? AppChipTone.flag : AppChipTone.safe,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _ReadOnlyRow extends StatelessWidget {
-  const _ReadOnlyRow({required this.value});
+/// Pill-shaped read-only field. Background = Neutral-10 (#eaeaea / borderSoft).
+class _ReadOnlyField extends StatelessWidget {
+  const _ReadOnlyField({required this.value});
   final String value;
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return AppCard(
+    return Container(
+      height: AppSizes.fieldHeight,
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.fieldPaddingH),
+      decoration: BoxDecoration(
+        color: AppColors.borderSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+      alignment: Alignment.centerLeft,
       child: Text(
         value,
-        style: textTheme.bodyMedium?.copyWith(color: AppColors.fgStrong),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: GoogleFonts.figtree(
+          fontSize: 15,
+          height: 22 / 15,
+          color: AppColors.fgFaint,
+        ),
       ),
     );
   }
 }
 
-class _AttachmentCard extends ConsumerWidget {
-  const _AttachmentCard({required this.log});
+/// Attachment cluster: photo preview + Change Picture pill + title +
+/// description + small download chip.
+class _AttachmentBlock extends ConsumerWidget {
+  const _AttachmentBlock({
+    required this.log,
+    required this.onChangePicturePressed,
+  });
 
   final AllergenLog log;
+  final VoidCallback onChangePicturePressed;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final textTheme = Theme.of(context).textTheme;
     final title = log.attachmentTitle;
     final description = log.attachmentDescription;
     final photoPath = log.photoUrl;
 
-    return AppCard(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (title != null && title.isNotEmpty)
-            Text(title, style: textTheme.titleSmall),
-          if (description != null && description.isNotEmpty) ...[
-            if (title != null && title.isNotEmpty)
-              const SizedBox(height: AppSizes.xs),
-            Text(
-              description,
-              style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
-            ),
-          ],
-          if (photoPath != null && photoPath.isNotEmpty) ...[
-            const SizedBox(height: AppSizes.md),
-            _PhotoPreview(photoPath: photoPath),
-          ],
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (photoPath != null && photoPath.isNotEmpty)
+          _PhotoPreview(photoPath: photoPath),
+        if (photoPath != null && photoPath.isNotEmpty) ...[
+          const SizedBox(height: AppSizes.sp12),
+          AppPillButton(
+            key: const Key('log_detail_change_picture'),
+            label: 'Change Picture',
+            onPressed: onChangePicturePressed,
+            variant: AppPillButtonVariant.ghost,
+          ),
         ],
-      ),
+        if ((title != null && title.isNotEmpty) ||
+            (description != null && description.isNotEmpty)) ...[
+          const SizedBox(height: AppSizes.md),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (title != null && title.isNotEmpty)
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          fontFamily: FontFamily.parkinsans,
+                          fontSize: 15,
+                          height: 22 / 15,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.fgStrong,
+                        ),
+                      ),
+                    if (description != null && description.isNotEmpty) ...[
+                      if (title != null && title.isNotEmpty)
+                        const SizedBox(height: 2),
+                      Text(
+                        description,
+                        style: GoogleFonts.figtree(
+                          fontSize: 15,
+                          height: 22 / 15,
+                          color: AppColors.fgFaint,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSizes.sm),
+              const _DownloadChip(),
+            ],
+          ),
+        ],
+      ],
     );
   }
 }
@@ -445,45 +501,72 @@ class _PhotoPreview extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final urlAsync = ref.watch(_signedPhotoUrlProvider(photoPath));
 
-    return urlAsync.when(
-      loading: () => Container(
-        height: 180,
-        decoration: BoxDecoration(
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+      child: urlAsync.when(
+        loading: () => Container(
+          height: 195,
+          width: double.infinity,
           color: AppColors.surfaceVariant,
-          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          alignment: Alignment.center,
+          child: const CircularProgressIndicator(),
         ),
-        alignment: Alignment.center,
-        child: const CircularProgressIndicator(),
-      ),
-      error: (_, __) => const AppChip(
-        label: 'Photo unavailable',
-        tone: AppChipTone.mute,
-        emoji: '📎',
-      ),
-      data: (url) {
-        if (url == null) {
-          return const AppChip(
-            label: 'Photo unavailable',
-            tone: AppChipTone.mute,
-            emoji: '📎',
-          );
-        }
-        return ClipRRect(
-          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-          child: Image.network(
+        error: (_, __) => Container(
+          height: 195,
+          width: double.infinity,
+          color: AppColors.surfaceVariant,
+          alignment: Alignment.center,
+          child: const Text('Photo unavailable'),
+        ),
+        data: (url) {
+          if (url == null) {
+            return Container(
+              height: 195,
+              width: double.infinity,
+              color: AppColors.surfaceVariant,
+              alignment: Alignment.center,
+              child: const Text('Photo unavailable'),
+            );
+          }
+          return Image.network(
             url,
-            height: 180,
+            height: 195,
             width: double.infinity,
             fit: BoxFit.cover,
             errorBuilder: (_, __, ___) => Container(
-              height: 180,
+              height: 195,
               color: AppColors.surfaceVariant,
               alignment: Alignment.center,
               child: const Text('Photo unavailable'),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// 35x35 round chip with a download glyph, sitting beside the attachment
+/// caption. Display-only per audit; no documented save-to-device flow yet.
+class _DownloadChip extends StatelessWidget {
+  const _DownloadChip();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 35,
+      height: 35,
+      decoration: const BoxDecoration(
+        color: AppColors.surface,
+        shape: BoxShape.circle,
+        boxShadow: AppSizes.shadowCard,
+      ),
+      alignment: Alignment.center,
+      child: const Icon(
+        Icons.file_download_outlined,
+        size: AppSizes.iconSm,
+        color: AppColors.fgStrong,
+      ),
     );
   }
 }

--- a/test/features/allergen/detail/allergen_detail_screen_test.dart
+++ b/test/features/allergen/detail/allergen_detail_screen_test.dart
@@ -142,9 +142,9 @@ void main() {
         // animation/animation-pumping can produce duplicate Text widgets
         // — assert presence, not exact count).
         expect(find.text('Safe'), findsWidgets);
-        // Contextual banner is the butter-wash safe variant.
+        // Contextual banner is the butter-wash safe variant (verbatim Figma).
         expect(
-          find.text("You've already introduced this allergen"),
+          find.textContaining("You've already introduced this allergen!"),
           findsOneWidget,
         );
       },
@@ -172,7 +172,7 @@ void main() {
         );
         // No safe banner.
         expect(
-          find.text("You've already introduced this allergen"),
+          find.textContaining("You've already introduced this allergen!"),
           findsNothing,
         );
       },
@@ -216,7 +216,7 @@ void main() {
         // The banner renders SizedBox.shrink when notStarted.
         expect(find.byType(DetailContextualBanner), findsOneWidget);
         expect(
-          find.text("You've already introduced this allergen"),
+          find.textContaining("You've already introduced this allergen!"),
           findsNothing,
         );
         expect(find.text('Not started'), findsOneWidget);

--- a/test/features/allergen/log_detail/allergen_log_detail_screen_test.dart
+++ b/test/features/allergen/log_detail/allergen_log_detail_screen_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/features/allergen/log_detail/allergen_log_detail_screen.dart';
+import 'package:nibbles/src/routing/route_enums.dart';
+
+class _MockAllergenService extends Mock implements AllergenService {}
+
+class _MockBabyProfileService extends Mock implements BabyProfileService {}
+
+const _babyId = 'baby-001';
+const _allergenKey = 'peanut';
+const _logId = 'log-1';
+final _logDate = DateTime(2026, 5);
+
+const _peanut = Allergen(
+  key: 'peanut',
+  name: 'Peanut',
+  sequenceOrder: 1,
+  emoji: '🥜',
+);
+
+final _baby = Baby(
+  id: _babyId,
+  userId: 'user-001',
+  name: 'Lily',
+  dateOfBirth: DateTime(2025, 6),
+  gender: Gender.female,
+  onboardingCompleted: true,
+);
+
+AllergenLog _makeLog({
+  bool hadReaction = false,
+  String? notes,
+  String? attachmentTitle,
+  String? attachmentDescription,
+  String? photoUrl,
+}) => AllergenLog(
+  id: _logId,
+  babyId: _babyId,
+  allergenKey: _allergenKey,
+  hadReaction: hadReaction,
+  emojiTaste: EmojiTaste.love,
+  logDate: _logDate,
+  createdAt: _logDate,
+  notes: notes,
+  attachmentTitle: attachmentTitle,
+  attachmentDescription: attachmentDescription,
+  photoUrl: photoUrl,
+);
+
+void main() {
+  late _MockAllergenService mockService;
+  late _MockBabyProfileService mockBabyService;
+
+  setUp(() {
+    mockService = _MockAllergenService();
+    mockBabyService = _MockBabyProfileService();
+    when(() => mockBabyService.getBaby()).thenAnswer((_) async => _baby);
+    when(
+      () => mockService.getAllergens(),
+    ).thenAnswer((_) async => const Result.success([_peanut]));
+    when(
+      () => mockService.getSignedPhotoUrl(any()),
+    ).thenAnswer((_) async => const Result.success('https://photo.test/p.jpg'));
+  });
+
+  void stubLogs(List<AllergenLog> logs) {
+    when(
+      () => mockService.getLogs(
+        any(),
+        allergenKey: any(named: 'allergenKey'),
+      ),
+    ).thenAnswer((_) async => Result.success(logs));
+  }
+
+  Widget buildSubject() {
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, __) => const AllergenLogDetailScreen(
+            allergenKey: _allergenKey,
+            logId: _logId,
+          ),
+        ),
+        GoRoute(
+          path: AppRoute.allergenLogEdit.path,
+          name: AppRoute.allergenLogEdit.name,
+          builder: (_, __) => const Scaffold(body: Text('EDIT_STUB')),
+        ),
+      ],
+    );
+
+    return ProviderScope(
+      overrides: [
+        allergenServiceProvider.overrideWithValue(mockService),
+        babyProfileServiceProvider.overrideWithValue(mockBabyService),
+      ],
+      child: MaterialApp.router(routerConfig: router),
+    );
+  }
+
+  group('AllergenLogDetailScreen', () {
+    testWidgets(
+      'Tried-Safe + no attachment: app bar "Reaction Log", "Log 1", "Safe" '
+      'pill, "Date" + "Notes" fields, no "Attachment (Optional)"',
+      (tester) async {
+        stubLogs([_makeLog(notes: 'My baby love it, no reaction')]);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Reaction Log'), findsOneWidget);
+        expect(find.text('Log 1'), findsOneWidget);
+        expect(find.text('Safe'), findsOneWidget);
+        expect(find.text('Date'), findsOneWidget);
+        expect(find.text('May 1, 2026'), findsOneWidget);
+        expect(find.text('Notes'), findsOneWidget);
+        expect(find.text('My baby love it, no reaction'), findsOneWidget);
+        expect(find.text('Attachment (Optional)'), findsNothing);
+        expect(find.text('Change Picture'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Tried-Unsafe + no attachment: "Unsafe" pill renders, no attachment '
+      'block',
+      (tester) async {
+        stubLogs([_makeLog(hadReaction: true, notes: 'Rash on cheek')]);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Log 1'), findsOneWidget);
+        expect(find.text('Unsafe'), findsOneWidget);
+        expect(find.text('Safe'), findsNothing);
+        expect(find.text('Attachment (Optional)'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Tried-Safe + attachment: "Attachment (Optional)" label, attachment '
+      'title/description, and "Change Picture" CTA are rendered',
+      (tester) async {
+        stubLogs([
+          _makeLog(
+            notes: 'My baby love it, no reaction',
+            attachmentTitle: 'Rash on cheek area',
+            attachmentDescription: 'Taken 30 min after feeding',
+            photoUrl: 'allergen-attachments/$_babyId/p.jpg',
+          ),
+        ]);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Attachment (Optional)'), findsOneWidget);
+        expect(find.text('Rash on cheek area'), findsOneWidget);
+        expect(find.text('Taken 30 min after feeding'), findsOneWidget);
+        expect(find.text('Change Picture'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Tried-Unsafe + attachment: Unsafe pill + attachment block visible',
+      (tester) async {
+        stubLogs([
+          _makeLog(
+            hadReaction: true,
+            notes: 'Rash on cheek',
+            attachmentTitle: 'Rash on cheek area',
+            attachmentDescription: 'Taken 30 min after feeding',
+            photoUrl: 'allergen-attachments/$_babyId/p.jpg',
+          ),
+        ]);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Unsafe'), findsOneWidget);
+        expect(find.text('Attachment (Optional)'), findsOneWidget);
+        expect(find.text('Change Picture'), findsOneWidget);
+        expect(find.text('Rash on cheek area'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'overflow menu exposes "Edit Reactions" and "Delete Log"',
+      (tester) async {
+        stubLogs([_makeLog(notes: 'note')]);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('log_detail_menu')));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Edit Reactions'), findsOneWidget);
+        expect(find.text('Delete Log'), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Re-skins the Allergen Reaction Log Detail screen to match the four Figma audit variants and aligns the parent Allergen Detail screen's contextual banners to the verbatim Figma copy.

## Figma frames

- 1525:28920 — Tried Safe + No Attachment
- 1525:28776 — Tried Safe + Attachment
- 1525:28946 — Tried Unsafe + No Attachment
- 1525:28856 — Tried Unsafe + Attachment
- 1525:31083 — Edit overlay (Edit Reactions / Delete Log menu items)
- 1116:19762 / 1525:20065 / 1525:20232 — parent banner copy source

## Audit reports

- `.figma-audit/allergen-tracker/allergen-tracker-detail-tried-safe-no-attachment/report.md`
- `.figma-audit/allergen-tracker/allergen-tracker-detail-tried-safe-attachment/report.md`
- `.figma-audit/allergen-tracker/allergen-tracker-detail-tried-unsafe-no-attachment/report.md`
- `.figma-audit/allergen-tracker/allergen-tracker-detail-tried-unsafe-attachment/report.md`

## Changes

### Allergen Log Detail screen (`allergen_log_detail_screen.dart`)

- App-bar title is now the verbatim "Reaction Log" (was "Log N").
- Body opens with a "Log N" headline + "Safe"/"Unsafe" status pill row.
- Labeled read-only fields: "Date" (formatted log date) and "Notes" (or em-dash when empty).
- Optional "Attachment (Optional)" cluster: photo preview (h195, radiusLg), "Change Picture" ghost pill button, attachment title + description row, 35x35 surface-circle download chip.
- Drops the previous emoji header card and "Reaction" (emoji-taste) section — neither appears in the audit screens. Emoji-taste data is still captured and edited via the Edit flow.
- Overflow menu items renamed to the verbatim "Edit Reactions" / "Delete Log" (per the edit-context overlay at 1525:31083). Both flows are unchanged: edit pushes `allergen-log-edit`, delete confirms then `deleteAllergenLog` and pops.
- "Change Picture" routes to the existing log-edit screen — no new image-picker pipeline added in this ticket (edit flow already supports replacing the photo).

### Parent Allergen Detail contextual banner (`detail_contextual_banner.dart`)

- Safe banner now uses the full verbatim Figma copy: "You've already introduced this allergen! Don't forget to include it regularly in your baby's meal prep to help maintain exposure."
- Flagged banner uses the full verbatim Figma copy: "You already tried this allergen, but it appears to be unsafe. Please consult a medical professional for further guidance." and the foreground color switches to `AppColors.burgundy` (#77393b) to match the audit `Nibble-primary-Burgundy` token.

### Tests

- New widget test `allergen_log_detail_screen_test.dart` covering each of the four audit variants + the overflow menu.
- Updates existing `allergen_detail_screen_test.dart` assertions for the new verbatim banner copy.

## Acceptance criteria

- [x] Verbatim copy matches the audit reports (app-bar title, "Log N", "Date", "Notes", "Attachment (Optional)", "Change Picture", banner copies).
- [x] All four log-detail state variants (safe/unsafe x attachment/no-attachment) render correctly.
- [x] Overflow menu exposes Edit Reactions + Delete Log; both wired to existing routes/services.
- [x] No hardcoded hex; tokens consumed from `AppColors`/`AppSizes`/typography.
- [x] `flutter analyze` introduces 0 new issues (2 pre-existing infos on unrelated files).
- [x] All allergen tests pass; full suite green.

## Notes / open questions

- The audit's small 35x35 chip beside the attachment caption is a download icon; the audit doesn't specify the on-tap behavior, so this PR ships it as display-only. Worth confirming with PO whether it should save the photo to the device.
- The "Reaction" (emoji-taste) row was dropped because it is absent from all four log-detail audits. Taste is still editable from the log-edit screen and surfaced on the tracker. Flag with PO if it should be restored as a read-only row.

## Test plan

- [ ] Open a Safe log without an attachment — Reaction Log header, Log N + Safe pill, Date, and Notes are visible. No Attachment section.
- [ ] Open a Safe log with an attachment — photo preview, Change Picture CTA, title + description, and download chip render.
- [ ] Open an Unsafe log (both with and without attachment) — pill flips to Unsafe with the coral/red palette.
- [ ] Tap "..." menu → Edit Reactions opens the log-edit screen; Delete Log triggers the confirm dialog.
- [ ] After a delete, the parent allergen detail + tracker reflect the removed log.
- [ ] Parent allergen detail safe + flagged banners show the full verbatim Figma copy.