### PR TITLE
feat(shopping-list): floating overflow menu + Clear-All confirm sheet [NIB-71]

### DIFF
--- a/lib/src/features/shopping_list/shopping_list_screen.dart
+++ b/lib/src/features/shopping_list/shopping_list_screen.dart
@@ -8,6 +8,8 @@ import 'package:nibbles/src/common/components/controls/app_segmented_control.dar
 import 'package:nibbles/src/common/domain/entities/shopping_list_item.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/shopping_list/shopping_list_controller.dart';
+import 'package:nibbles/src/features/shopping_list/widgets/clear_all_confirm_sheet.dart';
+import 'package:nibbles/src/features/shopping_list/widgets/shopping_list_menu.dart';
 
 /// Shopping List root screen — Figma frames 971:9851 (populated) and
 /// 971:9989 (empty). Header (Title 3/Bold + green-deep more_horiz chip) +
@@ -16,9 +18,15 @@ import 'package:nibbles/src/features/shopping_list/shopping_list_controller.dart
 /// Background: Grad-1 (linear-gradient 154.398deg, butterSoft → cream)
 /// matching the recipe library Grad-1 mapping.
 ///
-/// Add-item, swipe-delete, overflow menu actions, and the clear-all
-/// confirmation sheet live in separate frames (971:9872 / 971:9889 /
-/// 971:9915 / 971:9958) and are out of scope for this ticket.
+/// Header overflow chip opens a floating dropdown menu (971:9889 / 971:9936)
+/// with two actions:
+///   * "Copy to Clipboard" — copies the active List items as a bulleted
+///     string via the controller; surfaces a P2 toast on success/failure.
+///   * "Clear All Shopping List" — opens the Clear-All confirmation sheet
+///     (971:9958). Confirm calls the controller's `clearAll` and drops back
+///     to the empty state; cancel dismisses the sheet.
+///
+/// Add-item (971:9872) and swipe-delete (971:9915) remain out of scope.
 class ShoppingListScreen extends ConsumerWidget {
   const ShoppingListScreen({super.key});
 
@@ -89,13 +97,7 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
   int _selectedTab = 0; // 0 = List, 1 = Bought
 
   Future<void> _showClearConfirmation() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (_) => const _ConfirmDialog(
-        title: 'Clear list',
-        message: 'This will delete all items. Are you sure?',
-      ),
-    );
+    final confirmed = await showClearAllConfirmSheet(context);
     if (confirmed != true || !mounted) return;
     await _runWrite(
       ref.read(shoppingListControllerProvider(widget.babyId).notifier).clearAll,
@@ -184,9 +186,9 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
             _ShoppingListHeader(
               onMenuSelected: (action) {
                 switch (action) {
-                  case _MenuAction.copy:
+                  case ShoppingListMenuAction.copy:
                     _copyToClipboard();
-                  case _MenuAction.clear:
+                  case ShoppingListMenuAction.clear:
                     _showClearConfirmation();
                 }
               },
@@ -226,8 +228,6 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
   }
 }
 
-enum _MenuAction { copy, clear }
-
 // ---------------------------------------------------------------------------
 // Header — title + green-deep more_horiz overflow chip
 // ---------------------------------------------------------------------------
@@ -235,7 +235,7 @@ enum _MenuAction { copy, clear }
 class _ShoppingListHeader extends StatelessWidget {
   const _ShoppingListHeader({required this.onMenuSelected});
 
-  final ValueChanged<_MenuAction> onMenuSelected;
+  final ValueChanged<ShoppingListMenuAction> onMenuSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -247,50 +247,34 @@ class _ShoppingListHeader extends StatelessWidget {
             style: AppTypography.textTheme.titleSmall,
           ),
         ),
-        _OverflowChip(onSelected: onMenuSelected),
+        ShoppingListOverflowMenu(
+          onSelected: onMenuSelected,
+          child: const _OverflowChip(),
+        ),
       ],
     );
   }
 }
 
