### PR TITLE
fix(shopping-list): elevate item rows with card shadow

### DIFF
--- a/lib/src/features/shopping_list/shopping_list_screen.dart
+++ b/lib/src/features/shopping_list/shopping_list_screen.dart
@@ -496,6 +496,9 @@ class _ShoppingItemRow extends StatelessWidget {
           decoration: BoxDecoration(
             color: AppColors.cream,
             borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            // Figma 822:7262 — rows are elevated white cards on the Grad-1
+            // background; the shadow makes them pop vs a flat fill.
+            boxShadow: AppSizes.shadowCard,
           ),
           child: Row(
             children: [
@@ -509,8 +512,9 @@ class _ShoppingItemRow extends StatelessWidget {
                 child: Text(
                   item.name,
                   style: AppTypography.textTheme.bodyLarge?.copyWith(
-                    decoration:
-                        item.isChecked ? TextDecoration.lineThrough : null,
+                    decoration: item.isChecked
+                        ? TextDecoration.lineThrough
+                        : null,
                     color: item.isChecked ? AppColors.fgMuted : AppColors.text,
                   ),
                 ),


### PR DESCRIPTION
## Problem
The Shopping List rows used `cream` fill + rounded corners but **no shadow**, so they blended into the Grad-1 background and read as a flat stack. Figma (971:9851) shows each row as an **elevated white card** that pops off the background.

## Fix
Add the subtle `AppSizes.shadowCard` token to the row decoration.

## Verification
- `flutter analyze --fatal-infos --fatal-warnings` clean (matches CI)
- Visual gate on iPhone 17 sim (Grocery tab): rows now pop as elevated cards, matching Figma