### PR TITLE
feat(recipe): redesign add-to-shoplist sheet [NIB-75]

### DIFF
--- a/lib/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart
+++ b/lib/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart
@@ -5,16 +5,25 @@ import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/common/components/controls/app_checkbox.dart';
 import 'package:nibbles/src/common/domain/entities/ingredient.dart';
 
-/// Shows the Add-to-Shopping-List bottom sheet.
+/// Shows the Add-to-Shoplist bottom sheet (NIB-75 — Figma 971:9042 / 971:9204).
 ///
-/// Per Figma node 971:9042 — each row has a leading [AppCheckbox] and a
-/// trailing `X` that permanently removes the ingredient from this add's
-/// candidate list. A bottom toggle flips between Select All / Unselect All
-/// over the remaining (non-removed) rows. The `Add (N)` CTA returns the
-/// selected ingredient names, or `null` on dismiss / cancel.
+/// Layout matches the Figma:
+///   * sheet title "Add to Shoplist" with a close (X) button top-right
+///   * one row per ingredient — leading checkbox + name + trailing burgundy X
+///     that drops the row from this sheet's candidate list
+///   * side-by-side bottom CTAs:
+///       - butter ghost pill — "Unselect All" (when all selected) or
+///         "Select All" (when any are deselected)
+///       - green primary pill — "Add (N)" where N is the live selected count
 ///
-/// Names-only contract — reuses the existing
-/// `ShoppingListService.addFromRecipe` path. No data layer changes.
+/// All rows are pre-selected on open (success-1 state). Tapping "Unselect All"
+/// flips the toggle label and disables the primary CTA (success-2 state).
+///
+/// The verbatim "Mon, 20 - Thu 23 April" date subtitle from the Figma is a
+/// meal-plan-window artifact; recipe-scoped shopping list adds have no date
+/// context, so it is intentionally omitted.
+///
+/// Resolves to the picked ingredient names on confirm, or `null` on dismiss.
 Future<List<String>?> showAddToShoppingListSheet(
   BuildContext context,
   List<Ingredient> ingredients,
@@ -22,10 +31,10 @@ Future<List<String>?> showAddToShoppingListSheet(
   return showModalBottomSheet<List<String>>(
     context: context,
     isScrollControlled: true,
-    backgroundColor: AppColors.surface,
+    backgroundColor: AppColors.butterSoft,
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(
-        top: Radius.circular(AppSizes.radiusXl),
+        top: Radius.circular(AppSizes.radius2xl),
       ),
     ),
     builder: (context) => _ShoppingListSheet(ingredients: ingredients),
@@ -51,7 +60,7 @@ class _ShoppingListSheetState extends State<_ShoppingListSheet> {
   @override
   void initState() {
     super.initState();
-    // Default: every row pre-selected.
+    // Default: every row pre-selected (success-1 state).
     _selected = <int>{
       for (var i = 0; i < widget.ingredients.length; i++) i,
     };
@@ -116,6 +125,7 @@ class _ShoppingListSheetState extends State<_ShoppingListSheet> {
       for (var i = 0; i < widget.ingredients.length; i++)
         if (!_removed.contains(i)) i,
     ];
+    final toggleLabel = _allSelected ? 'Unselect All' : 'Select All';
 
     return SafeArea(
       top: false,
@@ -141,26 +151,36 @@ class _ShoppingListSheetState extends State<_ShoppingListSheet> {
               padding: const EdgeInsets.symmetric(
                 horizontal: AppSizes.pagePaddingH,
               ),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  'Add to Shopping List',
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    color: AppColors.fgStrong,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Add to Shoplist',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: AppColors.fgStrong,
+                      ),
+                    ),
                   ),
-                ),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: AppSizes.iconMd),
+                    color: AppColors.fgStrong,
+                    onPressed: () => Navigator.of(context).pop(),
+                    tooltip: 'Close',
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(
+                      minWidth: AppSizes.roundButtonSm,
+                      minHeight: AppSizes.roundButtonSm,
+                    ),
+                  ),
+                ],
               ),
             ),
             const SizedBox(height: AppSizes.sm),
