### PR TITLE
feat(shopping-list): rebuild root screen header + segmented tabs + rows + empty state [NIB-63]

### DIFF
--- a/lib/src/features/shopping_list/shopping_list_screen.dart
+++ b/lib/src/features/shopping_list/shopping_list_screen.dart
@@ -1,14 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+import 'package:nibbles/src/common/components/controls/app_segmented_control.dart';
 import 'package:nibbles/src/common/domain/entities/shopping_list_item.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/shopping_list/shopping_list_controller.dart';
-import 'package:nibbles/src/features/shopping_list/shopping_list_state.dart';
-import 'package:nibbles/src/routing/route_enums.dart';
 
+/// Shopping List root screen — Figma frames 971:9851 (populated) and
+/// 971:9989 (empty). Header (Title 3/Bold + green-deep more_horiz chip) +
+/// segmented control (List / Bought) + ingredient rows.
+///
+/// Background: Grad-1 (linear-gradient 154.398deg, butterSoft → cream)
+/// matching the recipe library Grad-1 mapping.
+///
+/// Add-item, swipe-delete, overflow menu actions, and the clear-all
+/// confirmation sheet live in separate frames (971:9872 / 971:9889 /
+/// 971:9915 / 971:9958) and are out of scope for this ticket.
 class ShoppingListScreen extends ConsumerWidget {
   const ShoppingListScreen({super.key});
 
@@ -18,18 +28,46 @@ class ShoppingListScreen extends ConsumerWidget {
 
     return babyIdAsync.when(
       loading: () =>
-          const Scaffold(body: Center(child: CircularProgressIndicator())),
-      error: (_, __) => const Scaffold(
+          const _PageScaffold(body: Center(child: CircularProgressIndicator())),
+      error: (_, __) => const _PageScaffold(
         body: Center(child: Text('Could not load baby profile.')),
       ),
       data: (babyId) {
         if (babyId == null) {
-          return const Scaffold(
+          return const _PageScaffold(
             body: Center(child: Text('No baby profile found.')),
           );
         }
-        return _ShoppingListBody(babyId: babyId);
+        return _PageScaffold(body: _ShoppingListBody(babyId: babyId));
       },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Page scaffold — Grad-1 wash (butterSoft → cream)
+// ---------------------------------------------------------------------------
+
+class _PageScaffold extends StatelessWidget {
+  const _PageScaffold({required this.body});
+
+  final Widget body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.19, 0.5],
+            colors: [AppColors.butterSoft, AppColors.cream],
+          ),
+        ),
+        child: body,
+      ),
     );
   }
 }
@@ -47,21 +85,8 @@ class _ShoppingListBody extends ConsumerStatefulWidget {
   ConsumerState<_ShoppingListBody> createState() => _ShoppingListBodyState();
 }
 
