### PR TITLE
feat(recipe-library): list screen redesign — butter hero, forest banner, salmon chip cards [NIB-53]

### DIFF
--- a/lib/src/features/recipe/library/recipe_library_screen.dart
+++ b/lib/src/features/recipe/library/recipe_library_screen.dart
@@ -16,13 +16,13 @@ import 'package:nibbles/src/features/recipe/library/widgets/recipe_category_row.
 import 'package:nibbles/src/features/recipe/library/widgets/recipe_search_empty.dart';
 import 'package:nibbles/src/features/recipe/library/widgets/recipe_search_results.dart';
 
-/// Recipe Library screen (RC-01, NIB-53 reskin + NIB-58 search rewire).
+/// Recipe Library screen (RC-01, NIB-53 redesign + NIB-58 search rewire).
 ///
-/// Reskins the previous SliverGrid layout to a butter-wash [LibraryHeader] +
-/// vertical stack of horizontal [RecipeCategoryRow]s, driven by
-/// `RecipeService.getRecipesByCategory`. A first-launch [ReadGuideBanner]
-/// appears above the first row when `LocalFlagService.isStartingGuideSeen()`
-/// is `false`. Section order:
+/// Reskins the Recipe Library tab to the butter-gradient hero + vertical
+/// stack of horizontal [RecipeCategoryRow]s per Figma 971:8644 / 971:8760.
+/// Driven by `RecipeService.getRecipesByCategory`. A first-launch forest
+/// 'New to Starting Solids?' [ReadGuideBanner] sits above the first row
+/// when `LocalFlagService.isStartingGuideSeen()` is `false`. Section order:
 ///   1. (optional) 'Recommendation for {ongoing allergen}' — recipes from
 ///      any category whose `allergenTags` contain the in-progress allergen.
 ///   2. One row per category in the order returned by the service.
@@ -43,23 +43,46 @@ class RecipeLibraryScreen extends ConsumerWidget {
     final babyIdAsync = ref.watch(currentBabyIdProvider);
 
     return babyIdAsync.when(
-      loading: () => const Scaffold(
-        backgroundColor: AppColors.cream,
+      loading: () => const _PageScaffold(
         body: Center(child: CircularProgressIndicator()),
       ),
-      error: (_, __) => const Scaffold(
-        backgroundColor: AppColors.cream,
+      error: (_, __) => const _PageScaffold(
         body: Center(child: Text('Could not load baby profile.')),
       ),
       data: (babyId) {
         if (babyId == null) {
-          return const Scaffold(
-            backgroundColor: AppColors.cream,
+          return const _PageScaffold(
             body: Center(child: Text('No baby profile found.')),
           );
         }
         return _RecipeLibraryBody(babyId: babyId);
       },
+    );
+  }
+}
+
+/// Shared scaffold with the Recipe Library butter -> cream page gradient
+/// (Figma 971:8644 root linear-gradient(128.4deg, #FFFCD5 19%, #F5F5F5 50%)).
+class _PageScaffold extends StatelessWidget {
+  const _PageScaffold({required this.body});
+
+  final Widget body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.19, 0.5],
+            colors: [AppColors.butterSoft, AppColors.cream],
+          ),
+        ),
+        child: body,
+      ),
     );
   }
 }
