### PR TITLE
fix(home): lime hairline border on tip cards

### DIFF
--- a/lib/src/common/components/cards/tip_card.dart
+++ b/lib/src/common/components/cards/tip_card.dart
@@ -26,6 +26,9 @@ class TipCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.butterSoft,
         borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+        // Figma tip cards are cream + a lime hairline border (home
+        // 1266:12201 + Helpful Guidance stack).
+        border: Border.all(color: AppColors.lime),
       ),
       padding: const EdgeInsets.symmetric(
         horizontal: AppSizes.md,


### PR DESCRIPTION
## Problem
Figma tip cards (home 1266:12201 + the Helpful Guidance stack, per design_context) are `butterSoft` fill + a **lime (#eaec98) hairline border**. The shared `TipCard` had the fill but no border.

## Fix
Add `Border.all(AppColors.lime)` to `TipCard`. Shared DS component → Getting Started, Helpful Guidance, and recipe tip surfaces all pick up the border consistently.

## Verification
- `flutter analyze --fatal-infos --fatal-warnings` → No issues found
- Visual gate on iPhone 17 sim (home empty state): Getting Started Tips card now shows the lime border, matching Figma