### PR TITLE
feat(meal-plan): empty-state form + Select Period Date sheet [NIB-76]

### DIFF
--- a/lib/src/features/meal_plan/meal_plan_screen.dart
+++ b/lib/src/features/meal_plan/meal_plan_screen.dart
@@ -15,6 +15,7 @@ import 'package:nibbles/src/features/meal_plan/map/map_meals_state.dart';
 import 'package:nibbles/src/features/meal_plan/meal_plan_controller.dart';
 import 'package:nibbles/src/features/meal_plan/meal_plan_state.dart';
 import 'package:nibbles/src/features/meal_plan/sheets/browse_meal_sheet.dart';
+import 'package:nibbles/src/features/meal_plan/sheets/select_period_date_sheet.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/add_date_pill.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/add_to_shopping_list_modal.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/clear_confirm_dialog.dart';
@@ -116,7 +117,13 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
     if (state.entries.isEmpty) {
       return MealPlanEmptyState(
         babyName: baby.name,
+        ageMonths: ageInMonths(baby.dateOfBirth),
         onCreateMealPlan: _onCreateMealPlanFromEmpty,
+        overflowButton: Builder(
+          builder: (btnContext) => MealPlanOverflowButton(
+            onTap: () => _openEmptyStateMenu(btnContext),
+          ),
+        ),
       );
     }
     return _PopulatedView(
@@ -294,20 +301,30 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
   }
 
   Future<void> _onCreateMealPrep(MealPlanState state) async {
-    final endDate = _effectiveWindowEnd(state);
-    final days = endDate.difference(state.windowStart).inDays + 1;
+    // First let the user pick the date range via the Select Period Date
+    // bottom-sheet (Figma 971:8000). Pre-fill with the current window so the
+    // sheet opens on the same range the planner is showing.
+    final range = await showSelectPeriodDateSheet(
+      context,
+      initialStart: state.windowStart,
+      initialEnd: _effectiveWindowEnd(state),
+    );
+    if (range == null) return;
+    if (!mounted) return;
+
+    final days = range.end.difference(range.start).inDays + 1;
     unawaited(
       ref.read(analyticsProvider).logMealPrepRangeSelected(days: days),
     );
     final picked = await showBrowseMealSheet(
       context,
       babyId: widget.babyId,
-      startDate: state.windowStart,
-      endDate: endDate,
+      startDate: range.start,
+      endDate: range.end,
     );
     if (picked == null || picked.isEmpty) return;
     if (!mounted) return;
-    await _pushMapMeals(picked, state.windowStart, endDate);
+    await _pushMapMeals(picked, range.start, range.end);
   }
 
   Future<void> _onClearWindow(MealPlanState state) async {
@@ -371,6 +388,57 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
       AppRoute.recipeDetail.name,
       pathParameters: {'recipeId': recipeId},
     );
+  }
+
+  /// Opens the screen-level overflow menu while the empty state is showing.
+  /// Empty state has no entries, so 'Add to shop list' and 'Clear current
+  /// week' are not actionable — only the 'Create new meal prep' route is
+  /// surfaced, which funnels through the same Select Period Date sheet.
+  Future<void> _openEmptyStateMenu(BuildContext btnContext) async {
+    final state = ref
+        .read(mealPlanControllerProvider(widget.babyId))
+        .valueOrNull;
+    if (state == null) return;
+
+    final renderBox = btnContext.findRenderObject() as RenderBox?;
+    final overlay =
+        Overlay.of(btnContext).context.findRenderObject() as RenderBox?;
+    if (renderBox == null || overlay == null) return;
+
+    final topRight = renderBox.localToGlobal(
+      Offset(renderBox.size.width, 0),
+      ancestor: overlay,
+    );
+    final position = RelativeRect.fromLTRB(
+      topRight.dx - AppSizes.pagePaddingH * 2,
+      topRight.dy + AppSizes.xxl,
+      AppSizes.pagePaddingH,
+      0,
+    );
+
+    final action = await showMenu<_ScreenMenuAction>(
+      context: btnContext,
+      position: position,
+      color: AppColors.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+      ),
+      items: const [
+        PopupMenuItem<_ScreenMenuAction>(
+          value: _ScreenMenuAction.createMealPrep,
+          padding: EdgeInsets.zero,
+          child: _ScreenMenuRow(
+            icon: Icons.add,
+            label: 'Create new meal prep',
+            highlight: true,
+          ),
+        ),
+      ],
+    );
+    if (action == _ScreenMenuAction.createMealPrep) {
+      unawaited(ref.read(analyticsProvider).logMealPrepCreateStarted());
+      await _onCreateMealPrep(state);
+    }
   }
 }
 