-class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody>
-    with SingleTickerProviderStateMixin {
-  late final TabController _tabController;
-
-  @override
-  void initState() {
-    super.initState();
-    _tabController = TabController(length: 2, vsync: this);
-  }
-
-  @override
-  void dispose() {
-    _tabController.dispose();
-    super.dispose();
-  }
+class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
+  int _selectedTab = 0; // 0 = List, 1 = Bought
 
   Future<void> _showClearConfirmation() async {
     final confirmed = await showDialog<bool>(
@@ -106,97 +131,93 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody>
       );
   }
 
+  Future<void> _delete(String itemId) async {
+    try {
+      await ref
+          .read(shoppingListControllerProvider(widget.babyId).notifier)
+          .delete(itemId);
+    } on Exception catch (_) {
+      if (!mounted) return;
+      _showToast("Couldn't delete item. Try again.");
+    }
+  }
+
+  Future<void> _check(String itemId) async {
+    try {
+      await ref
+          .read(shoppingListControllerProvider(widget.babyId).notifier)
+          .check(itemId);
+    } on Exception catch (_) {
+      if (!mounted) return;
+      _showToast("Couldn't update item. Try again.");
+    }
+  }
+
+  Future<void> _uncheck(String itemId) async {
+    try {
+      await ref
+          .read(shoppingListControllerProvider(widget.babyId).notifier)
+          .uncheck(itemId);
+    } on Exception catch (_) {
+      if (!mounted) return;
+      _showToast("Couldn't update item. Try again.");
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final controllerAsync = ref.watch(
       shoppingListControllerProvider(widget.babyId),
     );
 
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.surface,
-        elevation: 0,
-        title: Text(
-          'Shopping List',
-          style: Theme.of(context).textTheme.titleLarge,
+    return SafeArea(
+      bottom: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSizes.md,
+          AppSizes.sm,
+          AppSizes.md,
+          0,
         ),
-        actions: [
-          PopupMenuButton<_MenuAction>(
-            icon: const Icon(Icons.more_vert, color: AppColors.text),
-            onSelected: (action) {
-              switch (action) {
-                case _MenuAction.copy:
-                  _copyToClipboard();
-                case _MenuAction.clear:
-                  _showClearConfirmation();
-              }
-            },
-            itemBuilder: (_) => const [
-              PopupMenuItem(
-                value: _MenuAction.copy,
-                child: Text('Copy to clipboard'),
-              ),
-              PopupMenuItem(
-                value: _MenuAction.clear,
-                child: Text('Clear list'),
-              ),
-            ],
-          ),
-        ],
-        bottom: TabBar(
-          controller: _tabController,
-          labelColor: AppColors.primary,
-          unselectedLabelColor: AppColors.subtext,
-          indicatorColor: AppColors.primary,
-          tabs: const [
-            Tab(text: 'List'),
-            Tab(text: 'Bought'),
-          ],
-        ),
-      ),
-      body: controllerAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(
-          child: Padding(
-            padding: const EdgeInsets.all(AppSizes.pagePaddingH),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  'Could not load shopping list.',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: AppSizes.sm),
-                FilledButton(
-                  onPressed: () => ref.invalidate(
+        child: Column(
+          children: [
+            _ShoppingListHeader(
+              onMenuSelected: (action) {
+                switch (action) {
+                  case _MenuAction.copy:
+                    _copyToClipboard();
+                  case _MenuAction.clear:
+                    _showClearConfirmation();
+                }
+              },
+            ),
+            const SizedBox(height: AppSizes.sp12),
+            AppSegmentedControl(
+              segments: const ['List', 'Bought'],
+              selectedIndex: _selectedTab,
+              onChanged: (i) => setState(() => _selectedTab = i),
+            ),
+            const SizedBox(height: AppSizes.sp12),
+            Expanded(
+              child: controllerAsync.when(
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (e, _) => _ErrorState(
+                  onRetry: () => ref.invalidate(
                     shoppingListControllerProvider(widget.babyId),
                   ),
-                  child: const Text('Retry'),
                 ),
-              ],
-            ),
-          ),
-        ),
-        data: (state) => TabBarView(
-          controller: _tabController,
-          children: [
-            _ListTab(
-              state: state,
-              babyId: widget.babyId,
-              onAddFailed: () => _showToast("Couldn't add items. Try again."),
-              onDeleteFailed: () =>
-                  _showToast("Couldn't delete item. Try again."),
-              onCheckFailed: () =>
-                  _showToast("Couldn't update item. Try again."),
-            ),
-            _BoughtTab(
-              state: state,
-              babyId: widget.babyId,
-              onUncheckFailed: () =>
-                  _showToast("Couldn't update item. Try again."),
-              onDeleteFailed: () =>
-                  _showToast("Couldn't delete item. Try again."),
+                data: (state) => _selectedTab == 0
+                    ? _ItemsList(
+                        items: state.listItems,
+                        onToggle: _check,
+                        onDelete: _delete,
+                      )
+                    : _ItemsList(
+                        items: state.boughtItems,
+                        onToggle: _uncheck,
+                        onDelete: _delete,
+                      ),
+              ),
             ),
           ],
         ),
@@ -207,274 +228,104 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody>
 
 enum _MenuAction { copy, clear }
 
-// Top-level helpers shared by both List and Bought tabs.
-
-Future<void> _deleteShoppingItem(
-  WidgetRef ref,
-  String babyId,
-  String itemId,
-  VoidCallback onFailed,
-) async {
-  try {
-    await ref
-        .read(shoppingListControllerProvider(babyId).notifier)
-        .delete(itemId);
-  } on Exception catch (_) {
-    onFailed();
-  }
-}
-
-Future<void> _confirmAndDeleteShoppingItem(
-  BuildContext context,
-  WidgetRef ref,
-  String babyId,
-  String itemId,
-  VoidCallback onFailed,
-) async {
-  final confirmed = await showDialog<bool>(
-    context: context,
-    builder: (_) => const _ConfirmDialog(
-      title: 'Delete item',
-      message: "Are you sure you want to delete? You can't restore it.",
-    ),
-  );
-  if (confirmed != true) return;
-  await _deleteShoppingItem(ref, babyId, itemId, onFailed);
-}
-
 // ---------------------------------------------------------------------------
-// List Tab (unchecked items)
+// Header — title + green-deep more_horiz overflow chip
 // ---------------------------------------------------------------------------
 
-class _ListTab extends ConsumerStatefulWidget {
-  const _ListTab({
-    required this.state,
-    required this.babyId,
-    required this.onAddFailed,
-    required this.onDeleteFailed,
-    required this.onCheckFailed,
-  });
+class _ShoppingListHeader extends StatelessWidget {
+  const _ShoppingListHeader({required this.onMenuSelected});
 
-  final ShoppingListState state;
-  final String babyId;
-  final VoidCallback onAddFailed;
-  final VoidCallback onDeleteFailed;
-  final VoidCallback onCheckFailed;
-
-  @override
-  ConsumerState<_ListTab> createState() => _ListTabState();
-}
-
-class _ListTabState extends ConsumerState<_ListTab> {
-  final _textController = TextEditingController();
-  bool _isAdding = false;
-
-  @override
-  void dispose() {
-    _textController.dispose();
-    super.dispose();
-  }
-
-  Future<void> _add() async {
-    final name = _textController.text.trim();
-    if (name.isEmpty) return;
-    setState(() => _isAdding = true);
-    try {
-      await ref
-          .read(shoppingListControllerProvider(widget.babyId).notifier)
-          .addManual(name);
-      _textController.clear();
-    } on Exception catch (_) {
-      widget.onAddFailed();
-    } finally {
-      if (mounted) setState(() => _isAdding = false);
-    }
-  }
-
-  Future<void> _check(String itemId) async {
-    try {
-      await ref
-          .read(shoppingListControllerProvider(widget.babyId).notifier)
-          .check(itemId);
-    } on Exception catch (_) {
-      widget.onCheckFailed();
-    }
-  }
-
-  Future<void> _deleteDirect(String itemId) =>
-      _deleteShoppingItem(ref, widget.babyId, itemId, widget.onDeleteFailed);
-
-  Future<void> _deleteWithConfirm(String itemId) =>
-      _confirmAndDeleteShoppingItem(
-        context,
-        ref,
-        widget.babyId,
-        itemId,
-        widget.onDeleteFailed,
-      );
+  final ValueChanged<_MenuAction> onMenuSelected;
 
   @override
   Widget build(BuildContext context) {
-    final items = widget.state.listItems;
-
-    return Column(
+    return Row(
       children: [
-        // Add input
-        Container(
-          color: AppColors.surface,
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
-            vertical: AppSizes.md,
-          ),
-          child: Row(
-            children: [
-              Expanded(
-                child: TextField(
-                  controller: _textController,
-                  textCapitalization: TextCapitalization.sentences,
-                  decoration: InputDecoration(
-                    hintText: 'Add an item...',
-                    hintStyle: Theme.of(
-                      context,
-                    ).textTheme.bodyMedium?.copyWith(color: AppColors.hint),
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: AppSizes.md,
-                      vertical: AppSizes.sm,
-                    ),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(AppSizes.radiusSm),
-                      borderSide: const BorderSide(color: AppColors.divider),
-                    ),
-                    enabledBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(AppSizes.radiusSm),
-                      borderSide: const BorderSide(color: AppColors.divider),
-                    ),
-                    focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(AppSizes.radiusSm),
-                      borderSide: const BorderSide(color: AppColors.primary),
-                    ),
-                    filled: true,
-                    fillColor: AppColors.surfaceVariant,
-                  ),
-                  onSubmitted: (_) => _add(),
-                ),
-              ),
-              const SizedBox(width: AppSizes.sm),
-              SizedBox(
-                height: AppSizes.buttonHeightSm,
-                child: FilledButton(
-                  onPressed: _isAdding ? null : _add,
-                  style: FilledButton.styleFrom(
-                    backgroundColor: AppColors.primary,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: AppSizes.md,
-                    ),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(AppSizes.radiusSm),
-                    ),
-                  ),
-                  child: _isAdding
-                      ? const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: AppColors.onPrimary,
-                          ),
-                        )
-                      : const Text('Add'),
-                ),
-              ),
-            ],
-          ),
-        ),
-        const Divider(height: 1, color: AppColors.divider),
-        // List
         Expanded(
-          child: items.isEmpty
-              ? _ListEmptyState(
-                  onBrowseRecipes: () =>
-                      context.goNamed(AppRoute.recipeLibrary.name),
-                )
-              : ListView.separated(
-                  padding: const EdgeInsets.symmetric(vertical: AppSizes.sm),
-                  itemCount: items.length,
-                  separatorBuilder: (_, __) =>
-                      const Divider(height: 1, color: AppColors.divider),
-                  itemBuilder: (_, index) {
-                    final item = items[index];
-                    return _ShoppingItemTile(
-                      item: item,
-                      onToggle: () => _check(item.id),
-                      onDeleteDirect: () => _deleteDirect(item.id),
-                      onDeleteWithConfirm: () => _deleteWithConfirm(item.id),
-                    );
-                  },
-                ),
+          child: Text(
+            'Shopping List',
+            style: AppTypography.textTheme.titleSmall,
+          ),
         ),
+        _OverflowChip(onSelected: onMenuSelected),
       ],
     );
   }
 }
 