@@ -131,8 +154,7 @@ class _RecipeLibraryBodyState extends ConsumerState<_RecipeLibraryBody> {
 
     final searchValue = libraryAsync.valueOrNull?.searchQuery ?? '';
 
-    return Scaffold(
-      backgroundColor: AppColors.cream,
+    return _PageScaffold(
       body: Column(
         children: [
           LibraryHeader(

--- a/lib/src/features/recipe/library/widgets/library_header.dart
+++ b/lib/src/features/recipe/library/widgets/library_header.dart
@@ -3,17 +3,21 @@ import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 
-/// Butter-wash header for the Recipe Library screen (Figma 971:8760).
+/// Recipe Library header (Figma 971:8644 / 971:8760, NIB-53 redesign).
 ///
-/// Composes:
-///   * a butter -> butter-soft vertical gradient background
-///   * a 'Recipe Library' title row with a trailing green-deep bookmark
-///     button (rounded-square, 32x32) that pushes the Starting Guide
-///   * a pill-shaped search input with a search-prefix icon and an optional
-///     trailing clear button when [searchValue] is non-empty
+/// Sits inside the butter-gradient page background. Composes:
+///   * a 17/Bold 'Recipe Library' title row
+///   * a search row — neutral-10-filled 48x input with a forest-dark border
+///     (placeholder 'Search recipe') + a 47x47 forest-dark filter chip
+///     pinned to the right
 ///
 /// The search field is uncontrolled here — callers own the
-/// [TextEditingController] and the `onSearchChanged` callback.
+/// [TextEditingController] and the `onSearchChanged` callback. The filter
+/// chip mirrors the Figma `ButtonChips` Primary variant: a green-deep tile
+/// with the 'class' bookmark / ribbon glyph. Tapping it fires
+/// [onBookmarkTap]; per NIB-53 the host screen wires this to the Starting
+/// Guide nav (Read Guide CTA on the banner is the only place that also
+/// marks the seen flag).
 class LibraryHeader extends StatelessWidget {
   const LibraryHeader({
     required this.searchController,
@@ -28,43 +32,49 @@ class LibraryHeader extends StatelessWidget {
   final ValueChanged<String> onSearchChanged;
   final VoidCallback onBookmarkTap;
 
+  // Figma sizes (971:8650 input, 894:6480 button-chips).
+  static const double _inputHeight = 48;
+  static const double _chipSize = 47;
+
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [AppColors.butter, AppColors.butterSoft],
-        ),
-      ),
+    return Padding(
       padding: const EdgeInsets.fromLTRB(
         AppSizes.pagePaddingH,
         AppSizes.sm,
         AppSizes.pagePaddingH,
-        AppSizes.md,
+        AppSizes.sp12,
       ),
       child: SafeArea(
         bottom: false,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    'Recipe Library',
-                    style: AppTypography.textTheme.titleLarge,
-                  ),
-                ),
-                _BookmarkButton(onTap: onBookmarkTap),
-              ],
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: AppSizes.xs),
+              child: Text(
+                'Recipe Library',
+                style: AppTypography.textTheme.titleSmall,
+              ),
             ),
             const SizedBox(height: AppSizes.sp12),
-            _SearchPill(
-              controller: searchController,
-              value: searchValue,
-              onChanged: onSearchChanged,
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: _SearchInput(
+                    controller: searchController,
+                    value: searchValue,
+                    onChanged: onSearchChanged,
+                    height: _inputHeight,
+                  ),
+                ),
+                const SizedBox(width: AppSizes.sp12),
+                _FilterChipButton(
+                  size: _chipSize,
+                  onTap: onBookmarkTap,
+                ),
+              ],
             ),
           ],
         ),
@@ -73,59 +83,35 @@ class LibraryHeader extends StatelessWidget {
   }
 }
 
