### PR TITLE
fix(meal-plan): align root + accordion to Figma verbatim [NIB-69]

### DIFF
--- a/lib/src/features/meal_plan/meal_plan_screen.dart
+++ b/lib/src/features/meal_plan/meal_plan_screen.dart
@@ -500,31 +500,75 @@ class _PopulatedView extends StatelessWidget {
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(AppSizes.radiusLg),
       ),
-      items: [
+      items: const [
+        // First row carries the lime default-highlight (Figma 971:7826).
         PopupMenuItem<_ScreenMenuAction>(
           value: _ScreenMenuAction.addToShopList,
-          child: Text(
-            'Add to shop list',
-            style: AppTypography.textTheme.bodyMedium,
+          padding: EdgeInsets.zero,
+          child: _ScreenMenuRow(
+            icon: Icons.shopping_cart_outlined,
+            label: 'Add to shop list',
+            highlight: true,
           ),
         ),
         PopupMenuItem<_ScreenMenuAction>(
           value: _ScreenMenuAction.createMealPrep,
-          child: Text(
-            'Create new meal prep',
-            style: AppTypography.textTheme.bodyMedium,
+          child: _ScreenMenuRow(
+            icon: Icons.add,
+            label: 'Create new meal prep',
           ),
         ),
         PopupMenuItem<_ScreenMenuAction>(
           value: _ScreenMenuAction.clearCurrentWeek,
-          child: Text(
-            'Clear current week',
-            style: AppTypography.textTheme.bodyMedium,
+          child: _ScreenMenuRow(
+            icon: Icons.delete_outline,
+            label: 'Clear current week',
           ),
         ),
       ],
     );
     if (action != null) onScreenMenuSelected(action);
+  }
+}
+
+/// Row used inside the screen-level overflow popup. When [highlight] is
+/// true the entire row paints in lime (butter) with forest-deep text +
+/// icon — matches the default-active row in Figma 971:7826.
+class _ScreenMenuRow extends StatelessWidget {
+  const _ScreenMenuRow({
+    required this.icon,
+    required this.label,
+    this.highlight = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool highlight;
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = highlight ? AppColors.greenDeep : AppColors.fgStrong;
+    final row = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: AppSizes.iconSm, color: fg),
+        const SizedBox(width: AppSizes.sm),
+        Text(
+          label,
+          style: AppTypography.textTheme.bodyMedium?.copyWith(color: fg),
+        ),
+      ],
+    );
+    if (!highlight) return row;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md,
+        vertical: AppSizes.sm,
+      ),
+      color: AppColors.butter,
+      child: row,
+    );
   }
 }
 

--- a/lib/src/features/meal_plan/widgets/day_accordion_card.dart
+++ b/lib/src/features/meal_plan/widgets/day_accordion_card.dart
@@ -44,14 +44,14 @@ class DayAccordionCard extends StatelessWidget {
   final ValueChanged<String> onRecipeTap;
   final ValueChanged<DayCardMenuAction> onMenuSelected;
 
-  static const _weekdayShort = <String>[
-    'Mon',
-    'Tue',
-    'Wed',
-    'Thu',
-    'Fri',
-    'Sat',
-    'Sun',
+  static const _weekdayFull = <String>[
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+    'Sunday',
   ];
 
   static const _monthShort = <String>[
@@ -69,10 +69,11 @@ class DayAccordionCard extends StatelessWidget {
     'Dec',
   ];
 
+  /// Spec format: `Tuesday, 14 Apr` (Figma 971:8619 verbatim).
   String _dateLabel() {
-    final dow = _weekdayShort[day.weekday - 1];
+    final dow = _weekdayFull[day.weekday - 1];
     final mon = _monthShort[day.month - 1];
-    return '$dow ${day.day} $mon';
+    return '$dow, ${day.day} $mon';
   }
 
   @override
@@ -109,15 +110,11 @@ class DayAccordionCard extends StatelessWidget {
                 onRecipeTap: onRecipeTap,
               ),
             const SizedBox(height: AppSizes.sm),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: AppPillButton(
-                label: '+ Add',
-                size: AppPillButtonSize.small,
-                variant: AppPillButtonVariant.ghost,
-                expand: false,
-                onPressed: onAdd,
-              ),
+            // Full-width lime "Add" pill (Figma 971:8619, 971:7804).
+            AppPillButton(
+              label: 'Add',
+              variant: AppPillButtonVariant.ghost,
+              onPressed: onAdd,
             ),
           ],
         ],
@@ -152,32 +149,93 @@ class _Header extends StatelessWidget {
               style: AppTypography.textTheme.titleMedium,
             ),
           ),
