### PR TITLE
feat(recipe): align library search states to Figma spec [NIB-58]

### DIFF
--- a/lib/src/features/recipe/library/widgets/recipe_search_empty.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_search_empty.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
@@ -7,43 +6,34 @@ import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 /// Generic 'no results' empty state for the Recipe Library search
 /// (Figma 971:8813 / 971:8828).
 ///
-/// Centered butter-flower-glyph ([Quatrefoil]) + 16/700 title + caption
-/// subtitle. Copy is intentionally generic — the search query is NOT
-/// interpolated into the message.
+/// Centered butter-flower-glyph ([Quatrefoil], 136 per Figma Group74 box) +
+/// 16/700 title. Verbatim copy per Figma — smart apostrophe (U+2019), no
+/// subtitle. Search query is NOT interpolated into the message.
+///
+/// Renders the same in both keyboard-up (971:8813) and keyboard-dismissed
+/// (971:8828) variants — Scaffold's default `resizeToAvoidBottomInset` lets
+/// the `Center` re-centre against the available height when the OS keyboard
+/// is shown or hidden.
 class RecipeSearchEmpty extends StatelessWidget {
   const RecipeSearchEmpty({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return Center(
+    return const Center(
       child: Padding(
-        padding: const EdgeInsets.symmetric(
+        padding: EdgeInsets.symmetric(
           horizontal: AppSizes.pagePaddingH,
           vertical: AppSizes.xl,
         ),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Quatrefoil(),
-            const SizedBox(height: AppSizes.sm + 2),
-            const Text(
-              "We couldn't find any recipes",
+            Quatrefoil(size: 136),
+            SizedBox(height: AppSizes.sm + 2),
+            Text(
+              'We couldn’t find any recipes',
               textAlign: TextAlign.center,
               style: AppTypography.emptyStateTitle,
-            ),
-            const SizedBox(height: AppSizes.xs),
-            ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 240),
-              child: Text(
-                'Try a different keyword or clear the search to browse '
-                'every category.',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: AppColors.fgFaint,
-                ),
-              ),
             ),
           ],
         ),

--- a/lib/src/features/recipe/library/widgets/recipe_search_results.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_search_results.dart
@@ -7,10 +7,12 @@ import 'package:nibbles/src/routing/route_enums.dart';
 
 /// Search-results view for the Recipe Library (Figma 971:8803).
 ///
-/// Renders a flat vertical list of [RecipeGridCard]s — one card per result.
-/// The category-rows layout (NIB-53) is suppressed by the parent screen
-/// whenever `RecipeLibraryState.searchQuery` is non-empty; this widget owns
-/// only the list rendering.
+/// Renders matching recipes as a 2-column grid of [RecipeGridCard]s pinned to
+/// the design-system 158x220 box — mirrors the Figma typing-results layout
+/// where a single match sits in the first grid cell with the title wrapping
+/// onto two lines. The category-rows layout (NIB-53) is suppressed by the
+/// parent screen whenever `RecipeLibraryState.searchQuery` is non-empty; this
+/// widget owns only the grid rendering.
 class RecipeSearchResults extends StatelessWidget {
   const RecipeSearchResults({
     required this.recipes,
@@ -21,25 +23,43 @@ class RecipeSearchResults extends StatelessWidget {
   final List<Recipe> recipes;
   final Set<String> flaggedAllergenKeys;
 
+  static const double _cardWidth = 158;
+  static const double _cardHeight = 220;
+
   @override
   Widget build(BuildContext context) {
-    return ListView.separated(
+    return GridView.builder(
       padding: const EdgeInsets.fromLTRB(
         AppSizes.pagePaddingH,
         AppSizes.md,
         AppSizes.pagePaddingH,
         AppSizes.xl,
       ),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: AppSizes.sp12,
+        mainAxisSpacing: AppSizes.sp12,
+        mainAxisExtent: _cardHeight,
+      ),
       itemCount: recipes.length,
-      separatorBuilder: (_, __) => const SizedBox(height: AppSizes.sp12),
       itemBuilder: (context, index) {
         final recipe = recipes[index];
-        return RecipeGridCard(
-          recipe: recipe,
-          flaggedAllergenKeys: flaggedAllergenKeys,
-          onTap: () => context.pushNamed(
-            AppRoute.recipeDetail.name,
-            pathParameters: {'recipeId': recipe.id},
+        // Pin each cell to the 158x220 card box per Figma 971:8803 —
+        // align top-left so wider grid cells (tablets) don't stretch the
+        // card.
+        return Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: _cardWidth,
+            height: _cardHeight,
+            child: RecipeGridCard(
+              recipe: recipe,
+              flaggedAllergenKeys: flaggedAllergenKeys,
+              onTap: () => context.pushNamed(
+                AppRoute.recipeDetail.name,
+                pathParameters: {'recipeId': recipe.id},
+              ),
+            ),
           ),
         );
       },

--- a/test/features/recipe/library/recipe_library_screen_test.dart
+++ b/test/features/recipe/library/recipe_library_screen_test.dart
@@ -273,7 +273,8 @@ void main() {
         expect(find.byType(RecipeSearchResults), findsNothing);
         expect(find.byType(RecipeCategoryRow), findsNothing);
         // Generic copy — does NOT interpolate the query.
-        expect(find.textContaining("We couldn't find"), findsOneWidget);
+        // Smart apostrophe (U+2019) per Figma 971:8813 verbatim.
+        expect(find.textContaining('We couldn’t find'), findsOneWidget);
         expect(find.textContaining('zzzunknown'), findsNothing);
       },
     );


### PR DESCRIPTION
## Summary
Aligns Recipe Library search states (typing-results, no-results-keyboard, no-results-nokeyboard) to the locked Figma spec.

- **Typing-results**: `RecipeSearchResults` now renders a 2-column grid of 158x220 `RecipeGridCard` tiles instead of a flat full-width list. Matches Figma 971:8803 — single match sits in the first cell with the title wrapping onto two lines.
- **No-results-keyboard / no-results-nokeyboard**: `RecipeSearchEmpty` now uses the smart apostrophe (U+2019) in "We couldn't find any recipes" per Figma verbatim, drops the off-spec "Try a different keyword…" subtitle, and bumps the `Quatrefoil` illustration to 136 to match the Figma Group74 box (971:8813 / 971:8828). Default `Scaffold.resizeToAvoidBottomInset` handles the keyboard-up vs keyboard-dismissed re-centring — same widget for both variants.
- Test: updated the no-match assertion to use the smart apostrophe.

## Figma frames
- 971:8803 — search-2 (typing-results)
- 971:8813 — search-3 (no-results, keyboard up)
- 971:8828 — search-4 (no-results, keyboard dismissed)

## Audit reports
- `.figma-audit/recipe-library/recipe-library-search-2/report.md`
- `.figma-audit/recipe-library/recipe-library-search-3/report.md`
- `.figma-audit/recipe-library/recipe-library-search-4/report.md`

## Acceptance criteria
- [x] Typing a query in the search field collapses the category-rows layout into a grid of matching recipes (NIB-58).
- [x] Result grid uses 2 columns of 158x220 cards.
- [x] No matches shows the empty illustration + "We couldn't find any recipes" (smart apostrophe), no subtitle, no query interpolation.
- [x] Empty-state remains centred when keyboard is dismissed.
- [x] Verbatim copy strings match Figma exactly.
- [x] `flutter analyze` — no new warnings on changed files.
- [x] `flutter test` — full suite passes (576 tests).