--- a/lib/src/features/meal_plan/sheets/select_period_date_sheet.dart
+++ b/lib/src/features/meal_plan/sheets/select_period_date_sheet.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_date_range_form.dart';
+
+/// Bottom-sheet variant of the Meal Plan date range form (Figma 971:8000).
+///
+/// Title: 'Select Period Date'. Hosts the same [MealPlanDateRangeForm] used
+/// by the empty state, but with the 'Custom meal plan' CTA per the Figma
+/// frame. Launched from the meal-plan overflow → 'Create new meal prep'
+/// action. Pops with the chosen [DateTimeRange] on submit, or `null` on
+/// dismiss.
+class SelectPeriodDateSheet extends StatelessWidget {
+  const SelectPeriodDateSheet({
+    this.initialStart,
+    this.initialEnd,
+    super.key,
+  });
+
+  final DateTime? initialStart;
+  final DateTime? initialEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(
+            AppSizes.pagePaddingH,
+            AppSizes.md,
+            AppSizes.pagePaddingH,
+            AppSizes.lg,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: AppColors.borderMuted,
+                    borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppSizes.md),
+              Text(
+                'Select Period Date',
+                style: AppTypography.textTheme.titleSmall?.copyWith(
+                  color: AppColors.fgStrong,
+                ),
+              ),
+              const SizedBox(height: AppSizes.md),
+              MealPlanDateRangeForm(
+                ctaLabel: 'Custom meal plan',
+                initialStart: initialStart,
+                initialEnd: initialEnd,
+                onSubmit: (range) => Navigator.of(context).pop(range),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Helper that shows [SelectPeriodDateSheet] as a modal bottom sheet.
+/// Returns the chosen [DateTimeRange], or `null` on dismiss.
+Future<DateTimeRange?> showSelectPeriodDateSheet(
+  BuildContext context, {
+  DateTime? initialStart,
+  DateTime? initialEnd,
+}) {
+  return showModalBottomSheet<DateTimeRange>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppSizes.radiusLg),
+      ),
+    ),
+    builder: (_) => SelectPeriodDateSheet(
+      initialStart: initialStart,
+      initialEnd: initialEnd,
+    ),
+  );
+}