-/// 40x40 green-deep rounded-square chip hosting the more_horiz popup menu.
-/// Mirrors Figma 971:9858 (Button-chips, bg ForestDarkn, rounded-[10px]).
+/// 40x40 green-deep rounded-square chip. Mirrors Figma 971:9943
+/// (Button-chips, bg ForestDarkn, rounded-[10px]).
 class _OverflowChip extends StatelessWidget {
-  const _OverflowChip({required this.onSelected});
-
-  final ValueChanged<_MenuAction> onSelected;
+  const _OverflowChip();
 
   @override
   Widget build(BuildContext context) {
-    return PopupMenuButton<_MenuAction>(
-      onSelected: onSelected,
-      tooltip: 'More options',
-      position: PopupMenuPosition.under,
-      offset: const Offset(0, AppSizes.xs),
-      color: AppColors.surface,
-      shape: RoundedRectangleBorder(
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: AppColors.greenDeep,
         borderRadius: BorderRadius.circular(AppSizes.radiusMd),
       ),
-      itemBuilder: (_) => const [
-        PopupMenuItem(
-          value: _MenuAction.copy,
-          child: Text('Copy to clipboard'),
-        ),
-        PopupMenuItem(value: _MenuAction.clear, child: Text('Clear list')),
-      ],
-      child: Container(
-        width: 40,
-        height: 40,
-        decoration: BoxDecoration(
-          color: AppColors.greenDeep,
-          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-        ),
-        alignment: Alignment.center,
-        child: const Icon(
-          Icons.more_horiz,
-          color: AppColors.onGreen,
-          size: AppSizes.iconMd,
-        ),
+      alignment: Alignment.center,
+      child: const Icon(
+        Icons.more_horiz,
+        color: AppColors.onGreen,
+        size: AppSizes.iconMd,
       ),
     );
   }
@@ -504,38 +488,6 @@ class _ErrorState extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Confirm dialog (Clear All)
-// ---------------------------------------------------------------------------
-
-class _ConfirmDialog extends StatelessWidget {
-  const _ConfirmDialog({required this.title, required this.message});
-
-  final String title;
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = AppTypography.textTheme;
-
-    return AlertDialog(
-      title: Text(title, style: textTheme.titleMedium),
-      content: Text(message, style: textTheme.bodyMedium),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(false),
-          child: const Text('No'),
-        ),
-        FilledButton(
-          onPressed: () => Navigator.of(context).pop(true),
-          style: FilledButton.styleFrom(backgroundColor: AppColors.error),
-          child: const Text('Yes'),
-        ),
-      ],
     );
   }
 }

