### PR TITLE
fix(subscription): remove paywall close button (forced gate)

### DIFF
--- a/lib/src/features/subscription/paywall/paywall_sheet.dart
+++ b/lib/src/features/subscription/paywall/paywall_sheet.dart
@@ -127,9 +127,6 @@ class _PaywallSheetState extends ConsumerState<PaywallSheet> {
       ),
       child: _PaywallBody(
         state: state,
-        onClose: state.action == PaywallAction.none
-            ? () => Navigator.of(context).pop()
-            : null,
         onRestore: state.action == PaywallAction.none ? _onRestore : null,
         onPurchase:
             state.action == PaywallAction.none &&
@@ -153,7 +150,6 @@ class _PaywallSheetState extends ConsumerState<PaywallSheet> {
 class _PaywallBody extends StatelessWidget {
   const _PaywallBody({
     required this.state,
-    required this.onClose,
     required this.onRestore,
     required this.onPurchase,
     required this.onViewAllPlans,
@@ -161,7 +157,6 @@ class _PaywallBody extends StatelessWidget {
   });
 
   final PaywallState state;
-  final VoidCallback? onClose;
   final VoidCallback? onRestore;
   final VoidCallback? onPurchase;
   final VoidCallback? onViewAllPlans;
@@ -173,7 +168,6 @@ class _PaywallBody extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _SheetHeader(
-          onClose: onClose,
           onRestore: onRestore,
           restoreSpinning: state.action == PaywallAction.restoring,
         ),
@@ -195,36 +189,18 @@ class _PaywallBody extends StatelessWidget {
 }
 
 class _SheetHeader extends StatelessWidget {
-  const _SheetHeader({
-    required this.onClose,
-    required this.onRestore,
-    required this.restoreSpinning,
-  });
+  const _SheetHeader({required this.onRestore, required this.restoreSpinning});
 
-  final VoidCallback? onClose;
   final VoidCallback? onRestore;
   final bool restoreSpinning;
 
   @override
   Widget build(BuildContext context) {
-    // Close uses default 48x48 hit area to meet a11y minimum.
-    // Visual shape (radius 30) is preserved via style; only the
-    // restrictive SizedBox(34x33) + BoxConstraints(33/34) are dropped.
+    // No close affordance: the paywall is a forced entitlement gate (NIB-144)
+    // with nowhere to dismiss to. Only "Restore purchase" sits in the header.
     return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        IconButton(
-          key: const Key('paywall_close_button'),
-          icon: const Icon(Icons.close, size: AppSizes.iconMd),
-          color: AppColors.text,
-          onPressed: onClose,
-          tooltip: 'Close',
-          style: IconButton.styleFrom(
-            shape: const RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(Radius.circular(30)),
-            ),
-          ),
-        ),
         SizedBox(
           height: 42,
           child: TextButton(

--- a/test/features/subscription/paywall/paywall_sheet_test.dart
+++ b/test/features/subscription/paywall/paywall_sheet_test.dart
@@ -100,12 +100,8 @@ const _kOffering = SubscriptionOffering(
 
 Widget _buildSut({required SubscriptionService Function() factory}) {
   return ProviderScope(
-    overrides: [
-      subscriptionServiceProvider.overrideWith(factory),
-    ],
-    child: const MaterialApp(
-      home: Scaffold(body: PaywallSheet()),
-    ),
+    overrides: [subscriptionServiceProvider.overrideWith(factory)],
+    child: const MaterialApp(home: Scaffold(body: PaywallSheet())),
   );
 }
 
@@ -167,15 +163,12 @@ void main() {
         .map((rt) => rt.text.toPlainText())
         .toList();
     expect(
-      richTexts.any(
-        (text) => text.contains(r'Then billed at $12.34 yearly'),
-      ),
+      richTexts.any((text) => text.contains(r'Then billed at $12.34 yearly')),
       isTrue,
       reason: 'rendered trial card spans: $richTexts',
     );
 
-    // All four CTA keys are wired.
-    expect(find.byKey(const Key('paywall_close_button')), findsOneWidget);
+    // CTA keys are wired (no close button — forced entitlement gate, NIB-144).
     expect(
       find.byKey(const Key('paywall_restore_purchase_button')),
       findsOneWidget,
@@ -208,10 +201,7 @@ void main() {
     );
     // First pump — the controller has scheduled the offerings load but it
     // hasn't resolved yet, so the loading card is visible.
-    expect(
-      find.byKey(const Key('paywall_trial_card_loading')),
-      findsOneWidget,
-    );
+    expect(find.byKey(const Key('paywall_trial_card_loading')), findsOneWidget);
     // Resolve so the test ends cleanly (no pending timers).
     await tester.pump();
   });


### PR DESCRIPTION
## Why
The paywall is the M2 entitlement guard target (NIB-144) reached after onboarding for unsubscribed users — there's no valid place to dismiss to. The Close (X) popped to an empty route (**black screen**) and the guard didn't re-redirect. Confirmed live on the sim.

## Change
- Remove the close `IconButton` + all `onClose` plumbing (`_SheetHeader` / `_PaywallBody` / `PaywallSheet.build`); right-align "Restore purchase"
- Update the widget test (no `paywall_close_button` assertion)

## Verification
- `flutter analyze` clean; paywall tests pass (6/6)
- Visual gate on iPhone 17 sim (live via the guard): header shows only "Restore purchase", no X; a11y tree confirms no Close node

## Follow-up note
If the paywall is ever shown as a *dismissible* push (Settings → Go Premium — currently unreachable for unsubscribed users since the guard redirects them away from Settings), re-add a context-aware dismiss affordance.