--- a/lib/src/features/meal_plan/widgets/meal_plan_date_range_form.dart
+++ b/lib/src/features/meal_plan/widgets/meal_plan_date_range_form.dart
@@ -1,0 +1,249 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
+
+/// Shared Start Date / End Date form used by both the Meal Plan empty-state
+/// (`MealPlanEmptyState`) and the Select Period Date bottom-sheet
+/// (`SelectPeriodDateSheet`, Figma 971:8000). Renders two date fields plus
+/// a primary CTA. Tapping a field opens an [InlineCalendar] directly below
+/// it — the OS picker is intentionally never used (per NIB-76 AC: the
+/// typo'd Figma weekday row is not replicated and the picker is themed to
+/// sage/butter, not iOS blue).
+///
+/// Defaults to today + (today + 6 days) so the CTA is enabled on first
+/// paint, matching the Figma frame's pre-filled `17/04/2026` placeholders.
+class MealPlanDateRangeForm extends StatefulWidget {
+  const MealPlanDateRangeForm({
+    required this.ctaLabel,
+    required this.onSubmit,
+    this.initialStart,
+    this.initialEnd,
+    super.key,
+  });
+
+  /// CTA label. Empty-state uses 'Create meal plan' (Figma 971:8199); the
+  /// bottom-sheet variant (971:8000) uses 'Custom meal plan'.
+  final String ctaLabel;
+
+  /// Fires when the user taps the CTA with a valid range.
+  final ValueChanged<DateTimeRange> onSubmit;
+
+  /// Optional initial start date. Defaults to today (date-only).
+  final DateTime? initialStart;
+
+  /// Optional initial end date. Defaults to today + 6 days (date-only).
+  final DateTime? initialEnd;
+
+  @override
+  State<MealPlanDateRangeForm> createState() => _MealPlanDateRangeFormState();
+}
+
+enum _OpenField { none, start, end }
+
+class _MealPlanDateRangeFormState extends State<MealPlanDateRangeForm> {
+  late DateTime _startDate;
+  late DateTime _endDate;
+  late DateTime _focusedMonth;
+  _OpenField _openField = _OpenField.none;
+
+  static DateTime _dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
+
+  @override
+  void initState() {
+    super.initState();
+    final today = _dateOnly(DateTime.now());
+    _startDate = widget.initialStart != null
+        ? _dateOnly(widget.initialStart!)
+        : today;
+    _endDate = widget.initialEnd != null
+        ? _dateOnly(widget.initialEnd!)
+        : today.add(const Duration(days: 6));
+    _focusedMonth = DateTime(_startDate.year, _startDate.month);
+  }
+
+  bool get _canSubmit => !_endDate.isBefore(_startDate);
+
+  String? get _rangeError => _endDate.isBefore(_startDate)
+      ? 'End date must be on or after start date.'
+      : null;
+
+  void _toggleField(_OpenField field, DateTime current) {
+    setState(() {
+      if (_openField == field) {
+        _openField = _OpenField.none;
+      } else {
+        _openField = field;
+        _focusedMonth = DateTime(current.year, current.month);
+      }
+    });
+  }
+
+  void _onDaySelected(DateTime day) {
+    setState(() {
+      if (_openField == _OpenField.start) {
+        _startDate = day;
+        // Auto-bump end forward so the range stays valid.
+        if (_endDate.isBefore(day)) _endDate = day;
+      } else if (_openField == _OpenField.end) {
+        _endDate = day;
+      }
+      _openField = _OpenField.none;
+    });
+  }
+
+  void _onMonthChanged(DateTime month) {
+    setState(() => _focusedMonth = month);
+  }
+
+  void _onSubmit() {
+    if (!_canSubmit) return;
+    widget.onSubmit(DateTimeRange(start: _startDate, end: _endDate));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final rangeError = _rangeError;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _DateField(
+          label: 'Start Date',
+          value: _startDate,
+          isOpen: _openField == _OpenField.start,
+          onTap: () => _toggleField(_OpenField.start, _startDate),
+        ),
+        if (_openField == _OpenField.start) ...[
+          const SizedBox(height: AppSizes.sm),
+          InlineCalendar(
+            selectedDate: _startDate,
+            focusedMonth: _focusedMonth,
+            onDaySelected: _onDaySelected,
+            onMonthChanged: _onMonthChanged,
+          ),
+        ],
+        const SizedBox(height: AppSizes.md),
+        _DateField(
+          label: 'End Date',
+          value: _endDate,
+          isOpen: _openField == _OpenField.end,
+          onTap: () => _toggleField(_OpenField.end, _endDate),
+        ),
+        if (_openField == _OpenField.end) ...[
+          const SizedBox(height: AppSizes.sm),
+          InlineCalendar(
+            selectedDate: _endDate,
+            focusedMonth: _focusedMonth,
+            onDaySelected: _onDaySelected,
+            onMonthChanged: _onMonthChanged,
+            minDate: _startDate,
+          ),
+        ],
+        if (rangeError != null) ...[
+          const SizedBox(height: AppSizes.xs),
+          Text(
+            rangeError,
+            style: theme.textTheme.bodySmall?.copyWith(color: AppColors.error),
+          ),
+        ],
+        const SizedBox(height: AppSizes.md),
+        AppPillButton(
+          label: widget.ctaLabel,
+          onPressed: _canSubmit ? _onSubmit : null,
+        ),
+      ],
+    );
+  }
+}
+
+/// Single labelled date field. `value` is the currently chosen date —
+/// rendered as `dd/MM/yyyy` to match Figma's verbatim placeholder
+/// (`17/04/2026`). Open state paints a green-deep border + subtle glow.
+class _DateField extends StatelessWidget {
+  const _DateField({
+    required this.label,
+    required this.value,
+    required this.isOpen,
+    required this.onTap,
+  });
+
+  final String label;
+  final DateTime value;
+  final bool isOpen;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final displayText = _formatDate(value);
+    final borderColor = isOpen ? AppColors.greenDeep : AppColors.borderSoft;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.labelMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: AppColors.fgStrong,
+          ),
+        ),
+        const SizedBox(height: AppSizes.sm),
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 120),
+            height: AppSizes.fieldHeight,
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.fieldPaddingH,
+            ),
+            decoration: BoxDecoration(
+              color: isOpen ? AppColors.surface : AppColors.bgInput,
+              borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+              border: Border.all(
+                color: borderColor,
+                width: isOpen ? 2 : 1,
+              ),
+              boxShadow: isOpen
+                  ? [
+                      BoxShadow(
+                        color: AppColors.green.withValues(alpha: 0.15),
+                        spreadRadius: 3,
+                      ),
+                    ]
+                  : null,
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    displayText,
+                    style: AppTypography.textTheme.bodyLarge?.copyWith(
+                      color: AppColors.fgStrong,
+                    ),
+                  ),
+                ),
+                const Icon(
+                  Icons.calendar_today_outlined,
+                  size: AppSizes.iconSm,
+                  color: AppColors.greenDeep,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  static String _formatDate(DateTime d) {
+    final dd = d.day.toString().padLeft(2, '0');
+    final mm = d.month.toString().padLeft(2, '0');
+    return '$dd/$mm/${d.year}';
+  }
+}

--- a/lib/src/features/meal_plan/widgets/meal_plan_empty_state.dart
+++ b/lib/src/features/meal_plan/widgets/meal_plan_empty_state.dart
@@ -3,262 +3,77 @@ import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
-import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
-import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_date_range_form.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_header.dart';
 
-/// Meal Plan empty-state form. Renders a flower (Quatrefoil) illustration,
-/// a "Ready to start?" heading, two date fields (Start Date / End Date) and
-/// a "Create meal plan" CTA. Tapping a date field opens [InlineCalendar]
-/// below the field — the OS picker is never used.
+/// Meal Plan empty-state route (Figma 971:8199 / 971:8547).
 ///
