### PR TITLE
feat(routing): restore M2 paywall guard in GoRouter redirect [NIB-144]

### DIFF
--- a/lib/src/routing/routes.dart
+++ b/lib/src/routing/routes.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/common/services/auth_service.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/common/services/subscription_service.dart';
 import 'package:nibbles/src/features/allergen/complete/allergen_complete_screen.dart';
 import 'package:nibbles/src/features/allergen/detail/allergen_detail_screen.dart';
 import 'package:nibbles/src/features/allergen/log/allergen_log_screen.dart';
@@ -44,7 +45,14 @@ part 'routes.g.dart';
 
 class _RouterRefreshNotifier extends ChangeNotifier {
   _RouterRefreshNotifier(Ref ref) {
-    ref.listen<bool>(authServiceProvider, (_, __) => notifyListeners());
+    ref
+      ..listen<bool>(authServiceProvider, (_, __) => notifyListeners())
+      // NIB-144 — refresh on entitlement change so the M2 paywall guard
+      // re-evaluates as soon as `SubscriptionService.isActive` flips.
+      ..listen<bool>(
+        subscriptionServiceProvider,
+        (_, __) => notifyListeners(),
+      );
   }
 }
 
@@ -63,6 +71,7 @@ String? resolveAppRedirect({
   required bool babySetupDone,
   required bool readinessDone,
   required bool onboardingDone,
+  required bool isSubscribed,
 }) {
   // Allow splash through — it handles its own redirect after init.
   if (location == AppRoute.splash.path) return null;
@@ -118,8 +127,10 @@ String? resolveAppRedirect({
     return AppRoute.onboardingConsent.path;
   }
 
-  // 7. All onboarding done — any onboarding/auth/paywall screen redirects to
-  //    home. Paywall remains gated here while M2 is deferred.
+  // 7. All onboarding done — any onboarding/auth screen redirects to home.
+  //    Paywall is intentionally NOT in `gatedPaths` (NIB-144 / M2): an
+  //    onboarded user who is not subscribed must be sent TO the paywall, not
+  //    bounced away from it.
   const gatedPaths = {
     '/auth/login',
     '/auth/register',
@@ -131,9 +142,20 @@ String? resolveAppRedirect({
     '/onboarding/result',
     '/onboarding/consent',
     '/onboarding/baby-setup',
-    '/subscription/paywall',
   };
   if (gatedPaths.contains(location)) return AppRoute.home.path;
+
+  // 8. M2 paywall guard (NIB-144). Onboarded but unsubscribed users are
+  //    redirected to the paywall. Allow the paywall itself and the post-
+  //    purchase transition screen through so the purchase flow can complete.
+  if (!isSubscribed) {
+    const subscriptionAllowedPaths = {
+      '/subscription/paywall',
+      '/subscription/success',
+    };
+    if (subscriptionAllowedPaths.contains(location)) return null;
+    return AppRoute.paywall.path;
+  }
 
   return null;
 }
@@ -155,6 +177,8 @@ GoRouter goRouter(Ref ref) {
         babySetupDone: localFlags.isOnboardingBabySetupDone(),
         readinessDone: localFlags.isOnboardingReadinessDone(),
         onboardingDone: localFlags.isOnboardingDone(),
+        // NIB-144 — watch so router refreshes when entitlement flips.
+        isSubscribed: ref.watch(subscriptionServiceProvider),
       );
     },
     routes: [

--- a/lib/src/routing/routes.g.dart
+++ b/lib/src/routing/routes.g.dart
@@ -6,7 +6,7 @@ part of 'routes.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'4a5c05f07ace54e5e39198f72fc0a2979cda15c5';
+String _$goRouterHash() => r'a5c49454f79ca2f2576e5661d8aee232798e8012';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)

--- a/test/routing/resolve_app_redirect_test.dart
+++ b/test/routing/resolve_app_redirect_test.dart
@@ -10,6 +10,10 @@ import 'package:nibbles/src/routing/routes.dart';
 /// implementation detail.
 void main() {
   // Sugar so each case reads as a state row rather than a constructor.
+  //
+  // Defaults to `subscribed: true` so existing pre-NIB-144 matrix rows keep
+  // exercising the same redirect paths (without the M2 paywall guard kicking
+  // in). The dedicated "M2 paywall guard" group below flips this to false.
   String? resolve({
     required String at,
     bool launched = true,
@@ -17,6 +21,7 @@ void main() {
     bool babySetup = false,
     bool readiness = false,
     bool onboarding = false,
+    bool subscribed = true,
   }) => resolveAppRedirect(
     location: at,
     hasLaunched: launched,
@@ -24,6 +29,7 @@ void main() {
     babySetupDone: babySetup,
     readinessDone: readiness,
     onboardingDone: onboarding,
+    isSubscribed: subscribed,
   );
 
   group('splash + first launch', () {
@@ -204,6 +210,10 @@ void main() {
     'all done — onboarding_done = true (the reinstall seeded path)',
     () {
       test('any onboarding/auth path redirects to /home', () {
+        // Post-NIB-144: paywall is intentionally NOT in gatedPaths because
+        // the M2 guard sends unsubscribed onboarded users TO it. Subscribed
+        // onboarded users on paywall fall through to `null` (covered by the
+        // M2 group below).
         for (final gated in [
           AppRoute.onboardingIntro.path,
           AppRoute.onboardingName.path,
@@ -213,7 +223,6 @@ void main() {
           AppRoute.onboardingConsent.path,
           AppRoute.onboardingBabySetup.path,
           AppRoute.forgotPassword.path,
-          AppRoute.paywall.path,
         ]) {
           expect(
             resolve(
@@ -301,6 +310,102 @@ void main() {
           onboarding: true,
         ),
         isNull,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // NIB-144 — M2 paywall guard.
+  //
+  // Decision locked in NIB-120: M2 guard re-enabled, paywall mandatory.
+  // Onboarded but unsubscribed users are redirected to /subscription/paywall;
+  // the paywall itself and the post-purchase success screen are allowed
+  // through so the purchase flow can complete.
+  // ---------------------------------------------------------------------------
+  group('NIB-144 M2 paywall guard', () {
+    test(
+      'onboarded + unsubscribed user is redirected to /subscription/paywall',
+      () {
+        for (final p in [
+          AppRoute.home.path,
+          AppRoute.mealPlan.path,
+          AppRoute.shoppingList.path,
+          AppRoute.recipeLibrary.path,
+          AppRoute.profile.path,
+        ]) {
+          expect(
+            resolve(
+              at: p,
+              babySetup: true,
+              readiness: true,
+              onboarding: true,
+              subscribed: false,
+            ),
+            AppRoute.paywall.path,
+            reason: p,
+          );
+        }
+      },
+    );
+
+    test(
+      'onboarded + unsubscribed user can reach paywall + success screens',
+      () {
+        for (final p in [
+          AppRoute.paywall.path,
+          AppRoute.subscriptionSuccess.path,
+        ]) {
+          expect(
+            resolve(
+              at: p,
+              babySetup: true,
+              readiness: true,
+              onboarding: true,
+              subscribed: false,
+            ),
+            isNull,
+            reason: p,
+          );
+        }
+      },
+    );
+
+    test('onboarded + subscribed user can reach /home', () {
+      expect(
+        resolve(
+          at: AppRoute.home.path,
+          babySetup: true,
+          readiness: true,
+          onboarding: true,
+        ),
+        isNull,
+      );
+    });
+
+    test(
+      'onboarded + subscribed user on paywall passes through (no bounce)',
+      () {
+        expect(
+          resolve(
+            at: AppRoute.paywall.path,
+            babySetup: true,
+            readiness: true,
+            onboarding: true,
+          ),
+          isNull,
+        );
+      },
+    );
+
+    test('guard does not fire while still onboarding', () {
+      // Phase A — unsubscribed user must still be funneled through onboarding,
+      // not bounced to paywall.
+      expect(
+        resolve(
+          at: AppRoute.home.path,
+          subscribed: false,
+        ),
+        AppRoute.onboardingName.path,
       );
     });
   });


### PR DESCRIPTION
## Summary
Re-enables the M2 paywall guard in the router redirect per the decision locked in NIB-120. Onboarded but unsubscribed users are now redirected to `/subscription/paywall`; the paywall and post-purchase success screens are allowed through so the purchase flow can complete. With RevenueCat keys not yet wired, `SubscriptionService.isActive` always returns false, so all post-onboarding users fail closed into the paywall — the intended M2 behavior.

## Changes
- `lib/src/routing/routes.dart`
  - Add `subscription_service.dart` import.
  - `_RouterRefreshNotifier` now also listens to `subscriptionServiceProvider` so the router refreshes on entitlement change.
  - `resolveAppRedirect` gains a required `isSubscribed` parameter.
  - `/subscription/paywall` removed from `gatedPaths`.
  - New step 8 (post Phase D): if `!isSubscribed` and `location NOT IN {/subscription/paywall, /subscription/success}`, redirect to `/subscription/paywall`.
  - `goRouter` provider calls `ref.watch(subscriptionServiceProvider)` and passes `isSubscribed` through.
- `test/routing/resolve_app_redirect_test.dart`
  - Add `subscribed` parameter (defaults to `true` so pre-existing matrix rows still pin the same redirects).
  - Drop `paywall.path` from the "any onboarding/auth path redirects to /home" iteration — now covered by the M2 group.
  - New `NIB-144 M2 paywall guard` group covering:
    - onboarded + unsubscribed -> paywall (home / meal-plan / shopping-list / recipe-library / profile all bounce)
    - onboarded + unsubscribed can reach `/subscription/paywall` + `/subscription/success` (no bounce)
    - onboarded + subscribed reaches `/home`
    - onboarded + subscribed on paywall passes through
    - guard does not fire during onboarding (unsubscribed phase-A user still routes to `/onboarding/name`)

## Acceptance criteria
- [x] `resolveAppRedirect` test matrix updated for new param
- [x] Onboarded + unsubscribed user redirected to paywall
- [x] Onboarded + subscribed user can reach `/home`
- [x] Paywall is reachable (no longer in `gatedPaths`)
- [x] `flutter analyze` clean for changed files (2 pre-existing infos on `redesign` are unrelated)
- [x] All routing tests pass (26 tests in `resolve_app_redirect_test.dart`); full suite green (601 passed, 1 skipped)

## Test plan
- [x] `flutter analyze` — 0 new issues
- [x] `flutter test test/routing/resolve_app_redirect_test.dart` — 26/26 pass
- [x] `flutter test` — 601 pass / 1 skip