### PR TITLE
fix(ui): top safe-area pass + home allergen-ring nav

### DIFF
--- a/lib/src/features/home/home_screen.dart
+++ b/lib/src/features/home/home_screen.dart
@@ -160,16 +160,23 @@ class _HomeContent extends StatelessWidget {
     final ageMonths = _monthsBetween(baby.dateOfBirth, DateTime.now());
     final variant = state.variant;
 
+    // Lime hero paints to y=0 behind the status bar (top: false), so the
+    // scroll content carries the top safe inset itself to clear the notch.
+    final topInset = MediaQuery.of(context).padding.top;
+
     return Scaffold(
       backgroundColor: AppColors.background,
       body: SafeArea(
+        top: false,
         child: RefreshIndicator(
           onRefresh: onRefresh,
           child: SingleChildScrollView(
             physics: const AlwaysScrollableScrollPhysics(),
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSizes.pagePaddingH,
-              vertical: AppSizes.pagePaddingV,
+            padding: EdgeInsets.fromLTRB(
+              AppSizes.pagePaddingH,
+              AppSizes.pagePaddingV + topInset,
+              AppSizes.pagePaddingH,
+              AppSizes.pagePaddingV,
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -178,13 +185,14 @@ class _HomeContent extends StatelessWidget {
                   clipBehavior: Clip.none,
                   children: [
                     // Full-bleed lime hero behind header/greeting/stats —
-                    // escapes the scroll padding via negative insets.
-                    const Positioned(
-                      top: -AppSizes.pagePaddingV,
+                    // escapes the scroll padding via negative insets and
+                    // pulls past the top safe inset to reach the screen edge.
+                    Positioned(
+                      top: -(AppSizes.pagePaddingV + topInset),
                       left: -AppSizes.pagePaddingH,
                       right: -AppSizes.pagePaddingH,
                       bottom: -AppSizes.md,
-                      child: HomeHero(),
+                      child: const HomeHero(),
                     ),
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -209,6 +217,9 @@ class _HomeContent extends StatelessWidget {
                           inProgressCount: state.inProgressCount,
                           todayMealCount: state.todayMealCount,
                           todayMealTarget: 2,
+                          onAllergenTap: () => context.pushNamed(
+                            AppRoute.allergenTracker.name,
+                          ),
                         ),
                       ],
                     ),

--- a/lib/src/features/home/widgets/stat_ring_card.dart
+++ b/lib/src/features/home/widgets/stat_ring_card.dart
@@ -27,6 +27,7 @@ class StatRingCard extends StatelessWidget {
     this.todayMealCount = 0,
     this.todayMealTarget = 0,
     this.hasIronRichRecipes = false,
+    this.onAllergenTap,
     super.key,
   });
 
@@ -43,6 +44,9 @@ class StatRingCard extends StatelessWidget {
 
   // Gates the '✓ Iron Rich' chip; hidden by default per spec.
   final bool hasIronRichRecipes;
+
+  // Optional tap on the ALLERGEN ring — routes to the allergen tracker.
+  final VoidCallback? onAllergenTap;
 
   /// Canonical allergen board length — see `.claude/rules/domain.md`.
   static const int _allergenTotal = 9;
@@ -83,12 +87,16 @@ class StatRingCard extends StatelessWidget {
               ),
               const SizedBox(width: AppSizes.sp12),
               Expanded(
-                child: _StatRing(
-                  label: 'ALLERGEN',
-                  value: '$safeCount',
-                  max: '/$_allergenTotal',
-                  numerator: safeCount,
-                  denominator: _allergenTotal,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: onAllergenTap,
+                  child: _StatRing(
+                    label: 'ALLERGEN',
+                    value: '$safeCount',
+                    max: '/$_allergenTotal',
+                    numerator: safeCount,
+                    denominator: _allergenTotal,
+                  ),
                 ),
               ),
             ],

--- a/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
+++ b/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
@@ -300,7 +300,10 @@ class _BrowseMealSheetState extends ConsumerState<_BrowseMealSheet> {
         child: ConstrainedBox(
           constraints: BoxConstraints(maxHeight: maxHeight),
           child: Padding(
-            padding: EdgeInsets.only(bottom: mediaQuery.viewInsets.bottom),
+            padding: EdgeInsets.only(
+              top: mediaQuery.padding.top,
+              bottom: mediaQuery.viewInsets.bottom,
+            ),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [

--- a/lib/src/features/meal_plan/widgets/range_add_to_shoplist_sheet.dart
+++ b/lib/src/features/meal_plan/widgets/range_add_to_shoplist_sheet.dart
@@ -172,9 +172,9 @@ class _RangeAddToShoplistSheetState
           child: SafeArea(
             top: false,
             child: Padding(
-              padding: const EdgeInsets.fromLTRB(
+              padding: EdgeInsets.fromLTRB(
                 AppSizes.sp12,
-                AppSizes.lg,
+                AppSizes.lg + MediaQuery.of(context).padding.top,
                 AppSizes.sp12,
                 AppSizes.md,
               ),

--- a/lib/src/features/recipe/detail/widgets/recipe_detail_header.dart
+++ b/lib/src/features/recipe/detail/widgets/recipe_detail_header.dart
@@ -22,39 +22,42 @@ class RecipeDetailHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSizes.md,
-        AppSizes.sm,
-        AppSizes.md,
-        AppSizes.sm,
-      ),
-      child: Row(
-        children: [
-          AppRoundButton(
-            icon: const Icon(Icons.arrow_back),
-            onPressed: onBack,
-            semanticLabel: 'Back',
-          ),
-          Expanded(
-            child: Center(
-              child: Text(
-                'Recipe Detail',
-                style: theme.textTheme.titleMedium?.copyWith(
-                  color: AppColors.fgStrong,
+    return SafeArea(
+      bottom: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSizes.md,
+          AppSizes.sm,
+          AppSizes.md,
+          AppSizes.sm,
+        ),
+        child: Row(
+          children: [
+            AppRoundButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: onBack,
+              semanticLabel: 'Back',
+            ),
+            Expanded(
+              child: Center(
+                child: Text(
+                  'Recipe Detail',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: AppColors.fgStrong,
+                  ),
                 ),
               ),
             ),
-          ),
-          if (onOverflow != null)
-            AppRoundButton(
-              icon: const Icon(Icons.more_horiz),
-              onPressed: onOverflow,
-              semanticLabel: 'More options',
-            )
-          else
-            const SizedBox(width: AppSizes.roundButton),
-        ],
+            if (onOverflow != null)
+              AppRoundButton(
+                icon: const Icon(Icons.more_horiz),
+                onPressed: onOverflow,
+                semanticLabel: 'More options',
+              )
+            else
+              const SizedBox(width: AppSizes.roundButton),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## What
Backlog items #3, #4, #10, #13 from the on-device UI review.

- **#3 Home hero behind status bar** — the lime hero now paints to y=0 behind the status bar (no background strip above it); the scroll content carries `MediaQuery.padding.top` so the header/avatar/greeting clear the notch.
- **#10 Allergen nav** — the home ALLERGEN stat ring is now tappable and routes to `/home/allergen/tracker`.
- **#4 Recipe-detail header** — wrapped in `SafeArea(bottom: false)` so back/title/overflow clear the notch.
- **#13 Full-screen sheets** — Browse Meal + range Add-to-Shoplist headers now add the top safe inset (audited all 7 candidates; the other 5 are content-sized or already correct).

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean. Sim-verified on iPhone 17 (notch): home hero reaches the top edge with content below the notch; allergen ring navigates to the tracker; recipe-detail, reaction-log and add-to-meal-plan headers all clear the Dynamic Island.