-/// State is local: which field is focused, the chosen start + end dates,
-/// and which inline calendar is currently expanded. When the CTA fires
-/// with a valid range (`start <= end`), [onCreateMealPlan] receives a
-/// [DateTimeRange].
-class MealPlanEmptyState extends StatefulWidget {
+/// Layout (top → bottom):
+/// 1. Butter-gradient [MealPlanHeader] (title + age subtitle + overflow).
+/// 2. White rounded form card hosting [MealPlanDateRangeForm] with the
+///    'Create meal plan' CTA.
+/// 3. Brand [Quatrefoil] flower illustration.
+/// 4. Caption "Let's create meal plan for {babyName}!" (verbatim — the
+///    baby name interpolates the runtime value; the lowercase "oliver"
+///    in the Figma string is a designer artifact).
+///
+/// Tapping a date field opens an inline calendar directly below it — never
+/// the OS picker. Hitting the CTA emits a [DateTimeRange] via
+/// [onCreateMealPlan].
+class MealPlanEmptyState extends StatelessWidget {
   const MealPlanEmptyState({
     required this.babyName,
+    required this.ageMonths,
     required this.onCreateMealPlan,
+    this.overflowButton,
     super.key,
   });
 
   final String babyName;
+  final int ageMonths;
   final ValueChanged<DateTimeRange> onCreateMealPlan;
 
-  @override
-  State<MealPlanEmptyState> createState() => _MealPlanEmptyStateState();
-}
-
-enum _OpenField { none, start, end }
-
-class _MealPlanEmptyStateState extends State<MealPlanEmptyState> {
-  DateTime? _startDate;
-  DateTime? _endDate;
-  late DateTime _focusedMonth;
-  _OpenField _openField = _OpenField.none;
-
-  @override
-  void initState() {
-    super.initState();
-    final now = DateTime.now();
-    _focusedMonth = DateTime(now.year, now.month);
-  }
-
-  bool get _canSubmit =>
-      _startDate != null &&
-      _endDate != null &&
-      !_endDate!.isBefore(_startDate!);
-
-  String? get _rangeError {
-    if (_startDate != null &&
-        _endDate != null &&
-        _endDate!.isBefore(_startDate!)) {
-      return 'End date must be on or after start date.';
-    }
-    return null;
-  }
-
-  void _toggleField(_OpenField field, DateTime? current) {
-    setState(() {
-      if (_openField == field) {
-        _openField = _OpenField.none;
-      } else {
-        _openField = field;
-        final anchor = current ?? _startDate ?? DateTime.now();
-        _focusedMonth = DateTime(anchor.year, anchor.month);
-      }
-    });
-  }
-
-  void _onDaySelected(DateTime day) {
-    setState(() {
-      if (_openField == _OpenField.start) {
-        _startDate = day;
-        // Clear an end date that would now be invalid.
-        if (_endDate != null && _endDate!.isBefore(day)) {
-          _endDate = null;
-        }
-      } else if (_openField == _OpenField.end) {
-        _endDate = day;
-      }
-      _openField = _OpenField.none;
-    });
-  }
-
-  void _onMonthChanged(DateTime month) {
-    setState(() => _focusedMonth = month);
-  }
-
-  void _onSubmit() {
-    if (!_canSubmit) return;
-    widget.onCreateMealPlan(
-      DateTimeRange(start: _startDate!, end: _endDate!),
-    );
-  }
+  /// Optional overflow button slot — empty state still renders the header,
+  /// so pass a [MealPlanOverflowButton] to enable the screen-level menu.
+  final Widget? overflowButton;
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final rangeError = _rangeError;
-
-    return SafeArea(
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSizes.pagePaddingH,
-          vertical: AppSizes.pagePaddingV,
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const SizedBox(height: AppSizes.lg),
-            // TODO(NIB-69): swap stock Quatrefoil for the dedicated meal-plan
-            // flower illustration if/when Figma exports one.
-            const Center(child: Quatrefoil()),
-            const SizedBox(height: AppSizes.md),
-            const Text(
-              'Ready to start?',
-              textAlign: TextAlign.center,
-              style: AppTypography.emptyStateTitle,
-            ),
-            const SizedBox(height: AppSizes.sm),
-            Text(
-              "Pick a start and end date to plan ${widget.babyName}'s meals.",
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: AppColors.fgFaint,
-              ),
-            ),
-            const SizedBox(height: AppSizes.xl),
-            _DateField(
-              label: 'Start Date',
-              value: _startDate,
-              hintText: 'Select start date',
-              isOpen: _openField == _OpenField.start,
-              onTap: () => _toggleField(_OpenField.start, _startDate),
-            ),
-            if (_openField == _OpenField.start) ...[
-              const SizedBox(height: AppSizes.sm),
-              InlineCalendar(
-                selectedDate: _startDate,
-                focusedMonth: _focusedMonth,
-                onDaySelected: _onDaySelected,
-                onMonthChanged: _onMonthChanged,
-              ),
-            ],
-            const SizedBox(height: AppSizes.md),
-            _DateField(
-              label: 'End Date',
-              value: _endDate,
-              hintText: 'Select end date',
-              isOpen: _openField == _OpenField.end,
-              onTap: () => _toggleField(_OpenField.end, _endDate),
-            ),
-            if (_openField == _OpenField.end) ...[
-              const SizedBox(height: AppSizes.sm),
-              InlineCalendar(
-                selectedDate: _endDate,
-                focusedMonth: _focusedMonth,
-                onDaySelected: _onDaySelected,
-                onMonthChanged: _onMonthChanged,
-                minDate: _startDate,
-              ),
-            ],
-            if (rangeError != null) ...[
-              const SizedBox(height: AppSizes.xs),
-              Text(
-                rangeError,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: AppColors.error,
-                ),
-              ),
-            ],
-            const SizedBox(height: AppSizes.xl),
-            AppPillButton(
-              label: 'Create meal plan',
-              onPressed: _canSubmit ? _onSubmit : null,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _DateField extends StatelessWidget {
-  const _DateField({
-    required this.label,
-    required this.value,
-    required this.hintText,
-    required this.isOpen,
-    required this.onTap,
-  });
-
-  final String label;
-  final DateTime? value;
-  final String hintText;
-  final bool isOpen;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final hasValue = value != null;
-    final displayText = hasValue ? _formatDate(value!) : hintText;
-    final borderColor = isOpen ? AppColors.greenDeep : AppColors.borderSoft;
-
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          label,
-          style: theme.textTheme.labelMedium?.copyWith(
-            fontWeight: FontWeight.w700,
-            color: AppColors.fgStrong,
-          ),
+        MealPlanHeader(
+          babyName: babyName,
+          ageMonths: ageMonths,
+          overflowButton: overflowButton ?? const SizedBox.shrink(),
         ),
-        const SizedBox(height: AppSizes.sm),
-        GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: onTap,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 120),
-            height: AppSizes.fieldHeight,
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSizes.fieldPaddingH,
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(
+              AppSizes.pagePaddingH,
+              AppSizes.md,
+              AppSizes.pagePaddingH,
+              AppSizes.lg,
             ),
-            decoration: BoxDecoration(
-              color: isOpen ? AppColors.surface : AppColors.bgInput,
-              borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-              border: Border.all(
-                color: borderColor,
-                width: isOpen ? 2 : 1,
-              ),
-              boxShadow: isOpen
-                  ? [
-                      BoxShadow(
-                        color: AppColors.green.withValues(alpha: 0.15),
-                        spreadRadius: 3,
-                      ),
-                    ]
-                  : null,
-            ),
-            child: Row(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Expanded(
-                  child: Text(
-                    displayText,
-                    style: theme.textTheme.bodyLarge?.copyWith(
-                      color: hasValue
-                          ? AppColors.fgStrong
-                          : AppColors.greenSoft,
-                    ),
+                _FormCard(
+                  child: MealPlanDateRangeForm(
+                    ctaLabel: 'Create meal plan',
+                    onSubmit: onCreateMealPlan,
                   ),
                 ),
-                const Icon(
-                  Icons.calendar_today_outlined,
-                  size: AppSizes.iconSm,
-                  color: AppColors.greenDeep,
+                const SizedBox(height: AppSizes.xxl),
+                const Center(child: Quatrefoil()),
+                const SizedBox(height: AppSizes.md),
+                Center(
+                  child: Text(
+                    "Let's create meal plan for $babyName!",
+                    textAlign: TextAlign.center,
+                    style: AppTypography.emptyStateTitle,
+                  ),
                 ),
+                const SizedBox(height: AppSizes.lg),
               ],
             ),
           ),
@@ -266,35 +81,25 @@ class _DateField extends StatelessWidget {
       ],
     );
   }
+}
 
