### PR TITLE
feat(meal-plan): range-scoped Add to Shoplist sheet [NIB-136]

### DIFF
--- a/lib/src/common/services/meal_plan_service.dart
+++ b/lib/src/common/services/meal_plan_service.dart
@@ -166,6 +166,45 @@ class MealPlanService {
     return Result.success(names.toList());
   }
 
+  /// NIB-136: range-scoped ingredient aggregation for the
+  /// "Add to Shoplist" sheet launched from the screen-level overflow menu.
+  ///
+  /// Walks every meal-plan entry whose `planDate` falls inside
+  /// `[startDate, endDate]`, expands them into recipe ingredients, and
+  /// returns a list of unique ingredient names. Dedup is case-insensitive
+  /// (e.g. "olive oil" and "Olive Oil" collapse to one) but the display
+  /// casing of the first occurrence is preserved.
+  ///
+  /// Individual recipe fetch failures are skipped (best-effort); only a
+  /// failure to fetch the range's meal plan propagates as [Result.failure].
+  Future<Result<List<String>>> getRangeIngredientNames(
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
+  ) async {
+    final mealsResult = await _repo.getEntriesInRange(
+      babyId,
+      _dateOnly(startDate),
+      _dateOnly(endDate),
+    );
+    if (mealsResult.isFailure) {
+      return Result.failure(mealsResult.errorOrNull!);
+    }
+
+    final seenKeys = <String>{};
+    final names = <String>[];
+    for (final entry in mealsResult.dataOrNull!) {
+      final recipeResult = await _recipeRepo.getRecipeById(entry.recipeId);
+      if (recipeResult.isFailure) continue;
+      for (final ingredient in recipeResult.dataOrNull!.ingredients) {
+        final key = ingredient.name.toLowerCase();
+        if (seenKeys.add(key)) names.add(ingredient.name);
+      }
+    }
+
+    return Result.success(names);
+  }
+
   /// Deletes a single meal plan entry by ID.
   Future<Result<void>> removeEntry(String entryId) =>
       _repo.removeEntry(entryId);

--- a/lib/src/common/services/shopping_list_service.dart
+++ b/lib/src/common/services/shopping_list_service.dart
@@ -36,6 +36,30 @@ class ShoppingListService {
     return _repo.addItems(items);
   }
 
+  /// NIB-136: Adds ingredient names sourced from the meal-plan
+  /// "Add to Shoplist" range sheet. Same name-only insert as
+  /// [addFromRecipe], but tags rows with `source=mealPlan` so the
+  /// shopping list can attribute their origin.
+  Future<Result<void>> addFromMealPlan(
+    String babyId,
+    List<String> selectedIngredientNames,
+  ) {
+    final now = DateTime.now();
+    final items = selectedIngredientNames
+        .map(
+          (name) => ShoppingListItem(
+            id: '',
+            babyId: babyId,
+            name: name,
+            isChecked: false,
+            source: ShoppingListSource.mealPlan,
+            createdAt: now,
+          ),
+        )
+        .toList();
+    return _repo.addItems(items);
+  }
+
   /// Adds a single manually-entered item.
   Future<Result<void>> addManualItem(String babyId, String name) =>
       _repo.addItems([

--- a/lib/src/features/meal_plan/meal_plan_screen.dart
+++ b/lib/src/features/meal_plan/meal_plan_screen.dart
@@ -22,6 +22,7 @@ import 'package:nibbles/src/features/meal_plan/widgets/clear_confirm_dialog.dart
 import 'package:nibbles/src/features/meal_plan/widgets/day_accordion_card.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_empty_state.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_header.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/range_add_to_shoplist_sheet.dart';
 import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 import 'package:nibbles/src/utils/age_in_months.dart';
@@ -272,7 +273,7 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
                 .inDays +
             1;
         unawaited(analytics.logMealPlanAddToShopList(dayCount: dayCount));
-        await _openAddToShoppingList(state.windowStart);
+        await _openRangeAddToShoplist(start, end);
       case _ScreenMenuAction.createMealPrep:
         unawaited(analytics.logMealPrepCreateStarted());
         await _onCreateMealPrep(state);
@@ -362,6 +363,16 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
         ),
       ),
       builder: (_) => AddToShoppingListModal(babyId: widget.babyId, date: date),
