### PR TITLE
feat(ui): trim global text scale ~10%

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -14,11 +14,22 @@ class App extends ConsumerWidget {
       title: 'Nibbles',
       theme: AppTheme.light(),
       routerConfig: router,
-      builder: (context, child) => GestureDetector(
-        onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-        behavior: HitTestBehavior.translucent,
-        child: child,
-      ),
+      builder: (context, child) {
+        // Figma type sizes read a touch large on real devices; trim the global
+        // text scale ~10% while still honouring the device accessibility
+        // setting proportionally (clamped so very large settings can't break
+        // layouts).
+        final mq = MediaQuery.of(context);
+        final scaled = (mq.textScaler.scale(1) * 0.9).clamp(0.7, 1.3);
+        return MediaQuery(
+          data: mq.copyWith(textScaler: TextScaler.linear(scaled)),
+          child: GestureDetector(
+            onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+            behavior: HitTestBehavior.translucent,
+            child: child,
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
Figma type sizes read a touch large on a real device. Wrap the app builder in a MediaQuery scaling text to ~0.9x (still honours device a11y proportionally; clamped [0.7,1.3]). Gated on home — greeting now fits one line, cards less cramped. analyze --fatal-infos clean.