### PR TITLE
fix(ci): clear analyzer infos to make CI green

### DIFF
--- a/lib/src/features/allergen/detail/allergen_detail_controller.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_controller.dart
@@ -20,11 +20,11 @@ class AllergenDetailController extends _$AllergenDetailController {
 
     final allergensResult = await service.getAllergens();
     _throwIfFailure(allergensResult);
-    final allergen = allergensResult.dataOrNull!
-        .firstWhere(
-          (Allergen a) => a.key == allergenKey,
-          orElse: () => throw UnknownException('Allergen "$allergenKey" not found.'),
-        );
+    final allergen = allergensResult.dataOrNull!.firstWhere(
+      (Allergen a) => a.key == allergenKey,
+      orElse: () =>
+          throw UnknownException('Allergen "$allergenKey" not found.'),
+    );
 
     final logsResult = await service.getLogs(baby.id, allergenKey: allergenKey);
     _throwIfFailure(logsResult);

--- a/lib/src/features/onboarding/result/onboarding_result_screen.dart
+++ b/lib/src/features/onboarding/result/onboarding_result_screen.dart
@@ -21,7 +21,7 @@ import 'package:nibbles/src/routing/route_enums.dart';
 /// support" remains on row 1 pending PO cleanup.
 const List<String> _signLabels = [
   // ignore: no_adjacent_strings_in_list — verbatim Figma copy spans two phrases
-  'Can sit upright with minimal support. ' +
+  'Can sit upright with minimal support. '
       'Good head and neck control (can hold head steady)',
   'Sits upright with minimal support',
   "Loss of the tongue-thrust reflex (doesn't automatically push food out).",
@@ -192,15 +192,9 @@ class _HeroCard extends StatelessWidget {
       children: [
         Padding(
           padding: const EdgeInsets.only(top: overlap),
-          child: _SignsCard(
-            signsMet: signsMet,
-            answers: answers,
-            ready: ready,
-          ),
+          child: _SignsCard(signsMet: signsMet, answers: answers, ready: ready),
         ),
-        const Quatrefoil(
-          coreColor: AppColors.greenSoft,
-        ),
+        const Quatrefoil(coreColor: AppColors.greenSoft),
       ],
     );
   }
@@ -247,10 +241,7 @@ class _SignsCard extends StatelessWidget {
                     ),
                   ),
                 ),
-                _ScoreChip(
-                  signsMet: signsMet,
-                  total: _signLabels.length,
-                ),
+                _ScoreChip(signsMet: signsMet, total: _signLabels.length),
               ],
             ),
             const SizedBox(height: AppSizes.md),
@@ -293,9 +284,7 @@ class _ScoreChip extends StatelessWidget {
         ),
         child: Text(
           '$signsMet/$total',
-          style: textTheme.labelMedium?.copyWith(
-            color: AppColors.coralDeep,
-          ),
+          style: textTheme.labelMedium?.copyWith(color: AppColors.coralDeep),
         ),
       ),
     );

