### PR TITLE
feat(home): lime hero backdrop behind header/greeting/stats

### DIFF
--- a/lib/src/app/themes/app_colors.dart
+++ b/lib/src/app/themes/app_colors.dart
@@ -50,6 +50,8 @@ abstract final class AppColors {
   static const Color butter = Color(0xFFEAEC8C);
   static const Color butterSoft = Color(0xFFFFFCD5);
   static const Color butterDark = Color(0xFFC8CA5A);
+  // Nibble primary lime (Figma --nibble-primary-lime) — home hero + accents.
+  static const Color lime = Color(0xFFEAEC98);
 
   // Coral / peach
   static const Color coral = Color(0xFFF8A175);

--- a/lib/src/features/home/home_screen.dart
+++ b/lib/src/features/home/home_screen.dart
@@ -15,6 +15,7 @@ import 'package:nibbles/src/features/home/widgets/greeting_card.dart';
 import 'package:nibbles/src/features/home/widgets/helpful_guidance_card.dart';
 import 'package:nibbles/src/features/home/widgets/home_empty_state_full.dart';
 import 'package:nibbles/src/features/home/widgets/home_header.dart';
+import 'package:nibbles/src/features/home/widgets/home_hero.dart';
 import 'package:nibbles/src/features/home/widgets/home_no_meals_state.dart';
 import 'package:nibbles/src/features/home/widgets/ongoing_introduced_card.dart';
 import 'package:nibbles/src/features/home/widgets/stat_ring_card.dart';
@@ -173,25 +174,45 @@ class _HomeContent extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                HomeHeader(
-                  babyName: baby.name,
-                  ageMonths: ageMonths,
-                  onAvatarTap: () => context.pushNamed(AppRoute.profile.name),
-                ),
-                const SizedBox(height: AppSizes.md),
-                GreetingCard(
-                  babyName: baby.name,
-                  ageMonths: ageMonths,
-                  dateOfBirth: baby.dateOfBirth,
-                ),
-                const SizedBox(height: AppSizes.md),
-                StatRingCard(
-                  safeCount: state.safeCount,
-                  flaggedCount: state.flaggedCount,
-                  notStartedCount: state.notStartedCount,
-                  inProgressCount: state.inProgressCount,
-                  todayMealCount: state.todayMealCount,
-                  todayMealTarget: 2,
+                Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    // Full-bleed lime hero behind header/greeting/stats —
+                    // escapes the scroll padding via negative insets.
+                    const Positioned(
+                      top: -AppSizes.pagePaddingV,
+                      left: -AppSizes.pagePaddingH,
+                      right: -AppSizes.pagePaddingH,
+                      bottom: -AppSizes.md,
+                      child: HomeHero(),
+                    ),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        HomeHeader(
+                          babyName: baby.name,
+                          ageMonths: ageMonths,
+                          onAvatarTap: () =>
+                              context.pushNamed(AppRoute.profile.name),
+                        ),
+                        const SizedBox(height: AppSizes.md),
+                        GreetingCard(
+                          babyName: baby.name,
+                          ageMonths: ageMonths,
+                          dateOfBirth: baby.dateOfBirth,
+                        ),
+                        const SizedBox(height: AppSizes.md),
+                        StatRingCard(
+                          safeCount: state.safeCount,
+                          flaggedCount: state.flaggedCount,
+                          notStartedCount: state.notStartedCount,
+                          inProgressCount: state.inProgressCount,
+                          todayMealCount: state.todayMealCount,
+                          todayMealTarget: 2,
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
                 const SizedBox(height: AppSizes.md),
                 ..._middleSection(

--- a/lib/src/features/home/widgets/home_header.dart
+++ b/lib/src/features/home/widgets/home_header.dart
@@ -33,19 +33,10 @@ class HomeHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.md,
-        vertical: AppSizes.sm + AppSizes.xs,
-      ),
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [AppColors.butter, AppColors.butterSoft],
-        ),
-        borderRadius: BorderRadius.all(Radius.circular(AppSizes.radiusLg)),
-      ),
+    // Transparent: the header now sits directly on the lime HomeHero backdrop
+    // (Figma 1266:12135) rather than a butter card of its own.
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSizes.sm),
       child: Row(
         children: [
           const _TodayPill(),
@@ -114,11 +105,7 @@ class _HeaderAvatar extends StatelessWidget {
         color: AppColors.greenDeep,
         borderRadius: BorderRadius.circular(10),
       ),
-      child: const Icon(
-        Icons.person_outline,
-        size: 20,
-        color: AppColors.cream,
-      ),
+      child: const Icon(Icons.person_outline, size: 20, color: AppColors.cream),
     );
 
     if (onTap == null) return avatar;

--- a/lib/src/features/home/widgets/home_hero.dart
+++ b/lib/src/features/home/widgets/home_hero.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+
+/// Lime hero backdrop behind the Home dashboard's header + greeting + stats.
+///
+/// Mirrors Figma node 1189:10761 — a full-bleed lime (#EAEC98) panel whose
+/// bottom edge dips into a shallow centre curve. Rendered via a [ClipPath] so
+/// it needs no bundled asset. Meant to be the back layer of a [Stack] sized to
+/// the chrome it sits behind.
+class HomeHero extends StatelessWidget {
+  const HomeHero({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipPath(
+      clipper: _HeroClipper(),
+      child: const ColoredBox(color: AppColors.lime),
+    );
+  }
+}
+
+class _HeroClipper extends CustomClipper<Path> {
+  // Native Figma path box is 402×346; the straight sides drop to y=311.536
+  // before the bottom curve, so the curve occupies the lowest ~10%.
+  static const double _nativeW = 402;
+  static const double _nativeStraightY = 311.536;
+  static const double _nativeH = 346;
+
+  @override
+  Path getClip(Size size) {
+    final w = size.width;
+    final h = size.height;
+    final straightY = h * _nativeStraightY / _nativeH;
+    double sx(double x) => w * x / _nativeW;
+    return Path()
+      ..lineTo(w, 0)
+      ..lineTo(w, straightY)
+      ..cubicTo(w, straightY, sx(354.5), h, sx(201), h)
+      ..cubicTo(sx(47.5), h, 0, straightY, 0, straightY)
+      ..close();
+  }
+
+  @override
+  bool shouldReclip(covariant CustomClipper<Path> oldClipper) => false;
+}


### PR DESCRIPTION
## Problem
The home dashboard top rendered as a flat butter header card. Figma (1266:12135 / node 1189:10761) specs a **full-bleed lime (#EAEC98) hero** with a shallow curved bottom behind the header + greeting + stats — the stats card overlaps its lower edge.

## Change
- New `HomeHero` widget — native `ClipPath` reproducing the Figma path (no bundled asset)
- `AppColors.lime` token (#EAEC98)
- `HomeHeader` → transparent (sits on the lime, no butter card)
- `home_screen` → header/greeting/stats wrapped in a `Stack` with the full-bleed hero behind (negative insets escape the scroll padding)

## Verification
- `flutter analyze` clean
- Visual gate on iPhone 17 sim (subscribed): lime hero with curved bottom behind the chrome, header on the lime, stats card overlapping — matches Figma. The hero sits behind the **shared** chrome, so all 4 home variants render identically up top.

## Note
The hero starts at the SafeArea top; extending it behind the status bar is a possible future polish.