-// ---------------------------------------------------------------------------
-// Bought Tab (checked items)
-// ---------------------------------------------------------------------------
+/// 40x40 green-deep rounded-square chip hosting the more_horiz popup menu.
+/// Mirrors Figma 971:9858 (Button-chips, bg ForestDarkn, rounded-[10px]).
+class _OverflowChip extends StatelessWidget {
+  const _OverflowChip({required this.onSelected});
 
-class _BoughtTab extends ConsumerWidget {
-  const _BoughtTab({
-    required this.state,
-    required this.babyId,
-    required this.onUncheckFailed,
-    required this.onDeleteFailed,
-  });
-
-  final ShoppingListState state;
-  final String babyId;
-  final VoidCallback onUncheckFailed;
-  final VoidCallback onDeleteFailed;
-
-  Future<void> _uncheck(
-    BuildContext context,
-    WidgetRef ref,
-    String itemId,
-  ) async {
-    try {
-      await ref
-          .read(shoppingListControllerProvider(babyId).notifier)
-          .uncheck(itemId);
-    } on Exception catch (_) {
-      onUncheckFailed();
-    }
-  }
+  final ValueChanged<_MenuAction> onSelected;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final items = state.boughtItems;
+  Widget build(BuildContext context) {
+    return PopupMenuButton<_MenuAction>(
+      onSelected: onSelected,
+      tooltip: 'More options',
+      position: PopupMenuPosition.under,
+      offset: const Offset(0, AppSizes.xs),
+      color: AppColors.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      ),
+      itemBuilder: (_) => const [
+        PopupMenuItem(
+          value: _MenuAction.copy,
+          child: Text('Copy to clipboard'),
+        ),
+        PopupMenuItem(value: _MenuAction.clear, child: Text('Clear list')),
+      ],
+      child: Container(
+        width: 40,
+        height: 40,
+        decoration: BoxDecoration(
+          color: AppColors.greenDeep,
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        ),
+        alignment: Alignment.center,
+        child: const Icon(
+          Icons.more_horiz,
+          color: AppColors.onGreen,
+          size: AppSizes.iconMd,
+        ),
+      ),
+    );
+  }
+}
 