--- a/lib/src/features/profile/delete/delete_account_overlay.dart
+++ b/lib/src/features/profile/delete/delete_account_overlay.dart
@@ -111,9 +111,7 @@ class _DeleteAccountSheetState extends ConsumerState<_DeleteAccountSheet> {
       canPop: !submitting,
       child: SafeArea(
         child: ConstrainedBox(
-          constraints: BoxConstraints(
-            maxHeight: media.size.height * 0.92,
-          ),
+          constraints: BoxConstraints(maxHeight: media.size.height * 0.92),
           child: Padding(
             padding: EdgeInsets.only(bottom: media.viewInsets.bottom),
             child: SingleChildScrollView(
@@ -168,9 +166,10 @@ class _DeleteAccountSheetState extends ConsumerState<_DeleteAccountSheet> {
                     const SizedBox(height: AppSizes.sp12),
                     // Callout / Regular — Figtree 14/22, Black (#2c2c2c), left.
                     Text(
-                      'After your account is deleted, you will permanently lose '
-                      'your profile, meal history, preferences, and subscription '
-                      'data. This action cannot be undone.',
+                      'After your account is deleted, you will '
+                      'permanently lose your profile, meal history, '
+                      'preferences, and subscription data. This action '
+                      'cannot be undone.',
                       textAlign: TextAlign.left,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: AppColors.text,
@@ -181,7 +180,9 @@ class _DeleteAccountSheetState extends ConsumerState<_DeleteAccountSheet> {
                       const SizedBox(height: AppSizes.sp12),
                       _InlineError(
                         message: state.errorMessage!,
-                        onRetry: reasonPicked && !submitting ? _onContinue : null,
+                        onRetry: reasonPicked && !submitting
+                            ? _onContinue
+                            : null,
                       ),
                     ],
                     // Figma: warning-to-CTA stack gap (column → bottom stack).
@@ -228,10 +229,7 @@ class _SheetHeader extends StatelessWidget {
           onPressed: onClose,
           tooltip: 'Close',
           padding: EdgeInsets.zero,
-          constraints: const BoxConstraints(
-            minWidth: 34,
-            minHeight: 33,
-          ),
+          constraints: const BoxConstraints(minWidth: 34, minHeight: 33),
           style: IconButton.styleFrom(
             shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.all(Radius.circular(30)),

--- a/lib/src/features/splash/splash_screen.dart
+++ b/lib/src/features/splash/splash_screen.dart
@@ -69,10 +69,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
         SizedBox(height: AppSizes.md),
         FittedBox(
           fit: BoxFit.scaleDown,
-          child: Text(
-            'nibbles',
-            style: AppTypography.brandWordmark,
-          ),
+          child: Text('nibbles', style: AppTypography.brandWordmark),
         ),
       ],
     );
@@ -84,10 +81,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   /// While a retry is re-running the build (the previous error is carried over
   /// during the brand-minimum delay), the CTA is disabled so rapid taps can't
   /// keep restarting boot — guards against a tight retry loop when offline.
-  Widget _buildError(
-    BuildContext context, {
-    required bool isReloading,
-  }) {
+  Widget _buildError(BuildContext context, {required bool isReloading}) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
       child: Column(
@@ -102,9 +96,9 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
           Text(
             "We couldn't get things ready. Please check your connection "
             'and try again.',
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: AppColors.destructive,
-            ),
+            style: Theme.of(
+              context,
+            ).textTheme.bodyLarge?.copyWith(color: AppColors.destructive),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: AppSizes.xl),
@@ -114,7 +108,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
               enabled: false,
               button: true,
               liveRegion: true,
-              child: SizedBox(
+              child: const SizedBox(
                 height: AppSizes.buttonHeightSm,
                 child: Center(
                   child: SizedBox.square(

--- a/test/features/auth/register/register_screen_test.dart
+++ b/test/features/auth/register/register_screen_test.dart
@@ -34,8 +34,7 @@ GoRouter _routerFor(Widget screen) => GoRouter(
     GoRoute(
       path: AppRoute.onboardingBabySetup.path,
       name: AppRoute.onboardingBabySetup.name,
-      builder: (_, __) =>
-          const Scaffold(body: Text('Baby setup stub')),
+      builder: (_, __) => const Scaffold(body: Text('Baby setup stub')),
     ),
   ],
 );
@@ -68,7 +67,8 @@ void main() {
   ];
 
   testWidgets(
-    'renders Quatrefoil logo mark, email + password fields, and submit — NO name field',
+    'renders Quatrefoil logo mark, email + password fields, and submit '
+    '— NO name field',
     (tester) async {
       await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
       await tester.pumpAndSettle();
@@ -96,65 +96,57 @@ void main() {
     expect(find.byKey(const Key('register_apple_button')), findsOneWidget);
   });
 
-  testWidgets(
-    'valid-email checkmark appears only when EmailInput.isValid',
-    (tester) async {
-      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
-      await tester.pumpAndSettle();
+  testWidgets('valid-email checkmark appears only when EmailInput.isValid', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
 
-      Finder checkInEmailField() => find.descendant(
-        of: find.byKey(const Key('register_email_field')),
-        matching: find.byIcon(Icons.check_circle_rounded),
-      );
+    Finder checkInEmailField() => find.descendant(
+      of: find.byKey(const Key('register_email_field')),
+      matching: find.byIcon(Icons.check_circle_rounded),
+    );
 
-      // Initial — empty field, no check.
-      expect(checkInEmailField(), findsNothing);
+    // Initial — empty field, no check.
+    expect(checkInEmailField(), findsNothing);
 
-      // Invalid input — no check.
-      await tester.enterText(
-        find.byKey(const Key('register_email_field')),
-        'not-an-email',
-      );
-      await tester.pump();
-      expect(checkInEmailField(), findsNothing);
+    // Invalid input — no check.
+    await tester.enterText(
+      find.byKey(const Key('register_email_field')),
+      'not-an-email',
+    );
+    await tester.pump();
+    expect(checkInEmailField(), findsNothing);
 
-      // Valid input — check appears.
-      await tester.enterText(
-        find.byKey(const Key('register_email_field')),
-        'jane@example.com',
-      );
-      await tester.pump();
-      expect(checkInEmailField(), findsOneWidget);
-    },
-  );
+    // Valid input — check appears.
+    await tester.enterText(
+      find.byKey(const Key('register_email_field')),
+      'jane@example.com',
+    );
+    await tester.pump();
+    expect(checkInEmailField(), findsOneWidget);
+  });
 
-  testWidgets(
-    'password toggle flips obscureText (eye -> eye-off icon swap)',
-    (tester) async {
-      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
-      await tester.pumpAndSettle();
+  testWidgets('password toggle flips obscureText (eye -> eye-off icon swap)', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
 
-      Finder iconInPasswordField(IconData icon) => find.descendant(
-        of: find.byKey(const Key('register_password_field')),
-        matching: find.byIcon(icon),
-      );
+    Finder iconInPasswordField(IconData icon) => find.descendant(
+      of: find.byKey(const Key('register_password_field')),
+      matching: find.byIcon(icon),
+    );
 
-      expect(
-        iconInPasswordField(Icons.visibility_off_outlined),
-        findsOneWidget,
-      );
-      expect(iconInPasswordField(Icons.visibility_outlined), findsNothing);
+    expect(iconInPasswordField(Icons.visibility_off_outlined), findsOneWidget);
+    expect(iconInPasswordField(Icons.visibility_outlined), findsNothing);
 
-      await tester.tap(iconInPasswordField(Icons.visibility_off_outlined));
-      await tester.pump();
+    await tester.tap(iconInPasswordField(Icons.visibility_off_outlined));
+    await tester.pump();
 
-      expect(iconInPasswordField(Icons.visibility_outlined), findsOneWidget);
-      expect(
-        iconInPasswordField(Icons.visibility_off_outlined),
-        findsNothing,
-      );
-    },
-  );
+    expect(iconInPasswordField(Icons.visibility_outlined), findsOneWidget);
+    expect(iconInPasswordField(Icons.visibility_off_outlined), findsNothing);
+  });
 
   testWidgets(
     'Google tap calls controller.signInWithGoogle and logs analytics',
@@ -180,86 +172,80 @@ void main() {
     },
   );
 
-  testWidgets(
-    'Apple tap calls controller.signInWithApple and logs analytics',
-    (tester) async {
-      when(
-        () => mockRepo.signInWithApple(),
-      ).thenAnswer((_) async => const Result.success(true));
+  testWidgets('Apple tap calls controller.signInWithApple and logs analytics', (
+    tester,
+  ) async {
+    when(
+      () => mockRepo.signInWithApple(),
+    ).thenAnswer((_) async => const Result.success(true));
 
-      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
-      await tester.pumpAndSettle();
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
 
-      final appleBtn = find.byKey(const Key('register_apple_button'));
-      await tester.ensureVisible(appleBtn);
-      await tester.pumpAndSettle();
-      await tester.tap(appleBtn);
-      await tester.pumpAndSettle();
+    final appleBtn = find.byKey(const Key('register_apple_button'));
+    await tester.ensureVisible(appleBtn);
+    await tester.pumpAndSettle();
+    await tester.tap(appleBtn);
+    await tester.pumpAndSettle();
 
-      verify(() => mockRepo.signInWithApple()).called(1);
-      expect(
-        fakeAnalytics.eventNames,
-        containsAllInOrder(['sign_up_method_selected', 'sign_up_success']),
-      );
-    },
-  );
+    verify(() => mockRepo.signInWithApple()).called(1);
+    expect(
+      fakeAnalytics.eventNames,
+      containsAllInOrder(['sign_up_method_selected', 'sign_up_success']),
+    );
+  });
 
-  testWidgets(
-    'cancel-OAuth (Success(false)) shows NO error caption',
-    (tester) async {
-      when(
-        () => mockRepo.signInWithGoogle(),
-      ).thenAnswer((_) async => const Result.success(false));
+  testWidgets('cancel-OAuth (Success(false)) shows NO error caption', (
+    tester,
+  ) async {
+    when(
+      () => mockRepo.signInWithGoogle(),
+    ).thenAnswer((_) async => const Result.success(false));
 
-      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
-      await tester.pumpAndSettle();
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
 
-      final googleBtn = find.byKey(const Key('register_google_button'));
-      await tester.ensureVisible(googleBtn);
-      await tester.pumpAndSettle();
-      await tester.tap(googleBtn);
-      await tester.pumpAndSettle();
+    final googleBtn = find.byKey(const Key('register_google_button'));
+    await tester.ensureVisible(googleBtn);
+    await tester.pumpAndSettle();
+    await tester.tap(googleBtn);
+    await tester.pumpAndSettle();
 
-      expect(find.textContaining('failed'), findsNothing);
-      expect(find.textContaining('cancel'), findsNothing);
-      expect(
-        fakeAnalytics.eventNames,
-        containsAllInOrder([
-          'sign_up_method_selected',
-          'social_login_cancelled',
-        ]),
-      );
-    },
-  );
+    expect(find.textContaining('failed'), findsNothing);
+    expect(find.textContaining('cancel'), findsNothing);
+    expect(
+      fakeAnalytics.eventNames,
+      containsAllInOrder(['sign_up_method_selected', 'social_login_cancelled']),
+    );
+  });
 
-  testWidgets(
-    'submit failure renders the controller error message verbatim',
-    (tester) async {
-      when(() => mockRepo.signUp(any(), any())).thenAnswer(
-        (_) async =>
-            const Result.failure(ServerException('Email already in use.')),
-      );
+  testWidgets('submit failure renders the controller error message verbatim', (
+    tester,
+  ) async {
+    when(() => mockRepo.signUp(any(), any())).thenAnswer(
+      (_) async =>
+          const Result.failure(ServerException('Email already in use.')),
+    );
 
-      await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
-      await tester.pumpAndSettle();
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
 
-      // Submit button is gated on isValid — enter a valid email + 8+ char pw.
-      await tester.enterText(
-        find.byKey(const Key('register_email_field')),
-        'jane@example.com',
-      );
-      await tester.enterText(
-        find.byKey(const Key('register_password_field')),
-        'password123',
-      );
-      await tester.pump();
+    // Submit button is gated on isValid — enter a valid email + 8+ char pw.
+    await tester.enterText(
+      find.byKey(const Key('register_email_field')),
+      'jane@example.com',
+    );
+    await tester.enterText(
+      find.byKey(const Key('register_password_field')),
+      'password123',
+    );
+    await tester.pump();
 
-      await tester.tap(find.byKey(const Key('register_submit_button')));
-      await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('register_submit_button')));
+    await tester.pumpAndSettle();
 
-      expect(find.text('Email already in use.'), findsOneWidget);
-    },
-  );
+    expect(find.text('Email already in use.'), findsOneWidget);
+  });
 
   testWidgets(
     'renders verbatim Figma copy — title, body, social labels, footer link',


### PR DESCRIPTION
## Why
`analyze.yml` runs `flutter analyze --fatal-infos --fatal-warnings`. Pre-existing **info-level** lints on `main` (const constructors, adjacent strings, >80-char lines) made the analyze job fail on **every** PR — so all recent merges landed on a red CI.

## Fix
Cleared all 11 infos (none behavioural):
- `splash_screen` — `prefer_const_constructors` (dart fix)
- `onboarding_result` — adjacent-string concat + line wrap
- `allergen_detail_controller`, `delete_account_overlay`, `register_screen_test` — line wraps to ≤80

`flutter analyze --fatal-infos --fatal-warnings` now reports **No issues found**.

Going forward the loop runs this exact command locally before pushing and waits for the CI check to go green before merging.