### PR TITLE
feat(infra): per-flavor Google OAuth client IDs via xcconfig [NIB-147]

### DIFF
--- a/ios/Flutter/Dev.xcconfig
+++ b/ios/Flutter/Dev.xcconfig
@@ -2,3 +2,7 @@
 PRODUCT_BUNDLE_IDENTIFIER=com.aydev.nibbles.dev
 FLUTTER_TARGET=lib/main_dev.dart
 DISPLAY_NAME=Nibbles Dev
+
+// Google OAuth (NIB-147) — dev iOS client ID + reversed URL scheme.
+GIDClientID=50776105003-8hr72ci96hfi386va9s94civdjlegnqo.apps.googleusercontent.com
+GIDReversedClientID=com.googleusercontent.apps.50776105003-8hr72ci96hfi386va9s94civdjlegnqo

--- a/ios/Flutter/Prod.xcconfig
+++ b/ios/Flutter/Prod.xcconfig
@@ -2,3 +2,7 @@
 PRODUCT_BUNDLE_IDENTIFIER=com.aydev.nibbles
 FLUTTER_TARGET=lib/main.dart
 DISPLAY_NAME=Nibbles
+
+// Google OAuth (NIB-147) — prod iOS client ID + reversed URL scheme.
+GIDClientID=50776105003-uofrn3terv21srf5phm0rkhgfpnal5dj.apps.googleusercontent.com
+GIDReversedClientID=com.googleusercontent.apps.50776105003-uofrn3terv21srf5phm0rkhgfpnal5dj

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,10 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>GIDClientID</key>
+	<string>$(GIDClientID)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Nibbles</string>
+	<string>$(DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -48,21 +50,15 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.aydev.nibbles</string>
-				<string>com.aydev.nibbles.dev</string>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			</array>
 		</dict>
-		<!-- Google OAuth callback (NIB-117). The scheme is the REVERSED Google OAuth
-		     iOS client ID from GCP, e.g. com.googleusercontent.apps.123456789-abcdef.
-		     TODO: replace REPLACE_WITH_REVERSED_GOOGLE_OAUTH_CLIENT_ID with the real
-		     reversed client ID from the GCP OAuth 2.0 iOS client (dev + prod share
-		     one entry; if dev and prod use separate GCP clients, add a second dict). -->
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>REPLACE_WITH_REVERSED_GOOGLE_OAUTH_CLIENT_ID</string>
+				<string>$(GIDReversedClientID)</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
## Summary
Per-flavor Google OAuth client IDs via xcconfig — fixes `make run-dev` rejecting Google sign-in due to bundle/client mismatch.

## What changed
- `Dev.xcconfig` + `Prod.xcconfig` each set `GIDClientID` + `GIDReversedClientID` for their flavor
- `Info.plist` now references `$(GIDClientID)` + `$(GIDReversedClientID)` instead of hardcoded strings
- Also switched `CFBundleDisplayName` to `$(DISPLAY_NAME)` and the bundle id URL scheme to `$(PRODUCT_BUNDLE_IDENTIFIER)` for consistency

## Test plan
- [x] `make run-dev` picks up dev iOS client ID
- [x] `make run-prod` picks up prod iOS client ID