### PR TITLE
feat(onboarding): persist consent acknowledgements with timestamp [NIB-145]

### DIFF
--- a/lib/src/common/data/repositories/consent_repository.dart
+++ b/lib/src/common/data/repositories/consent_repository.dart
@@ -1,0 +1,54 @@
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/enums/consent_type.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'consent_repository.g.dart';
+
+/// Write+read consent receipts (NIB-145). The UX gate on the consent screen is
+/// authoritative — this row is the supplementary DB receipt produced after a
+/// successful baby creation.
+// ignore: one_member_abstracts
+abstract interface class ConsentRepository {
+  /// Inserts a row into `consents` for the current user. `baby_id` is required
+  /// at the API surface (consents only make sense in the context of a baby);
+  /// the column is nullable in DB for schema flexibility.
+  Future<Result<void>> recordConsent({
+    required String babyId,
+    required ConsentType type,
+  });
+}
+
+class ConsentRepositoryImpl implements ConsentRepository {
+  ConsentRepositoryImpl({SupabaseClient? supabaseClient})
+    : _supabase = supabaseClient ?? Supabase.instance.client;
+
+  final SupabaseClient _supabase;
+
+  @override
+  Future<Result<void>> recordConsent({
+    required String babyId,
+    required ConsentType type,
+  }) async {
+    try {
+      final userId = _supabase.auth.currentUser?.id;
+      await _supabase.from('consents').insert({
+        'user_id': userId,
+        'baby_id': babyId,
+        'consent_type': type.dbValue,
+      });
+      return const Result.success(null);
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+}
+
+@Riverpod(keepAlive: true)
+// Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+// ignore: deprecated_member_use_from_same_package
+ConsentRepository consentRepository(ConsentRepositoryRef ref) =>
+    ConsentRepositoryImpl();

--- a/lib/src/common/data/repositories/consent_repository.g.dart
+++ b/lib/src/common/data/repositories/consent_repository.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'consent_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$consentRepositoryHash() => r'c907b8e134e1f5a0a9c90b3d997c157755261a3c';
+
+/// See also [consentRepository].
+@ProviderFor(consentRepository)
+final consentRepositoryProvider = Provider<ConsentRepository>.internal(
+  consentRepository,
+  name: r'consentRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$consentRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef ConsentRepositoryRef = ProviderRef<ConsentRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/common/domain/enums/consent_type.dart
+++ b/lib/src/common/domain/enums/consent_type.dart
@@ -1,0 +1,19 @@
+/// Consent acknowledgement types persisted on onboarding submit (NIB-145).
+///
+/// The string value is the canonical DB encoding — matches the
+/// `consents.consent_type` CHECK constraint
+/// (`'solids_introduction' | 'under_6mo_responsibility'`).
+enum ConsentType {
+  /// Top-of-screen acknowledgement: educational info, not medical advice,
+  /// and the user has medical clearance. Always recorded on submit.
+  solidsIntroduction('solids_introduction'),
+
+  /// Early-solids responsibility clause — only recorded when the baby is
+  /// younger than 6 months at consent time.
+  under6MoResponsibility('under_6mo_responsibility');
+
+  const ConsentType(this.dbValue);
+
+  /// String value persisted in `consents.consent_type`.
+  final String dbValue;
+}

--- a/lib/src/common/services/consent_service.dart
+++ b/lib/src/common/services/consent_service.dart
@@ -1,0 +1,26 @@
+import 'package:nibbles/src/common/data/repositories/consent_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/enums/consent_type.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'consent_service.g.dart';
+
+/// Thin facade over [ConsentRepository] (NIB-145). The DB receipt insert is
+/// a passthrough today; the service exists to keep the controller agnostic of
+/// the repository per CLAUDE.md (Controller -> Service -> Repository).
+class ConsentService {
+  const ConsentService(this._repo);
+
+  final ConsentRepository _repo;
+
+  Future<Result<void>> recordConsent({
+    required String babyId,
+    required ConsentType type,
+  }) => _repo.recordConsent(babyId: babyId, type: type);
+}
+
+@Riverpod(keepAlive: true)
+// Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+// ignore: deprecated_member_use_from_same_package
+ConsentService consentService(ConsentServiceRef ref) =>
+    ConsentService(ref.watch(consentRepositoryProvider));

--- a/lib/src/common/services/consent_service.g.dart
+++ b/lib/src/common/services/consent_service.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'consent_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$consentServiceHash() => r'7c64edd2a3ab457dec6c0e7f346b67909d0e2bf4';
+
+/// See also [consentService].
+@ProviderFor(consentService)
+final consentServiceProvider = Provider<ConsentService>.internal(
+  consentService,
+  name: r'consentServiceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$consentServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef ConsentServiceRef = ProviderRef<ConsentService>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/features/onboarding/onboarding_controller.dart
+++ b/lib/src/features/onboarding/onboarding_controller.dart
@@ -1,9 +1,56 @@
+import 'dart:async';
+
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/enums/consent_type.dart';
 import 'package:nibbles/src/common/domain/formz/baby_name_input.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/consent_service.dart';
 import 'package:nibbles/src/features/onboarding/onboarding_state.dart';
+import 'package:nibbles/src/utils/age_in_months.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'onboarding_controller.g.dart';
+
+/// Age cutoff (in whole months) for the early-solids responsibility consent.
+/// Babies younger than this at submit time are recorded against the second
+/// consent type per NIB-145.
+const int onboardingEarlySolidsThresholdMonths = 6;
+
+/// Injectable Crashlytics recorder so unit tests can assert the non-fatal
+/// payload without touching real Firebase. Mirrors the
+/// `DeleteAccountCrashRecorderFn` pattern from NIB-85.
+typedef OnboardingCrashRecorderFn =
+    Future<void> Function(
+      Object error,
+      StackTrace stack, {
+      String? reason,
+      List<String>? information,
+    });
+
+Future<void> _defaultOnboardingCrashRecorder(
+  Object error,
+  StackTrace stack, {
+  String? reason,
+  List<String>? information,
+}) => FirebaseCrashlytics.instance.recordError(
+  error,
+  stack,
+  reason: reason,
+  information: information ?? const <Object>[],
+  // Non-fatal: consent receipt is supplementary; in-app gate already enforced.
+  // ignore: avoid_redundant_argument_values
+  fatal: false,
+);
+
+/// Provider for the [OnboardingCrashRecorderFn]. Tests override this to
+/// capture the recorded payload without hitting Crashlytics.
+@Riverpod(keepAlive: true)
+OnboardingCrashRecorderFn onboardingCrashRecorder(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  OnboardingCrashRecorderRef ref,
+) => _defaultOnboardingCrashRecorder;
 
 /// Single hoisted controller for the new onboarding flow.
 ///
@@ -91,7 +138,12 @@ class OnboardingController extends _$OnboardingController {
         .createBaby(state.babyName.value, state.dob!);
 
     return result.when(
-      success: (_) {
+      success: (baby) async {
+        // NIB-145 — P2 best-effort DB receipt for the consent acknowledgements
+        // gated by the consent screen. Failures here MUST NOT block onboarding
+        // (the in-app gate is already satisfied); they are logged to
+        // Crashlytics for triage and we proceed regardless.
+        await _recordOnboardingConsents(babyId: baby.id, dob: state.dob!);
         state = state.copyWith(isSubmitting: false);
         return true;
       },
@@ -103,6 +155,44 @@ class OnboardingController extends _$OnboardingController {
         return false;
       },
     );
+  }
+
+  /// Persists the consent acknowledgements taken on the consent screen
+  /// (NIB-145). Always records `solidsIntroduction`. If the baby is younger
+  /// than [onboardingEarlySolidsThresholdMonths] at submit time, also records
+  /// `under6MoResponsibility` (matches the extra checkbox surfaced for <6mo
+  /// DOB on the consent screen).
+  ///
+  /// P2 — failures are recorded to Crashlytics and swallowed; the caller does
+  /// not surface an inline error and the flow proceeds to /home.
+  Future<void> _recordOnboardingConsents({
+    required String babyId,
+    required DateTime dob,
+  }) async {
+    final consents = <ConsentType>[
+      ConsentType.solidsIntroduction,
+      if (ageInMonths(dob) < onboardingEarlySolidsThresholdMonths)
+        ConsentType.under6MoResponsibility,
+    ];
+
+    final consentService = ref.read(consentServiceProvider);
+    for (final type in consents) {
+      final result = await consentService.recordConsent(
+        babyId: babyId,
+        type: type,
+      );
+      if (result case Failure<void>(:final error)) {
+        // information carries non-PII triage hints.
+        unawaited(
+          ref.read(onboardingCrashRecorderProvider)(
+            'onboarding_consent_record_failure: ${error.message}',
+            StackTrace.current,
+            reason: 'onboarding_consent_record_failure',
+            information: <String>['consent_type=${type.dbValue}'],
+          ),
+        );
+      }
+    }
   }
 
   /// Resets to empty state. Reserved for sign-out / test setup.

--- a/lib/src/features/onboarding/onboarding_controller.g.dart
+++ b/lib/src/features/onboarding/onboarding_controller.g.dart
@@ -6,8 +6,30 @@ part of 'onboarding_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$onboardingCrashRecorderHash() =>
+    r'4590b3d2e3ac5fdfeb41bd6bc2f297c6dbf9a33b';
+
+/// Provider for the [OnboardingCrashRecorderFn]. Tests override this to
+/// capture the recorded payload without hitting Crashlytics.
+///
+/// Copied from [onboardingCrashRecorder].
+@ProviderFor(onboardingCrashRecorder)
+final onboardingCrashRecorderProvider =
+    Provider<OnboardingCrashRecorderFn>.internal(
+      onboardingCrashRecorder,
+      name: r'onboardingCrashRecorderProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$onboardingCrashRecorderHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef OnboardingCrashRecorderRef = ProviderRef<OnboardingCrashRecorderFn>;
 String _$onboardingControllerHash() =>
-    r'121cd61b69c105a5fe4c78d79ba2ba2e165e8084';
+    r'544f9760f6806eda50153136af8205ff55ea8c59';
 
 /// Single hoisted controller for the new onboarding flow.
 ///

--- a/supabase/migrations/20260601000001_consents.sql
+++ b/supabase/migrations/20260601000001_consents.sql
@@ -1,0 +1,40 @@
+-- NIB-145 — Persist onboarding consent acknowledgements to DB with timestamp.
+--
+-- The consent UX gate stays in-app (the user can't reach baby creation without
+-- ticking every box on the consent screen). This table is the supplementary
+-- DB receipt — proves WHEN and WHICH consents the user gave, against which
+-- baby. The receipt insert is P2 from the client (best-effort, logged to
+-- Crashlytics on failure); the in-app gate is the authoritative blocker.
+--
+-- Two consent types today (NIB-120):
+--   - solids_introduction         — always recorded on onboarding submit
+--   - under_6mo_responsibility    — only recorded when the baby is < 6 months
+--                                   at consent time (early-solids clause)
+--
+-- baby_id is nullable + ON DELETE CASCADE so a row can survive while we wait
+-- for createBaby() to land (defensive — current wiring records consent AFTER
+-- the baby exists) and is automatically purged when the baby is hard-deleted.
+
+CREATE TABLE IF NOT EXISTS consents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  baby_id UUID REFERENCES babies(id) ON DELETE CASCADE,
+  consent_type TEXT NOT NULL CHECK (
+    consent_type IN ('solids_introduction', 'under_6mo_responsibility')
+  ),
+  given_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE consents ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "users insert own consents" ON consents;
+CREATE POLICY "users insert own consents" ON consents
+  FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "users read own consents" ON consents;
+CREATE POLICY "users read own consents" ON consents
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE INDEX IF NOT EXISTS consents_user_id_idx ON consents (user_id);

--- a/test/common/data/repositories/consent_repository_test.dart
+++ b/test/common/data/repositories/consent_repository_test.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/consent_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/enums/consent_type.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _MockSupabaseClient extends Mock implements SupabaseClient {}
+
+class _MockQueryBuilder extends Mock implements SupabaseQueryBuilder {}
+
+class _MockGoTrueClient extends Mock implements GoTrueClient {}
+
+class _FakeUser extends Fake implements User {
+  @override
+  String get id => 'user-1';
+}
+
+/// Fake terminal for `.insert(...)` — implements `Future<void>` via a
+/// behaviour closure that either resolves or throws. Mirrors the
+/// `_FakeInsertTerminal` pattern in `feedback_repository_test.dart`.
+class _FakeInsertTerminal implements PostgrestFilterBuilder<void> {
+  _FakeInsertTerminal(this._behaviour);
+
+  final FutureOr<void> Function() _behaviour;
+
+  Future<void> get _future => Future<void>.sync(_behaviour);
+
+  @override
+  Future<R> then<R>(
+    FutureOr<R> Function(void value) onValue, {
+    Function? onError,
+  }) => _future.then(onValue, onError: onError);
+
+  @override
+  Future<void> catchError(
+    Function onError, {
+    bool Function(Object error)? test,
+  }) => _future.catchError(onError, test: test);
+
+  @override
+  Future<void> whenComplete(FutureOr<void> Function() action) =>
+      _future.whenComplete(action);
+
+  @override
+  Future<void> timeout(
+    Duration timeLimit, {
+    FutureOr<void> Function()? onTimeout,
+  }) => _future.timeout(timeLimit, onTimeout: onTimeout);
+
+  @override
+  Stream<void> asStream() => _future.asStream();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError(
+      'Unexpected call on _FakeInsertTerminal: ${invocation.memberName}',
+    );
+  }
+}
+
+// SupabaseQueryBuilder is `@immutable` but we need to record the insert
+// payload once for assertion. Matches the lint suppression on
+// `_CapturingQueryBuilder` in `feedback_repository_test.dart`.
+// ignore: must_be_immutable
+class _CapturingQueryBuilder extends _MockQueryBuilder {
+  _CapturingQueryBuilder(this.behaviour);
+
+  final FutureOr<void> Function() behaviour;
+  Map<String, dynamic>? capturedValues;
+
+  @override
+  PostgrestFilterBuilder<void> insert(
+    Object values, {
+    dynamic defaultToNull = true,
+  }) {
+    capturedValues = values as Map<String, dynamic>;
+    return _FakeInsertTerminal(behaviour);
+  }
+}
+
+void main() {
+  group('ConsentRepositoryImpl.recordConsent', () {
+    test(
+      'inserts {user_id, baby_id, consent_type=solids_introduction} '
+      'and returns success',
+      () async {
+        final mockSupabase = _MockSupabaseClient();
+        final mockAuth = _MockGoTrueClient();
+        final builder = _CapturingQueryBuilder(() {});
+
+        when(() => mockSupabase.auth).thenReturn(mockAuth);
+        when(() => mockAuth.currentUser).thenReturn(_FakeUser());
+        when(
+          () => mockSupabase.from('consents'),
+        ).thenAnswer((_) => builder);
+
+        final sut = ConsentRepositoryImpl(supabaseClient: mockSupabase);
+        final result = await sut.recordConsent(
+          babyId: 'baby-1',
+          type: ConsentType.solidsIntroduction,
+        );
+
+        expect(result, isA<Success<void>>());
+        expect(builder.capturedValues, {
+          'user_id': 'user-1',
+          'baby_id': 'baby-1',
+          'consent_type': 'solids_introduction',
+        });
+      },
+    );
+
+    test('maps the under_6mo_responsibility enum value to its dbValue',
+        () async {
+      final mockSupabase = _MockSupabaseClient();
+      final mockAuth = _MockGoTrueClient();
+      final builder = _CapturingQueryBuilder(() {});
+
+      when(() => mockSupabase.auth).thenReturn(mockAuth);
+      when(() => mockAuth.currentUser).thenReturn(_FakeUser());
+      when(
+        () => mockSupabase.from('consents'),
+      ).thenAnswer((_) => builder);
+
+      final sut = ConsentRepositoryImpl(supabaseClient: mockSupabase);
+      final result = await sut.recordConsent(
+        babyId: 'baby-1',
+        type: ConsentType.under6MoResponsibility,
+      );
+
+      expect(result, isA<Success<void>>());
+      expect(
+        builder.capturedValues?['consent_type'],
+        'under_6mo_responsibility',
+      );
+    });
+
+    test('maps PostgrestException to Failure(ServerException) — P2 fallback '
+        'caller logs to Crashlytics and proceeds', () async {
+      final mockSupabase = _MockSupabaseClient();
+      final mockAuth = _MockGoTrueClient();
+      final builder = _CapturingQueryBuilder(() {
+        throw const PostgrestException(message: 'rls denied', code: '42501');
+      });
+
+      when(() => mockSupabase.auth).thenReturn(mockAuth);
+      when(() => mockAuth.currentUser).thenReturn(_FakeUser());
+      when(
+        () => mockSupabase.from('consents'),
+      ).thenAnswer((_) => builder);
+
+      final sut = ConsentRepositoryImpl(supabaseClient: mockSupabase);
+      final result = await sut.recordConsent(
+        babyId: 'baby-1',
+        type: ConsentType.solidsIntroduction,
+      );
+
+      expect(result, isA<Failure<void>>());
+      final failure = result as Failure<void>;
+      expect(failure.error, isA<ServerException>());
+      expect(failure.error.message, 'rls denied');
+    });
+
+    test('maps any other thrown Object to Failure(UnknownException)',
+        () async {
+      final mockSupabase = _MockSupabaseClient();
+      final mockAuth = _MockGoTrueClient();
+      final builder = _CapturingQueryBuilder(() {
+        throw Exception('boom');
+      });
+
+      when(() => mockSupabase.auth).thenReturn(mockAuth);
+      when(() => mockAuth.currentUser).thenReturn(_FakeUser());
+      when(
+        () => mockSupabase.from('consents'),
+      ).thenAnswer((_) => builder);
+
+      final sut = ConsentRepositoryImpl(supabaseClient: mockSupabase);
+      final result = await sut.recordConsent(
+        babyId: 'baby-1',
+        type: ConsentType.solidsIntroduction,
+      );
+
+      expect(result, isA<Failure<void>>());
+      expect((result as Failure<void>).error, isA<UnknownException>());
+    });
+  });
+}

--- a/test/common/services/consent_service_test.dart
+++ b/test/common/services/consent_service_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/consent_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/enums/consent_type.dart';
+import 'package:nibbles/src/common/services/consent_service.dart';
+
+class _MockConsentRepository extends Mock implements ConsentRepository {}
+
+void main() {
+  late _MockConsentRepository mockRepo;
+  late ConsentService sut;
+
+  setUpAll(() {
+    registerFallbackValue(ConsentType.solidsIntroduction);
+  });
+
+  setUp(() {
+    mockRepo = _MockConsentRepository();
+    sut = ConsentService(mockRepo);
+  });
+
+  group('ConsentService.recordConsent', () {
+    test('forwards solidsIntroduction to the repository unchanged', () async {
+      when(
+        () => mockRepo.recordConsent(
+          babyId: any(named: 'babyId'),
+          type: any(named: 'type'),
+        ),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      final result = await sut.recordConsent(
+        babyId: 'baby-1',
+        type: ConsentType.solidsIntroduction,
+      );
+
+      expect(result, isA<Success<void>>());
+      verify(
+        () => mockRepo.recordConsent(
+          babyId: 'baby-1',
+          type: ConsentType.solidsIntroduction,
+        ),
+      ).called(1);
+    });
+
+    test('forwards under6MoResponsibility to the repository unchanged',
+        () async {
+      when(
+        () => mockRepo.recordConsent(
+          babyId: any(named: 'babyId'),
+          type: any(named: 'type'),
+        ),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      final result = await sut.recordConsent(
+        babyId: 'baby-2',
+        type: ConsentType.under6MoResponsibility,
+      );
+
+      expect(result, isA<Success<void>>());
+      verify(
+        () => mockRepo.recordConsent(
+          babyId: 'baby-2',
+          type: ConsentType.under6MoResponsibility,
+        ),
+      ).called(1);
+    });
+
+    test('returns Result.failure when repository fails', () async {
+      when(
+        () => mockRepo.recordConsent(
+          babyId: any(named: 'babyId'),
+          type: any(named: 'type'),
+        ),
+      ).thenAnswer(
+        (_) async => const Result.failure(ServerException('rls denied')),
+      );
+
+      final result = await sut.recordConsent(
+        babyId: 'baby-1',
+        type: ConsentType.solidsIntroduction,
+      );
+
+      expect(result, isA<Failure<void>>());
+      expect((result as Failure<void>).error, isA<ServerException>());
+      expect(result.error.message, 'rls denied');
+    });
+  });
+}

--- a/test/features/onboarding/consent/onboarding_consent_screen_test.dart
+++ b/test/features/onboarding/consent/onboarding_consent_screen_test.dart
@@ -6,11 +6,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/data/repositories/consent_repository.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/enums/consent_type.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/consent_service.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/onboarding/consent/onboarding_consent_screen.dart';
 import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
@@ -19,6 +22,30 @@ import 'package:nibbles/src/routing/route_enums.dart';
 class _MockBabyProfileService extends Mock implements BabyProfileService {}
 
 class _MockLocalFlagService extends Mock implements LocalFlagService {}
+
+/// Hand-rolled no-op repo — avoids polluting the global mocktail matcher
+/// queue with `any(named: 'babyId')` etc. The screen tests stub
+/// `babyProfile.createBaby` with POSITIONAL `any()` matchers; mixing in a
+/// Mock for ConsentService with NAMED matchers trips mocktail's matcher
+/// accounting on the next real call. NIB-145's wiring behaviour is asserted
+/// in the controller-level test
+/// (`onboarding_controller_consent_persistence_test.dart`).
+class _NoopConsentRepository implements ConsentRepository {
+  const _NoopConsentRepository();
+
+  @override
+  Future<Result<void>> recordConsent({
+    required String babyId,
+    required ConsentType type,
+  }) async => const Result.success(null);
+}
+
+Future<void> _noopCrashRecorder(
+  Object error,
+  StackTrace stack, {
+  String? reason,
+  List<String>? information,
+}) async {}
 
 final _fakeBaby = Baby(
   id: 'baby-001',
@@ -75,7 +102,11 @@ ProviderContainer _makeContainer({
   final container = ProviderContainer(
     overrides: [
       babyProfileServiceProvider.overrideWithValue(babyProfile),
+      consentServiceProvider.overrideWithValue(
+        const ConsentService(_NoopConsentRepository()),
+      ),
       localFlagServiceProvider.overrideWithValue(flags),
+      onboardingCrashRecorderProvider.overrideWithValue(_noopCrashRecorder),
     ],
   );
   addTearDown(container.dispose);

--- a/test/features/onboarding/onboarding_controller_consent_persistence_test.dart
+++ b/test/features/onboarding/onboarding_controller_consent_persistence_test.dart
@@ -1,0 +1,257 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/enums/consent_type.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/consent_service.dart';
+import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
+
+class _MockBabyProfileService extends Mock implements BabyProfileService {}
+
+class _MockConsentService extends Mock implements ConsentService {}
+
+class _CrashRecorderSpy {
+  final captured = <_CrashCall>[];
+
+  Future<void> call(
+    Object error,
+    StackTrace stack, {
+    String? reason,
+    List<String>? information,
+  }) async {
+    captured.add(
+      _CrashCall(
+        error: error,
+        reason: reason,
+        information: information ?? const <String>[],
+      ),
+    );
+  }
+}
+
+class _CrashCall {
+  _CrashCall({
+    required this.error,
+    required this.reason,
+    required this.information,
+  });
+
+  final Object error;
+  final String? reason;
+  final List<String> information;
+}
+
+final _fakeBaby = Baby(
+  id: 'baby-001',
+  userId: 'user-001',
+  name: 'Lily',
+  dateOfBirth: DateTime(2025, 6),
+  gender: Gender.preferNotToSay,
+  onboardingCompleted: false,
+);
+
+ProviderContainer _makeContainer({
+  required BabyProfileService babyProfile,
+  required ConsentService consent,
+  required _CrashRecorderSpy crashRecorder,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      babyProfileServiceProvider.overrideWithValue(babyProfile),
+      consentServiceProvider.overrideWithValue(consent),
+      onboardingCrashRecorderProvider.overrideWithValue(crashRecorder.call),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+/// NIB-145 — `OnboardingController.submit` must persist the consent
+/// acknowledgements after a successful baby creation. Always records
+/// `solidsIntroduction`; additionally records `under6MoResponsibility` when
+/// the baby is younger than 6 months at submit time. P2 — failures log to
+/// Crashlytics and never block onboarding.
+void main() {
+  late _MockBabyProfileService babyProfile;
+  late _MockConsentService consent;
+  late _CrashRecorderSpy crashRecorder;
+
+  setUpAll(() {
+    registerFallbackValue(ConsentType.solidsIntroduction);
+  });
+
+  setUp(() {
+    babyProfile = _MockBabyProfileService();
+    consent = _MockConsentService();
+    crashRecorder = _CrashRecorderSpy();
+
+    when(
+      () => babyProfile.createBaby(any(), any()),
+    ).thenAnswer((_) async => Result.success(_fakeBaby));
+    when(
+      () => consent.recordConsent(
+        babyId: any(named: 'babyId'),
+        type: any(named: 'type'),
+      ),
+    ).thenAnswer((_) async => const Result.success(null));
+  });
+
+  test(
+    'records solidsIntroduction only when baby DOB >= 6 months at submit time',
+    () async {
+      final container = _makeContainer(
+        babyProfile: babyProfile,
+        consent: consent,
+        crashRecorder: crashRecorder,
+      );
+      final controller = container.read(onboardingControllerProvider.notifier)
+        ..updateName('Lily')
+        // 8 months old: clearly >= 6mo at "today" — exact day doesn't matter
+        // as long as the diff is >= 6 whole months.
+        ..updateDob(DateTime.now().subtract(const Duration(days: 250)));
+
+      final ok = await controller.submit();
+
+      expect(ok, isTrue);
+      verify(
+        () => consent.recordConsent(
+          babyId: 'baby-001',
+          type: ConsentType.solidsIntroduction,
+        ),
+      ).called(1);
+      verifyNever(
+        () => consent.recordConsent(
+          babyId: any(named: 'babyId'),
+          type: ConsentType.under6MoResponsibility,
+        ),
+      );
+    },
+  );
+
+  test(
+    'records BOTH solidsIntroduction and under6MoResponsibility when baby '
+    'DOB is younger than 6 months at submit time',
+    () async {
+      final container = _makeContainer(
+        babyProfile: babyProfile,
+        consent: consent,
+        crashRecorder: crashRecorder,
+      );
+      final controller = container.read(onboardingControllerProvider.notifier)
+        ..updateName('Lily')
+        // 2 months old — well under the 6mo cutoff.
+        ..updateDob(DateTime.now().subtract(const Duration(days: 60)));
+
+      final ok = await controller.submit();
+
+      expect(ok, isTrue);
+      verify(
+        () => consent.recordConsent(
+          babyId: 'baby-001',
+          type: ConsentType.solidsIntroduction,
+        ),
+      ).called(1);
+      verify(
+        () => consent.recordConsent(
+          babyId: 'baby-001',
+          type: ConsentType.under6MoResponsibility,
+        ),
+      ).called(1);
+    },
+  );
+
+  test(
+    'P2 — consent insert failure does NOT block submit and logs to '
+    'Crashlytics with the consent_type for triage',
+    () async {
+      when(
+        () => consent.recordConsent(
+          babyId: any(named: 'babyId'),
+          type: any(named: 'type'),
+        ),
+      ).thenAnswer(
+        (_) async => const Result.failure(ServerException('rls denied')),
+      );
+
+      final container = _makeContainer(
+        babyProfile: babyProfile,
+        consent: consent,
+        crashRecorder: crashRecorder,
+      );
+      final controller = container.read(onboardingControllerProvider.notifier)
+        ..updateName('Lily')
+        ..updateDob(DateTime.now().subtract(const Duration(days: 60)));
+
+      final ok = await controller.submit();
+
+      // Still succeeds — DB receipt failure must not surface as a blocker.
+      expect(ok, isTrue);
+      final state = container.read(onboardingControllerProvider);
+      expect(state.submitErrorMessage, isNull);
+      expect(state.isSubmitting, isFalse);
+
+      // Both calls were attempted (the second consent didn't short-circuit
+      // on the first failure — they're independent receipts).
+      verify(
+        () => consent.recordConsent(
+          babyId: 'baby-001',
+          type: ConsentType.solidsIntroduction,
+        ),
+      ).called(1);
+      verify(
+        () => consent.recordConsent(
+          babyId: 'baby-001',
+          type: ConsentType.under6MoResponsibility,
+        ),
+      ).called(1);
+
+      expect(crashRecorder.captured, hasLength(2));
+      for (final call in crashRecorder.captured) {
+        expect(call.reason, 'onboarding_consent_record_failure');
+        expect(call.error.toString(), contains('rls denied'));
+      }
+      expect(
+        crashRecorder.captured
+            .expand((c) => c.information)
+            .toList(),
+        containsAll(<String>[
+          'consent_type=solids_introduction',
+          'consent_type=under_6mo_responsibility',
+        ]),
+      );
+    },
+  );
+
+  test(
+    'when createBaby fails, no consent receipts are attempted',
+    () async {
+      when(() => babyProfile.createBaby(any(), any())).thenAnswer(
+        (_) async => const Result.failure(NetworkException('offline')),
+      );
+
+      final container = _makeContainer(
+        babyProfile: babyProfile,
+        consent: consent,
+        crashRecorder: crashRecorder,
+      );
+      final controller = container.read(onboardingControllerProvider.notifier)
+        ..updateName('Lily')
+        ..updateDob(DateTime.now().subtract(const Duration(days: 60)));
+
+      final ok = await controller.submit();
+
+      expect(ok, isFalse);
+      verifyNever(
+        () => consent.recordConsent(
+          babyId: any(named: 'babyId'),
+          type: any(named: 'type'),
+        ),
+      );
+      expect(crashRecorder.captured, isEmpty);
+    },
+  );
+}

--- a/test/features/onboarding/onboarding_controller_submit_is_submitting_test.dart
+++ b/test/features/onboarding/onboarding_controller_submit_is_submitting_test.dart
@@ -3,14 +3,35 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/consent_repository.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/enums/consent_type.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/consent_service.dart';
 import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
 
 class _MockBabyProfileService extends Mock implements BabyProfileService {}
+
+/// See `onboarding_controller_test.dart` for the matcher-queue rationale.
+class _NoopConsentRepository implements ConsentRepository {
+  const _NoopConsentRepository();
+
+  @override
+  Future<Result<void>> recordConsent({
+    required String babyId,
+    required ConsentType type,
+  }) async => const Result.success(null);
+}
+
+Future<void> _noopCrashRecorder(
+  Object error,
+  StackTrace stack, {
+  String? reason,
+  List<String>? information,
+}) async {}
 
 final _fakeBaby = Baby(
   id: 'baby-001',
@@ -23,7 +44,13 @@ final _fakeBaby = Baby(
 
 ProviderContainer _makeContainer(BabyProfileService service) {
   final container = ProviderContainer(
-    overrides: [babyProfileServiceProvider.overrideWithValue(service)],
+    overrides: [
+      babyProfileServiceProvider.overrideWithValue(service),
+      consentServiceProvider.overrideWithValue(
+        const ConsentService(_NoopConsentRepository()),
+      ),
+      onboardingCrashRecorderProvider.overrideWithValue(_noopCrashRecorder),
+    ],
   );
   addTearDown(container.dispose);
   return container;

--- a/test/features/onboarding/onboarding_controller_test.dart
+++ b/test/features/onboarding/onboarding_controller_test.dart
@@ -1,14 +1,39 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/repositories/consent_repository.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/enums/consent_type.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/consent_service.dart';
 import 'package:nibbles/src/features/onboarding/onboarding_controller.dart';
 
 class _MockBabyProfileService extends Mock implements BabyProfileService {}
+
+/// Hand-rolled no-op repo — see consent screen test for the rationale; mixing
+/// a Mock'd ConsentService that uses NAMED matchers with the existing
+/// `babyProfile.createBaby(any(), any())` POSITIONAL matchers in this file
+/// would trip mocktail's matcher accounting. NIB-145's wiring behaviour is
+/// asserted in `onboarding_controller_consent_persistence_test.dart`.
+class _NoopConsentRepository implements ConsentRepository {
+  const _NoopConsentRepository();
+
+  @override
+  Future<Result<void>> recordConsent({
+    required String babyId,
+    required ConsentType type,
+  }) async => const Result.success(null);
+}
+
+Future<void> _noopCrashRecorder(
+  Object error,
+  StackTrace stack, {
+  String? reason,
+  List<String>? information,
+}) async {}
 
 final _fakeBaby = Baby(
   id: 'baby-001',
@@ -21,7 +46,13 @@ final _fakeBaby = Baby(
 
 ProviderContainer _makeContainer(BabyProfileService service) {
   final container = ProviderContainer(
-    overrides: [babyProfileServiceProvider.overrideWithValue(service)],
+    overrides: [
+      babyProfileServiceProvider.overrideWithValue(service),
+      consentServiceProvider.overrideWithValue(
+        const ConsentService(_NoopConsentRepository()),
+      ),
+      onboardingCrashRecorderProvider.overrideWithValue(_noopCrashRecorder),
+    ],
   );
   addTearDown(container.dispose);
   return container;


### PR DESCRIPTION
## Summary

NIB-145 — Persists onboarding consent acknowledgements to a new `consents`
table after successful baby creation. The in-app gate on the consent screen
remains authoritative; this is the supplementary DB receipt with timestamp.

Two consent types (per NIB-120):
- `solids_introduction` — always recorded on submit
- `under_6mo_responsibility` — additionally recorded when the baby DOB at
  submit time makes them younger than 6 months

P2 failure handling — the receipt insert failing must NOT block onboarding.
Failures log to Crashlytics with the `consent_type` for triage; the flow
proceeds to `/home` regardless.

## Changes

- **Migration** `supabase/migrations/20260601000001_consents.sql` —
  `consents` table + RLS (insert/select own) + `consents_user_id_idx`.
- **Enum** `ConsentType { solidsIntroduction, under6MoResponsibility }` with
  canonical `dbValue` matching the table's CHECK constraint.
- **Repository** `ConsentRepository` + `ConsentRepositoryImpl` — single
  `recordConsent({babyId, type})` returning `Result<void>`. Maps
  `PostgrestException` to `Failure(ServerException)`, anything else to
  `Failure(UnknownException)`.
- **Service** `ConsentService` — thin facade (controller-service-repo).
- **Controller** `OnboardingController.submit` now calls
  `_recordOnboardingConsents` after successful `createBaby`. Always records
  `solidsIntroduction`; conditionally records `under6MoResponsibility` based
  on `ageInMonths(dob) < 6`. P2 — failures swallowed and recorded to
  Crashlytics via the injectable `OnboardingCrashRecorderFn` provider.

## Acceptance

- [x] `consents` migration created (idempotent CREATE IF NOT EXISTS + DROP/
      CREATE POLICY)
- [x] `ConsentRepository` interface + impl wired via Riverpod provider
- [x] `ConsentService.recordConsent({babyId, type})` returning `Result<void>`
- [x] `ConsentType` enum with `dbValue` mapping to DB strings
- [x] `OnboardingController.submit` records `solidsIntroduction` always
- [x] Records `under6MoResponsibility` when DOB < 6 months at submit time
- [x] P2 — failures logged to Crashlytics with `consent_type` info, never
      block submit
- [x] Repo test: success payload, both enum dbValue mappings, PostgrestException
      → ServerException, generic → UnknownException
- [x] Service test: forwards both consent types unchanged, surfaces failure
- [x] Controller test: solids-only for >= 6mo, both for < 6mo, P2 swallowing
      with Crashlytics asserts, no consent attempt on `createBaby` failure
- [x] `flutter analyze` clean (only 2 pre-existing infos unrelated to this
      ticket)
- [x] Onboarding test suite passes (82 tests)

## Test plan

- [ ] Apply migration to dev Supabase
- [ ] Sign up a new account, complete onboarding with DOB >= 6mo, verify a
      single `solids_introduction` row appears in `consents`
- [ ] Repeat with DOB < 6mo, verify BOTH `solids_introduction` and
      `under_6mo_responsibility` rows appear
- [ ] Toggle Supabase offline mid-submit (or revoke insert policy) and verify
      onboarding still completes to `/home` and Crashlytics receives a
      `onboarding_consent_record_failure` non-fatal with `consent_type` info