### PR TITLE
fix(meal-plan): map screen spec pass — CTA state, filled chips, slot card [NIB-95]

### DIFF
--- a/lib/src/features/meal_plan/map/map_meals_screen.dart
+++ b/lib/src/features/meal_plan/map/map_meals_screen.dart
@@ -64,6 +64,7 @@ class MapMealsScreen extends ConsumerWidget {
               startDate: state.startDate,
               endDate: state.endDate,
               selectedDay: state.selectedDay,
+              filledDays: state.filledDays(),
               onSelect: notifier.selectDay,
             ),
             const SizedBox(height: AppSizes.md),
@@ -74,16 +75,22 @@ class MapMealsScreen extends ConsumerWidget {
                 ),
                 children: [
                   _SelectedDayHeader(state: state, weekdayNames: _weekdayName),
+                  if (state.recipesForSelectedDay().isNotEmpty) ...[
+                    const SizedBox(height: AppSizes.xs),
+                    Text(
+                      'Drag & drop or click meals below to add them',
+                      style: AppTypography.caption.copyWith(
+                        color: AppColors.fgMuted,
+                      ),
+                    ),
+                  ],
                   const SizedBox(height: AppSizes.sm),
                   SelectedDaySlotList(
                     recipes: state.recipesForSelectedDay(),
                     onRemove: notifier.unassign,
                   ),
                   const SizedBox(height: AppSizes.lg),
-                  Text(
-                    'Meals Picked — ${state.totalCount} selected',
-                    style: AppTypography.sectionTitle,
-                  ),
+                  _MealsPickedHeader(totalCount: state.totalCount),
                   const SizedBox(height: AppSizes.sm),
                   for (var i = 0; i < state.pickedRecipes.length; i++) ...[
                     if (i != 0) const SizedBox(height: AppSizes.sm),
@@ -220,6 +227,33 @@ class _MapMealsAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 }
 
+/// "Meals Picked" section header. Per Figma frames 03–07 the title sits
+/// flush-left and the picked-count chip (`N selected`) sits flush-right
+/// on the same row.
+class _MealsPickedHeader extends StatelessWidget {
+  const _MealsPickedHeader({required this.totalCount});
+
+  final int totalCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Expanded(
+          child: Text('Meals Picked', style: AppTypography.sectionTitle),
+        ),
+        Text(
+          '$totalCount selected',
+          style: AppTypography.caption.copyWith(
+            color: AppColors.fgMuted,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class _SelectedDayHeader extends StatelessWidget {
   const _SelectedDayHeader({required this.state, required this.weekdayNames});
 
@@ -238,6 +272,14 @@ class _SelectedDayHeader extends StatelessWidget {
   }
 }
 
+/// Floating commit bar for the Map Meals Plan screen.
+///
+/// Per the Figma spec (frames 971:8375 → 971:8511) the CTA progresses
+/// through three states based on how many picked recipes are assigned:
+///
+/// * 0 assignments      → bar is hidden (frames 03/04 show no CTA at all)
+/// * 1..N-1 assignments → `Add (<remaining>)`
+/// * N == totalCount    → `Complete Mapping`
 class _CommitBar extends StatelessWidget {
   const _CommitBar({required this.state, required this.onCommit});
 
@@ -246,8 +288,14 @@ class _CommitBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hasAssignments = state.assignments.isNotEmpty;
-    final disabled = !hasAssignments || state.isCommitting;
+    final filled = state.filledCount;
+    final total = state.totalCount;
+    if (filled == 0) return const SizedBox.shrink();
+
+    final isComplete = filled >= total;
+    final label = isComplete ? 'Complete Mapping' : 'Add (${total - filled})';
+    final disabled = state.isCommitting;
+
     return SafeArea(
       top: false,
       child: Padding(
@@ -262,9 +310,7 @@ class _CommitBar extends StatelessWidget {
           height: AppSizes.buttonHeight,
           child: FilledButton(
             style: FilledButton.styleFrom(
-              backgroundColor: disabled
-                  ? AppColors.borderMuted
-                  : AppColors.greenDeep,
+              backgroundColor: AppColors.greenDeep,
               foregroundColor: AppColors.onGreen,
               disabledBackgroundColor: AppColors.borderMuted,
               disabledForegroundColor: AppColors.fgFaint,
@@ -282,7 +328,7 @@ class _CommitBar extends StatelessWidget {
                       color: AppColors.onGreen,
                     ),
                   )
-                : Text('Mapp Meal Plan', style: AppTypography.button),
+                : Text(label, style: AppTypography.button),
           ),
         ),
       ),

--- a/lib/src/features/meal_plan/map/map_meals_state.dart
+++ b/lib/src/features/meal_plan/map/map_meals_state.dart
@@ -52,5 +52,13 @@ class MapMealsState with _$MapMealsState {
     return pickedRecipes.where((r) => ids.contains(r.id)).toList();
   }
 
+  /// Set of days (date-only) that have at least one assignment — drives
+  /// the day-chip "Filled" variant (frame 971:8441).
+  Set<DateTime> filledDays() {
+    return assignments.values
+        .map((d) => DateTime(d.year, d.month, d.day))
+        .toSet();
+  }
+
   static String _dateKey(DateTime dt) => '${dt.year}-${dt.month}-${dt.day}';
 }

--- a/lib/src/features/meal_plan/map/widgets/day_chip_row.dart
+++ b/lib/src/features/meal_plan/map/widgets/day_chip_row.dart
@@ -5,15 +5,19 @@ import 'package:nibbles/src/app/themes/app_typography.dart';
 
 /// Horizontal day chip row for the Map Meals Plan screen (NIB-95).
 ///
-/// Renders one chip per day in `[startDate, endDate]`. Selected chip uses
-/// [AppColors.greenDeep]; unselected chips show the day abbreviation and
-/// numeric date in muted text on cream.
+/// Renders one chip per day in `[startDate, endDate]`. Each chip renders
+/// in one of three states (Figma frame 971:8441 / CalendarPerday):
+///
+/// * Selected (current chip)        — forestdarkn bg / cream text
+/// * Filled (has any assigned meal) — cream bg / forestdarkn text + check
+/// * Not-selected                   — white bg / forestdarkn text
 class DayChipRow extends StatelessWidget {
   const DayChipRow({
     required this.startDate,
     required this.endDate,
     required this.selectedDay,
     required this.onSelect,
+    this.filledDays = const <DateTime>{},
     super.key,
   });
 
@@ -21,6 +25,10 @@ class DayChipRow extends StatelessWidget {
   final DateTime endDate;
   final DateTime selectedDay;
   final ValueChanged<DateTime> onSelect;
+
+  /// Set of days (date-only) that have at least one assigned meal — used
+  /// to render the "Filled" chip variant.
+  final Set<DateTime> filledDays;
 
   static const _weekdayAbbrev = <int, String>{
     DateTime.monday: 'Mon',
@@ -32,6 +40,21 @@ class DayChipRow extends StatelessWidget {
     DateTime.sunday: 'Sun',
   };
 
+  static const _monthAbbrev = <int, String>{
+    1: 'Jan',
+    2: 'Feb',
+    3: 'Mar',
+    4: 'Apr',
+    5: 'May',
+    6: 'Jun',
+    7: 'Jul',
+    8: 'Aug',
+    9: 'Sep',
+    10: 'Oct',
+    11: 'Nov',
+    12: 'Dec',
+  };
+
   List<DateTime> _days() {
     final start = DateTime(startDate.year, startDate.month, startDate.day);
     final end = DateTime(endDate.year, endDate.month, endDate.day);
@@ -39,7 +62,7 @@ class DayChipRow extends StatelessWidget {
     return List<DateTime>.generate(count, (i) => start.add(Duration(days: i)));
   }
 
-  bool _isSameDay(DateTime a, DateTime b) =>
+  static bool _isSameDay(DateTime a, DateTime b) =>
       a.year == b.year && a.month == b.month && a.day == b.day;
 
   @override
@@ -55,9 +78,12 @@ class DayChipRow extends StatelessWidget {
         itemBuilder: (context, index) {
           final day = days[index];
           final isSelected = _isSameDay(day, selectedDay);
+          final isFilled =
+              filledDays.any((d) => _isSameDay(d, day));
           return _DayChip(
             day: day,
             isSelected: isSelected,
+            isFilled: isFilled,
             onTap: () => onSelect(day),
           );
         },
@@ -70,19 +96,36 @@ class _DayChip extends StatelessWidget {
   const _DayChip({
     required this.day,
     required this.isSelected,
+    required this.isFilled,
     required this.onTap,
   });
 
   final DateTime day;
   final bool isSelected;
+  final bool isFilled;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final abbrev = DayChipRow._weekdayAbbrev[day.weekday] ?? '';
-    final bg = isSelected ? AppColors.greenDeep : AppColors.surface;
-    final fg = isSelected ? AppColors.onGreen : AppColors.fgDefault;
-    final borderColor = isSelected ? AppColors.greenDeep : AppColors.borderSoft;
+    final monthAbbrev = DayChipRow._monthAbbrev[day.month] ?? '';
+
+    final Color bg;
+    final Color fg;
+    final Color borderColor;
+    if (isSelected) {
+      bg = AppColors.greenDeep;
+      fg = AppColors.onGreen;
+      borderColor = AppColors.greenDeep;
+    } else if (isFilled) {
+      bg = AppColors.butterSoft;
+      fg = AppColors.greenDeep;
+      borderColor = AppColors.greenDeep;
+    } else {
+      bg = AppColors.surface;
+      fg = AppColors.fgDefault;
+      borderColor = AppColors.borderSoft;
+    }
 
     return GestureDetector(
       onTap: onTap,
@@ -94,12 +137,19 @@ class _DayChip extends StatelessWidget {
           border: Border.all(color: borderColor),
         ),
         padding: const EdgeInsets.symmetric(
-          vertical: AppSizes.sp12,
-          horizontal: AppSizes.sm,
+          vertical: AppSizes.sm,
+          horizontal: AppSizes.xs,
         ),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
           children: [
+            if (isFilled && !isSelected)
+              Icon(
+                Icons.check,
+                color: fg,
+                size: AppSizes.iconSm,
+              ),
             Text(
               abbrev,
               style: AppTypography.caption.copyWith(
@@ -107,10 +157,13 @@ class _DayChip extends StatelessWidget {
                 fontWeight: FontWeight.w600,
               ),
             ),
-            const SizedBox(height: AppSizes.xs),
             Text(
-              '${day.day}',
-              style: AppTypography.sectionTitle.copyWith(color: fg),
+              '${day.day} $monthAbbrev',
+              style: AppTypography.caption.copyWith(
+                color: fg,
+                fontWeight: FontWeight.w700,
+                fontSize: 12,
+              ),
             ),
           ],
         ),

--- a/lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart
+++ b/lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart
@@ -1,14 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/constants/allergen_emoji.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 
+/// Verbatim helper line under "Meals for {Day} (X/Y)" — see Figma frames
+/// 971:8375 (inside the empty placeholder) and 971:8476 (above the
+/// populated container).
+const _kHelperText = 'Drag & drop or click meals below to add them';
+
 /// "Meals for {Day}" panel for the Map Meals Plan screen (NIB-95).
 ///
-/// Shows the recipes currently assigned to the selected day. If empty,
-/// renders the dashed "No Meals Mapped Yet" placeholder. Each assigned
-/// row exposes a remove button that unassigns the recipe.
+/// * Empty: dashed-border placeholder card containing
+///   "No Meals Mapped Yet" + a Drag-&-drop helper line (frame 971:8375).
+/// * Populated: cream-tinted dashed container holding one row per
+///   assigned recipe (thumbnail + title + allergen tags + delete_outline
+///   to unassign) — see frames 971:8476 / 971:8511.
 class SelectedDaySlotList extends StatelessWidget {
   const SelectedDaySlotList({
     required this.recipes,
@@ -24,23 +32,54 @@ class SelectedDaySlotList extends StatelessWidget {
     if (recipes.isEmpty) {
       return const _EmptyDayPlaceholder();
     }
+    return _PopulatedDayContainer(recipes: recipes, onRemove: onRemove);
+  }
+}
 
-    return Column(
-      children: [
-        for (var i = 0; i < recipes.length; i++) ...[
-          if (i != 0) const SizedBox(height: AppSizes.sm),
-          _AssignedRow(
-            recipe: recipes[i],
-            onRemove: () => onRemove(recipes[i].id),
-          ),
-        ],
-      ],
+/// Cream-tinted dashed container holding the assigned recipe rows.
+class _PopulatedDayContainer extends StatelessWidget {
+  const _PopulatedDayContainer({
+    required this.recipes,
+    required this.onRemove,
+  });
+
+  final List<Recipe> recipes;
+  final ValueChanged<String> onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: const _DashedBorderPainter(),
+      child: Container(
+        width: double.infinity,
+        decoration: BoxDecoration(
+          color: AppColors.butterSoft,
+          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        ),
+        padding: const EdgeInsets.all(AppSizes.sp12),
+        child: Column(
+          children: [
+            for (var i = 0; i < recipes.length; i++) ...[
+              if (i != 0) const SizedBox(height: AppSizes.sm),
+              _AssignedRecipeCard(
+                recipe: recipes[i],
+                onRemove: () => onRemove(recipes[i].id),
+              ),
+            ],
+          ],
+        ),
+      ),
     );
   }
 }
 
-class _AssignedRow extends StatelessWidget {
-  const _AssignedRow({required this.recipe, required this.onRemove});
+/// Recipe card displayed inside a filled day slot.
+///
+/// Mirrors the Figma frame 971:8476 layout — thumbnail, two-line title,
+/// allergen tag chips, and a trailing `delete_outline` icon that
+/// unassigns the recipe.
+class _AssignedRecipeCard extends StatelessWidget {
+  const _AssignedRecipeCard({required this.recipe, required this.onRemove});
 
   final Recipe recipe;
   final VoidCallback onRemove;
@@ -48,45 +87,115 @@ class _AssignedRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.sp12,
-        vertical: AppSizes.sp12,
-      ),
+      padding: const EdgeInsets.all(AppSizes.sp12),
       decoration: BoxDecoration(
-        color: AppColors.greenTint,
+        color: AppColors.surface,
         borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-        border: Border.all(color: AppColors.green),
       ),
       child: Row(
         children: [
-          const Icon(
-            Icons.check_circle,
-            color: AppColors.greenDeep,
-            size: AppSizes.iconMd,
-          ),
-          const SizedBox(width: AppSizes.sm),
+          _Thumbnail(url: recipe.thumbnailUrl),
+          const SizedBox(width: AppSizes.sp12),
           Expanded(
-            child: Text(
-              recipe.title,
-              style: AppTypography.bodyBold.copyWith(
-                color: AppColors.greenDeep,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  recipe.title,
+                  style: AppTypography.bodyBold,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (recipe.allergenTags.isNotEmpty) ...[
+                  const SizedBox(height: AppSizes.xs),
+                  _TagsRow(tags: recipe.allergenTags),
+                ],
+              ],
             ),
           ),
+          const SizedBox(width: AppSizes.sm),
           IconButton(
             onPressed: onRemove,
             icon: const Icon(
-              Icons.close,
-              color: AppColors.greenDeep,
-              size: AppSizes.iconSm,
+              Icons.delete_outline,
+              color: AppColors.fgMuted,
+              size: AppSizes.iconMd,
             ),
             visualDensity: VisualDensity.compact,
             splashRadius: AppSizes.iconMd,
           ),
         ],
       ),
+    );
+  }
+}
+
+class _Thumbnail extends StatelessWidget {
+  const _Thumbnail({required this.url});
+
+  final String? url;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      child: Container(
+        width: AppSizes.iconXl,
+        height: AppSizes.iconXl,
+        color: AppColors.surfaceVariant,
+        child: url == null
+            ? const Icon(
+                Icons.restaurant,
+                color: AppColors.fgFaint,
+                size: AppSizes.iconMd,
+              )
+            : Image.network(
+                url!,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => const Icon(
+                  Icons.restaurant,
+                  color: AppColors.fgFaint,
+                  size: AppSizes.iconMd,
+                ),
+              ),
+      ),
+    );
+  }
+}
+
+class _TagsRow extends StatelessWidget {
+  const _TagsRow({required this.tags});
+
+  final List<String> tags;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: AppSizes.xs,
+      runSpacing: AppSizes.xs,
+      children: tags
+          .take(3)
+          .map(
+            (t) => Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.sm,
+                vertical: 2,
+              ),
+              decoration: BoxDecoration(
+                color: AppColors.coralSoft,
+                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              ),
+              child: Text(
+                '${AllergenEmoji.get(t)} ${t.replaceAll('_', ' ')}',
+                style: AppTypography.caption.copyWith(
+                  color: AppColors.coralDeep,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          )
+          .toList(),
     );
   }
 }
@@ -104,10 +213,19 @@ class _EmptyDayPlaceholder extends StatelessWidget {
           horizontal: AppSizes.md,
           vertical: AppSizes.lg,
         ),
-        alignment: Alignment.center,
-        child: Text(
-          'No Meals Mapped Yet',
-          style: AppTypography.bodyBold.copyWith(color: AppColors.fgMuted),
+        child: Column(
+          children: [
+            Text(
+              'No Meals Mapped Yet',
+              style: AppTypography.bodyBold.copyWith(color: AppColors.fgMuted),
+            ),
+            const SizedBox(height: AppSizes.sm),
+            Text(
+              _kHelperText,
+              textAlign: TextAlign.center,
+              style: AppTypography.caption.copyWith(color: AppColors.fgMuted),
+            ),
+          ],
         ),
       ),
     );

--- a/test/features/meal_plan/map/map_meals_screen_test.dart
+++ b/test/features/meal_plan/map/map_meals_screen_test.dart
@@ -156,18 +156,42 @@ void main() {
     });
 
     testWidgets(
-      '"Mapp Meal Plan" CTA is disabled until at least 1 assignment exists',
+      'floating CTA is absent with 0 assignments, says "Add (N)" while '
+      'partial, and "Complete Mapping" once every picked recipe is assigned',
       (tester) async {
         await pumpMap(tester);
 
-        final cta = find.widgetWithText(FilledButton, 'Mapp Meal Plan');
-        expect(cta, findsOneWidget);
-        expect(tester.widget<FilledButton>(cta).onPressed, isNull);
+        // 0 assignments → no CTA rendered at all.
+        expect(find.byType(FilledButton), findsNothing);
 
+        // 1 of 2 assigned → "Add (1)".
         await tester.tap(find.text(_recipeA.title));
         await tester.pumpAndSettle();
+        expect(
+          find.widgetWithText(FilledButton, 'Add (1)'),
+          findsOneWidget,
+        );
 
-        expect(tester.widget<FilledButton>(cta).onPressed, isNotNull);
+        // 2 of 2 assigned → "Complete Mapping".
+        await tester.tap(find.text(_recipeB.title));
+        await tester.pumpAndSettle();
+        expect(
+          find.widgetWithText(FilledButton, 'Complete Mapping'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'empty selected-day shows "No Meals Mapped Yet" + drag-drop helper text',
+      (tester) async {
+        await pumpMap(tester);
+
+        expect(find.text('No Meals Mapped Yet'), findsOneWidget);
+        expect(
+          find.text('Drag & drop or click meals below to add them'),
+          findsOneWidget,
+        );
       },
     );
 
@@ -230,11 +254,13 @@ void main() {
       await tester.tap(find.text('Push'));
       await tester.pumpAndSettle();
 
-      // Assign one recipe + commit.
+      // Assign both recipes (so the CTA says "Complete Mapping") + commit.
       await tester.tap(find.text(_recipeA.title));
       await tester.pumpAndSettle();
+      await tester.tap(find.text(_recipeB.title));
+      await tester.pumpAndSettle();
       await tester.tap(
-        find.widgetWithText(FilledButton, 'Mapp Meal Plan'),
+        find.widgetWithText(FilledButton, 'Complete Mapping'),
       );
       await tester.pumpAndSettle();
 
@@ -262,8 +288,10 @@ void main() {
 
         await tester.tap(find.text(_recipeA.title));
         await tester.pumpAndSettle();
+        await tester.tap(find.text(_recipeB.title));
+        await tester.pumpAndSettle();
         await tester.tap(
-          find.widgetWithText(FilledButton, 'Mapp Meal Plan'),
+          find.widgetWithText(FilledButton, 'Complete Mapping'),
         );
         await tester.pumpAndSettle();
 


### PR DESCRIPTION
Spec-conformance pass on the Map Meals Plan screen (NIB-95). The screen was already merged via PR #173 — this PR closes the remaining gaps against the Figma audit artifacts.

## Acceptance criteria
- [x] Verbatim copy for static strings (Map Meals Plan, Meals for {Day} (X/Y), No Meals Mapped Yet, Drag & drop helper, Meals Picked, floating CTA labels per state).
- [x] X of Y slots filled is dynamic (filled / pickedRecipes.length).
- [x] Day chips render Selected / Not-selected / Filled and switch on tap.
- [x] Slot container shows dashed-empty / cream-highlight populated visuals.
- [x] Delete affordance removes the meal and returns it to Meals Picked.
- [x] Floating CTA: absent at 0 → Add (N) while partial → Complete Mapping when every picked recipe is assigned; commits range to meal_plan_entries.
- [x] All tokens consumed from the design system; no hardcoded hex outside the foundation.
- [x] flutter analyze clean for the modified files; widget tests cover empty-day / partial / complete CTA states + helper copy.

## Figma frames
- 971:8375 (empty selected day)
- 971:8409 (1 of 2 filled)
- 971:8441 (multi-day partial, floating Add (N))
- 971:8476 (one filled with delete affordance)
- 971:8511 (day full, Complete Mapping)

## Audit reports
- .figma-audit/meal-plan/meal-prep-mapper-03-meal-planner-generated/report.md
- .figma-audit/meal-plan/meal-prep-mapper-04-meal-planner-generated/report.md
- .figma-audit/meal-plan/meal-prep-mapper-05-meal-planner-generated/report.md
- .figma-audit/meal-plan/meal-prep-mapper-06-meal-planner-generated/report.md
- .figma-audit/meal-plan/meal-prep-mapper-07-meal-planner-generated/report.md