### PR TITLE
fix(inputs): AppTextField double-border + audit all text inputs

### DIFF
--- a/lib/src/common/components/inputs/app_text_field.dart
+++ b/lib/src/common/components/inputs/app_text_field.dart
@@ -90,15 +90,15 @@ class _AppTextFieldState extends State<AppTextField> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final hasError = widget.errorText != null;
     final focused = _focusNode.hasFocus;
     final errorColor = widget.errorColor ?? AppColors.error;
 
-    final borderColor = hasError
-        ? errorColor
-        : focused
-            ? AppColors.greenDeep
-            : AppColors.borderSoft;
+    OutlineInputBorder borderOf(Color color, double width) {
+      return OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+        borderSide: BorderSide(color: color, width: width),
+      );
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -114,70 +114,46 @@ class _AppTextFieldState extends State<AppTextField> {
           ),
           const SizedBox(height: AppSizes.sm),
         ],
-        AnimatedContainer(
-          duration: const Duration(milliseconds: 120),
-          height: AppSizes.fieldHeight,
-          decoration: BoxDecoration(
-            color: focused ? AppColors.surface : AppColors.bgInput,
-            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-            border: Border.all(
-              color: borderColor,
-              width: focused || hasError ? 2 : 1,
+        // Single box driven by the field's own InputDecoration — no wrapping
+        // container and no hard-edged focus shadow (the previous spreadRadius
+        // BoxShadow rendered a phantom second border). Border + fill + error
+        // caption + suffix icon are all native decoration slots.
+        TextField(
+          controller: widget.controller,
+          focusNode: _focusNode,
+          enabled: widget.enabled,
+          obscureText: widget.obscureText,
+          keyboardType: widget.keyboardType,
+          textInputAction: widget.textInputAction,
+          onChanged: widget.onChanged,
+          onSubmitted: widget.onSubmitted,
+          autocorrect: widget.autocorrect,
+          enableSuggestions: widget.enableSuggestions,
+          textCapitalization: widget.textCapitalization,
+          style: theme.textTheme.bodyLarge?.copyWith(color: AppColors.fgStrong),
+          cursorColor: AppColors.greenDeep,
+          decoration: InputDecoration(
+            filled: true,
+            fillColor: focused ? AppColors.surface : AppColors.bgInput,
+            isDense: true,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.md,
+              vertical: AppSizes.sp12 + 1,
             ),
-            boxShadow: focused && !hasError
-                ? [
-                    BoxShadow(
-                      color: AppColors.green.withValues(alpha: 0.18),
-                      spreadRadius: 3,
-                    ),
-                  ]
-                : null,
-          ),
-          alignment: Alignment.center,
-          padding: const EdgeInsets.symmetric(horizontal: AppSizes.md - 2),
-          child: Row(
-            children: [
-              Expanded(
-                child: TextField(
-                  controller: widget.controller,
-                  focusNode: _focusNode,
-                  enabled: widget.enabled,
-                  obscureText: widget.obscureText,
-                  keyboardType: widget.keyboardType,
-                  textInputAction: widget.textInputAction,
-                  onChanged: widget.onChanged,
-                  onSubmitted: widget.onSubmitted,
-                  autocorrect: widget.autocorrect,
-                  enableSuggestions: widget.enableSuggestions,
-                  textCapitalization: widget.textCapitalization,
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    color: AppColors.fgStrong,
-                  ),
-                  cursorColor: AppColors.greenDeep,
-                  decoration: InputDecoration(
-                    isCollapsed: true,
-                    border: InputBorder.none,
-                    hintText: widget.hintText,
-                    hintStyle: theme.textTheme.bodyLarge?.copyWith(
-                      color: AppColors.greenSoft,
-                    ),
-                  ),
-                ),
-              ),
-              if (widget.suffixIcon != null) ...[
-                const SizedBox(width: AppSizes.sm),
-                widget.suffixIcon!,
-              ],
-            ],
+            hintText: widget.hintText,
+            hintStyle: theme.textTheme.bodyLarge?.copyWith(
+              color: AppColors.greenSoft,
+            ),
+            suffixIcon: widget.suffixIcon,
+            enabledBorder: borderOf(AppColors.borderSoft, 1),
+            disabledBorder: borderOf(AppColors.borderSoft, 1),
+            focusedBorder: borderOf(AppColors.greenDeep, 2),
+            errorBorder: borderOf(errorColor, 1),
+            focusedErrorBorder: borderOf(errorColor, 2),
+            errorText: widget.errorText,
+            errorStyle: theme.textTheme.bodySmall?.copyWith(color: errorColor),
           ),
         ),
-        if (hasError) ...[
-          const SizedBox(height: AppSizes.xs),
-          Text(
-            widget.errorText!,
-            style: theme.textTheme.bodySmall?.copyWith(color: errorColor),
-          ),
-        ],
       ],
     );
   }