-  static const List<String> _weekdayShort = <String>[
-    'Mon',
-    'Tue',
-    'Wed',
-    'Thu',
-    'Fri',
-    'Sat',
-    'Sun',
-  ];
+/// White rounded card with soft shadow that wraps the date-range form
+/// — matches the Figma 971:8199 card around the Start/End/CTA stack.
+class _FormCard extends StatelessWidget {
+  const _FormCard({required this.child});
 
-  static const List<String> _monthShort = <String>[
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
-  ];
+  final Widget child;
 
-  String _formatDate(DateTime d) {
-    final dow = _weekdayShort[d.weekday - 1];
-    final mon = _monthShort[d.month - 1];
-    return '$dow, ${d.day} $mon ${d.year}';
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppSizes.md),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        boxShadow: AppSizes.shadowCard,
+      ),
+      child: child,
+    );
   }
 }

--- a/lib/src/features/meal_plan/widgets/meal_plan_header.dart
+++ b/lib/src/features/meal_plan/widgets/meal_plan_header.dart
@@ -13,14 +13,17 @@ class MealPlanHeader extends StatelessWidget {
   const MealPlanHeader({
     required this.babyName,
     required this.ageMonths,
-    required this.dayCount,
     required this.overflowButton,
+    this.dayCount,
     super.key,
   });
 
   final String babyName;
   final int ageMonths;
-  final int dayCount;
+  // Optional day-count line. Populated view renders it; empty state omits it
+  // (Figma 971:8199 shows only the title + '4 Month' subtitle on the empty
+  // route).
+  final int? dayCount;
   final Widget overflowButton;
 
   @override
@@ -60,11 +63,13 @@ class MealPlanHeader extends StatelessWidget {
               '$ageMonths Month',
               style: AppTypography.caption.copyWith(color: AppColors.fgFaint),
             ),
-            const SizedBox(height: AppSizes.sp12),
-            Text(
-              'Meal plan for $dayCount days',
-              style: AppTypography.sectionTitle,
-            ),
+            if (dayCount != null) ...[
+              const SizedBox(height: AppSizes.sp12),
+              Text(
+                'Meal plan for $dayCount days',
+                style: AppTypography.sectionTitle,
+              ),
+            ],
           ],
         ),
       ),

