### PR TITLE
fix(infra): wire Pods xcconfig + dev/prod build configs [NIB-148]

### DIFF
--- a/ios/Flutter/Dev.xcconfig
+++ b/ios/Flutter/Dev.xcconfig
@@ -1,3 +1,4 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-dev.xcconfig"
 #include "Generated.xcconfig"
 PRODUCT_BUNDLE_IDENTIFIER=com.aydev.nibbles.dev
 FLUTTER_TARGET=lib/main_dev.dart

--- a/ios/Flutter/Prod.xcconfig
+++ b/ios/Flutter/Prod.xcconfig
@@ -1,3 +1,4 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-prod.xcconfig"
 #include "Generated.xcconfig"
 PRODUCT_BUNDLE_IDENTIFIER=com.aydev.nibbles
 FLUTTER_TARGET=lib/main.dart

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -8,6 +8,12 @@ project 'Runner', {
   'Debug' => :debug,
   'Profile' => :release,
   'Release' => :release,
+  'Debug-dev' => :debug,
+  'Profile-dev' => :release,
+  'Release-dev' => :release,
+  'Debug-prod' => :debug,
+  'Profile-prod' => :release,
+  'Release-prod' => :release,
 }
 
 def flutter_root


### PR DESCRIPTION
## Summary
Wires CocoaPods integration to the dev/prod build configs. Without this, `flutter build ios --flavor dev` failed with "Unable to load contents of file list: '/Target Support Files/...'" because `PODS_ROOT` was never set under Debug-dev/Debug-prod.

## Changes
- `ios/Podfile`: extend `project 'Runner'` map to all 9 build configs (Debug/Release/Profile × base/dev/prod)
- `ios/Flutter/Dev.xcconfig`: `#include?` the Pods-Runner.debug-dev.xcconfig at the top so PODS_ROOT et al resolve
- `ios/Flutter/Prod.xcconfig`: same for debug-prod

## Test plan
- [x] `flutter build ios --simulator --debug --flavor dev -t lib/main_dev.dart` builds clean
- [x] Built .app has GIDClientID = dev iOS client ID, CFBundleIdentifier = com.aydev.nibbles.dev, CFBundleDisplayName = "Nibbles Dev", reversed-client-id URL scheme present