--- a/lib/src/features/onboarding/baby_setup/onboarding_baby_setup_screen.dart
+++ b/lib/src/features/onboarding/baby_setup/onboarding_baby_setup_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/components.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/features/onboarding/baby_setup/baby_setup_controller.dart';
 import 'package:nibbles/src/features/onboarding/baby_setup/baby_setup_state.dart';
@@ -82,17 +83,15 @@ class _NameStep extends StatelessWidget {
         const SizedBox(height: AppSizes.lg),
         Text("What's your baby's name?", style: textTheme.headlineLarge),
         const SizedBox(height: AppSizes.xl),
-        TextField(
+        AppTextField(
           key: const Key('baby_name_field'),
-          onChanged: controller.updateName,
+          hintText: "Baby's name",
           textCapitalization: TextCapitalization.words,
-          decoration: InputDecoration(
-            labelText: "Baby's name",
-            errorText:
-                state.babyName.isNotValid && state.babyName.value.isNotEmpty
-                ? 'Please enter a valid name.'
-                : null,
-          ),
+          onChanged: controller.updateName,
+          errorText:
+              state.babyName.isNotValid && state.babyName.value.isNotEmpty
+              ? 'Please enter a valid name.'
+              : null,
         ),
         const Spacer(),
         SizedBox(

--- a/lib/src/features/profile/feedback/feedback_screen.dart
+++ b/lib/src/features/profile/feedback/feedback_screen.dart
@@ -147,10 +147,7 @@ class _FeedbackEntryScreen extends StatelessWidget {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          SafeArea(
-            bottom: false,
-            child: _FeedbackHeader(onBack: onBack),
-          ),
+          SafeArea(bottom: false, child: _FeedbackHeader(onBack: onBack)),
           Expanded(
             child: SingleChildScrollView(
               padding: const EdgeInsets.fromLTRB(
@@ -162,10 +159,7 @@ class _FeedbackEntryScreen extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  _FeedbackField(
-                    initialValue: message,
-                    onChanged: onChanged,
-                  ),
+                  _FeedbackField(initialValue: message, onChanged: onChanged),
                   const SizedBox(height: AppSizes.sp12),
                   Text(
                     'Thank you. We read every message.',
@@ -329,10 +323,7 @@ class _FeedbackHeader extends StatelessWidget {
 /// Multiline textarea matching the kit `.field` fill (bgInput) + radiusMd.
 /// Sized for 5-8 visible lines. Placeholder matches the Figma copy exactly.
 class _FeedbackField extends StatefulWidget {
-  const _FeedbackField({
-    required this.initialValue,
-    required this.onChanged,
-  });
+  const _FeedbackField({required this.initialValue, required this.onChanged});
 
   final String initialValue;
   final ValueChanged<String> onChanged;
@@ -377,14 +368,6 @@ class _FeedbackFieldState extends State<_FeedbackField> {
           color: focused ? AppColors.greenDeep : AppColors.borderSoft,
           width: focused ? 2 : 1,
         ),
-        boxShadow: focused
-            ? [
-                BoxShadow(
-                  color: AppColors.green.withValues(alpha: 0.18),
-                  spreadRadius: 3,
-                ),
-              ]
-            : null,
       ),
       padding: const EdgeInsets.symmetric(
         horizontal: AppSizes.md - 2,


### PR DESCRIPTION
## Problem
The text fields rendered a **double-box** (a phantom inner/outer border). Root cause: `AppTextField` wrapped a borderless `TextField` in a decorated `AnimatedContainer` and, on focus, added `BoxShadow(spreadRadius: 3)` with **no blur** — a hard-edged ring that reads as a second border.

## Fix
Drive the box from the `TextField`'s own `InputDecoration` — the idiomatic approach:
- `filled` + `fillColor` (white on focus), `enabledBorder`/`focusedBorder`/`errorBorder`/`focusedErrorBorder`, `suffixIcon` slot, `errorText` slot
- No wrapping container, no hard shadow

## Audited every text input ("check across all")
| Input | Before | Action |
|---|---|---|
| AppTextField (17 uses) | container + hard focus shadow | rewritten to InputDecoration |
| feedback_screen | same hard focus shadow | shadow removed |
| baby_name | stock Material TextField (floating label) | now uses AppTextField |
| AppSearchField, recipe search, allergen notes, add-ingredient | borderless field, no shadow | already clean — unchanged |

## Verification
- `flutter analyze` clean
- Visual gate on iPhone 17 sim (Login): **unfocused** = clean single filled box; **focused** = single green border, no phantom ring. baby_name reuses the gated component; feedback is the same shadow removal.