-class _BookmarkButton extends StatelessWidget {
-  const _BookmarkButton({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: AppColors.greenDeep,
-      borderRadius: BorderRadius.circular(AppSizes.radiusSm),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(AppSizes.radiusSm),
-        onTap: onTap,
-        child: const SizedBox(
-          width: AppSizes.roundButtonSm,
-          height: AppSizes.roundButtonSm,
-          child: Icon(
-            Icons.bookmark_outline,
-            color: AppColors.onGreen,
-            size: AppSizes.iconMd,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _SearchPill extends StatelessWidget {
-  const _SearchPill({
+class _SearchInput extends StatelessWidget {
+  const _SearchInput({
     required this.controller,
     required this.value,
     required this.onChanged,
+    required this.height,
   });
 
   final TextEditingController controller;
   final String value;
   final ValueChanged<String> onChanged;
+  final double height;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: 44,
+      height: height,
       decoration: BoxDecoration(
-        color: AppColors.bgInput,
-        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+        color: AppColors.divider,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        border: Border.all(color: AppColors.greenDeep),
       ),
-      padding: const EdgeInsets.symmetric(horizontal: AppSizes.fieldPaddingH),
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.sp12),
       child: Row(
         children: [
           const Icon(
             Icons.search,
             color: AppColors.greenDeep,
-            size: AppSizes.iconMd,
+            size: AppSizes.iconMd - 4,
           ),
           const SizedBox(width: AppSizes.sm),
           Expanded(
@@ -135,7 +121,7 @@ class _SearchPill extends StatelessWidget {
               textInputAction: TextInputAction.search,
               style: AppTypography.textTheme.bodyLarge,
               decoration: InputDecoration(
-                hintText: 'Search recipes…',
+                hintText: 'Search recipe',
                 hintStyle: AppTypography.textTheme.bodyLarge?.copyWith(
                   color: AppColors.fgFaint,
                 ),
@@ -164,6 +150,34 @@ class _SearchPill extends StatelessWidget {
               },
             ),
         ],
+      ),
+    );
+  }
+}
+
+class _FilterChipButton extends StatelessWidget {
+  const _FilterChipButton({required this.size, required this.onTap});
+
+  final double size;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.greenDeep,
+      borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        onTap: onTap,
+        child: SizedBox(
+          width: size,
+          height: size,
+          child: const Icon(
+            Icons.bookmark_outline,
+            color: AppColors.onGreen,
+            size: AppSizes.iconMd,
+          ),
+        ),
       ),
     );
   }

--- a/lib/src/features/recipe/library/widgets/read_guide_banner.dart
+++ b/lib/src/features/recipe/library/widgets/read_guide_banner.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
-import 'package:nibbles/src/app/themes/app_typography.dart';
 
-/// First-launch 'Read Guide' banner for the Recipe Library (Figma 971:8644
-/// outer, 1015:6821 inner). Butter-soft tip card with a green-deep glyph,
-/// title, supporting copy, and a green-deep 'Read Guide' CTA.
+/// First-launch 'New to Starting Solids?' banner for the Recipe Library
+/// (Figma 971:8644 → 1015:6820). Forest-green card with white title, white
+/// 10/Regular supporting copy, and a full-width white-outlined 'Read Guide'
+/// CTA.
 ///
 /// Visibility is gated upstream by `LocalFlagService.isStartingGuideSeen()`;
 /// the banner itself is a pure presentation widget — tapping the CTA fires
@@ -17,6 +18,13 @@ class ReadGuideBanner extends StatelessWidget {
 
   final VoidCallback onTap;
 
+  // Token mapping for the Figma 'Banner' container (1015:6820):
+  //   bg               -> Nibble-primary-Forest    (#5C7852)
+  //   shadow           -> 0 4 10 rgba(92,120,82,0.04)
+  //   radius           -> 12
+  //   padding          -> 24 vertical / 12 horizontal
+  //   inner column gap -> 12
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -26,79 +34,65 @@ class ReadGuideBanner extends StatelessWidget {
         AppSizes.pagePaddingH,
         0,
       ),
-      padding: const EdgeInsets.all(AppSizes.md - 2),
-      decoration: BoxDecoration(
-        color: AppColors.bgCardTint,
-        borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.sp12,
+        vertical: AppSizes.lg,
       ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const _Glyph(),
-          const SizedBox(width: AppSizes.sp12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'New to solids?',
-                  style: AppTypography.textTheme.titleSmall?.copyWith(
-                    color: AppColors.fgStrong,
-                    fontSize: 15,
-                    height: 1.3,
-                  ),
-                ),
-                const SizedBox(height: AppSizes.xs),
-                Text(
-                  'Start here — our Starting Guide walks you through '
-                  'first foods, portions, and what to watch out for.',
-                  style: AppTypography.textTheme.bodyMedium?.copyWith(
-                    color: AppColors.fgMuted,
-                  ),
-                ),
-                const SizedBox(height: AppSizes.sm + 2),
-                _ReadGuideCta(onTap: onTap),
-              ],
-            ),
+      decoration: BoxDecoration(
+        color: AppColors.green,
+        borderRadius: BorderRadius.circular(AppSizes.sp12),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x0A5C7852),
+            offset: Offset(0, 4),
+            blurRadius: 10,
           ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'New to Starting Solids?',
+            style: _bannerTitleStyle,
+          ),
+          const SizedBox(height: AppSizes.sp12),
+          Text(
+            'Start your baby’s food journey the right way with simple '
+            'basics.',
+            style: _bannerBodyStyle,
+          ),
+          const SizedBox(height: AppSizes.sp12),
+          _ReadGuideCta(onTap: onTap),
         ],
       ),
     );
   }
 }
 