+// ---------------------------------------------------------------------------
+// List body
+// ---------------------------------------------------------------------------
+
+class _ItemsList extends StatelessWidget {
+  const _ItemsList({
+    required this.items,
+    required this.onToggle,
+    required this.onDelete,
+  });
+
+  final List<ShoppingListItem> items;
+  final ValueChanged<String> onToggle;
+  final ValueChanged<String> onDelete;
+
+  @override
+  Widget build(BuildContext context) {
     if (items.isEmpty) {
-      return const _BoughtEmptyState();
+      return const _EmptyState();
     }
-
     return ListView.separated(
-      padding: const EdgeInsets.symmetric(vertical: AppSizes.sm),
+      padding: const EdgeInsets.only(bottom: AppSizes.md),
       itemCount: items.length,
-      separatorBuilder: (_, __) =>
-          const Divider(height: 1, color: AppColors.divider),
+      separatorBuilder: (_, __) => const SizedBox(height: AppSizes.sm),
       itemBuilder: (_, index) {
         final item = items[index];
-        return _ShoppingItemTile(
+        return _ShoppingItemRow(
           item: item,
-          onToggle: () => _uncheck(context, ref, item.id),
-          onDeleteDirect: () =>
-              _deleteShoppingItem(ref, babyId, item.id, onDeleteFailed),
-          onDeleteWithConfirm: () => _confirmAndDeleteShoppingItem(
-            context,
-            ref,
-            babyId,
-            item.id,
-            onDeleteFailed,
-          ),
+          onToggle: () => onToggle(item.id),
+          onDelete: () => onDelete(item.id),
         );
       },
     );
@@ -482,123 +333,159 @@ class _BoughtTab extends ConsumerWidget {
 }
 
 // ---------------------------------------------------------------------------
-// Shared item tile
+// Row — Figma 822:7262 List variant
+//   White card, rounded-10, custom 30x30 square checkbox (greenDeep border),
+//   label (body/regular), trailing 37x37 cancel chip.
 // ---------------------------------------------------------------------------
 
-class _ShoppingItemTile extends StatelessWidget {
-  const _ShoppingItemTile({
+class _ShoppingItemRow extends StatelessWidget {
+  const _ShoppingItemRow({
     required this.item,
     required this.onToggle,
-    // Called after swipe-confirm — no dialog needed, already confirmed.
-    required this.onDeleteDirect,
-    // Called by trash icon — shows confirmation dialog.
-    required this.onDeleteWithConfirm,
+    required this.onDelete,
   });
 
   final ShoppingListItem item;
   final VoidCallback onToggle;
-  final VoidCallback onDeleteDirect;
-  final VoidCallback onDeleteWithConfirm;
+  final VoidCallback onDelete;
+
+  static const double _checkboxSize = 30;
+  static const double _cancelChipSize = 37;
 
   @override
   Widget build(BuildContext context) {
-    // Optimistic placeholders have id=''; use createdAt to avoid key collision.
-    final key = item.id.isEmpty
-        ? ValueKey('new_${item.createdAt.millisecondsSinceEpoch}')
-        : ValueKey(item.id);
-    return Dismissible(
-      key: key,
-      direction: DismissDirection.endToStart,
-      background: Container(
-        alignment: Alignment.centerRight,
-        padding: const EdgeInsets.only(right: AppSizes.lg),
-        color: AppColors.error,
-        child: const Icon(Icons.delete_outline, color: AppColors.onError),
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.sp12,
+        vertical: AppSizes.sm,
       ),
-      confirmDismiss: (_) async {
-        return showDialog<bool>(
-          context: context,
-          builder: (_) => const _ConfirmDialog(
-            title: 'Delete item',
-            message: "Are you sure you want to delete? You can't restore it.",
-          ),
-        );
-      },
-      onDismissed: (_) => onDeleteDirect(),
-      child: ListTile(
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: AppSizes.pagePaddingH,
-          vertical: AppSizes.xs,
-        ),
-        leading: Checkbox(
-          value: item.isChecked,
-          activeColor: AppColors.primary,
-          onChanged: (_) => onToggle(),
-        ),
-        title: Text(
-          item.name,
-          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-            decoration: item.isChecked ? TextDecoration.lineThrough : null,
-            color: item.isChecked ? AppColors.subtext : AppColors.text,
-          ),
-        ),
-        trailing: IconButton(
-          icon: const Icon(Icons.delete_outline, size: AppSizes.iconMd),
-          color: AppColors.hint,
-          onPressed: onDeleteWithConfirm,
-        ),
+      decoration: BoxDecoration(
+        color: AppColors.cream,
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
       ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Empty states
-// ---------------------------------------------------------------------------
-
-class _ListEmptyState extends StatelessWidget {
-  const _ListEmptyState({required this.onBrowseRecipes});
-
-  final VoidCallback onBrowseRecipes;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSizes.pagePaddingH),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text('🛒', style: TextStyle(fontSize: 56)),
-            const SizedBox(height: AppSizes.md),
-            Text(
-              "It seems you don't have any shopping list :(",
-              style: textTheme.titleSmall,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: AppSizes.sm),
-            TextButton(
-              onPressed: onBrowseRecipes,
-              child: Text(
-                'Browse recipes to get started',
-                style: textTheme.bodyMedium?.copyWith(
-                  color: AppColors.primary,
-                  decoration: TextDecoration.underline,
-                  decorationColor: AppColors.primary,
-                ),
+      child: Row(
+        children: [
+          _SquareCheckbox(
+            value: item.isChecked,
+            onTap: onToggle,
+            size: _checkboxSize,
+          ),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Text(
+              item.name,
+              style: AppTypography.textTheme.bodyLarge?.copyWith(
+                decoration: item.isChecked ? TextDecoration.lineThrough : null,
+                color: item.isChecked ? AppColors.fgMuted : AppColors.text,
               ),
             ),
-          ],
+          ),
+          const SizedBox(width: AppSizes.sp12),
+          _CancelChip(onTap: onDelete, size: _cancelChipSize),
+        ],
+      ),
+    );
+  }
+}
+
+/// Custom square checkbox — 30x30, greenDeep border, radius 10.
+/// Mirrors Figma 871:7708 (Checkbox/default).
+class _SquareCheckbox extends StatelessWidget {
+  const _SquareCheckbox({
+    required this.value,
+    required this.onTap,
+    required this.size,
+  });
+
+  final bool value;
+  final VoidCallback onTap;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          color: value ? AppColors.greenDeep : AppColors.cream,
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          border: Border.all(color: AppColors.greenDeep, width: 1.5),
+        ),
+        alignment: Alignment.center,
+        child: value
+            ? const Icon(Icons.check, size: 18, color: AppColors.onGreen)
+            : null,
+      ),
+    );
+  }
+}
+
+/// Per-row cancel chip — 37x37, rounded 10, burgundy circle X icon.
+/// Mirrors Figma 898:18568 (cancel) inside Button-chips wrapper.
+class _CancelChip extends StatelessWidget {
+  const _CancelChip({required this.onTap, required this.size});
+
+  final VoidCallback onTap;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: const Center(
+          child: Icon(
+            Icons.cancel,
+            color: AppColors.burgundy,
+            size: AppSizes.iconMd,
+          ),
         ),
       ),
     );
   }
 }
 
