### PR TITLE
fix(meal-plan): drop date-field calendar icon

### DIFF
--- a/lib/src/features/meal_plan/widgets/meal_plan_date_range_form.dart
+++ b/lib/src/features/meal_plan/widgets/meal_plan_date_range_form.dart
@@ -210,22 +210,16 @@ class _DateField extends StatelessWidget {
               borderRadius: BorderRadius.circular(AppSizes.radiusMd),
               border: Border.all(color: borderColor, width: isOpen ? 2 : 1),
             ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    displayText,
-                    style: AppTypography.textTheme.bodyLarge?.copyWith(
-                      color: AppColors.fgStrong,
-                    ),
-                  ),
+            // No trailing calendar icon — Figma 971:8199 date inputs show only
+            // the date text; the field still opens the inline calendar on tap.
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                displayText,
+                style: AppTypography.textTheme.bodyLarge?.copyWith(
+                  color: AppColors.fgStrong,
                 ),
-                const Icon(
-                  Icons.calendar_today_outlined,
-                  size: AppSizes.iconSm,
-                  color: AppColors.greenDeep,
-                ),
-              ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Figma 971:8199 date inputs show only the date text — no trailing calendar glyph. Removed it (field still opens the inline calendar on tap). analyze --fatal-infos clean; gated on the Meals tab.