-class _Glyph extends StatelessWidget {
-  const _Glyph();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: AppSizes.tipGlyph,
-      height: AppSizes.tipGlyph,
-      decoration: const BoxDecoration(
-        color: AppColors.greenDeep,
-        shape: BoxShape.circle,
-      ),
-      alignment: Alignment.center,
-      child: const Icon(
-        Icons.menu_book_outlined,
-        color: AppColors.butter,
-        size: AppSizes.iconSm,
-      ),
-    );
-  }
-}
-
-/// Local display-font CTA style for the 'Read Guide' button.
-///
-/// Matches kit `components-empty-state.html .btn` / `kit.css .pillbtn--sm`:
-/// `700 13px/1 var(--font-display)` (Parkinsans). Defined locally instead of
-/// mutating the shared [AppTypography.button] token (out of scope for NIB-53).
-const TextStyle _readGuideCtaStyle = TextStyle(
+// Figma Headline/SemiBold — Parkinsans SemiBold 15/22 white (1015:6812).
+const TextStyle _bannerTitleStyle = TextStyle(
   fontFamily: FontFamily.parkinsans,
-  fontSize: 13,
-  fontWeight: FontWeight.w700,
-  height: 1,
+  fontSize: 15,
+  fontWeight: FontWeight.w600,
+  height: 22 / 15,
+  color: AppColors.cream,
+);
+
+// Figma Caption/Regular — Figtree Regular 10/16 white (1015:6813).
+final TextStyle _bannerBodyStyle = GoogleFonts.figtree(
+  fontSize: 10,
+  fontWeight: FontWeight.w400,
+  height: 16 / 10,
+  color: AppColors.cream,
+);
+
+// Figma button label — Parkinsans SemiBold 15/22 white (I1015:6814;1015:9925).
+const TextStyle _ctaLabelStyle = TextStyle(
+  fontFamily: FontFamily.parkinsans,
+  fontSize: 15,
+  fontWeight: FontWeight.w600,
+  height: 22 / 15,
   color: AppColors.cream,
 );
 
@@ -110,30 +104,21 @@ class _ReadGuideCta extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: AppColors.greenDeep,
-      borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(AppSizes.lg),
       child: InkWell(
-        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+        borderRadius: BorderRadius.circular(AppSizes.lg),
         onTap: onTap,
-        child: const Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: AppSizes.md,
-            vertical: AppSizes.sm,
+        child: Container(
+          padding: const EdgeInsets.all(AppSizes.radiusMd),
+          decoration: BoxDecoration(
+            border: Border.all(color: AppColors.cream),
+            borderRadius: BorderRadius.circular(AppSizes.lg),
           ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                'Read Guide',
-                style: _readGuideCtaStyle,
-              ),
-              SizedBox(width: AppSizes.xs),
-              Icon(
-                Icons.arrow_forward_rounded,
-                color: AppColors.cream,
-                size: AppSizes.iconSm,
-              ),
-            ],
+          alignment: Alignment.center,
+          child: const Text(
+            'Read Guide',
+            style: _ctaLabelStyle,
           ),
         ),
       ),

--- a/lib/src/features/recipe/library/widgets/recipe_category_row.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_category_row.dart
@@ -10,10 +10,9 @@ import 'package:nibbles/src/routing/route_enums.dart';
 /// A horizontally-scrolling row of [RecipeGridCard]s under a section title.
 ///
 /// Each card is pinned to the design-system 158x220 box per Figma 971:8760.
