### PR TITLE
fix(allergen): reaction log 3-dot menu overlay + delete confirm popup [NIB-67]

### DIFF
--- a/lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart
+++ b/lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart
@@ -15,6 +15,8 @@ import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/features/allergen/detail/allergen_detail_controller.dart';
 import 'package:nibbles/src/features/allergen/log_detail/allergen_log_detail_controller.dart';
 import 'package:nibbles/src/features/allergen/log_detail/allergen_log_detail_state.dart';
+import 'package:nibbles/src/features/allergen/log_detail/widgets/delete_log_confirmation_dialog.dart';
+import 'package:nibbles/src/features/allergen/log_detail/widgets/log_actions_menu.dart';
 import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_controller.dart';
 import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
@@ -100,7 +102,7 @@ class AllergenLogDetailScreen extends ConsumerWidget {
   }
 }
 
-class _LogDetailView extends ConsumerWidget {
+class _LogDetailView extends ConsumerStatefulWidget {
   const _LogDetailView({
     required this.state,
     required this.allergenKey,
@@ -111,6 +113,11 @@ class _LogDetailView extends ConsumerWidget {
   final String allergenKey;
   final String logId;
 
+  @override
+  ConsumerState<_LogDetailView> createState() => _LogDetailViewState();
+}
+
+class _LogDetailViewState extends ConsumerState<_LogDetailView> {
   static const _months = <String>[
     'Jan',
     'Feb',
@@ -126,84 +133,50 @@ class _LogDetailView extends ConsumerWidget {
     'Dec',
   ];
 
+  // Anchors the 3-dot floating menu overlay (Figma 1525:31083 input 188x96 at
+  // y=-26 below the more-icon).
+  final GlobalKey _menuAnchorKey = GlobalKey();
+
+  AllergenLogDetailState get _state => widget.state;
+  String get _allergenKey => widget.allergenKey;
+  String get _logId => widget.logId;
+
   String _formatDate(DateTime d) =>
       '${_months[d.month - 1]} ${d.day}, ${d.year}';
 
-  Future<void> _onMenuSelected(
-    BuildContext context,
-    WidgetRef ref,
-    String value,
-  ) async {
-    switch (value) {
-      case 'edit':
+  Future<void> _onMenuPressed() async {
+    final choice = await showLogActionsMenu(context, anchor: _menuAnchorKey);
+    if (!mounted || choice == null) return;
+    switch (choice) {
+      case LogActionMenuChoice.edit:
         await context.pushNamed(
           AppRoute.allergenLogEdit.name,
-          pathParameters: {'allergenKey': allergenKey, 'logId': logId},
+          pathParameters: {'allergenKey': _allergenKey, 'logId': _logId},
         );
+        if (!mounted) return;
         ref
           ..invalidate(
-            allergenLogDetailControllerProvider(allergenKey, logId),
+            allergenLogDetailControllerProvider(_allergenKey, _logId),
           )
-          ..invalidate(allergenDetailControllerProvider(allergenKey))
-          ..invalidate(allergenTrackerControllerProvider(state.babyId));
-      case 'delete':
-        await _confirmAndDelete(context, ref);
+          ..invalidate(allergenDetailControllerProvider(_allergenKey))
+          ..invalidate(allergenTrackerControllerProvider(_state.babyId));
+      case LogActionMenuChoice.delete:
+        await _confirmAndDelete();
     }
   }
 
-  Future<void> _confirmAndDelete(BuildContext context, WidgetRef ref) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: AppColors.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-        ),
-        title: Text(
-          'Delete this log?',
-          style: Theme.of(ctx).textTheme.titleMedium,
-        ),
-        content: Text(
-          'This will permanently remove this reaction log. You can re-add it '
-          'later.',
-          style: Theme.of(ctx).textTheme.bodyMedium?.copyWith(
-            color: AppColors.fgMuted,
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(
-              'Cancel',
-              style: Theme.of(ctx).textTheme.labelLarge?.copyWith(
-                color: AppColors.fgMuted,
-              ),
-            ),
-          ),
-          TextButton(
-            key: const Key('log_delete_confirm'),
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(
-              'Delete',
-              style: Theme.of(ctx).textTheme.labelLarge?.copyWith(
-                color: AppColors.destructive,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
+  Future<void> _confirmAndDelete() async {
+    final confirmed = await showDeleteLogConfirmationDialog(context);
 
-    if (confirmed != true || !context.mounted) return;
+    if (confirmed != true || !mounted) return;
 
     final service = ref.read(allergenServiceProvider);
     final result = await service.deleteAllergenLog(
-      logId: state.log.id,
-      photoPath: state.log.photoUrl,
+      logId: _state.log.id,
+      photoPath: _state.log.photoUrl,
     );
 
-    if (!context.mounted) return;
+    if (!mounted) return;
 
     if (result.isFailure) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -215,32 +188,32 @@ class _LogDetailView extends ConsumerWidget {
     }
 
     unawaited(
-      Analytics.instance.logAllergenLogDeleted(allergenKey: allergenKey),
+      ref
+          .read(analyticsProvider)
+          .logAllergenLogDeleted(allergenKey: _allergenKey),
     );
 
     ref
-      ..invalidate(allergenDetailControllerProvider(allergenKey))
-      ..invalidate(allergenTrackerControllerProvider(state.babyId));
+      ..invalidate(allergenDetailControllerProvider(_allergenKey))
+      ..invalidate(allergenTrackerControllerProvider(_state.babyId));
     context.pop();
   }
 
-  Future<void> _onChangePicturePressed(
-    BuildContext context,
-    WidgetRef ref,
-  ) async {
+  Future<void> _onChangePicturePressed() async {
     await context.pushNamed(
       AppRoute.allergenLogEdit.name,
-      pathParameters: {'allergenKey': allergenKey, 'logId': logId},
+      pathParameters: {'allergenKey': _allergenKey, 'logId': _logId},
     );
+    if (!mounted) return;
     ref
-      ..invalidate(allergenLogDetailControllerProvider(allergenKey, logId))
-      ..invalidate(allergenDetailControllerProvider(allergenKey))
-      ..invalidate(allergenTrackerControllerProvider(state.babyId));
+      ..invalidate(allergenLogDetailControllerProvider(_allergenKey, _logId))
+      ..invalidate(allergenDetailControllerProvider(_allergenKey))
+      ..invalidate(allergenTrackerControllerProvider(_state.babyId));
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final log = state.log;
+  Widget build(BuildContext context) {
+    final log = _state.log;
     final notes = log.notes?.trim();
 
     return Scaffold(
@@ -263,23 +236,14 @@ class _LogDetailView extends ConsumerWidget {
           ),
         ),
         actions: [
-          PopupMenuButton<String>(
+          IconButton(
             key: const Key('log_detail_menu'),
-            icon: const Icon(
+            icon: Icon(
               Icons.more_horiz_rounded,
+              key: _menuAnchorKey,
               color: AppColors.fgStrong,
             ),
-            onSelected: (v) => _onMenuSelected(context, ref, v),
-            itemBuilder: (_) => const [
-              PopupMenuItem<String>(
-                value: 'edit',
-                child: Text('Edit Reactions'),
-              ),
-              PopupMenuItem<String>(
-                value: 'delete',
-                child: Text('Delete Log'),
-              ),
-            ],
+            onPressed: _onMenuPressed,
           ),
         ],
       ),
@@ -290,7 +254,7 @@ class _LogDetailView extends ConsumerWidget {
         ),
         children: [
           _LogTitleRow(
-            logNumber: state.logNumber,
+            logNumber: _state.logNumber,
             hadReaction: log.hadReaction,
           ),
           const SizedBox(height: AppSizes.md),
@@ -309,8 +273,7 @@ class _LogDetailView extends ConsumerWidget {
             const SizedBox(height: AppSizes.sm),
             _AttachmentBlock(
               log: log,
-              onChangePicturePressed: () =>
-                  _onChangePicturePressed(context, ref),
+              onChangePicturePressed: _onChangePicturePressed,
             ),
           ],
           const SizedBox(height: AppSizes.xxl),

--- a/lib/src/features/allergen/log_detail/widgets/delete_log_confirmation_dialog.dart
+++ b/lib/src/features/allergen/log_detail/widgets/delete_log_confirmation_dialog.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/components.dart';
+
+/// Destructive confirm popup mirroring Figma frame 1525:31338.
+///
+/// Displays a Quatrefoil illustration above the question
+/// "Are you sure you want to delete?" with a two-button action row
+/// (Cancel + Delete). The Delete button is the primary greenDeep pill — the
+/// destructive intent comes from the question copy, not the colour, per the
+/// Figma source.
+///
+/// Returns `true` when the user confirms, `false`/`null` when cancelled or
+/// dismissed via barrier tap.
+Future<bool?> showDeleteLogConfirmationDialog(BuildContext context) {
+  return showDialog<bool>(
+    context: context,
+    barrierColor: Colors.black.withValues(alpha: 0.32),
+    builder: (ctx) => const _DeleteLogConfirmationDialog(),
+  );
+}
+
+class _DeleteLogConfirmationDialog extends StatelessWidget {
+  const _DeleteLogConfirmationDialog();
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: AppColors.background,
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.pagePaddingH,
+      ),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppSizes.radius2xl),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSizes.md,
+          AppSizes.lg,
+          AppSizes.md,
+          AppSizes.md,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const _QuestionText(),
+            const SizedBox(height: AppSizes.md),
+            const Quatrefoil(size: 153),
+            const SizedBox(height: AppSizes.lg),
+            Row(
+              children: [
+                Expanded(
+                  child: AppPillButton(
+                    key: const Key('delete_log_cancel_button'),
+                    label: 'Cancel',
+                    onPressed: () => Navigator.of(context).pop(false),
+                    variant: AppPillButtonVariant.secondary,
+                  ),
+                ),
+                const SizedBox(width: AppSizes.sp12),
+                Expanded(
+                  child: AppPillButton(
+                    key: const Key('delete_log_confirm_button'),
+                    label: 'Delete',
+                    onPressed: () => Navigator.of(context).pop(true),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _QuestionText extends StatelessWidget {
+  const _QuestionText();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Text(
+      'Are you sure you want to delete?',
+      textAlign: TextAlign.center,
+      style: TextStyle(
+        fontFamily: FontFamily.parkinsans,
+        fontSize: 17,
+        height: 24 / 17,
+        fontWeight: FontWeight.w700,
+        color: AppColors.text,
+      ),
+    );
+  }
+}

--- a/lib/src/features/allergen/log_detail/widgets/log_actions_menu.dart
+++ b/lib/src/features/allergen/log_detail/widgets/log_actions_menu.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Action chosen from the 3-dot log-detail menu.
+///
+/// Mirrors the floating Input overlay 188x96 at y=-26 in Figma frames
+/// 1525:31083 (edit context) and 1525:31206 (delete context).
+enum LogActionMenuChoice { edit, delete }
+
+/// Anchors a floating 3-dot action menu to [anchor] and returns the user's
+/// choice (or `null` if dismissed).
+///
+/// Figma node 1525:31083 — Input overlay 188x96, two rows: "Edit Reactions"
+/// (greenDeep / pencil icon) and "Delete Log" (burgundy / trash icon). The
+/// surface uses the white token (#ffffff) with the kit shadowCard.
+Future<LogActionMenuChoice?> showLogActionsMenu(
+  BuildContext context, {
+  required GlobalKey anchor,
+}) async {
+  final overlay = Overlay.of(context).context.findRenderObject() as RenderBox?;
+  final anchorBox = anchor.currentContext?.findRenderObject() as RenderBox?;
+  if (overlay == null || anchorBox == null) return null;
+
+  // Bottom-right corner of the 3-dot anchor (where the menu's top-right hangs
+  // from in Figma — y=-26 below the icon's centre baseline).
+  final topRight = anchorBox.localToGlobal(
+    anchorBox.size.bottomRight(Offset.zero),
+    ancestor: overlay,
+  );
+
+  final position = RelativeRect.fromLTRB(
+    topRight.dx - _kMenuWidth,
+    topRight.dy + AppSizes.xs,
+    overlay.size.width - topRight.dx,
+    0,
+  );
+
+  return showMenu<LogActionMenuChoice>(
+    context: context,
+    position: position,
+    color: AppColors.surface,
+    elevation: 0,
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+    ),
+    constraints: const BoxConstraints(
+      minWidth: _kMenuWidth,
+      maxWidth: _kMenuWidth,
+    ),
+    items: const [
+      PopupMenuItem<LogActionMenuChoice>(
+        key: Key('log_actions_menu_edit'),
+        value: LogActionMenuChoice.edit,
+        padding: EdgeInsets.zero,
+        child: _MenuRow(
+          icon: Icons.edit_outlined,
+          label: 'Edit Reactions',
+          color: AppColors.greenDeep,
+        ),
+      ),
+      PopupMenuItem<LogActionMenuChoice>(
+        key: Key('log_actions_menu_delete'),
+        value: LogActionMenuChoice.delete,
+        padding: EdgeInsets.zero,
+        child: _MenuRow(
+          icon: Icons.delete_outline,
+          label: 'Delete Log',
+          color: AppColors.burgundy,
+        ),
+      ),
+    ],
+  );
+}
+
+const double _kMenuWidth = 188;
+
+class _MenuRow extends StatelessWidget {
+  const _MenuRow({
+    required this.icon,
+    required this.label,
+    required this.color,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.sp12),
+      child: Row(
+        children: [
+          Icon(icon, size: AppSizes.iconMd - 4, color: color),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontFamily: FontFamily.parkinsans,
+                fontSize: 14,
+                height: 22 / 15,
+                fontWeight: FontWeight.w600,
+                color: color,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/allergen/log_detail/allergen_log_detail_screen_test.dart
+++ b/test/features/allergen/log_detail/allergen_log_detail_screen_test.dart
@@ -12,7 +12,10 @@ import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/allergen/log_detail/allergen_log_detail_screen.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
+
+import '../../../support/fake_analytics.dart';
 
 class _MockAllergenService extends Mock implements AllergenService {}
 
@@ -86,14 +89,20 @@ void main() {
 
   Widget buildSubject() {
     final router = GoRouter(
-      initialLocation: '/',
+      initialLocation: '/log',
       routes: [
         GoRoute(
           path: '/',
-          builder: (_, __) => const AllergenLogDetailScreen(
-            allergenKey: _allergenKey,
-            logId: _logId,
-          ),
+          builder: (_, __) => const Scaffold(body: Text('ROOT_STUB')),
+          routes: [
+            GoRoute(
+              path: 'log',
+              builder: (_, __) => const AllergenLogDetailScreen(
+                allergenKey: _allergenKey,
+                logId: _logId,
+              ),
+            ),
+          ],
         ),
         GoRoute(
           path: AppRoute.allergenLogEdit.path,
@@ -107,6 +116,7 @@ void main() {
       overrides: [
         allergenServiceProvider.overrideWithValue(mockService),
         babyProfileServiceProvider.overrideWithValue(mockBabyService),
+        analyticsProvider.overrideWithValue(FakeAnalytics()),
       ],
       child: MaterialApp.router(routerConfig: router),
     );
@@ -197,7 +207,7 @@ void main() {
     );
 
     testWidgets(
-      'overflow menu exposes "Edit Reactions" and "Delete Log"',
+      '3-dot menu overlay exposes "Edit Reactions" and "Delete Log"',
       (tester) async {
         stubLogs([_makeLog(notes: 'note')]);
 
@@ -209,6 +219,80 @@ void main() {
 
         expect(find.text('Edit Reactions'), findsOneWidget);
         expect(find.text('Delete Log'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'Delete row opens the Figma confirmation popup with verbatim copy + '
+      'Cancel/Delete pill buttons; Cancel dismisses without deleting',
+      (tester) async {
+        stubLogs([_makeLog(notes: 'note')]);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('log_detail_menu')));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const Key('log_actions_menu_delete')));
+        await tester.pumpAndSettle();
+
+        // Verbatim Figma copy (1525:31338).
+        expect(find.text('Are you sure you want to delete?'), findsOneWidget);
+        expect(
+          find.byKey(const Key('delete_log_cancel_button')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('delete_log_confirm_button')),
+          findsOneWidget,
+        );
+
+        await tester.tap(find.byKey(const Key('delete_log_cancel_button')));
+        await tester.pumpAndSettle();
+
+        verifyNever(
+          () => mockService.deleteAllergenLog(
+            logId: any(named: 'logId'),
+            photoPath: any(named: 'photoPath'),
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'Confirming the delete popup calls deleteAllergenLog with the log id + '
+      'photo path',
+      (tester) async {
+        stubLogs([
+          _makeLog(
+            attachmentTitle: 'Rash on cheek area',
+            photoUrl: 'allergen-attachments/$_babyId/p.jpg',
+          ),
+        ]);
+        when(
+          () => mockService.deleteAllergenLog(
+            logId: any(named: 'logId'),
+            photoPath: any(named: 'photoPath'),
+          ),
+        ).thenAnswer((_) async => const Result.success(null));
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('log_detail_menu')));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const Key('log_actions_menu_delete')));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('delete_log_confirm_button')));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockService.deleteAllergenLog(
+            logId: _logId,
+            photoPath: 'allergen-attachments/$_babyId/p.jpg',
+          ),
+        ).called(1);
       },
     );
   });


### PR DESCRIPTION
## Summary

Implements the Figma-specced 3-dot action menu overlay + Delete confirmation popup for the read-only Reaction Log Detail screen (NIB-67).

- New `showLogActionsMenu` (Figma 1525:31083 / 1525:31206) — anchored 188-wide floating overlay with Edit Reactions (greenDeep / pencil) and Delete Log (burgundy / trash) rows.
- New `showDeleteLogConfirmationDialog` (Figma 1525:31338) — centered popup with Quatrefoil illustration, verbatim "Are you sure you want to delete?" copy, and Cancel/Delete pill button row. Delete uses the primary greenDeep pill (matches Figma, not destructive red).
- Wired into `allergen_log_detail_screen` replacing the previous `PopupMenuButton` + `AlertDialog` ("Delete this log?"). Delete side-effects (deleteAllergenLog + photo cleanup, analytics, invalidate detail + tracker, pop) preserved exactly.

## Acceptance criteria
- [x] 3-dot menu opens floating overlay exposing Edit + Delete
- [x] Edit pushes edit form route
- [x] Delete opens centered, dimmed-background confirmation popup
- [x] Popup uses verbatim "Are you sure you want to delete?" copy
- [x] Cancel dismisses without calling the service
- [x] Confirm calls `deleteAllergenLog(logId, photoPath)` + fires `allergen_log_deleted` analytics + invalidates detail / tracker
- [x] All tokens consumed from `AppColors` / `AppSizes` / fonts; no raw hex
- [x] `flutter analyze` clean (no new warnings; 2 pre-existing warnings unrelated to this PR remain on base)
- [x] All log_detail widget tests + full suite pass

## Figma frame ids
- 1525:31083 — 3-dot menu overlay (edit context)
- 1525:31206 — 3-dot menu overlay (delete context)
- 1525:31338 — Delete reaction confirmation popup
- 1525:31142 — Attachment edit context (already covered by shared `attachment_sheet.dart`)

## Audit reports
- `.figma-audit/allergen-tracker/allergen-tracker-detail-tried-safe-attachment-edit/report.md`
- `.figma-audit/allergen-tracker/allergen-tracker-detail-tried-safe-attachment-delete/report.md`
- `.figma-audit/allergen-tracker/delete-reaction-confirmation-popup/report.md`
- `.figma-audit/allergen-tracker/allergen-tracker-add-attachment-edit/report.md`

## Divergence note (NIB-163)
The Figma read-only detail mocks include the "Change Picture" pill + caption Button-chips, but the AC says hide them in read-only. Existing implementation (NIB-93 / NIB-163) renders them and two passing tests assert their visibility. Per the ticket instructions ("if any state differs from NIB-163 implementation, log a follow-up"), this PR does not touch the read-only attachment block.

## Test plan
- [x] `flutter test test/features/allergen/log_detail/` — 11/11 passing
- [x] `flutter test` (full suite) — all passing