### PR TITLE
fix(home): ready-to-start card cream bg + readable body

### DIFF
--- a/lib/src/features/home/widgets/home_empty_state_full.dart
+++ b/lib/src/features/home/widgets/home_empty_state_full.dart
@@ -75,11 +75,9 @@ class ReadyToStartCard extends StatelessWidget {
     return Container(
       width: double.infinity,
       decoration: BoxDecoration(
-        gradient: const LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [AppColors.butter, AppColors.butterSoft],
-        ),
+        // Figma 1266:12195 — solid cream card (#fffdf8), not the butter→soft
+        // gradient (which over-saturated the card vs the white spec).
+        color: AppColors.cream,
         borderRadius: BorderRadius.circular(AppSizes.radiusXl),
         boxShadow: AppSizes.shadowCard,
       ),
@@ -100,7 +98,7 @@ class ReadyToStartCard extends StatelessWidget {
             'Begin $possessive food journey by creating your first meal '
             'prep and introducing allergens safely.',
             textAlign: TextAlign.center,
-            style: textTheme.bodyLarge?.copyWith(color: AppColors.fgFaint),
+            style: textTheme.bodyLarge?.copyWith(color: AppColors.text),
           ),
           const SizedBox(height: AppSizes.lg),
           AppPillButton(label: 'Create First Meal', onPressed: onPressed),


### PR DESCRIPTION
## Problem
The home "Ready to Start?" card rendered as a saturated butter/lime gradient. Figma (1266:12195) specs a solid near-white **cream (#fffdf8)** card with **#2c2c2c** body copy; mine used `butter→butterSoft` gradient + faded `fgFaint` body.

## Fix
- Card decoration: gradient → solid `AppColors.cream`
- Body text: `fgFaint` → `AppColors.text`

## Verification
- `flutter analyze` clean
- Visual gate on iPhone 17 sim (subscribed via Try-for-$0 → home): card now cream/white with dark readable body, matching Figma

## Backlog (logged for its own iteration)
The home top is missing the **sage-green cloud hero background** (SVG, Figma node 1189:10761) behind the header/greeting/stats — and the header is wrapped in a butter card instead of sitting on the hero. Bigger layout/asset change across 4 home variants; deferred.