+    );
+  }
+
+  /// NIB-136: range-scoped sheet from the screen-level overflow menu.
+  Future<void> _openRangeAddToShoplist(DateTime start, DateTime end) async {
+    await showRangeAddToShoplistSheet(
+      context,
+      babyId: widget.babyId,
+      startDate: start,
+      endDate: end,
     );
   }
 

--- a/lib/src/features/meal_plan/widgets/range_add_to_shoplist_sheet.dart
+++ b/lib/src/features/meal_plan/widgets/range_add_to_shoplist_sheet.dart
@@ -1,0 +1,493 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:nibbles/src/common/services/shopping_list_service.dart';
+
+/// NIB-136: range-scoped "Add to Shoplist" bottom sheet (Figma 971:7850 /
+/// 971:7924). Aggregates de-duplicated ingredient names across every recipe
+/// planned inside `[startDate, endDate]` and lets the user toggle which ones
+/// land in the shopping list with `source=mealPlan`.
+///
+/// Launched from the meal-planner screen-level overflow menu. The per-day
+/// overflow continues to use the day-scoped `AddToShoppingListModal`.
+class RangeAddToShoplistSheet extends ConsumerStatefulWidget {
+  const RangeAddToShoplistSheet({
+    required this.babyId,
+    required this.startDate,
+    required this.endDate,
+    super.key,
+  });
+
+  final String babyId;
+  final DateTime startDate;
+  final DateTime endDate;
+
+  @override
+  ConsumerState<RangeAddToShoplistSheet> createState() =>
+      _RangeAddToShoplistSheetState();
+}
+
+class _RangeAddToShoplistSheetState
+    extends ConsumerState<RangeAddToShoplistSheet> {
+  static const _weekdayShort = <String>[
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat',
+    'Sun',
+  ];
+
+  static const _monthLong = <String>[
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+
+  List<String>? _ingredients;
+  Set<String> _selected = <String>{};
+  bool _loading = true;
+  bool _submitting = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadIngredients();
+  }
+
+  Future<void> _loadIngredients() async {
+    final result = await ref
+        .read(mealPlanServiceProvider)
+        .getRangeIngredientNames(
+          widget.babyId,
+          widget.startDate,
+          widget.endDate,
+        );
+    if (!mounted) return;
+    if (result.isFailure) {
+      setState(() {
+        _error = 'Could not load ingredients.';
+        _loading = false;
+      });
+      return;
+    }
+    final items = result.dataOrNull ?? <String>[];
+    setState(() {
+      _ingredients = items;
+      _selected = items.toSet();
+      _loading = false;
+    });
+  }
+
+  void _toggle(String name) {
+    setState(() {
+      if (_selected.contains(name)) {
+        _selected = {..._selected}..remove(name);
+      } else {
+        _selected = {..._selected, name};
+      }
+    });
+  }
+
+  void _toggleAll() {
+    final items = _ingredients;
+    if (items == null || items.isEmpty) return;
+    setState(() {
+      _selected = _selected.isEmpty ? items.toSet() : <String>{};
+    });
+  }
+
+  Future<void> _submit() async {
+    final selected = _ingredients
+        ?.where(_selected.contains)
+        .toList(growable: false);
+    if (selected == null || selected.isEmpty) return;
+
+    setState(() => _submitting = true);
+    final result = await ref
+        .read(shoppingListServiceProvider)
+        .addFromMealPlan(widget.babyId, selected);
+    if (!mounted) return;
+    setState(() => _submitting = false);
+
+    final messenger = ScaffoldMessenger.of(context);
+    if (result.isFailure) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text("Couldn't add items. Try again.")),
+      );
+      return;
+    }
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Added to shopping list.')),
+    );
+    Navigator.of(context).pop(true);
+  }
+
+  /// Spec format: `Mon, 20 - Thu 23 April` (Figma 971:7908). Comma only
+  /// after the start weekday; month name appears once at the end.
+  String _dateRangeLabel() {
+    final start = widget.startDate;
+    final end = widget.endDate;
+    final startDow = _weekdayShort[start.weekday - 1];
+    final endDow = _weekdayShort[end.weekday - 1];
+    final endMonth = _monthLong[end.month - 1];
+    return '$startDow, ${start.day} - $endDow ${end.day} $endMonth';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      initialChildSize: 0.85,
+      minChildSize: 0.5,
+      maxChildSize: 0.95,
+      expand: false,
+      builder: (context, scrollController) {
+        return DecoratedBox(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              stops: [0.19, 0.50],
+              colors: [AppColors.butterSoft, Color(0xFFF5F5F5)],
+            ),
+            borderRadius: BorderRadius.vertical(
+              top: Radius.circular(AppSizes.xl - 2),
+            ),
+          ),
+          child: SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.sp12,
+                AppSizes.lg,
+                AppSizes.sp12,
+                AppSizes.md,
+              ),
+              child: Column(
+                children: [
+                  _Header(
+                    title: 'Add to Shoplist',
+                    subtitle: _dateRangeLabel(),
+                    onClose: () => Navigator.of(context).pop(),
+                  ),
+                  const SizedBox(height: AppSizes.sp12),
+                  Expanded(child: _buildList(scrollController)),
+                  if (!_loading && _error == null)
+                    _BottomActions(
+                      anySelected: _selected.isNotEmpty,
+                      selectedCount: _selected.length,
+                      submitting: _submitting,
+                      onToggleAll: _toggleAll,
+                      onSubmit: _submit,
+                    ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildList(ScrollController controller) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSizes.md),
+          child: Text(
+            _error!,
+            style: AppTypography.textTheme.bodyLarge?.copyWith(
+              color: AppColors.fgMuted,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+    final items = _ingredients!;
+    if (items.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSizes.md),
+          child: Text(
+            'No ingredients yet.',
+            style: AppTypography.textTheme.bodyLarge?.copyWith(
+              color: AppColors.fgMuted,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+    return ListView.separated(
+      controller: controller,
+      padding: EdgeInsets.zero,
+      itemCount: items.length,
+      separatorBuilder: (_, __) => const SizedBox(height: AppSizes.sp12),
+      itemBuilder: (context, index) {
+        final name = items[index];
+        return _IngredientRow(
+          name: name,
+          selected: _selected.contains(name),
+          onTap: () => _toggle(name),
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Header — title + subtitle (date range) + close button
+// ---------------------------------------------------------------------------
+
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.title,
+    required this.subtitle,
+    required this.onClose,
+  });
+
+  final String title;
+  final String subtitle;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                title,
+                style: AppTypography.textTheme.titleSmall?.copyWith(
+                  color: AppColors.text,
+                ),
+              ),
+              const SizedBox(height: AppSizes.xs),
+              Text(
+                subtitle,
+                style: AppTypography.textTheme.bodyMedium?.copyWith(
+                  color: AppColors.text,
+                ),
+              ),
+            ],
+          ),
+        ),
+        InkWell(
+          onTap: onClose,
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          child: const Padding(
+            padding: EdgeInsets.all(AppSizes.sm),
+            child: Icon(
+              Icons.close,
+              size: AppSizes.iconSm + 8,
+              color: AppColors.text,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ingredient row — full-width tappable card with checkbox + name + close X
+// ---------------------------------------------------------------------------
+
+class _IngredientRow extends StatelessWidget {
+  const _IngredientRow({
+    required this.name,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String name;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        child: Container(
+          padding: const EdgeInsets.all(AppSizes.sp12),
+          decoration: BoxDecoration(
+            color: selected ? AppColors.butter : AppColors.cream,
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          ),
+          child: Row(
+            children: [
+              _CheckboxIcon(checked: selected),
+              const SizedBox(width: AppSizes.sp12),
+              Expanded(
+                child: Text(
+                  name,
+                  style: AppTypography.textTheme.bodyLarge?.copyWith(
+                    color: AppColors.text,
+                  ),
+                ),
+              ),
+              const Padding(
+                padding: EdgeInsets.only(left: AppSizes.sm),
+                child: Icon(
+                  Icons.close,
+                  size: 18,
+                  color: AppColors.burgundy,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CheckboxIcon extends StatelessWidget {
+  const _CheckboxIcon({required this.checked});
+
+  final bool checked;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(
+      checked ? Icons.check_box : Icons.check_box_outline_blank,
+      size: 18,
+      color: AppColors.greenDeep,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bottom actions — outlined toggle on left, filled Add on right
+// ---------------------------------------------------------------------------
+
+class _BottomActions extends StatelessWidget {
+  const _BottomActions({
+    required this.anySelected,
+    required this.selectedCount,
+    required this.submitting,
+    required this.onToggleAll,
+    required this.onSubmit,
+  });
+
+  final bool anySelected;
+  final int selectedCount;
+  final bool submitting;
+  final VoidCallback onToggleAll;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    final toggleLabel = anySelected ? 'Unselect All' : 'Select All';
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.sm,
+        AppSizes.md,
+        AppSizes.sm,
+        AppSizes.sm,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton(
+              onPressed: submitting ? null : onToggleAll,
+              style: OutlinedButton.styleFrom(
+                minimumSize: const Size.fromHeight(AppSizes.xxl),
+                side: const BorderSide(color: AppColors.greenDeep),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(AppSizes.radius2xl),
+                ),
+                foregroundColor: AppColors.greenDeep,
+              ),
+              child: Text(
+                toggleLabel,
+                style: AppTypography.textTheme.bodyLarge?.copyWith(
+                  color: AppColors.greenDeep,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: FilledButton(
+              onPressed: anySelected && !submitting ? onSubmit : null,
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(AppSizes.xxl),
+                backgroundColor: AppColors.greenDeep,
+                disabledBackgroundColor: AppColors.greenDeep.withValues(
+                  alpha: 0.5,
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(AppSizes.radius2xl),
+                ),
+              ),
+              child: submitting
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: AppColors.onGreen,
+                      ),
+                    )
+                  : Text(
+                      'Add ($selectedCount)',
+                      style: AppTypography.textTheme.bodyLarge?.copyWith(
+                        color: AppColors.onGreen,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Helper that opens [RangeAddToShoplistSheet] as a modal bottom sheet.
+/// Returns `true` if the user confirmed an add; `null` on dismiss.
+Future<bool?> showRangeAddToShoplistSheet(
+  BuildContext context, {
+  required String babyId,
+  required DateTime startDate,
+  required DateTime endDate,
+}) {
+  return showModalBottomSheet<bool>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: Colors.black.withValues(alpha: 0.5),
+    builder: (_) => RangeAddToShoplistSheet(
+      babyId: babyId,
+      startDate: startDate,
+      endDate: endDate,
+    ),
+  );
+}

--- a/test/common/services/meal_plan_service_test.dart
+++ b/test/common/services/meal_plan_service_test.dart
@@ -212,6 +212,150 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // NIB-136: getRangeIngredientNames
+  // ---------------------------------------------------------------------------
+
+  group('MealPlanService.getRangeIngredientNames', () {
+    final rangeStart = DateTime(2026, 4, 20);
+    final rangeEnd = DateTime(2026, 4, 23);
+
+    test(
+      'normalizes range to date-only and queries repo via getEntriesInRange',
+      () async {
+        final start = DateTime(2026, 4, 20, 9, 30);
+        final end = DateTime(2026, 4, 23, 23, 59);
+        when(
+          () => mockMealPlanRepo.getEntriesInRange(any(), any(), any()),
+        ).thenAnswer((_) async => const Result.success([]));
+
+        await sut.getRangeIngredientNames(_babyId, start, end);
+
+        verify(
+          () => mockMealPlanRepo.getEntriesInRange(
+            _babyId,
+            DateTime(2026, 4, 20),
+            DateTime(2026, 4, 23),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'deduplicates case-insensitively, preserves first-occurrence casing',
+      () async {
+        when(
+          () => mockMealPlanRepo.getEntriesInRange(any(), any(), any()),
+        ).thenAnswer(
+          (_) async => Result.success([
+            _makeEntry(),
+            _makeEntry(id: 'e2', recipeId: 'r2'),
+          ]),
+        );
+        when(() => mockRecipeRepo.getRecipeById('r1')).thenAnswer(
+          (_) async => Result.success(
+            _makeRecipe(
+              ingredients: [
+                const Ingredient(name: 'Olive Oil', quantity: '1 tbsp'),
+                const Ingredient(name: 'Rice', quantity: '1 cup'),
+              ],
+            ),
+          ),
+        );
+        when(() => mockRecipeRepo.getRecipeById('r2')).thenAnswer(
+          (_) async => Result.success(
+            _makeRecipe(
+              id: 'r2',
+              ingredients: [
+                // Different casing — should collapse into the first occurrence.
+                const Ingredient(name: 'rice', quantity: '2 cups'),
+                const Ingredient(name: 'OLIVE OIL', quantity: '2 tbsp'),
+                const Ingredient(name: 'Sugar', quantity: '1 tsp'),
+              ],
+            ),
+          ),
+        );
+
+        final result = await sut.getRangeIngredientNames(
+          _babyId,
+          rangeStart,
+          rangeEnd,
+        );
+
+        expect(result.isSuccess, isTrue);
+        final names = result.dataOrNull!;
+        // First-occurrence casing preserved; dedup case-insensitive.
+        expect(names, equals(['Olive Oil', 'Rice', 'Sugar']));
+      },
+    );
+
+    test('skips failed recipe fetch (best-effort)', () async {
+      when(
+        () => mockMealPlanRepo.getEntriesInRange(any(), any(), any()),
+      ).thenAnswer(
+        (_) async => Result.success([
+          _makeEntry(),
+          _makeEntry(id: 'e2', recipeId: 'r2'),
+        ]),
+      );
+      when(() => mockRecipeRepo.getRecipeById('r1')).thenAnswer(
+        (_) async => const Result.failure(ServerException('not found')),
+      );
+      when(() => mockRecipeRepo.getRecipeById('r2')).thenAnswer(
+        (_) async => Result.success(
+          _makeRecipe(
+            id: 'r2',
+            ingredients: [
+              const Ingredient(name: 'Bread', quantity: '2 slices'),
+            ],
+          ),
+        ),
+      );
+
+      final result = await sut.getRangeIngredientNames(
+        _babyId,
+        rangeStart,
+        rangeEnd,
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.dataOrNull, equals(['Bread']));
+    });
+
+    test('getEntriesInRange failure propagates without recipe fetches',
+        () async {
+      when(
+        () => mockMealPlanRepo.getEntriesInRange(any(), any(), any()),
+      ).thenAnswer(
+        (_) async => const Result.failure(ServerException('DB error')),
+      );
+
+      final result = await sut.getRangeIngredientNames(
+        _babyId,
+        rangeStart,
+        rangeEnd,
+      );
+
+      expect(result.isFailure, isTrue);
+      verifyNever(() => mockRecipeRepo.getRecipeById(any()));
+    });
+
+    test('empty range returns empty list', () async {
+      when(
+        () => mockMealPlanRepo.getEntriesInRange(any(), any(), any()),
+      ).thenAnswer((_) async => const Result.success([]));
+
+      final result = await sut.getRangeIngredientNames(
+        _babyId,
+        rangeStart,
+        rangeEnd,
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.dataOrNull, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // NIB-59: getRolling7
   // ---------------------------------------------------------------------------
 

--- a/test/common/services/shopping_list_service_test.dart
+++ b/test/common/services/shopping_list_service_test.dart
@@ -83,6 +83,46 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // NIB-136: addFromMealPlan
+  // ---------------------------------------------------------------------------
+
+  group('ShoppingListService.addFromMealPlan', () {
+    test(
+      'creates items with source=mealPlan, isChecked=false, id empty',
+      () async {
+        when(
+          () => mockRepo.addItems(any()),
+        ).thenAnswer((_) async => const Result.success(null));
+
+        await sut.addFromMealPlan(_babyId, ['Flour', 'Sugar', 'Butter']);
+
+        final captured =
+            verify(() => mockRepo.addItems(captureAny())).captured.single
+                as List<ShoppingListItem>;
+        expect(captured, hasLength(3));
+        expect(captured.map((i) => i.name).toList(),
+            equals(['Flour', 'Sugar', 'Butter']));
+        for (final item in captured) {
+          expect(item.source, ShoppingListSource.mealPlan);
+          expect(item.isChecked, isFalse);
+          expect(item.id, '');
+          expect(item.babyId, _babyId);
+        }
+      },
+    );
+
+    test('repo failure propagates', () async {
+      when(() => mockRepo.addItems(any())).thenAnswer(
+        (_) async => const Result.failure(ServerException('DB error')),
+      );
+
+      final result = await sut.addFromMealPlan(_babyId, ['Flour']);
+
+      expect(result.isFailure, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // addManualItem
   // ---------------------------------------------------------------------------
 

--- a/test/features/meal_plan/widgets/range_add_to_shoplist_sheet_test.dart
+++ b/test/features/meal_plan/widgets/range_add_to_shoplist_sheet_test.dart
@@ -1,0 +1,303 @@
+// NIB-136: widget tests for the range-scoped Add to Shoplist bottom sheet.
+//
+// Covers the two captured Figma states (shoplist-03 most-selected / -04 all
+// unselected), the Select All / Unselect All toggle, and the submit success
+// + failure paths.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:nibbles/src/common/services/shopping_list_service.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/range_add_to_shoplist_sheet.dart';
+
+class _MockMealPlanService extends Mock implements MealPlanService {}
+
+class _MockShoppingListService extends Mock implements ShoppingListService {}
+
+const _babyId = 'baby-001';
+final _start = DateTime(2026, 4, 20);
+final _end = DateTime(2026, 4, 23);
+
+const _ingredients = <String>[
+  'Flour',
+  'Sugar',
+  'Butter',
+  'Eggs',
+  'Baking Powder',
+  'Salt',
+];
+
+Future<void> _pumpSheet(
+  WidgetTester tester, {
+  required MealPlanService mealPlanService,
+  required ShoppingListService shoppingListService,
+}) async {
+  tester.view.physicalSize = const Size(1080, 2400);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        mealPlanServiceProvider.overrideWithValue(mealPlanService),
+        shoppingListServiceProvider.overrideWithValue(shoppingListService),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => showRangeAddToShoplistSheet(
+                  context,
+                  babyId: _babyId,
+                  startDate: _start,
+                  endDate: _end,
+                ),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('Open'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 350));
+}
+
+void main() {
+  late _MockMealPlanService mealPlanService;
+  late _MockShoppingListService shoppingListService;
+
+  setUpAll(() {
+    registerFallbackValue(<String>[]);
+    registerFallbackValue(DateTime(2026));
+  });
+
+  setUp(() {
+    mealPlanService = _MockMealPlanService();
+    shoppingListService = _MockShoppingListService();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Initial render — shoplist-03 baseline (all selected)
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'renders verbatim header, date range, and all ingredients selected '
+    '(shoplist-03 baseline)',
+    (tester) async {
+      when(
+        () => mealPlanService.getRangeIngredientNames(any(), any(), any()),
+      ).thenAnswer((_) async => const Result.success(_ingredients));
+
+      await _pumpSheet(
+        tester,
+        mealPlanService: mealPlanService,
+        shoppingListService: shoppingListService,
+      );
+
+      // Wait for async load to settle.
+      await tester.pump();
+
+      // Verbatim copy.
+      expect(find.text('Add to Shoplist'), findsOneWidget);
+      expect(find.text('Mon, 20 - Thu 23 April'), findsOneWidget);
+      // All ingredients visible.
+      for (final name in _ingredients) {
+        expect(find.text(name), findsOneWidget);
+      }
+      // Baseline = all selected → toggle reads "Unselect All", Add (N=count).
+      expect(find.text('Unselect All'), findsOneWidget);
+      expect(find.text('Add (${_ingredients.length})'), findsOneWidget);
+      // Range fetch invoked with the range bounds.
+      verify(
+        () =>
+            mealPlanService.getRangeIngredientNames(_babyId, _start, _end),
+      ).called(1);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // shoplist-04 — every ingredient unselected → 'Select All' toggle
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'tapping Unselect All clears every pill and CTA becomes Add (0) disabled '
+    '(shoplist-04 state)',
+    (tester) async {
+      when(
+        () => mealPlanService.getRangeIngredientNames(any(), any(), any()),
+      ).thenAnswer((_) async => const Result.success(_ingredients));
+
+      await _pumpSheet(
+        tester,
+        mealPlanService: mealPlanService,
+        shoppingListService: shoppingListService,
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('Unselect All'));
+      await tester.pump();
+
+      // After clearing: toggle flips to 'Select All', CTA count drops to 0.
+      expect(find.text('Select All'), findsOneWidget);
+      expect(find.text('Add (0)'), findsOneWidget);
+      // Add CTA is disabled when count is 0.
+      final addBtn = tester.widget<FilledButton>(
+        find.ancestor(
+          of: find.text('Add (0)'),
+          matching: find.byType(FilledButton),
+        ),
+      );
+      expect(addBtn.onPressed, isNull);
+    },
+  );
+
+  testWidgets(
+    'Select All re-selects every pill and CTA shows full count',
+    (tester) async {
+      when(
+        () => mealPlanService.getRangeIngredientNames(any(), any(), any()),
+      ).thenAnswer((_) async => const Result.success(_ingredients));
+
+      await _pumpSheet(
+        tester,
+        mealPlanService: mealPlanService,
+        shoppingListService: shoppingListService,
+      );
+      await tester.pump();
+
+      // Clear → re-select.
+      await tester.tap(find.text('Unselect All'));
+      await tester.pump();
+      await tester.tap(find.text('Select All'));
+      await tester.pump();
+
+      expect(find.text('Unselect All'), findsOneWidget);
+      expect(find.text('Add (${_ingredients.length})'), findsOneWidget);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Pill tap toggles selection — count updates dynamically
+  // ---------------------------------------------------------------------------
+
+  testWidgets('tapping a pill toggles its selection + decrements Add (N)',
+      (tester) async {
+    when(
+      () => mealPlanService.getRangeIngredientNames(any(), any(), any()),
+    ).thenAnswer((_) async => const Result.success(_ingredients));
+
+    await _pumpSheet(
+      tester,
+      mealPlanService: mealPlanService,
+      shoppingListService: shoppingListService,
+    );
+    await tester.pump();
+
+    expect(find.text('Add (${_ingredients.length})'), findsOneWidget);
+
+    await tester.tap(find.text('Flour'));
+    await tester.pump();
+
+    expect(find.text('Add (${_ingredients.length - 1})'), findsOneWidget);
+    // 'Unselect All' still shown — at least one selected.
+    expect(find.text('Unselect All'), findsOneWidget);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Submit success — pops sheet + shows P2 toast
+  // ---------------------------------------------------------------------------
+
+  testWidgets('submit success → calls addFromMealPlan, pops, shows P2 toast',
+      (tester) async {
+    when(
+      () => mealPlanService.getRangeIngredientNames(any(), any(), any()),
+    ).thenAnswer((_) async => const Result.success(_ingredients));
+    when(
+      () => shoppingListService.addFromMealPlan(any(), any()),
+    ).thenAnswer((_) async => const Result.success(null));
+
+    await _pumpSheet(
+      tester,
+      mealPlanService: mealPlanService,
+      shoppingListService: shoppingListService,
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('Add (${_ingredients.length})'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+
+    final captured =
+        verify(() => shoppingListService.addFromMealPlan(_babyId, captureAny()))
+            .captured
+            .single as List<String>;
+    expect(captured, equals(_ingredients));
+    expect(find.text('Added to shopping list.'), findsOneWidget);
+    expect(find.text('Add to Shoplist'), findsNothing);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Submit failure — sheet stays open, P2 error toast
+  // ---------------------------------------------------------------------------
+
+  testWidgets('submit failure → sheet stays open + shows error toast',
+      (tester) async {
+    when(
+      () => mealPlanService.getRangeIngredientNames(any(), any(), any()),
+    ).thenAnswer((_) async => const Result.success(_ingredients));
+    when(
+      () => shoppingListService.addFromMealPlan(any(), any()),
+    ).thenAnswer(
+      (_) async => const Result.failure(ServerException('DB error')),
+    );
+
+    await _pumpSheet(
+      tester,
+      mealPlanService: mealPlanService,
+      shoppingListService: shoppingListService,
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('Add (${_ingredients.length})'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(find.text("Couldn't add items. Try again."), findsOneWidget);
+    // Sheet remains open after failure.
+    expect(find.text('Add to Shoplist'), findsOneWidget);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Load failure — error inline + Add hidden
+  // ---------------------------------------------------------------------------
+
+  testWidgets('load failure → shows inline error and hides bottom actions',
+      (tester) async {
+    when(
+      () => mealPlanService.getRangeIngredientNames(any(), any(), any()),
+    ).thenAnswer(
+      (_) async => const Result.failure(ServerException('boom')),
+    );
+
+    await _pumpSheet(
+      tester,
+      mealPlanService: mealPlanService,
+      shoppingListService: shoppingListService,
+    );
+    await tester.pump();
+
+    expect(find.text('Could not load ingredients.'), findsOneWidget);
+    expect(find.textContaining('Add ('), findsNothing);
+    expect(find.text('Unselect All'), findsNothing);
+    expect(find.text('Select All'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Re-implements the screen-level "Add to Shop list" surface as a range-scoped
bottom sheet matching the Figma spec (shoplist-03 / shoplist-04). The
existing day-scoped modal stays for the per-card overflow path.

- New `RangeAddToShoplistSheet` widget — verbatim Figma copy
  ("Add to Shoplist", "Mon, 20 - Thu 23 April", "Select All" / "Unselect All",
  "Add (N)"), per-row checkbox + name + close glyph, Forest Darkn /
  butter / cream tokens, butter-gradient background.
- `MealPlanService.getRangeIngredientNames(babyId, start, end)` — new
  range-scoped aggregation, case-insensitive dedup, preserves the
  first-occurrence casing.
- `ShoppingListService.addFromMealPlan(babyId, names)` — name-only
  bulk insert with `source=ShoppingListSource.mealPlan`.
- `meal_plan_screen.dart` — screen-level overflow now routes to the new
  range sheet (window = `windowStart`..`effectiveWindowEnd`). Per-day
  card menu continues to use the day-scoped `AddToShoppingListModal`.
- Tests — service tests for `getRangeIngredientNames` (range passthrough,
  case-insensitive dedup, best-effort recipe-fetch skip, failure
  propagation, empty range) + `addFromMealPlan` (source tagging,
  failure propagation); widget tests for shoplist-03 baseline,
  shoplist-04 toggle, pill toggle counter, submit success/failure,
  and load failure.

## Acceptance checklist

- [x] Pixel-close to shoplist-03 + shoplist-04 screenshots
- [x] Verbatim copy: "Add to Shoplist", "Select All" / "Unselect All", "Add (N)"
- [x] Sheet is range-scoped (start, end) — uses the current planner window
- [x] Ingredient list de-duplicated across all recipes in the range
- [x] Pills render selected/unselected with token-driven colors
- [x] Select All / Unselect All toggles every pill in one action
- [x] "Add (N)" dynamic; 0-count disables submission
- [x] Successful submission inserts rows with `source=mealPlan` + dismisses
- [x] Failure shows P2 toast "Couldn't add items. Try again."
- [x] Day-scoped modal still used by per-card overflow
- [x] All tokens consumed from `AppColors` / `AppSizes` / `AppTypography`
- [x] `flutter analyze` clean (2 pre-existing unrelated infos remain)
- [x] Service + widget tests for both captured states and submit paths

## Figma frames

- Meal planner overflow → shoplist-03 (most selected) — node 971:7850
- Meal planner overflow → shoplist-04 (none selected) — node 971:7924
- Section: Meal Plan (971:7802)

## Audit artifacts

- `.figma-audit/meal-plan/shoplist-03-meal-planner-generated/`
- `.figma-audit/meal-plan/shoplist-04-meal-planner-generated/`