+          // Green-filled rounded-square overflow button (Figma 971:8619).
           PopupMenuButton<DayCardMenuAction>(
             tooltip: 'More',
-            icon: const Icon(
-              Icons.more_horiz,
-              color: AppColors.fgMuted,
-              size: AppSizes.iconMd,
+            position: PopupMenuPosition.under,
+            color: AppColors.surface,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppSizes.radiusLg),
             ),
+            padding: EdgeInsets.zero,
             onSelected: onMenuSelected,
             itemBuilder: (_) => const [
               PopupMenuItem<DayCardMenuAction>(
                 value: DayCardMenuAction.addToShopList,
-                child: Text('Add to shop list'),
+                child: _MenuRow(
+                  icon: Icons.shopping_cart_outlined,
+                  label: 'Add to shop list',
+                ),
               ),
               PopupMenuItem<DayCardMenuAction>(
                 value: DayCardMenuAction.clearCurrentWeek,
-                child: Text('Clear current week'),
+                child: _MenuRow(
+                  icon: Icons.delete_outline,
+                  label: 'Clear current week',
+                ),
               ),
             ],
+            child: const _DayCardChip(icon: Icons.more_horiz),
           ),
-          Icon(
-            isExpanded ? Icons.expand_less : Icons.expand_more,
-            color: AppColors.fgMuted,
-            size: AppSizes.iconMd,
+          const SizedBox(width: AppSizes.xs),
+          // Green-filled rounded-square chevron button (Figma 971:8619).
+          _DayCardChip(
+            icon: isExpanded
+                ? Icons.keyboard_arrow_up
+                : Icons.keyboard_arrow_down,
+            onTap: onToggle,
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Green-deep rounded-square chip used in the day-card header for the
+/// overflow (left) and chevron (right) buttons. Matches the screen-level
+/// header's `MealPlanOverflowButton` visual.
+class _DayCardChip extends StatelessWidget {
+  const _DayCardChip({required this.icon, this.onTap});
+
+  final IconData icon;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final box = SizedBox(
+      width: AppSizes.roundButtonSm,
+      height: AppSizes.roundButtonSm,
+      child: Icon(icon, color: AppColors.onGreen, size: AppSizes.iconMd),
+    );
+    return Material(
+      color: AppColors.greenDeep,
+      borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+      child: onTap == null
+          ? box
+          : InkWell(
+              borderRadius: BorderRadius.circular(AppSizes.radiusSm),
+              onTap: onTap,
+              child: box,
+            ),
+    );
+  }
+}
+
+class _MenuRow extends StatelessWidget {
+  const _MenuRow({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: AppSizes.iconSm, color: AppColors.fgStrong),
+        const SizedBox(width: AppSizes.sm),
+        Text(label, style: AppTypography.textTheme.bodyMedium),
+      ],
     );
   }
 }
@@ -186,10 +244,12 @@ class _EmptyHint extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: AppSizes.xs),
-      child: Text(
-        'No meal plan yet.',
-        style: AppTypography.caption.copyWith(color: AppColors.fgFaint),
+      padding: const EdgeInsets.symmetric(vertical: AppSizes.sm),
+      child: Center(
+        child: Text(
+          'No meal plan yet.',
+          style: AppTypography.textTheme.titleSmall,
+        ),
       ),
     );
   }

