### PR TITLE
refactor(meal-plan): anchor 7-day window on most-recent Monday [NIB-143]

### DIFF
--- a/lib/src/features/meal_plan/meal_plan_controller.dart
+++ b/lib/src/features/meal_plan/meal_plan_controller.dart
@@ -20,6 +20,14 @@ class MealPlanController extends _$MealPlanController {
 
   static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
 
+  /// NIB-143: most-recent Monday on or before [dt] (local-date floor).
+  /// `DateTime.weekday` is 1 (Mon) through 7 (Sun), so subtracting
+  /// `weekday - 1` lands on Monday.
+  static DateTime _mondayOnOrBefore(DateTime dt) {
+    final dateOnly = _dateOnly(dt);
+    return dateOnly.subtract(Duration(days: dateOnly.weekday - 1));
+  }
+
   /// Normalize an expand-map key to a UTC date-only [DateTime] so keys match
   /// regardless of the input's local TZ or sub-day precision.
   static DateTime _expandedKey(DateTime day) =>
@@ -29,7 +37,9 @@ class MealPlanController extends _$MealPlanController {
   Future<MealPlanState> build(String babyId) async {
     _babyId = babyId;
 
-    final windowStart = _dateOnly(DateTime.now());
+    // NIB-143: anchor the 7-day window on the most-recent Monday
+    // on/before today so the planner always renders a Mon-Sun week.
+    final windowStart = _mondayOnOrBefore(DateTime.now());
     final windowEnd = windowStart.add(const Duration(days: 6));
 
     final mealPlanService = ref.read(mealPlanServiceProvider);

--- a/lib/src/features/meal_plan/meal_plan_controller.g.dart
+++ b/lib/src/features/meal_plan/meal_plan_controller.g.dart
@@ -7,7 +7,7 @@ part of 'meal_plan_controller.dart';
 // **************************************************************************
 
 String _$mealPlanControllerHash() =>
-    r'105041357b42992b5652e8c4faf5674ff6d423b3';
+    r'3733978b88a27612d76a74775e4d793043990915';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/test/features/meal_plan/meal_plan_controller_test.dart
+++ b/test/features/meal_plan/meal_plan_controller_test.dart
@@ -154,8 +154,9 @@ void main() {
 
   group('MealPlanController.build', () {
     test(
-      'sets windowStart to today (date-only), windowEnd to today+6, '
-      'populates entries + baby, expanded starts empty',
+      'NIB-143: windowStart is most-recent Monday on/before today, '
+      'windowEnd is windowStart + 6 (Sunday), populates entries + baby, '
+      'expanded starts empty',
       () async {
         final entry = _makeEntry();
         stubHappy(entries: [entry]);
@@ -166,16 +167,48 @@ void main() {
         );
 
         final today = DateTime.now();
-        final expectedStart = DateTime(today.year, today.month, today.day);
+        final todayDateOnly = DateTime(today.year, today.month, today.day);
+        final expectedStart = todayDateOnly.subtract(
+          Duration(days: todayDateOnly.weekday - 1),
+        );
         final expectedEnd = expectedStart.add(const Duration(days: 6));
 
         expect(state.windowStart, expectedStart);
+        expect(state.windowStart.weekday, DateTime.monday);
         expect(state.windowEnd, expectedEnd);
+        expect(state.windowEnd.weekday, DateTime.sunday);
+        expect(
+          state.windowEnd.difference(state.windowStart).inDays,
+          6,
+        );
         expect(state.entries, hasLength(1));
         expect(state.entries.single.id, 'mp-1');
         expect(state.baby?.id, _babyId);
         expect(state.expanded, isEmpty);
         expect(state.recipes['recipe-001']?.title, 'Peanut Butter Toast');
+      },
+    );
+
+    test(
+      'NIB-143: getRolling7 is invoked with the Monday windowStart, '
+      'not today',
+      () async {
+        stubHappy();
+        final container = buildContainer();
+        await container.read(mealPlanControllerProvider(_babyId).future);
+
+        final today = DateTime.now();
+        final todayDateOnly = DateTime(today.year, today.month, today.day);
+        final expectedStart = todayDateOnly.subtract(
+          Duration(days: todayDateOnly.weekday - 1),
+        );
+
+        verify(
+          () => mockMealPlanService.getRolling7(
+            _babyId,
+            today: expectedStart,
+          ),
+        ).called(1);
       },
     );
 

--- a/test/features/meal_plan/meal_plan_screen_test.dart
+++ b/test/features/meal_plan/meal_plan_screen_test.dart
@@ -385,7 +385,10 @@ void main() {
         final startDate = captured[0] as DateTime;
         final endDate = captured[1] as DateTime;
         expect(startDate, endDate, reason: 'single-day range');
-        expect(startDate, today);
+        // NIB-143: first day card is Monday of the current week, which is the
+        // most-recent Monday on/before today.
+        final monday = today.subtract(Duration(days: today.weekday - 1));
+        expect(startDate, monday);
         final assignments = captured[2] as List<dynamic>;
         expect(assignments, hasLength(1));
       },


### PR DESCRIPTION
## Summary
NIB-143: meal plan window now spans Mon-Sun.

- `windowStart` is the most-recent Monday on/before today (was: today)
- `windowEnd` is `windowStart + 6` (Sunday)
- Window length unchanged at 7 days
- `getRolling7` is invoked with the Monday anchor, so the rendered week is always Mon..Sun

## Files touched
- `lib/src/features/meal_plan/meal_plan_controller.dart`
- `lib/src/features/meal_plan/meal_plan_controller.g.dart` (regen)
- `test/features/meal_plan/meal_plan_controller_test.dart`
- `test/features/meal_plan/meal_plan_screen_test.dart` (single-day add test now expects Monday)

## Figma frame ids
- Root canonical Meal Planner: node 971:8619 (Meal Plan section 971:7802)

## Audit report paths
- `.figma-audit/meal-plan/root-meal-planner-generated/report.md`

## Acceptance
- [x] `MealPlanController.build` derives Monday on/before today
- [x] Window is 7 days inclusive (Mon..Sun)
- [x] Service call uses the Monday windowStart
- [x] `flutter test` passes
- [x] `flutter analyze` clean for changed files (pre-existing project-wide infos untouched)