--- a/test/features/meal_plan/meal_plan_screen_test.dart
+++ b/test/features/meal_plan/meal_plan_screen_test.dart
@@ -18,6 +18,7 @@ import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/common/services/meal_plan_service.dart';
 import 'package:nibbles/src/common/services/recipe_service.dart';
 import 'package:nibbles/src/features/meal_plan/meal_plan_screen.dart';
+import 'package:nibbles/src/features/meal_plan/sheets/select_period_date_sheet.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/add_date_pill.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/day_accordion_card.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_empty_state.dart';
@@ -178,14 +179,20 @@ void main() {
   }
 
   group('MealPlanScreen empty branch', () {
-    testWidgets('renders MealPlanEmptyState when entries is empty',
+    testWidgets(
+        'renders MealPlanEmptyState + header (no day-count line) and no '
+        'DayAccordionCards when entries is empty',
         (tester) async {
       stubBoot();
       await pumpScreen(tester);
 
       expect(find.byType(MealPlanEmptyState), findsOneWidget);
       expect(find.byType(DayAccordionCard), findsNothing);
-      expect(find.byType(MealPlanHeader), findsNothing);
+      // Per Figma 971:8199 the empty state still shows the header (title +
+      // age subtitle + overflow button) — only the populated view renders
+      // the "Meal plan for X days" line.
+      expect(find.byType(MealPlanHeader), findsOneWidget);
+      expect(find.textContaining('Meal plan for'), findsNothing);
     });
   });
 
@@ -227,6 +234,34 @@ void main() {
         findsNWidgets(3),
       );
     });
