### PR TITLE
feat(shopping-list): floating Add card + swipe-to-delete + per-row delete behavior [NIB-81]

### DIFF
--- a/lib/src/app/themes/app_sizes.dart
+++ b/lib/src/app/themes/app_sizes.dart
@@ -21,6 +21,8 @@ abstract final class AppSizes {
   static const double radiusLg = 16;
   static const double radiusXl = 20;
   static const double radius2xl = 24;
+  // Floating Add-Ingredient card — Figma 971:9883 (rounded-[30px]).
+  static const double radius3xl = 30;
   static const double radiusFull = 999;
 
   // Icon sizes

--- a/lib/src/features/shopping_list/shopping_list_screen.dart
+++ b/lib/src/features/shopping_list/shopping_list_screen.dart
@@ -8,11 +8,14 @@ import 'package:nibbles/src/common/components/controls/app_segmented_control.dar
 import 'package:nibbles/src/common/domain/entities/shopping_list_item.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/shopping_list/shopping_list_controller.dart';
+import 'package:nibbles/src/features/shopping_list/widgets/add_ingredient_card.dart';
 import 'package:nibbles/src/features/shopping_list/widgets/clear_all_confirm_sheet.dart';
 import 'package:nibbles/src/features/shopping_list/widgets/shopping_list_menu.dart';
+import 'package:nibbles/src/features/shopping_list/widgets/swipe_reveal_row.dart';
 
-/// Shopping List root screen — Figma frames 971:9851 (populated) and
-/// 971:9989 (empty). Header (Title 3/Bold + green-deep more_horiz chip) +
+/// Shopping List root screen — Figma frames 971:9851 (populated),
+/// 971:9989 (empty), 971:9872 (add-card overlay), 971:9915 (swipe-delete).
+/// Header (Title 3/Bold + "+" add chip + green-deep more_horiz chip) +
 /// segmented control (List / Bought) + ingredient rows.
 ///
 /// Background: Grad-1 (linear-gradient 154.398deg, butterSoft → cream)
@@ -26,7 +29,10 @@ import 'package:nibbles/src/features/shopping_list/widgets/shopping_list_menu.da
 ///     (971:9958). Confirm calls the controller's `clearAll` and drops back
 ///     to the empty state; cancel dismisses the sheet.
 ///
-/// Add-item (971:9872) and swipe-delete (971:9915) remain out of scope.
+/// Per-row trailing close-X commits delete directly (no confirm modal).
+/// Swipe-left reveals a burgundy Delete pill; tap commits delete.
+/// "+" chip opens the floating Add Ingredient card over the keyboard
+/// (NIB-81 — frames 971:9872 / 971:9915).
 class ShoppingListScreen extends ConsumerWidget {
   const ShoppingListScreen({super.key});
 
@@ -65,6 +71,10 @@ class _PageScaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.transparent,
+      // Critical: resizeToAvoidBottomInset=false lets the floating Add card
+      // sit ABOVE the keyboard via MediaQuery.viewInsets, instead of having
+      // the whole layout reflow when the keyboard appears.
+      resizeToAvoidBottomInset: false,
       body: Container(
         decoration: const BoxDecoration(
           gradient: LinearGradient(
@@ -95,6 +105,22 @@ class _ShoppingListBody extends ConsumerStatefulWidget {
 
 class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
   int _selectedTab = 0; // 0 = List, 1 = Bought
+
+  // Controller that tracks which row (by id) currently has its swipe
+  // reveal open. Allows tap-outside-to-close and one-open-at-a-time.
+  final SwipeRevealController _swipeController = SwipeRevealController();
+
+  bool _addCardOpen = false;
+  final TextEditingController _addController = TextEditingController();
+  final FocusNode _addFocusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _swipeController.dispose();
+    _addController.dispose();
+    _addFocusNode.dispose();
+    super.dispose();
+  }
 
   Future<void> _showClearConfirmation() async {
     final confirmed = await showClearAllConfirmSheet(context);
@@ -134,6 +160,7 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
   }
 
   Future<void> _delete(String itemId) async {
+    _swipeController.close();
     try {
       await ref
           .read(shoppingListControllerProvider(widget.babyId).notifier)
@@ -166,6 +193,36 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
     }
   }
 
+  void _openAddCard() {
+    _swipeController.close();
+    setState(() => _addCardOpen = true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _addFocusNode.requestFocus();
+    });
+  }
+
+  void _closeAddCard() {
+    _addFocusNode.unfocus();
+    setState(() => _addCardOpen = false);
+    _addController.clear();
+  }
+
+  Future<void> _submitAdd() async {
+    final raw = _addController.text;
+    if (raw.trim().isEmpty) return;
+    // Default per Open Question 3: keep card open, clear field after add.
+    _addController.clear();
+
+    try {
+      await ref
+          .read(shoppingListControllerProvider(widget.babyId).notifier)
+          .addManual(raw);
+    } on Exception catch (_) {
+      if (!mounted) return;
+      _showToast("Couldn't add items. Try again.");
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final controllerAsync = ref.watch(
@@ -174,67 +231,98 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
 
     return SafeArea(
       bottom: false,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(
-          AppSizes.md,
-          AppSizes.sm,
-          AppSizes.md,
-          0,
-        ),
-        child: Column(
-          children: [
-            _ShoppingListHeader(
-              onMenuSelected: (action) {
-                switch (action) {
-                  case ShoppingListMenuAction.copy:
-                    _copyToClipboard();
-                  case ShoppingListMenuAction.clear:
-                    _showClearConfirmation();
-                }
-              },
-            ),
-            const SizedBox(height: AppSizes.sp12),
-            AppSegmentedControl(
-              segments: const ['List', 'Bought'],
-              selectedIndex: _selectedTab,
-              onChanged: (i) => setState(() => _selectedTab = i),
-            ),
-            const SizedBox(height: AppSizes.sp12),
-            Expanded(
-              child: controllerAsync.when(
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (e, _) => _ErrorState(
-                  onRetry: () => ref.invalidate(
-                    shoppingListControllerProvider(widget.babyId),
+      child: Stack(
+        children: [
+          // Tap anywhere outside the add card / open swipe row to dismiss them.
+          GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () {
+              if (_addCardOpen) _closeAddCard();
+              _swipeController.close();
+            },
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSizes.md,
+                AppSizes.sm,
+                AppSizes.md,
+                0,
+              ),
+              child: Column(
+                children: [
+                  _ShoppingListHeader(
+                    onAddPressed: _openAddCard,
+                    onMenuSelected: (action) {
+                      switch (action) {
+                        case ShoppingListMenuAction.copy:
+                          _copyToClipboard();
+                        case ShoppingListMenuAction.clear:
+                          _showClearConfirmation();
+                      }
+                    },
                   ),
-                ),
-                data: (state) => _selectedTab == 0
-                    ? _ItemsList(
-                        items: state.listItems,
-                        onToggle: _check,
-                        onDelete: _delete,
-                      )
-                    : _ItemsList(
-                        items: state.boughtItems,
-                        onToggle: _uncheck,
-                        onDelete: _delete,
+                  const SizedBox(height: AppSizes.sp12),
+                  AppSegmentedControl(
+                    segments: const ['List', 'Bought'],
+                    selectedIndex: _selectedTab,
+                    onChanged: (i) => setState(() => _selectedTab = i),
+                  ),
+                  const SizedBox(height: AppSizes.sp12),
+                  Expanded(
+                    child: controllerAsync.when(
+                      loading: () =>
+                          const Center(child: CircularProgressIndicator()),
+                      error: (e, _) => _ErrorState(
+                        onRetry: () => ref.invalidate(
+                          shoppingListControllerProvider(widget.babyId),
+                        ),
                       ),
+                      data: (state) => _selectedTab == 0
+                          ? _ItemsList(
+                              items: state.listItems,
+                              swipeController: _swipeController,
+                              onToggle: _check,
+                              onDelete: _delete,
+                            )
+                          : _ItemsList(
+                              items: state.boughtItems,
+                              swipeController: _swipeController,
+                              onToggle: _uncheck,
+                              onDelete: _delete,
+                            ),
+                    ),
+                  ),
+                ],
               ),
             ),
-          ],
-        ),
+          ),
+          if (_addCardOpen)
+            Positioned(
+              left: AppSizes.md,
+              right: AppSizes.md,
+              bottom: MediaQuery.of(context).viewInsets.bottom + AppSizes.sm,
+              child: AddIngredientCard(
+                controller: _addController,
+                focusNode: _addFocusNode,
+                onAdd: _submitAdd,
+              ),
+            ),
+        ],
       ),
     );
   }
 }
 
 // ---------------------------------------------------------------------------
-// Header — title + green-deep more_horiz overflow chip
+// Header — title + "+" add chip + green-deep more_horiz overflow chip
 // ---------------------------------------------------------------------------
 
 class _ShoppingListHeader extends StatelessWidget {
-  const _ShoppingListHeader({required this.onMenuSelected});
+  const _ShoppingListHeader({
+    required this.onAddPressed,
+    required this.onMenuSelected,
+  });
 
+  final VoidCallback onAddPressed;
   final ValueChanged<ShoppingListMenuAction> onMenuSelected;
 
   @override
@@ -247,6 +335,8 @@ class _ShoppingListHeader extends StatelessWidget {
             style: AppTypography.textTheme.titleSmall,
           ),
         ),
+        _AddChip(onTap: onAddPressed),
+        const SizedBox(width: AppSizes.sm),
         ShoppingListOverflowMenu(
           onSelected: onMenuSelected,
           child: const _OverflowChip(),
@@ -256,8 +346,39 @@ class _ShoppingListHeader extends StatelessWidget {
   }
 }
 
-/// 40x40 green-deep rounded-square chip. Mirrors Figma 971:9943
-/// (Button-chips, bg ForestDarkn, rounded-[10px]).
+/// 40x40 green-deep rounded-square chip with "+" icon. Opens the floating
+/// Add Ingredient card. Mirrors the header chip treatment in 971:9872.
+class _AddChip extends StatelessWidget {
+  const _AddChip({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        width: 40,
+        height: 40,
+        decoration: BoxDecoration(
+          color: AppColors.greenDeep,
+          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        ),
+        alignment: Alignment.center,
+        child: const Icon(
+          Icons.add,
+          color: AppColors.onGreen,
+          size: AppSizes.iconMd,
+        ),
+      ),
+    );
+  }
+}
+
+/// 40x40 green-deep rounded-square chip hosting the more_horiz overflow.
+/// Wrapped externally by [ShoppingListOverflowMenu] which handles tap-to-open.
+/// Mirrors Figma 971:9858 / 971:9943 (Button-chips, bg ForestDarkn, rounded-[10px]).
 class _OverflowChip extends StatelessWidget {
   const _OverflowChip();
 
@@ -287,11 +408,13 @@ class _OverflowChip extends StatelessWidget {
 class _ItemsList extends StatelessWidget {
   const _ItemsList({
     required this.items,
+    required this.swipeController,
     required this.onToggle,
     required this.onDelete,
   });
 
   final List<ShoppingListItem> items;
+  final SwipeRevealController swipeController;
   final ValueChanged<String> onToggle;
   final ValueChanged<String> onDelete;
 
@@ -306,10 +429,21 @@ class _ItemsList extends StatelessWidget {
       separatorBuilder: (_, __) => const SizedBox(height: AppSizes.sm),
       itemBuilder: (_, index) {
         final item = items[index];
-        return _ShoppingItemRow(
-          item: item,
-          onToggle: () => onToggle(item.id),
+        // Optimistic placeholder id=='' would collide if multiple are pending;
+        // fall back to a createdAt-based key.
+        final rowKey = item.id.isNotEmpty
+            ? item.id
+            : 'pending-${item.createdAt.microsecondsSinceEpoch}';
+        return SwipeRevealRow(
+          key: ValueKey(rowKey),
+          rowId: rowKey,
+          controller: swipeController,
           onDelete: () => onDelete(item.id),
+          child: _ShoppingItemRow(
+            item: item,
+            onToggle: () => onToggle(item.id),
+            onDelete: () => onDelete(item.id),
+          ),
         );
       },
     );
@@ -409,6 +543,7 @@ class _SquareCheckbox extends StatelessWidget {
 
 /// Per-row cancel chip — 37x37, rounded 10, burgundy circle X icon.
 /// Mirrors Figma 898:18568 (cancel) inside Button-chips wrapper.
+/// Single-tap directly commits delete — no confirm dialog (NIB-81).
 class _CancelChip extends StatelessWidget {
   const _CancelChip({required this.onTap, required this.size});
 

--- a/lib/src/features/shopping_list/widgets/add_ingredient_card.dart
+++ b/lib/src/features/shopping_list/widgets/add_ingredient_card.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+
+/// Floating Add Ingredient card. Figma 971:9883 / 971:9884.
+///
+/// 370x164 white rounded-[30px] card, shadow 0 4px 10px rgba(0,0,0,0.1).
+/// Bare borderless text field with "Ingredients" placeholder
+/// (Figtree Regular 15, color neutral-50 / fgFaint) + lime pill "Add"
+/// button (77x30, rounded-[24px], bg butter, label Parkinsans SemiBold 15
+/// in greenDeep) anchored top-right.
+///
+/// Owner provides the [controller] + [focusNode]. The caller is responsible
+/// for opening the keyboard (request focus after mount) and for the
+/// addManual write — this widget is purely presentational.
+class AddIngredientCard extends StatelessWidget {
+  const AddIngredientCard({
+    required this.controller,
+    required this.focusNode,
+    required this.onAdd,
+    super.key,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      // Figma fixed height — 164 — but we let it size to content so the
+      // padding/insets behave on smaller devices.
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radius3xl),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x1A000000),
+            offset: Offset(0, 4),
+            blurRadius: 10,
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.lg,
+        vertical: AppSizes.md,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          _AddPillButton(onTap: onAdd),
+          const SizedBox(height: AppSizes.md),
+          TextField(
+            controller: controller,
+            focusNode: focusNode,
+            onSubmitted: (_) => onAdd(),
+            textInputAction: TextInputAction.done,
+            // Figma body/regular — Figtree 15/22 (matches textTheme.bodyLarge).
+            style: AppTypography.textTheme.bodyLarge,
+            cursorColor: AppColors.greenDeep,
+            decoration: InputDecoration(
+              isCollapsed: true,
+              border: InputBorder.none,
+              hintText: 'Ingredients',
+              hintStyle: AppTypography.textTheme.bodyLarge?.copyWith(
+                color: AppColors.fgFaint,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Lime "Add" pill — Figma 1465:49397. 77x30 rounded-[24px] bg butter
+/// (#eaec8c), label "Add" Parkinsans SemiBold 15 in greenDeep (#3d5236).
+class _AddPillButton extends StatelessWidget {
+  const _AddPillButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        width: 77,
+        height: 30,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: AppColors.butter,
+          borderRadius: BorderRadius.circular(AppSizes.radius2xl),
+        ),
+        child: const Text(
+          'Add',
+          style: TextStyle(
+            fontFamily: FontFamily.parkinsans,
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            height: 22 / 15,
+            color: AppColors.greenDeep,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/shopping_list/widgets/swipe_reveal_row.dart
+++ b/lib/src/features/shopping_list/widgets/swipe_reveal_row.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+
+/// Width of the burgundy Delete pill revealed behind the row.
+const double _deleteRevealWidth = 100;
+
+/// Shared controller that tracks which row currently has its swipe
+/// revealed. Only one row can be open at a time, and any tap outside
+/// the open row closes it.
+class SwipeRevealController extends ChangeNotifier {
+  String? _openRowId;
+  String? get openRowId => _openRowId;
+
+  void open(String rowId) {
+    if (_openRowId == rowId) return;
+    _openRowId = rowId;
+    notifyListeners();
+  }
+
+  void close() {
+    if (_openRowId == null) return;
+    _openRowId = null;
+    notifyListeners();
+  }
+}
+
+/// Wraps a shopping-list row with a swipe-to-reveal Delete pill.
+///
+/// Figma 971:9915 (Shoplist - slide delete): user drags the row left,
+/// the row compresses, and a burgundy Delete pill is revealed beside it.
+/// Tap on the pill commits delete. Only one row can be open at a time —
+/// opening a new one closes the previous. Tap outside closes too.
+class SwipeRevealRow extends StatefulWidget {
+  const SwipeRevealRow({
+    required this.rowId,
+    required this.controller,
+    required this.onDelete,
+    required this.child,
+    super.key,
+  });
+
+  final String rowId;
+  final SwipeRevealController controller;
+  final VoidCallback onDelete;
+  final Widget child;
+
+  @override
+  State<SwipeRevealRow> createState() => _SwipeRevealRowState();
+}
+
+class _SwipeRevealRowState extends State<SwipeRevealRow>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _anim;
+  double _dragOffset = 0; // 0 = closed, _deleteRevealWidth = fully revealed
+
+  @override
+  void initState() {
+    super.initState();
+    _anim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 180),
+    )..addListener(() {
+        setState(() {
+          _dragOffset = _anim.value * _deleteRevealWidth;
+        });
+      });
+    widget.controller.addListener(_onControllerChange);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onControllerChange);
+    _anim.dispose();
+    super.dispose();
+  }
+
+  void _onControllerChange() {
+    final isOpen = widget.controller.openRowId == widget.rowId;
+    if (isOpen && _dragOffset == 0) {
+      _animateTo(1);
+    } else if (!isOpen && _dragOffset > 0) {
+      _animateTo(0);
+    }
+  }
+
+  void _animateTo(double target) {
+    _anim
+      ..stop()
+      ..value = _dragOffset / _deleteRevealWidth
+      ..animateTo(target, curve: Curves.easeOut);
+  }
+
+  void _onHorizontalDragUpdate(DragUpdateDetails d) {
+    setState(() {
+      // dx is negative when dragging left
+      _dragOffset = (_dragOffset - d.delta.dx).clamp(
+        0.0,
+        _deleteRevealWidth,
+      );
+    });
+  }
+
+  void _onHorizontalDragEnd(DragEndDetails d) {
+    final velocity = d.primaryVelocity ?? 0;
+    final shouldOpen =
+        velocity < -200 || _dragOffset > _deleteRevealWidth * 0.5;
+    if (shouldOpen) {
+      widget.controller.open(widget.rowId);
+      _animateTo(1);
+    } else {
+      widget.controller.close();
+      _animateTo(0);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onHorizontalDragUpdate: _onHorizontalDragUpdate,
+      onHorizontalDragEnd: _onHorizontalDragEnd,
+      child: Stack(
+        children: [
+          // Burgundy Delete pill behind the row, aligned to the right edge,
+          // visible only when the row is shifted left.
+          Positioned.fill(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: SizedBox(
+                width: _dragOffset,
+                child: ClipRect(
+                  child: OverflowBox(
+                    maxWidth: _deleteRevealWidth,
+                    alignment: Alignment.centerRight,
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: AppSizes.sp12),
+                      child: _DeletePill(onTap: widget.onDelete),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Transform.translate(
+            offset: Offset(-_dragOffset, 0),
+            child: widget.child,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Burgundy Delete pill — Figma 875:15198. flex-1 h-48, rounded-[24px],
+/// bg burgundy (#77393b), label "Delete" Parkinsans SemiBold 15/22 white.
+class _DeletePill extends StatelessWidget {
+  const _DeletePill({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        height: 48,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: AppColors.burgundy,
+          borderRadius: BorderRadius.circular(AppSizes.radius2xl),
+        ),
+        child: const Text(
+          'Delete',
+          style: TextStyle(
+            fontFamily: FontFamily.parkinsans,
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            height: 22 / 15,
+            color: AppColors.onGreen,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/shopping_list/shopping_list_screen_test.dart
+++ b/test/features/shopping_list/shopping_list_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/common/components/controls/app_segmented_control.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
@@ -259,7 +260,9 @@ void main() {
       await tester.tap(find.text('Clear All Shopping List'));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Delete'));
+      // Disambiguate from the SwipeRevealRow's hidden "Delete" pill — the
+      // bottom-sheet's Delete button is wrapped in AppPillButton.
+      await tester.tap(find.widgetWithText(AppPillButton, 'Delete'));
       await tester.pumpAndSettle();
 
       verify(() => mockService.clearAll(_babyId)).called(1);


### PR DESCRIPTION
## Summary

Implements NIB-81 (Add-Ingredient card + DS swipe-to-delete + per-row delete behavior) per Figma audit frames 971:9872 and 971:9915.

## Changes

- **AddIngredientCard** widget: 30px rounded white card positioned over iOS keyboard with "Ingredients" placeholder + lime "Add" pill (rounded-24, Parkinsans SemiBold 15 in forestdarkn). Per Figma 971:9872.
- **SwipeRevealRow** widget: burgundy Delete pill revealed on swipe-left (h-48, rounded-24, white label). Per Figma 971:9915.
- **Per-row close-X chip** commits direct delete with P2 toast on failure (no confirm dialog per the PO-confirmed direct behavior).
- `AppSizes.radius3xl=30` added for the floating card corner.

## Test plan

- [x] flutter analyze — 0 new issues
- [x] flutter test test/features/shopping_list — 10/10 pass