--- a/test/features/meal_plan/meal_plan_screen_test.dart
+++ b/test/features/meal_plan/meal_plan_screen_test.dart
@@ -303,17 +303,20 @@ void main() {
 
         await pumpScreen(tester);
 
-        // Expand the first day card so its '+ Add' pill is visible.
+        // Expand the first day card so its 'Add' pill is visible.
         final firstCard = find.byType(DayAccordionCard).first;
         final chevron = find
-            .descendant(of: firstCard, matching: find.byIcon(Icons.expand_more))
+            .descendant(
+              of: firstCard,
+              matching: find.byIcon(Icons.keyboard_arrow_down),
+            )
             .first;
         await tester.tap(chevron);
         await tester.pumpAndSettle();
 
-        // Tap the '+ Add' pill inside the expanded card.
+        // Tap the 'Add' pill inside the expanded card.
         final addPill = find
-            .descendant(of: firstCard, matching: find.text('+ Add'))
+            .descendant(of: firstCard, matching: find.text('Add'))
             .first;
         await tester.tap(addPill);
         // Drive the sheet entrance + _load() — pumpAndSettle would hang on

--- a/test/features/meal_plan/widgets/day_accordion_card_test.dart
+++ b/test/features/meal_plan/widgets/day_accordion_card_test.dart
@@ -69,11 +69,11 @@ void main() {
         isExpanded: false,
       );
 
-      // Header includes the date label e.g. "Sat 30 May".
+      // Header includes the date label e.g. "Saturday, 30 May".
       expect(find.textContaining('30 May'), findsOneWidget);
       // Body content (recipe title + Add pill) is hidden.
       expect(find.text('Peanut Butter Toast'), findsNothing);
-      expect(find.text('+ Add'), findsNothing);
+      expect(find.text('Add'), findsNothing);
       expect(find.text('No meal plan yet.'), findsNothing);
     });
 
@@ -91,7 +91,7 @@ void main() {
         );
 
         expect(find.text('Peanut Butter Toast'), findsOneWidget);
-        expect(find.text('+ Add'), findsOneWidget);
+        expect(find.text('Add'), findsOneWidget);
         // Tag chips render with replaced underscore labels.
         expect(find.text('peanut'), findsOneWidget);
         expect(find.text('egg'), findsOneWidget);
@@ -134,7 +134,7 @@ void main() {
       );
 
       expect(find.text('No meal plan yet.'), findsOneWidget);
-      expect(find.text('+ Add'), findsOneWidget);
+      expect(find.text('Add'), findsOneWidget);
     });
 
     testWidgets('header tap fires onToggle', (tester) async {
@@ -154,7 +154,7 @@ void main() {
       expect(toggled, 1);
     });
 
-    testWidgets('"+ Add" pill tap fires onAdd', (tester) async {
+    testWidgets('"Add" pill tap fires onAdd', (tester) async {
       var added = 0;
       await _pumpCard(
         tester,
@@ -164,7 +164,7 @@ void main() {
         onAdd: () => added++,
       );
 
-      await tester.tap(find.text('+ Add'));
+      await tester.tap(find.text('Add'));
       await tester.pumpAndSettle();
 
       expect(added, 1);


### PR DESCRIPTION
## Summary

Aligns the Meal Plan root screen to the NIB-69 Figma spec.

- Day-card label uses the full weekday + comma format: `Tuesday, 14 Apr`.
- Expanded "Add" CTA is a full-width lime pill labeled `Add` (was small ghost `+ Add`).
- Day-card right side now renders the two green-deep rounded chips (more_horiz + chevron) matching the screen-level overflow button.
- Empty-day hint centered with `titleSmall`, matching screenshot 971:7804.
- Per-day overflow menu items get shopping-cart and trash icons.
- Screen overflow menu rows get shopping-cart / plus / trash icons, with the first row default-highlighted in lime per Figma 971:7826.

## Figma frame ids

- root / populated: 971:8619
- shoplist-01 / Tuesday empty + accordion: 971:7804
- shoplist-02 / overflow menu open: 971:7826
- a-day-section-01 / one day expanded: 971:8571
- add-date-pop-up-01 / extended week: 971:8597

## Audit artifacts

- `.figma-audit/meal-plan/root-meal-planner-generated/`
- `.figma-audit/meal-plan/a-day-section-01-meal-planner-generated/`
- `.figma-audit/meal-plan/shoplist-02-meal-planner-generated/`
- `.figma-audit/meal-plan/add-date-pop-up-01-meal-planner-generated/`

## Acceptance criteria

- [x] Day labels follow `Weekday, DD MonShort` verbatim spec.
- [x] Expanded Add pill is full-width lime, label `Add` in both empty and populated states.
- [x] Screen overflow menu shows exactly 3 items with icons; first row lime-highlighted.
- [x] Per-day overflow menu shows exactly 2 items with icons.
- [x] All listed state variants reachable: populated, populated-with-empty-day, overflow-open, extended week.
- [x] `flutter analyze` clean for meal-plan scope (2 pre-existing infos outside scope).
- [x] `flutter test` passes (553 tests, 1 pre-existing skip).

## Notes

- Header `Meal Planner for {babyName}` is rendered without the trailing whitespace flagged as a copy-bug artifact in the ticket PO note.