+
+    testWidgets(
+      'empty-state overflow → Create new meal prep opens '
+      'SelectPeriodDateSheet',
+      (tester) async {
+        // Force the empty branch so we land on MealPlanEmptyState with the
+        // single-item overflow menu.
+        stubBoot();
+        await pumpScreen(tester);
+
+        // Tap the header overflow button on the empty state.
+        await tester.tap(find.byType(MealPlanOverflowButton));
+        await tester.pumpAndSettle();
+
+        // The empty-state menu carries only 'Create new meal prep'.
+        expect(find.text('Create new meal prep'), findsOneWidget);
+        expect(
+          find.byWidgetPredicate((w) => w is PopupMenuItem),
+          findsOneWidget,
+        );
+
+        // Picking it opens the Select Period Date sheet.
+        await tester.tap(find.text('Create new meal prep'));
+        await tester.pumpAndSettle();
+        expect(find.byType(SelectPeriodDateSheet), findsOneWidget);
+        expect(find.text('Select Period Date'), findsOneWidget);
+      },
+    );
 
     testWidgets('per-card overflow menu shows exactly 2 items', (tester) async {
       final start = DateTime.now();

--- a/test/features/meal_plan/sheets/select_period_date_sheet_test.dart
+++ b/test/features/meal_plan/sheets/select_period_date_sheet_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/features/meal_plan/sheets/select_period_date_sheet.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
+
+Future<DateTimeRange?> _open(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(1080, 2800);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  DateTimeRange? captured;
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) => Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              onPressed: () async {
+                captured = await showSelectPeriodDateSheet(context);
+              },
+              child: const Text('Open Sheet'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('Open Sheet'));
+  await tester.pumpAndSettle();
+  return captured;
+}
+
+void main() {
+  group('SelectPeriodDateSheet', () {
+    testWidgets('renders Figma verbatim title + Custom meal plan CTA',
+        (tester) async {
+      await _open(tester);
+
+      expect(find.text('Select Period Date'), findsOneWidget);
+      expect(find.text('Start Date'), findsOneWidget);
+      expect(find.text('End Date'), findsOneWidget);
+      expect(
+        find.widgetWithText(AppPillButton, 'Custom meal plan'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping Start Date opens the inline calendar', (tester) async {
+      await _open(tester);
+
+      expect(find.byType(InlineCalendar), findsNothing);
+      final today = DateTime.now();
+      final dd = today.day.toString().padLeft(2, '0');
+      final mm = today.month.toString().padLeft(2, '0');
+      final startText = '$dd/$mm/${today.year}';
+      await tester.tap(find.text(startText).first);
+      await tester.pumpAndSettle();
+      expect(find.byType(InlineCalendar), findsOneWidget);
+    });
+
+    testWidgets('tapping CTA pops the sheet with a DateTimeRange',
+        (tester) async {
+      tester.view.physicalSize = const Size(1080, 2800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      DateTimeRange? captured;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () async {
+                    captured = await showSelectPeriodDateSheet(context);
+                  },
+                  child: const Text('Open Sheet'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open Sheet'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.widgetWithText(AppPillButton, 'Custom meal plan'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(
+        captured!.end.difference(captured!.start).inDays,
+        6,
+        reason: 'Default end = start + 6 days.',
+      );
+    });
+  });
+}

--- a/test/features/meal_plan/widgets/meal_plan_empty_state_test.dart
+++ b/test/features/meal_plan/widgets/meal_plan_empty_state_test.dart
@@ -3,15 +3,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_empty_state.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_header.dart';
+
+String _formatDdMmYyyy(DateTime d) {
+  final dd = d.day.toString().padLeft(2, '0');
+  final mm = d.month.toString().padLeft(2, '0');
+  return '$dd/$mm/${d.year}';
+}
 
 Future<void> _pump(
   WidgetTester tester, {
   required String babyName,
+  int ageMonths = 4,
   ValueChanged<DateTimeRange>? onCreate,
 }) async {
   // Give the screen extra height so the CTA + calendars fit in the viewport
   // without scrolling — keeps taps deterministic.
-  tester.view.physicalSize = const Size(1080, 2400);
+  tester.view.physicalSize = const Size(1080, 2800);
   tester.view.devicePixelRatio = 1;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
@@ -20,6 +28,7 @@ Future<void> _pump(
       home: Scaffold(
         body: MealPlanEmptyState(
           babyName: babyName,
+          ageMonths: ageMonths,
           onCreateMealPlan: onCreate ?? (_) {},
         ),
       ),
@@ -29,119 +38,114 @@ Future<void> _pump(
 
 void main() {
   group('MealPlanEmptyState', () {
-    testWidgets('renders babyName in copy', (tester) async {
-      await _pump(tester, babyName: 'Lily');
-      expect(find.textContaining("Lily's meals"), findsOneWidget);
-      expect(find.text('Ready to start?'), findsOneWidget);
+    testWidgets('renders Figma verbatim copy with babyName', (tester) async {
+      await _pump(tester, babyName: 'Oliver');
+
+      // Header from MealPlanHeader.
+      expect(find.byType(MealPlanHeader), findsOneWidget);
+      expect(find.text('Meal Planner for Oliver'), findsOneWidget);
+      expect(find.text('4 Month'), findsOneWidget);
+
+      // Form labels + verbatim caption under the flower.
+      expect(find.text('Start Date'), findsOneWidget);
+      expect(find.text('End Date'), findsOneWidget);
+      expect(find.text("Let's create meal plan for Oliver!"), findsOneWidget);
     });
 
-    testWidgets('CTA is disabled until both start and end are set', (
-      tester,
-    ) async {
-      await _pump(tester, babyName: 'Lily');
+    testWidgets(
+      'CTA is enabled by default — defaults are today + (today + 6 days)',
+      (tester) async {
+        await _pump(tester, babyName: 'Oliver');
 
-      final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
-      expect(cta, findsOneWidget);
+        final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
+        expect(cta, findsOneWidget);
 
-      // Initially disabled (no dates picked).
-      expect(tester.widget<AppPillButton>(cta).onPressed, isNull);
-
-      // Tap Start Date hint → inline calendar appears.
-      await tester.tap(find.text('Select start date'));
-      await tester.pumpAndSettle();
-      expect(find.byType(InlineCalendar), findsOneWidget);
-
-      // Pick day 10 → start date set, calendar closes.
-      await tester.tap(find.text('10').first);
-      await tester.pumpAndSettle();
-      // CTA still disabled (end not set).
-      expect(tester.widget<AppPillButton>(cta).onPressed, isNull);
-    });
-
-    testWidgets('CTA stays disabled when end date is before start date', (
-      tester,
-    ) async {
-      await _pump(tester, babyName: 'Lily');
-
-      final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
-
-      // Pick start = 20.
-      await tester.tap(find.text('Select start date'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('20').first);
-      await tester.pumpAndSettle();
-
-      // Pick end = 10 (before start).
-      await tester.tap(find.text('Select end date'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('10').first);
-      await tester.pumpAndSettle();
-
-      // CTA must remain disabled: production code rejects end < start
-      // (either by auto-clearing the invalid end or by gating the validator).
-      expect(
-        tester.widget<AppPillButton>(cta).onPressed,
-        isNull,
-        reason: 'CTA must stay disabled when end < start.',
-      );
-    });
+        // Enabled on first paint because defaults are populated.
+        expect(tester.widget<AppPillButton>(cta).onPressed, isNotNull);
+      },
+    );
 
     testWidgets('tapping a date field opens the inline calendar', (
       tester,
     ) async {
-      await _pump(tester, babyName: 'Lily');
+      await _pump(tester, babyName: 'Oliver');
 
-      // No calendar at first.
       expect(find.byType(InlineCalendar), findsNothing);
 
-      await tester.tap(find.text('Select start date'));
+      // The field is tappable via its dd/MM/yyyy value text inside the
+      // GestureDetector. Use today's value to find the Start Date row.
+      final today = DateTime.now();
+      final startText = _formatDdMmYyyy(
+        DateTime(today.year, today.month, today.day),
+      );
+      await tester.tap(find.text(startText).first);
       await tester.pumpAndSettle();
       expect(find.byType(InlineCalendar), findsOneWidget);
 
       // Toggle the same field — should close.
-      await tester.tap(find.text('Select start date'));
+      await tester.tap(find.text(startText).first);
       await tester.pumpAndSettle();
       expect(find.byType(InlineCalendar), findsNothing);
     });
 
     testWidgets(
-      'tapping CTA fires onCreateMealPlan with the picked DateTimeRange',
+      'picking a Start Date keeps CTA enabled (form auto-bumps end)',
       (tester) async {
         DateTimeRange? captured;
         await _pump(
           tester,
-          babyName: 'Lily',
+          babyName: 'Oliver',
           onCreate: (r) => captured = r,
         );
 
-        // Pick start date.
-        await tester.tap(find.text('Select start date'));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('10').first);
-        await tester.pumpAndSettle();
-
-        // Pick end date — once start is picked the hint is no longer shown.
-        // The picked-start row now reads its formatted date; the end-date row
-        // still shows the placeholder.
-        await tester.tap(find.text('Select end date'));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('20').first);
-        await tester.pumpAndSettle();
-
-        // CTA should now be enabled.
         final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
+        final today = DateTime.now();
+        final startText = _formatDdMmYyyy(
+          DateTime(today.year, today.month, today.day),
+        );
+
+        // Open the Start Date inline calendar and pick day 28 of the
+        // focused month (day 28 exists in every month).
+        await tester.tap(find.text(startText).first);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('28').first);
+        await tester.pumpAndSettle();
+
+        // CTA must remain enabled — the form auto-bumps end if needed so
+        // end >= start.
         expect(
           tester.widget<AppPillButton>(cta).onPressed,
           isNotNull,
-          reason: 'CTA should enable once both dates are picked.',
+          reason: 'Form must auto-bump end so range stays valid.',
         );
 
         await tester.tap(cta);
         await tester.pumpAndSettle();
+        expect(captured, isNotNull);
+        expect(!captured!.end.isBefore(captured!.start), isTrue);
+      },
+    );
+
+    testWidgets(
+      'tapping CTA emits the picked DateTimeRange via onCreateMealPlan',
+      (tester) async {
+        DateTimeRange? captured;
+        await _pump(
+          tester,
+          babyName: 'Oliver',
+          onCreate: (r) => captured = r,
+        );
+
+        final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
+        await tester.tap(cta);
+        await tester.pumpAndSettle();
 
         expect(captured, isNotNull);
-        expect(captured!.start.day, 10);
-        expect(captured!.end.day, 20);
+        expect(
+          captured!.end.difference(captured!.start).inDays,
+          6,
+          reason: 'Default end = start + 6 days.',
+        );
       },
     );
   });


### PR DESCRIPTION
## Summary
Restructures the Meal Plan empty state to match Figma 971:8199 and adds the Select Period Date bottom sheet (971:8000). Extracts the shared date-range form so the empty state and the sheet are powered by the same widget.

## Audit reports
- `.figma-audit/meal-plan/date-picker-01-meal-planner-empty-state/` (971:8199 — empty + form idle)
- `.figma-audit/meal-plan/date-picker-02-meal-planner-empty-state/` (971:8222 — picker open over Start)
- `.figma-audit/meal-plan/date-picker-03-meal-planner-empty-state/` (971:8246 — picker open over End)
- `.figma-audit/meal-plan/create-new-meal-prep-01-meal-planner-generated/` (971:8000 — Select Period Date sheet)

## Acceptance criteria
- [x] Empty state layout matches Figma 971:8199 — header + white form card (Start/End/CTA) + Quatrefoil flower + caption.
- [x] Verbatim copy used: "Meal Planner for {babyName}", "{N} Month", "Start Date", "End Date", "Create meal plan", "Let's create meal plan for {babyName}!".
- [x] Date placeholder format `dd/MM/yyyy` matches the Figma "17/04/2026" verbatim.
- [x] Defaults: Start = today, End = today + 6 days (CTA enabled on first paint).
- [x] Validation: End >= Start (form auto-bumps End when Start is moved past it).
- [x] Tapping Start Date / End Date opens the inline calendar directly below that field (the OS / iOS-Compact picker is intentionally not used — the Figma frame's typo'd `SUN MON WED THU FRI SAT SUN` row is not replicated, per AC).
- [x] Select Period Date bottom sheet (971:8000) reuses the same `MealPlanDateRangeForm` widget with the `Custom meal plan` CTA, launched from screen overflow -> `Create new meal prep`.
- [x] Empty-state overflow surfaces only `Create new meal prep` (no entries to clear / add to shop list); populated view keeps the existing 3-item menu.
- [x] No hardcoded hex outside foundation tokens.
- [x] `flutter analyze` clean (2 pre-existing infos unchanged from base).
- [x] `flutter test` -- all 557 tests pass.

## Deliberate deviations from Figma frames 02 / 03
The two `picker open` Figma frames render an iOS-Compact native picker with `#0088ff` accents. The shared `InlineCalendar` (sage / butter themed) is reused instead because:
- The AC explicitly requires not replicating the typo'd Figma weekday row.
- The blue accent comes from an un-restyled iOS native artifact and conflicts with the redesign palette + the "no hardcoded hex outside foundation" rule.
- `InlineCalendar` is the canonical themed picker used in `add_to_meal_plan_sheet` too.

## Test plan
- [x] `flutter analyze` — no new warnings.
- [x] `flutter test test/features/meal_plan/widgets/meal_plan_empty_state_test.dart`
- [x] `flutter test test/features/meal_plan/sheets/select_period_date_sheet_test.dart`
- [x] `flutter test test/features/meal_plan/meal_plan_screen_test.dart`
- [x] Full suite -- `flutter test`.