-            const Divider(
-              height: AppSizes.dividerThickness,
-              thickness: AppSizes.dividerThickness,
-              color: AppColors.borderSoft,
-            ),
             Flexible(
               child: ConstrainedBox(
                 constraints: BoxConstraints(
-                  maxHeight: MediaQuery.of(context).size.height * 0.5,
+                  maxHeight: MediaQuery.of(context).size.height * 0.6,
                 ),
                 child: visibleIndices.isEmpty
                     ? _EmptyState(theme: theme)
@@ -185,11 +205,6 @@ class _ShoppingListSheetState extends State<_ShoppingListSheet> {
                       ),
               ),
             ),
-            const Divider(
-              height: AppSizes.dividerThickness,
-              thickness: AppSizes.dividerThickness,
-              color: AppColors.borderSoft,
-            ),
             Padding(
               padding: EdgeInsets.fromLTRB(
                 AppSizes.pagePaddingH,
@@ -197,20 +212,22 @@ class _ShoppingListSheetState extends State<_ShoppingListSheet> {
                 AppSizes.pagePaddingH,
                 AppSizes.sp12 + MediaQuery.of(context).padding.bottom,
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
+              child: Row(
                 children: [
-                  Align(
-                    alignment: Alignment.centerLeft,
-                    child: _SelectAllToggle(
-                      label: _allSelected ? 'Unselect All' : 'Select All',
-                      onPressed: _remainingCount == 0 ? null : _toggleSelectAll,
+                  Expanded(
+                    child: AppPillButton(
+                      label: toggleLabel,
+                      variant: AppPillButtonVariant.ghost,
+                      onPressed:
+                          _remainingCount == 0 ? null : _toggleSelectAll,
                     ),
                   ),
-                  const SizedBox(height: AppSizes.sm),
-                  AppPillButton(
-                    label: 'Add ($selectedCount)',
-                    onPressed: selectedCount == 0 ? null : _confirm,
+                  const SizedBox(width: AppSizes.sp12),
+                  Expanded(
+                    child: AppPillButton(
+                      label: 'Add ($selectedCount)',
+                      onPressed: selectedCount == 0 ? null : _confirm,
+                    ),
                   ),
                 ],
               ),
@@ -240,7 +257,7 @@ class _IngredientRow extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Material(
-      color: AppColors.surface,
+      color: AppColors.cream,
       borderRadius: BorderRadius.circular(AppSizes.radiusMd),
       child: InkWell(
         onTap: onToggle,
@@ -251,7 +268,7 @@ class _IngredientRow extends StatelessWidget {
             vertical: AppSizes.sp12,
           ),
           decoration: BoxDecoration(
-            color: AppColors.surface,
+            color: AppColors.cream,
             borderRadius: BorderRadius.circular(AppSizes.radiusMd),
             border: Border.all(color: AppColors.borderSoft),
           ),
@@ -287,56 +304,22 @@ class _RemoveButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Plain X glyph in Nibble-primary-Burgundy (Figma 971:9042 — token
+    // Nibble-primary-Burgundy #77393b). No circular background per the
+    // Figma rows.
     return Semantics(
       button: true,
       label: 'Remove',
       child: InkResponse(
         onTap: onPressed,
-        radius: AppSizes.checkbox,
-        child: Container(
-          width: AppSizes.checkbox,
-          height: AppSizes.checkbox,
-          alignment: Alignment.center,
-          decoration: const BoxDecoration(
-            color: AppColors.destructiveSoft,
-            shape: BoxShape.circle,
-          ),
-          child: const Icon(
-            Icons.close_rounded,
+        radius: AppSizes.iconMd,
+        child: const SizedBox(
+          width: AppSizes.iconMd,
+          height: AppSizes.iconMd,
+          child: Icon(
+            Icons.close,
             size: AppSizes.iconSm,
-            color: AppColors.destructive,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _SelectAllToggle extends StatelessWidget {
-  const _SelectAllToggle({required this.label, required this.onPressed});
-
-  final String label;
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final disabled = onPressed == null;
-    final color = disabled ? AppColors.fgFaint : AppColors.greenDeep;
-
-    return InkWell(
-      onTap: onPressed,
-      borderRadius: BorderRadius.circular(AppSizes.radiusSm),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSizes.xs,
-          vertical: AppSizes.xs,
-        ),
-        child: Text(
-          label,
-          style: theme.textTheme.labelMedium?.copyWith(
-            color: color,
-            fontWeight: FontWeight.w700,
+            color: AppColors.burgundy,
           ),
         ),
       ),

--- a/test/features/recipe/detail/widgets/add_to_shopping_list_sheet_test.dart
+++ b/test/features/recipe/detail/widgets/add_to_shopping_list_sheet_test.dart
@@ -1,4 +1,4 @@
-// Widget tests for the redesigned Add-to-Shopping-List sheet (NIB-68).
+// Widget tests for the redesigned Add-to-Shoplist sheet (NIB-75 / NIB-68).
 //
 // Drives `showAddToShoppingListSheet(context, ingredients)` and asserts:
 //   * each row renders a leading checkbox and a trailing remove ('Remove')
@@ -66,7 +66,7 @@ void main() {
         await setupViewport(tester);
         await _openSheet(tester);
 
-        expect(find.text('Add to Shopping List'), findsOneWidget);
+        expect(find.text('Add to Shoplist'), findsOneWidget);
         for (final ing in _ingredients) {
           expect(find.text(ing.name), findsOneWidget);
         }


### PR DESCRIPTION
## Summary
Redesigns the Recipe Detail Add-to-Shoplist bottom sheet to match the redesign Figma frames.

## Figma frames
- Recipe Library - Meal Plan Success (1) — node `971:9042` (all-selected state)
- Recipe Library - Meal Plan Success (2) — node `971:9204` (all-deselected state)

## Audit reports
- `.figma-audit/recipe-library/recipe-library-meal-plan-success-1/`
- `.figma-audit/recipe-library/recipe-library-meal-plan-success-2/`

## Acceptance criteria
- [x] Sheet title is the verbatim Figma string `Add to Shoplist` (was `Add to Shopping List`).
- [x] Top-right close (X) IconButton (matches the `add_to_meal_plan_sheet` pattern).
- [x] Each ingredient row: leading `AppCheckbox`, name, trailing burgundy `X` glyph (token `AppColors.burgundy` = Nibble-primary-Burgundy `#77393b`). Cream row surface, `borderSoft` border.
- [x] Side-by-side bottom CTAs in a Row:
  - butter ghost `AppPillButton` toggle — label `Unselect All` (all selected, success-1) / `Select All` (any deselected, success-2)
  - green primary `AppPillButton` `Add (N)` where `N` is the live selected count; disabled at `N=0`
- [x] All-selected default on open (success-1).
- [x] Per-row X drops the ingredient from this sheet's candidate list with a snackbar confirmation.
- [x] Dismiss without confirm resolves the future to `null`; confirm resolves to the picked names list.
- [x] Sheet background is `butterSoft` with `radius2xl` top corners — matches the Figma cream sheet.

## Intentional divergences from the Figma
- **Date-range subtitle `Mon, 20 - Thu 23 April` omitted.** The sheet API `showAddToShoppingListSheet(context, ingredients)` is recipe-scoped — there is no meal-plan window to render. The Figma frame is a stacked snapshot over the meal-plan flow (audit reports flag it). The dedicated `RangeAddToShoplistSheet` (NIB-136) owns the date-range case.
- "Shoplist" diverges from the product-wide "Shopping List" wording — kept verbatim per the audit. Worth confirming with design.

## Notes
- `showAddToShoppingListSheet` is currently not wired to a CTA in `lib/`; this ticket is scoped to the sheet redesign + its states only.
- Existing widget test updated for the new title; all 7 sheet tests pass. Full suite (576 tests) green.

## Test plan
- [x] `flutter test test/features/recipe/detail/widgets/add_to_shopping_list_sheet_test.dart`
- [x] `flutter test` (full suite green)
- [x] `flutter analyze` (no new issues; pre-existing 2 unrelated to this ticket)