-/// The row leaves the page padding intact (cards begin at
-/// [AppSizes.pagePaddingH] from the left edge); horizontal padding is applied
-/// to the inner list so that the section title and the first card both align
-/// to the same gutter.
+/// The section title is rendered with the Headline/SemiBold token
+/// (Parkinsans SemiBold 15/22) per the audit spec; cards are spaced by
+/// the Figma 24px row gap.
 class RecipeCategoryRow extends StatelessWidget {
   const RecipeCategoryRow({
     required this.title,
@@ -28,6 +27,8 @@ class RecipeCategoryRow extends StatelessWidget {
 
   static const double _cardWidth = 158;
   static const double _cardHeight = 220;
+  // Figma row gap (971:8660 etc.) — 24px between cards.
+  static const double _cardGap = AppSizes.lg;
 
   @override
   Widget build(BuildContext context) {
@@ -39,11 +40,14 @@ class RecipeCategoryRow extends StatelessWidget {
             AppSizes.pagePaddingH,
             AppSizes.md,
             AppSizes.pagePaddingH,
-            AppSizes.sm + 2,
+            AppSizes.sp12,
           ),
           child: Text(
             title,
-            style: AppTypography.sectionTitle.copyWith(
+            style: AppTypography.textTheme.titleSmall?.copyWith(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              height: 22 / 15,
               color: AppColors.fgStrong,
             ),
           ),
@@ -56,7 +60,7 @@ class RecipeCategoryRow extends StatelessWidget {
               horizontal: AppSizes.pagePaddingH,
             ),
             itemCount: recipes.length,
-            separatorBuilder: (_, __) => const SizedBox(width: AppSizes.sp12),
+            separatorBuilder: (_, __) => const SizedBox(width: _cardGap),
             itemBuilder: (context, index) {
               final recipe = recipes[index];
               return SizedBox(

--- a/lib/src/features/recipe/library/widgets/recipe_grid_card.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_grid_card.dart
@@ -1,17 +1,18 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
-import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/chips/app_chip.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 
-/// Recipe library / home recommendation card (NIB-53 reskin).
+/// Recipe library / home recommendation card (NIB-53 redesign).
 ///
-/// Visual target is a 158x220 tile per Figma 971:8760 — image-top + headline
-/// + a leading nutrition chip with a `+N` overflow chip when the recipe has
-/// more than one nutrition tag. Flagged-allergen recipes show a
-/// [AppChipTone.flag] 'Not safe' chip overlaid on the image.
+/// Visual target is a 158x220 tile per Figma 971:8661 — image-top (117 high,
+/// white surface) + 12px-padded content column containing a 2-line title and
+/// a row of salmon-ghost chips ('Iron Rich' bolt chip + a `+N` overflow
+/// chip). Flagged-allergen recipes show a [AppChipTone.flag] 'Not safe'
+/// chip overlaid on the image and dim the card slightly.
 ///
 /// The card is width-flexible (parent provides the box) so the same widget
 /// continues to render in the Home carousel (140-wide `SizedBox`) and the
@@ -32,6 +33,10 @@ class RecipeGridCard extends StatelessWidget {
   bool get _hasUnsafeAllergen =>
       recipe.allergenTags.any(flaggedAllergenKeys.contains);
 
+  // Figma 760:7436 paragraph block (158x117 thumb + 12 padding + 40px
+  // title block + 24px chip row + 12 padding = 220 total).
+  static const double _titleBlockHeight = 40;
+
   @override
   Widget build(BuildContext context) {
     final isUnsafe = _hasUnsafeAllergen;
@@ -40,33 +45,46 @@ class RecipeGridCard extends StatelessWidget {
       onTap: onTap,
       child: Opacity(
         opacity: isUnsafe ? 0.85 : 1,
-        child: Container(
-          decoration: BoxDecoration(
-            color: AppColors.surface,
-            borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-            boxShadow: AppSizes.shadowCard,
-          ),
-          padding: const EdgeInsets.all(AppSizes.sp12),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _CardThumbnail(
-                url: recipe.thumbnailUrl,
-                isUnsafe: isUnsafe,
-              ),
-              const SizedBox(height: AppSizes.sm + 2),
-              Text(
-                recipe.title,
-                style: AppTypography.textTheme.titleSmall?.copyWith(
-                  fontSize: 13,
-                  height: 1.25,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          child: ColoredBox(
+            color: AppColors.cream,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _CardThumbnail(
+                  url: recipe.thumbnailUrl,
+                  isUnsafe: isUnsafe,
                 ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-              const SizedBox(height: AppSizes.sm - 2),
-              _NutritionChipRow(tags: recipe.nutritionTags),
-            ],
+                Padding(
+                  padding: const EdgeInsets.all(AppSizes.sp12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        height: _titleBlockHeight,
+                        child: Text(
+                          recipe.title,
+                          style: const TextStyle(
+                            fontFamily: FontFamily.parkinsans,
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            height: 20 / 13,
+                            color: AppColors.fgStrong,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(height: AppSizes.sm),
+                      _NutritionChipRow(tags: recipe.nutritionTags),
+                    ],
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -80,59 +98,62 @@ class _CardThumbnail extends StatelessWidget {
   final String? url;
   final bool isUnsafe;
 
+  // Figma 760:7432 thumbnail container: 158w x 117h, white bg.
+  static const double _thumbHeight = 117;
+
   @override
   Widget build(BuildContext context) {
-    return AspectRatio(
-      aspectRatio: 134 / 110,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(AppSizes.radiusLg - 2),
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            if (url == null || url!.isEmpty)
-              const ColoredBox(
+    return SizedBox(
+      height: _thumbHeight,
+      width: double.infinity,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          if (url == null || url!.isEmpty)
+            const ColoredBox(
+              color: AppColors.tan20,
+              child: Icon(
+                Icons.restaurant_outlined,
+                color: AppColors.tan60,
+                size: AppSizes.iconLg,
+              ),
+            )
+          else
+            CachedNetworkImage(
+              imageUrl: url!,
+              fit: BoxFit.cover,
+              placeholder: (_, __) =>
+                  const ColoredBox(color: AppColors.tan20),
+              errorWidget: (_, __, ___) => const ColoredBox(
                 color: AppColors.tan20,
                 child: Icon(
                   Icons.restaurant_outlined,
                   color: AppColors.tan60,
                   size: AppSizes.iconLg,
                 ),
-              )
-            else
-              CachedNetworkImage(
-                imageUrl: url!,
-                fit: BoxFit.cover,
-                placeholder: (_, __) =>
-                    const ColoredBox(color: AppColors.tan20),
-                errorWidget: (_, __, ___) => const ColoredBox(
-                  color: AppColors.tan20,
-                  child: Icon(
-                    Icons.restaurant_outlined,
-                    color: AppColors.tan60,
-                    size: AppSizes.iconLg,
-                  ),
-                ),
               ),
-            if (isUnsafe)
-              const Positioned(
-                top: AppSizes.xs + 2,
-                left: AppSizes.xs + 2,
-                child: AppChip(
-                  label: 'Not safe',
-                  tone: AppChipTone.flag,
-                  icon: Icon(Icons.warning_amber_rounded),
-                ),
+            ),
+          if (isUnsafe)
+            const Positioned(
+              top: AppSizes.xs + 2,
+              left: AppSizes.xs + 2,
+              child: AppChip(
+                label: 'Not safe',
+                tone: AppChipTone.flag,
+                icon: Icon(Icons.warning_amber_rounded),
               ),
-          ],
-        ),
+            ),
+        ],
       ),
     );
   }
 }
 
-/// First nutrition tag as a salmon-ghost chip + `+N` mute chip for the rest.
-/// When there are no tags, renders a fixed-height spacer so the card height
-/// stays stable across recipes.
+/// First nutrition tag as a salmon-ghost chip (Figma 'Iron Rich' label) +
+/// `+N` overflow chip for the rest. Both use [AppChipTone.neutral] so the
+/// chip background and text colour follow the Figma 'LabelContain' token
+/// (salmon-ghost / salmon-dark). When there are no tags, renders a fixed-
+/// height spacer so the card height stays stable across recipes.
 class _NutritionChipRow extends StatelessWidget {
   const _NutritionChipRow({required this.tags});
 
@@ -148,11 +169,14 @@ class _NutritionChipRow extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         Flexible(
-          child: AppChip(label: tags.first),
+          child: AppChip(
+            label: tags.first,
+            icon: const Icon(Icons.bolt),
+          ),
         ),
         if (extra > 0) ...[
           const SizedBox(width: AppSizes.xs),
-          AppChip(label: '+$extra', tone: AppChipTone.mute),
+          AppChip(label: '+$extra'),
         ],
       ],
     );


### PR DESCRIPTION
## Summary
Recipe Library list screen redesign for NIB-53. Reskins the header, banner, category rows, and recipe cards to match the Figma redesign while keeping all controller / service / repository wiring and the NIB-58 search behaviour intact.

## Figma frames
- `recipe-library-first-launch` — 971:8644 (default first-launch state with banner)
- `recipe-library-search-1` — 971:8760 (default landing in shell, banner hidden)

## Audit artifacts
- `.figma-audit/recipe-library/recipe-library-first-launch/`
- `.figma-audit/recipe-library/recipe-library-search-1/`

## Visual changes
- Page background: butter -> cream linear gradient (Figma root `linear-gradient(128.4deg, #FFFCD5 19%, #F5F5F5 50%)`).
- Title "Recipe Library" -> 17/Bold Parkinsans (Title 3) instead of 22/Bold.
- Search input: neutral-10 fill + forest-dark border, radius 10, placeholder "Search recipe".
- Filter chip: 47x47 forest-dark tile, radius 10, white bookmark / library glyph.
- "New to Starting Solids?" banner: forest-green fill, white 15/SemiBold title, 10/Regular Figtree body verbatim "Start your baby's food journey the right way with simple basics.", full-width white-outlined "Read Guide" CTA.
- Section labels: 15/SemiBold Parkinsans (Headline) instead of 20/Bold.
- Recipe card (158x220): white surface, radius 10, 117px image-top, 12px content padding, salmon-ghost "Iron Rich" bolt chip + salmon-ghost +N overflow chip; flagged-allergen "Not safe" chip retained.

## Behaviour preserved
- AsyncNotifier-backed controller, services, repository, Result<T> error contract.
- Search query collapses category rows into RecipeSearchResults; empty result -> RecipeSearchEmpty (generic copy).
- ReadGuideBanner gated by LocalFlagService.isStartingGuideSeen() (only the banner CTA marks the flag; the filter chip does not).
- Recommendation-for-{ongoing-allergen} section unchanged (English spelling kept; Figma "Recomendation" typo flagged in audit report and not propagated).
- RefreshIndicator wiring + RecipeGridCard navigation push to `/home/recipes/:recipeId`.

## Acceptance criteria
- [x] Butter -> cream page gradient applied at scaffold level.
- [x] Title is 17/Bold Parkinsans.
- [x] Search input uses neutral-10 fill + forest-dark border + "Search recipe" placeholder.
- [x] 47x47 forest-dark filter chip with white glyph, radius 10.
- [x] "New to Starting Solids?" banner uses forest-green fill, verbatim copy, white outlined "Read Guide" CTA.
- [x] Section labels use the 15/SemiBold Headline token.
- [x] Recipe card matches 158x220 Figma spec (117 thumb, 12 content padding, salmon-ghost chips, radius 10).
- [x] First-launch state (banner visible) and Search-1 state (banner hidden, shell nav owned by parent ShellRoute) both reachable.
- [x] `flutter analyze` reports 0 issues in the recipe library directory.
- [x] `flutter test` passes (576 tests).

## Test plan
- [ ] Visual smoke on the iOS Simulator: open Recipe Library tab on first launch and verify banner copy + CTA visuals.
- [ ] Tap "Read Guide" -> banner disappears on next entry.
- [ ] Type a query into the search field -> rows collapse to RecipeSearchResults; clear -> rows return.
- [ ] Flag an allergen and verify "Not safe" chip appears on affected cards.