-class _BoughtEmptyState extends StatelessWidget {
-  const _BoughtEmptyState();
+// ---------------------------------------------------------------------------
+// Empty state — Figma 971:9989
+//   Centered Quatrefoil flower + verbatim caption, no CTA.
+// ---------------------------------------------------------------------------
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Quatrefoil(size: 153),
+          const SizedBox(height: AppSizes.sm),
+          Text(
+            "You don't have any list yet",
+            textAlign: TextAlign.center,
+            style: AppTypography.textTheme.bodyLarge,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error retry
+// ---------------------------------------------------------------------------
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.onRetry});
+
+  final VoidCallback onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -608,13 +495,12 @@ class _BoughtEmptyState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Text('✅', style: TextStyle(fontSize: 56)),
-            const SizedBox(height: AppSizes.md),
             Text(
-              'No items bought yet.',
-              style: Theme.of(context).textTheme.titleSmall,
-              textAlign: TextAlign.center,
+              'Could not load shopping list.',
+              style: AppTypography.textTheme.titleMedium,
             ),
+            const SizedBox(height: AppSizes.sm),
+            FilledButton(onPressed: onRetry, child: const Text('Retry')),
           ],
         ),
       ),
@@ -623,7 +509,7 @@ class _BoughtEmptyState extends StatelessWidget {
 }
 
 // ---------------------------------------------------------------------------