--- a/lib/src/features/shopping_list/widgets/clear_all_confirm_sheet.dart
+++ b/lib/src/features/shopping_list/widgets/clear_all_confirm_sheet.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+
+/// Bulk-delete confirmation sheet for the Shopping List
+/// (Figma 971:9958 — Clear All confirm).
+///
+/// White sheet with top corners rounded 30px, scrim 50% black.
+/// Title "Are you sure you want to delete?" (Parkinsans Bold 17, centered),
+/// 153px quatrefoil illustration, Cancel (outline forest) + Delete (filled
+/// forest) bottom row. Resolves to `true` when Delete is tapped, `false` /
+/// `null` otherwise.
+Future<bool?> showClearAllConfirmSheet(BuildContext context) {
+  return showModalBottomSheet<bool>(
+    context: context,
+    backgroundColor: AppColors.surface,
+    barrierColor: Colors.black.withValues(alpha: 0.5),
+    isScrollControlled: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(30)),
+    ),
+    builder: (_) => const _ClearAllConfirmSheet(),
+  );
+}
+
+class _ClearAllConfirmSheet extends StatelessWidget {
+  const _ClearAllConfirmSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSizes.sp12,
+          AppSizes.lg,
+          AppSizes.sp12,
+          AppSizes.sm,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(
+              child: SizedBox(
+                width: 212,
+                child: Text(
+                  'Are you sure you want to delete?',
+                  textAlign: TextAlign.center,
+                  style: AppTypography.textTheme.titleSmall,
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSizes.sm),
+            const Center(child: Quatrefoil(size: 153)),
+            const SizedBox(height: AppSizes.sm),
+            Row(
+              children: [
+                Expanded(
+                  child: AppPillButton(
+                    label: 'Cancel',
+                    variant: AppPillButtonVariant.secondary,
+                    onPressed: () => Navigator.of(context).pop(false),
+                  ),
+                ),
+                const SizedBox(width: AppSizes.sp12),
+                Expanded(
+                  child: AppPillButton(
+                    label: 'Delete',
+                    onPressed: () => Navigator.of(context).pop(true),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/shopping_list/widgets/shopping_list_menu.dart
+++ b/lib/src/features/shopping_list/widgets/shopping_list_menu.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+
+/// Actions surfaced by [ShoppingListOverflowMenu].
+enum ShoppingListMenuAction { copy, clear }
+
+/// Floating dropdown menu anchored to the Shopping List header overflow chip
+/// (Figma 971:9889 / 971:9936 — Overlay Menu - Input).
+///
+/// White card 262 wide, pad-12, gap-4 between rows, rounded-10 with a soft
+/// drop shadow. Each row is a px-12 py-6 rounded-6 button containing an
+/// 18px leading icon + Figtree Body/Regular 15/22 label. The pressed/hover
+/// row fills lime (`AppColors.butter`).
+///
+/// Wrap the trigger in [ShoppingListOverflowMenu] and pass the trigger as
+/// [child]; tapping the child opens the menu, tapping outside dismisses.
+class ShoppingListOverflowMenu extends StatefulWidget {
+  const ShoppingListOverflowMenu({
+    required this.onSelected,
+    required this.child,
+    super.key,
+  });
+
+  final ValueChanged<ShoppingListMenuAction> onSelected;
+  final Widget child;
+
+  @override
+  State<ShoppingListOverflowMenu> createState() =>
+      _ShoppingListOverflowMenuState();
+}
+
+class _ShoppingListOverflowMenuState extends State<ShoppingListOverflowMenu> {
+  final OverlayPortalController _controller = OverlayPortalController();
+  final LayerLink _link = LayerLink();
+
+  static const double _menuWidth = 262;
+  static const double _menuOffsetY = 8;
+
+  void _toggle() {
+    if (_controller.isShowing) {
+      _controller.hide();
+    } else {
+      _controller.show();
+    }
+  }
+
+  void _handleSelected(ShoppingListMenuAction action) {
+    _controller.hide();
+    widget.onSelected(action);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CompositedTransformTarget(
+      link: _link,
+      child: OverlayPortal(
+        controller: _controller,
+        overlayChildBuilder: (overlayContext) {
+          return Stack(
+            children: [
+              // Tap-outside dismiss.
+              Positioned.fill(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: _controller.hide,
+                ),
+              ),
+              CompositedTransformFollower(
+                link: _link,
+                showWhenUnlinked: false,
+                targetAnchor: Alignment.bottomRight,
+                followerAnchor: Alignment.topRight,
+                offset: const Offset(0, _menuOffsetY),
+                child: _MenuCard(
+                  width: _menuWidth,
+                  onSelected: _handleSelected,
+                ),
+              ),
+            ],
+          );
+        },
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: _toggle,
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+}
+
+class _MenuCard extends StatelessWidget {
+  const _MenuCard({required this.width, required this.onSelected});
+
+  final double width;
+  final ValueChanged<ShoppingListMenuAction> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      type: MaterialType.transparency,
+      child: Container(
+        width: width,
+        padding: const EdgeInsets.all(AppSizes.sp12),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x1A6E6E6E),
+              offset: Offset(0, 4),
+              blurRadius: 5,
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _MenuRow(
+              icon: Icons.add,
+              label: 'Copy to Clipboard',
+              onTap: () => onSelected(ShoppingListMenuAction.copy),
+            ),
+            const SizedBox(height: AppSizes.xs),
+            _MenuRow(
+              icon: Icons.delete_outline,
+              label: 'Clear All Shopping List',
+              onTap: () => onSelected(ShoppingListMenuAction.clear),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MenuRow extends StatefulWidget {
+  const _MenuRow({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  State<_MenuRow> createState() => _MenuRowState();
+}
+
+class _MenuRowState extends State<_MenuRow> {
+  bool _pressed = false;
+
+  void _setPressed(bool value) {
+    if (_pressed == value) return;
+    setState(() => _pressed = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: widget.onTap,
+      onTapDown: (_) => _setPressed(true),
+      onTapCancel: () => _setPressed(false),
+      onTapUp: (_) => _setPressed(false),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 80),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSizes.sp12,
+          vertical: 6,
+        ),
+        decoration: BoxDecoration(
+          color: _pressed ? AppColors.butter : Colors.transparent,
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Row(
+          children: [
+            Icon(widget.icon, size: 18, color: AppColors.text),
+            const SizedBox(width: AppSizes.sm),
+            Expanded(
+              child: Text(
+                widget.label,
+                style: AppTypography.textTheme.bodyLarge,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/shopping_list/shopping_list_screen_test.dart
+++ b/test/features/shopping_list/shopping_list_screen_test.dart
@@ -213,34 +213,89 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // Clear list menu
+  // Clear All Shopping List menu — Figma 971:9936 / 971:9958
   // ---------------------------------------------------------------------------
 
-  group('ShoppingListScreen - clear list', () {
-    testWidgets('Clear list menu shows confirmation dialog', (tester) async {
+  group('ShoppingListScreen - clear all', () {
+    testWidgets(
+      'Clear All Shopping List opens the verbatim confirmation sheet',
+      (tester) async {
+        await tester.pumpWidget(_buildSut(mockService));
+        await tester.pumpAndSettle();
+
+        // Open overflow menu via the green-deep more_horiz chip.
+        await tester.tap(find.byIcon(Icons.more_horiz));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Clear All Shopping List'));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('Are you sure you want to delete?'),
+          findsOneWidget,
+        );
+        expect(find.text('Cancel'), findsOneWidget);
+        expect(find.text('Delete'), findsOneWidget);
+        // Legacy AlertDialog must not surface.
+        expect(find.byType(AlertDialog), findsNothing);
+      },
+    );
+
+    testWidgets('tapping Delete calls clearAll and empties the list', (
+      tester,
+    ) async {
+      when(
+        () => mockService.getItems(any()),
+      ).thenAnswer((_) async => Result.success([_makeItem()]));
+      when(
+        () => mockService.clearAll(any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
       await tester.pumpWidget(_buildSut(mockService));
       await tester.pumpAndSettle();
 
-      // Open overflow menu via the green-deep more_horiz chip.
       await tester.tap(find.byIcon(Icons.more_horiz));
       await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Clear list').last);
+      await tester.tap(find.text('Clear All Shopping List'));
       await tester.pumpAndSettle();
 
-      expect(
-        find.text('This will delete all items. Are you sure?'),
-        findsOneWidget,
-      );
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockService.clearAll(_babyId)).called(1);
+      expect(find.text("You don't have any list yet"), findsOneWidget);
+    });
+
+    testWidgets('tapping Cancel dismisses the sheet without clearing', (
+      tester,
+    ) async {
+      when(
+        () => mockService.getItems(any()),
+      ).thenAnswer((_) async => Result.success([_makeItem()]));
+
+      await tester.pumpWidget(_buildSut(mockService));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Clear All Shopping List'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      verifyNever(() => mockService.clearAll(any()));
+      expect(find.text('Are you sure you want to delete?'), findsNothing);
+      expect(find.text('Apples'), findsOneWidget);
     });
   });
 
   // ---------------------------------------------------------------------------
-  // Copy to clipboard
+  // Copy to Clipboard menu — Figma 971:9889
   // ---------------------------------------------------------------------------
 
   group('ShoppingListScreen - clipboard', () {
-    testWidgets('Copy to clipboard shows success snackbar', (tester) async {
+    testWidgets('Copy to Clipboard shows success snackbar', (tester) async {
       when(
         () => mockService.getItems(any()),
       ).thenAnswer((_) async => Result.success([_makeItem()]));
@@ -252,13 +307,13 @@ void main() {
       await tester.tap(find.byIcon(Icons.more_horiz));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Copy to clipboard'));
+      await tester.tap(find.text('Copy to Clipboard'));
       await tester.pumpAndSettle();
 
       expect(find.text('Copied to clipboard'), findsOneWidget);
     });
 
-    testWidgets('Copy to clipboard shows error snackbar when clipboard fails', (
+    testWidgets('Copy to Clipboard shows error snackbar when clipboard fails', (
       tester,
     ) async {
       when(
@@ -278,7 +333,7 @@ void main() {
       await tester.tap(find.byIcon(Icons.more_horiz));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Copy to clipboard'));
+      await tester.tap(find.text('Copy to Clipboard'));
       await tester.pumpAndSettle();
 
       expect(find.text("Couldn't copy. Try again."), findsOneWidget);


### PR DESCRIPTION
## Summary
- Replaces the native `PopupMenuButton` with a custom `OverlayPortal`-based floating dropdown matching Figma 971:9889 / 971:9936 (262-wide white card, pad-12 / gap-4 / radius-10, soft drop shadow, lime pressed-state, 18px add/delete_outline glyphs + Figtree Body/Regular 15/22 labels).
- Replaces the legacy AlertDialog Clear-All confirmation with a DS bottom sheet (Figma 971:9958) — white sheet with 30px top corners, scrim 50% black, "Are you sure you want to delete?" Parkinsans Bold 17 centered, 153px Quatrefoil illustration, Cancel (outline forest) + Delete (filled forest) using `AppPillButton`.
- Verbatim Figma copy across both surfaces ("Copy to Clipboard", "Clear All Shopping List", "Are you sure you want to delete?", "Cancel", "Delete"). Updated existing widget tests to match.

## Acceptance criteria
- [x] Overflow chip opens the floating dropdown (not a native PopupMenu).
- [x] Tap outside the menu dismisses it.
- [x] Pressed row fills lime; idle rows are plain white.
- [x] "Copy to Clipboard" copies the active List items and surfaces a P2 toast on success/failure.
- [x] "Clear All Shopping List" opens the bottom-sheet confirmation.
- [x] Bottom sheet: title wraps to 2 lines (width 212), Quatrefoil 153px, Cancel/Delete side-by-side, 30px top corners, 50% black scrim.
- [x] Delete button uses forest (not destructive red) per Figma.
- [x] Cancel dismisses the sheet; Delete calls `clearAll` and drops back to the empty state.
- [x] `flutter analyze` clean for changed files (2 pre-existing infos are unrelated to this ticket).
- [x] `flutter test` — 596 pass / 1 pre-existing skip.

## Figma frames
- 971:9889 — overflow menu (Copy highlighted preview)
- 971:9936 — overflow menu (Clear All highlighted preview)
- 971:9958 — Clear-All confirmation sheet

## Audit reports
- `.figma-audit/shopping-list/shoplist-menu-971-9889/`
- `.figma-audit/shopping-list/shoplist-list-971-9936/`
- `.figma-audit/shopping-list/shoplist-list-971-9958/`

## Test plan
- [ ] Open the Shopping List with items present, tap the green-deep overflow chip; floating menu appears anchored under the chip.
- [ ] Tap outside the menu — it dismisses without firing an action.
- [ ] Tap "Copy to Clipboard" — list bullets land on the system clipboard, "Copied to clipboard" toast appears.
- [ ] Tap "Clear All Shopping List" — bottom sheet appears with scrim, illustration, and Cancel/Delete row.
- [ ] Tap Cancel — sheet dismisses, list intact.
- [ ] Tap Delete — list clears to the empty state.