-// Reusable confirm dialog
+// Confirm dialog (Clear All)
 // ---------------------------------------------------------------------------
 
 class _ConfirmDialog extends StatelessWidget {
@@ -634,7 +520,7 @@ class _ConfirmDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
+    final textTheme = AppTypography.textTheme;
 
     return AlertDialog(
       title: Text(title, style: textTheme.titleMedium),

--- a/test/features/shopping_list/shopping_list_screen_test.dart
+++ b/test/features/shopping_list/shopping_list_screen_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/components/controls/app_segmented_control.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/shopping_list_item.dart';
 import 'package:nibbles/src/common/domain/enums/shopping_list_source.dart';
@@ -61,18 +63,35 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // Empty state
+  // Header / chrome
   // ---------------------------------------------------------------------------
 
-  group('ShoppingListScreen - empty state', () {
-    testWidgets('List tab shows empty state when no items', (tester) async {
+  group('ShoppingListScreen - chrome', () {
+    testWidgets('renders Shopping List title + segmented tabs', (tester) async {
       await tester.pumpWidget(_buildSut(mockService));
       await tester.pumpAndSettle();
 
-      expect(
-        find.text("It seems you don't have any shopping list :("),
-        findsOneWidget,
-      );
+      expect(find.text('Shopping List'), findsOneWidget);
+      expect(find.byType(AppSegmentedControl), findsOneWidget);
+      expect(find.text('List'), findsOneWidget);
+      expect(find.text('Bought'), findsOneWidget);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Empty state — Figma 971:9989
+  // ---------------------------------------------------------------------------
+
+  group('ShoppingListScreen - empty state', () {
+    testWidgets('List tab shows verbatim empty-state copy + no CTA', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildSut(mockService));
+      await tester.pumpAndSettle();
+
+      expect(find.text("You don't have any list yet"), findsOneWidget);
+      // No browse-recipes CTA in this frame.
+      expect(find.text('Browse recipes to get started'), findsNothing);
     });
   });
 
@@ -113,7 +132,7 @@ void main() {
       expect(find.text('Apples'), findsOneWidget);
       expect(find.text('Bananas'), findsNothing);
 
-      // Switch to Bought tab
+      // Switch to Bought tab via segmented control
       await tester.tap(find.text('Bought'));
       await tester.pumpAndSettle();
 
@@ -123,13 +142,11 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // Check / uncheck
+  // Check / uncheck — tap the square checkbox
   // ---------------------------------------------------------------------------
 
   group('ShoppingListScreen - check', () {
-    testWidgets('tapping checkbox calls checkItem on the service', (
-      tester,
-    ) async {
+    testWidgets('tapping the square checkbox calls checkItem', (tester) async {
       when(
         () => mockService.getItems(any()),
       ).thenAnswer((_) async => Result.success([_makeItem()]));
@@ -140,8 +157,11 @@ void main() {
       await tester.pumpWidget(_buildSut(mockService));
       await tester.pumpAndSettle();
 
-      // Tap the Checkbox widget
-      await tester.tap(find.byType(Checkbox).first);
+      // The square checkbox sits to the left of the row label inside the row
+      // card. Tap roughly at the box's center (~24px left of the label).
+      final apples = find.text('Apples');
+      final rowBox = tester.getRect(apples);
+      await tester.tapAt(Offset(rowBox.left - 24, rowBox.center.dy));
       await tester.pumpAndSettle();
 
       verify(() => mockService.checkItem('item-1')).called(1);
@@ -149,27 +169,13 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // Delete with confirmation dialog
+  // Delete — per-row cancel chip → P2 toast on failure, no confirm dialog
   // ---------------------------------------------------------------------------
 
   group('ShoppingListScreen - delete', () {
-    testWidgets('delete icon tap shows confirmation dialog', (tester) async {
-      when(
-        () => mockService.getItems(any()),
-      ).thenAnswer((_) async => Result.success([_makeItem()]));
-
-      await tester.pumpWidget(_buildSut(mockService));
-      await tester.pumpAndSettle();
-
-      // Tap the trash icon
-      await tester.tap(find.byIcon(Icons.delete_outline).first);
-      await tester.pumpAndSettle();
-
-      expect(find.text('Delete item'), findsOneWidget);
-      expect(find.byType(AlertDialog), findsOneWidget);
-    });
-
-    testWidgets('confirm Yes → deleteItem called', (tester) async {
+    testWidgets('cancel chip directly deletes (no confirm dialog)', (
+      tester,
+    ) async {
       when(
         () => mockService.getItems(any()),
       ).thenAnswer((_) async => Result.success([_makeItem()]));
@@ -180,31 +186,29 @@ void main() {
       await tester.pumpWidget(_buildSut(mockService));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byIcon(Icons.delete_outline).first);
-      await tester.pumpAndSettle();
-
-      // Tap Yes in dialog
-      await tester.tap(find.text('Yes'));
+      await tester.tap(find.byIcon(Icons.cancel).first);
       await tester.pumpAndSettle();
 
       verify(() => mockService.deleteItem('item-1')).called(1);
+      // No AlertDialog should ever surface.
+      expect(find.byType(AlertDialog), findsNothing);
     });
 
-    testWidgets('confirm No → deleteItem never called', (tester) async {
+    testWidgets('delete failure surfaces P2 toast', (tester) async {
       when(
         () => mockService.getItems(any()),
       ).thenAnswer((_) async => Result.success([_makeItem()]));
+      when(
+        () => mockService.deleteItem(any()),
+      ).thenAnswer((_) async => const Result.failure(UnknownException('boom')));
 
       await tester.pumpWidget(_buildSut(mockService));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byIcon(Icons.delete_outline).first);
+      await tester.tap(find.byIcon(Icons.cancel).first);
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('No'));
-      await tester.pumpAndSettle();
-
-      verifyNever(() => mockService.deleteItem(any()));
+      expect(find.text("Couldn't delete item. Try again."), findsOneWidget);
     });
   });
 
@@ -217,14 +221,13 @@ void main() {
       await tester.pumpWidget(_buildSut(mockService));
       await tester.pumpAndSettle();
 
-      // Open overflow menu
-      await tester.tap(find.byIcon(Icons.more_vert));
+      // Open overflow menu via the green-deep more_horiz chip.
+      await tester.tap(find.byIcon(Icons.more_horiz));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Clear list'));
+      await tester.tap(find.text('Clear list').last);
       await tester.pumpAndSettle();
 
-      expect(find.text('Clear list'), findsWidgets);
       expect(
         find.text('This will delete all items. Are you sure?'),
         findsOneWidget,
@@ -246,7 +249,7 @@ void main() {
       await tester.pumpWidget(_buildSut(mockService));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.tap(find.byIcon(Icons.more_horiz));
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('Copy to clipboard'));
@@ -272,7 +275,7 @@ void main() {
       await tester.pumpWidget(_buildSut(mockService));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byIcon(Icons.more_vert));
+      await tester.tap(find.byIcon(Icons.more_horiz));
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('Copy to clipboard'));


### PR DESCRIPTION
## Summary
Rebuild Shopping List root screen to match Figma redesign (frames 971:9851 populated, 971:9989 empty). Header title + green-deep more_horiz chip, AppSegmentedControl for List/Bought tabs, white-card ShopRow tiles with square checkbox + cancel chip, and centered Quatrefoil empty state with verbatim caption.

## Scope
- Presentation rewrite of `shopping_list_screen.dart` only.
- Test file updated in lockstep to match the new design.
- Controller / state / service / repository unchanged (already wired).

## Acceptance criteria
- [x] Pixel-close match to populated frame 971:9851 and empty frame 971:9989.
- [x] Verbatim empty-state copy `You don't have any list yet` (straight apostrophe per source bytes — flagged Open Q6 in section_report).
- [x] Header title "Shopping List" uses Parkinsans Bold 17 (titleSmall slot).
- [x] AppSegmentedControl renders List / Bought (shared component — minor token delta noted below).
- [x] Header overflow chip + segmented control + per-row checkbox/cancel chip all reachable.
- [x] Loading / empty / populated / error states all reachable.
- [x] All tokens from `AppColors` / `AppTypography` — no hardcoded hex outside the foundation.
- [x] Zero analyze warnings in changed files; widget tests cover populated + empty + check + delete + clear + clipboard.
- [x] Grad-1 background mapped via `_PageScaffold` (matching recipe library's Grad-1 mapping).

## Implementation notes / open-question dispositions
- Row 1 "Flour" Delete-variant on the Figma frame is treated as a designer demo artifact (Open Q2 in section_report). All rows render uniform with the List variant: square checkbox + label + cancel chip.
- Per-row cancel chip wires to direct delete (no confirm dialog). Delete failure surfaces a P2 toast per `error-handling.md`.
- Inline add-item bar from the legacy screen is removed — add flow lives in a separate frame (971:9872) and a separate ticket. Existing controller `addManual` API is preserved for that follow-up.
- Header overflow menu retained (Copy to clipboard / Clear list) since the controller already exposes those actions; the dedicated overflow-menu ticket (NIB-71) can later swap this PopupMenu for the design's white floating card.
- Per-row swipe-to-delete (NIB-81) intentionally not implemented here.
- Empty-state: no body CTA (per Open Q7 + acceptance criteria).
- Active-segment token delta: `AppSegmentedControl` uses `greenDeep #3d5236`; raw Figma uses `Forest #5c7852`. Reusing the shared component for consistency rather than forking — flagging the 1-token delta.

## Audit artifacts
- `.figma-audit/shopping-list/shoplist-list-971-9851/report.md` + `screenshot.png` + `variables.json`
- `.figma-audit/shopping-list/shoplist-list-971-9989/report.md` + `screenshot.png` + `variables.json`

## Test plan
- [x] `flutter analyze` — 0 issues on changed files
- [x] `flutter test test/features/shopping_list/` — 10/10 pass
- [x] `flutter test` — full suite passes
- [ ] Manual smoke on simulator (recommended pre-merge)