### PR TITLE
fix(ui): meal-plan + shopping polish (menu ripple, calendar anim, add-ingredient sheet)

### DIFF
--- a/lib/src/features/meal_plan/meal_plan_screen.dart
+++ b/lib/src/features/meal_plan/meal_plan_screen.dart
@@ -160,9 +160,11 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
         babyName: baby.name,
         ageMonths: ageInMonths(baby.dateOfBirth),
         onCreateMealPlan: _onCreateMealPlanFromEmpty,
-        overflowButton: Builder(
-          builder: (btnContext) => MealPlanOverflowButton(
-            onTap: () => _openEmptyStateMenu(btnContext),
+        overflowButton: _NoFlashMenuTheme(
+          child: Builder(
+            builder: (btnContext) => MealPlanOverflowButton(
+              onTap: () => _openEmptyStateMenu(btnContext),
+            ),
           ),
         ),
       );
@@ -556,9 +558,11 @@ class _PopulatedView extends StatelessWidget {
           babyName: baby.name,
           ageMonths: ageInMonths(baby.dateOfBirth),
           dayCount: days.length,
-          overflowButton: Builder(
-            builder: (btnContext) => MealPlanOverflowButton(
-              onTap: () => _openScreenMenu(btnContext),
+          overflowButton: _NoFlashMenuTheme(
+            child: Builder(
+              builder: (btnContext) => MealPlanOverflowButton(
+                onTap: () => _openScreenMenu(btnContext),
+              ),
             ),
           ),
         ),
@@ -647,6 +651,28 @@ class _PopulatedView extends StatelessWidget {
       ],
     );
     if (action != null) onScreenMenuSelected(action);
+  }
+}
+
+/// Strips the grey/tinted [InkWell] splash + highlight from the overflow
+/// menu rows. `showMenu` captures the ambient [Theme] from the trigger
+/// context, so wrapping the overflow button here makes the popup rows
+/// stay white on press — only a resting `highlight` row paints lime.
+class _NoFlashMenuTheme extends StatelessWidget {
+  const _NoFlashMenuTheme({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: Theme.of(context).copyWith(
+        splashColor: Colors.transparent,
+        highlightColor: Colors.transparent,
+        hoverColor: Colors.transparent,
+      ),
+      child: child,
+    );
   }
 }
 

--- a/lib/src/features/meal_plan/widgets/meal_plan_date_range_form.dart
+++ b/lib/src/features/meal_plan/widgets/meal_plan_date_range_form.dart
@@ -117,15 +117,15 @@ class _MealPlanDateRangeFormState extends State<MealPlanDateRangeForm> {
           isOpen: _openField == _OpenField.start,
           onTap: () => _toggleField(_OpenField.start, _startDate),
         ),
-        if (_openField == _OpenField.start) ...[
-          const SizedBox(height: AppSizes.sm),
-          InlineCalendar(
+        _CalendarReveal(
+          isOpen: _openField == _OpenField.start,
+          child: InlineCalendar(
             selectedDate: _startDate,
             focusedMonth: _focusedMonth,
             onDaySelected: _onDaySelected,
             onMonthChanged: _onMonthChanged,
           ),
-        ],
+        ),
         const SizedBox(height: AppSizes.md),
         _DateField(
           label: 'End Date',
@@ -133,16 +133,16 @@ class _MealPlanDateRangeFormState extends State<MealPlanDateRangeForm> {
           isOpen: _openField == _OpenField.end,
           onTap: () => _toggleField(_OpenField.end, _endDate),
         ),
-        if (_openField == _OpenField.end) ...[
-          const SizedBox(height: AppSizes.sm),
-          InlineCalendar(
+        _CalendarReveal(
+          isOpen: _openField == _OpenField.end,
+          child: InlineCalendar(
             selectedDate: _endDate,
             focusedMonth: _focusedMonth,
             onDaySelected: _onDaySelected,
             onMonthChanged: _onMonthChanged,
             minDate: _startDate,
           ),
-        ],
+        ),
         if (rangeError != null) ...[
           const SizedBox(height: AppSizes.xs),
           Text(
@@ -156,6 +156,41 @@ class _MealPlanDateRangeFormState extends State<MealPlanDateRangeForm> {
           onPressed: _canSubmit ? _onSubmit : null,
         ),
       ],
+    );
+  }
+}
+
+/// Eases the inline calendar in/out instead of a hard blink when the
+/// owning field toggles. Combines a [SizeTransition] (height reveal) with
+/// a [FadeTransition] via [AnimatedSwitcher] (~200ms, easeOut). Adds the
+/// `sm` gap above the calendar only while open so collapsed spacing stays
+/// flush.
+class _CalendarReveal extends StatelessWidget {
+  const _CalendarReveal({required this.isOpen, required this.child});
+
+  final bool isOpen;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 200),
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeOut,
+      transitionBuilder: (child, animation) => SizeTransition(
+        sizeFactor: animation,
+        child: FadeTransition(opacity: animation, child: child),
+      ),
+      child: isOpen
+          ? Column(
+              key: const ValueKey<bool>(true),
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: AppSizes.sm),
+                child,
+              ],
+            )
+          : const SizedBox(width: double.infinity),
     );
   }
 }

--- a/lib/src/features/shopping_list/shopping_list_screen.dart
+++ b/lib/src/features/shopping_list/shopping_list_screen.dart
@@ -31,7 +31,7 @@ import 'package:nibbles/src/features/shopping_list/widgets/swipe_reveal_row.dart
 ///
 /// Per-row trailing close-X commits delete directly (no confirm modal).
 /// Swipe-left reveals a burgundy Delete pill; tap commits delete.
-/// "+" chip opens the floating Add Ingredient card over the keyboard
+/// "+" chip opens the Add Ingredients bottom sheet over the keyboard
 /// (NIB-81 — frames 971:9872 / 971:9915).
 class ShoppingListScreen extends ConsumerWidget {
   const ShoppingListScreen({super.key});
@@ -71,9 +71,8 @@ class _PageScaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.transparent,
-      // Critical: resizeToAvoidBottomInset=false lets the floating Add card
-      // sit ABOVE the keyboard via MediaQuery.viewInsets, instead of having
-      // the whole layout reflow when the keyboard appears.
+      // Critical: resizeToAvoidBottomInset=false stops the list behind the
+      // Add Ingredients sheet from reflowing when the keyboard appears.
       resizeToAvoidBottomInset: false,
       body: Container(
         decoration: const BoxDecoration(
@@ -110,7 +109,6 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
   // reveal open. Allows tap-outside-to-close and one-open-at-a-time.
   final SwipeRevealController _swipeController = SwipeRevealController();
 
-  bool _addCardOpen = false;
   final TextEditingController _addController = TextEditingController();
   final FocusNode _addFocusNode = FocusNode();
 
@@ -195,16 +193,12 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
 
   void _openAddCard() {
     _swipeController.close();
-    setState(() => _addCardOpen = true);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _addFocusNode.requestFocus();
-    });
-  }
-
-  void _closeAddCard() {
-    _addFocusNode.unfocus();
-    setState(() => _addCardOpen = false);
-    _addController.clear();
+    showAddIngredientSheet(
+      context,
+      controller: _addController,
+      focusNode: _addFocusNode,
+      onAdd: _submitAdd,
+    ).whenComplete(_addController.clear);
   }
 
   Future<void> _submitAdd() async {
@@ -236,10 +230,7 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
           // Tap anywhere outside the add card / open swipe row to dismiss them.
           GestureDetector(
             behavior: HitTestBehavior.translucent,
-            onTap: () {
-              if (_addCardOpen) _closeAddCard();
-              _swipeController.close();
-            },
+            onTap: _swipeController.close,
             child: Padding(
               padding: const EdgeInsets.fromLTRB(
                 AppSizes.md,
@@ -295,17 +286,6 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
               ),
             ),
           ),
-          if (_addCardOpen)
-            Positioned(
-              left: AppSizes.md,
-              right: AppSizes.md,
-              bottom: MediaQuery.of(context).viewInsets.bottom + AppSizes.sm,
-              child: AddIngredientCard(
-                controller: _addController,
-                focusNode: _addFocusNode,
-                onAdd: _submitAdd,
-              ),
-            ),
         ],
       ),
     );

--- a/lib/src/features/shopping_list/widgets/add_ingredient_card.dart
+++ b/lib/src/features/shopping_list/widgets/add_ingredient_card.dart
@@ -4,17 +4,93 @@ import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 
-/// Floating Add Ingredient card. Figma 971:9883 / 971:9884.
+/// Opens the "Add Ingredients" bottom sheet (backlog #9). White surface,
+/// top corners rounded 30px, lifts above the keyboard via
+/// `isScrollControlled` + viewInsets padding. Hosts [AddIngredientCard]
+/// (Ingredients field + lime Add pill). The caller owns [controller] /
+/// [focusNode] and the addManual write via [onAdd]; this sheet is purely
+/// presentational.
+Future<void> showAddIngredientSheet(
+  BuildContext context, {
+  required TextEditingController controller,
+  required FocusNode focusNode,
+  required VoidCallback onAdd,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    backgroundColor: AppColors.surface,
+    barrierColor: Colors.black.withValues(alpha: 0.5),
+    isScrollControlled: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(30)),
+    ),
+    builder: (_) => _AddIngredientSheet(
+      controller: controller,
+      focusNode: focusNode,
+      onAdd: onAdd,
+    ),
+  );
+}
+
+class _AddIngredientSheet extends StatelessWidget {
+  const _AddIngredientSheet({
+    required this.controller,
+    required this.focusNode,
+    required this.onAdd,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: AppSizes.sm),
+            // Grab handle.
+            Container(
+              width: AppSizes.sp40,
+              height: AppSizes.xs,
+              decoration: BoxDecoration(
+                color: AppColors.borderSoft,
+                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              ),
+            ),
+            const SizedBox(height: AppSizes.md),
+            Text(
+              'Add Ingredients',
+              style: AppTypography.textTheme.titleMedium?.copyWith(
+                color: AppColors.fgStrong,
+              ),
+            ),
+            const SizedBox(height: AppSizes.sm),
+            AddIngredientCard(
+              controller: controller,
+              focusNode: focusNode,
+              onAdd: onAdd,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Add Ingredients content — Figma 971:9883 / 971:9884.
 ///
-/// 370x164 white rounded-[30px] card, shadow 0 4px 10px rgba(0,0,0,0.1).
 /// Bare borderless text field with "Ingredients" placeholder
 /// (Figtree Regular 15, color neutral-50 / fgFaint) + lime pill "Add"
 /// button (77x30, rounded-[24px], bg butter, label Parkinsans SemiBold 15
-/// in greenDeep) anchored top-right.
-///
-/// Owner provides the [controller] + [focusNode]. The caller is responsible
-/// for opening the keyboard (request focus after mount) and for the
-/// addManual write — this widget is purely presentational.
+/// in greenDeep) anchored top-right. Rendered inside the Add Ingredients
+/// bottom sheet — no card chrome of its own.
 class AddIngredientCard extends StatelessWidget {
   const AddIngredientCard({
     required this.controller,
@@ -29,20 +105,8 @@ class AddIngredientCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      // Figma fixed height — 164 — but we let it size to content so the
-      // padding/insets behave on smaller devices.
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(AppSizes.radius3xl),
-        boxShadow: const [
-          BoxShadow(
-            color: Color(0x1A000000),
-            offset: Offset(0, 4),
-            blurRadius: 10,
-          ),
-        ],
-      ),
+    return Padding(
+      // Sheet supplies the surface/rounded-top; this is just inner padding.
       padding: const EdgeInsets.symmetric(
         horizontal: AppSizes.lg,
         vertical: AppSizes.md,
@@ -56,6 +120,7 @@ class AddIngredientCard extends StatelessWidget {
           TextField(
             controller: controller,
             focusNode: focusNode,
+            autofocus: true,
             onSubmitted: (_) => onAdd(),
             textInputAction: TextInputAction.done,
             // Figma body/regular — Figtree 15/22 (matches textTheme.bodyLarge).

--- a/lib/src/features/shopping_list/widgets/shopping_list_menu.dart
+++ b/lib/src/features/shopping_list/widgets/shopping_list_menu.dart
@@ -174,7 +174,9 @@ class _MenuRowState extends State<_MenuRow> {
           vertical: 6,
         ),
         decoration: BoxDecoration(
-          color: _pressed ? AppColors.butter : Colors.transparent,
+          // Press feedback is a neutral wash, not lime — pressing a row
+          // must not flash yellow (backlog #6).
+          color: _pressed ? AppColors.surfaceVariant : Colors.transparent,
           borderRadius: BorderRadius.circular(6),
         ),
         child: Row(


### PR DESCRIPTION
## What
Backlog items #6, #7, #9 from the on-device UI review.

- **#6 Menu ripple** — meal-plan overflow rows (`_NoFlashMenuTheme` strips the theme-derived splash/highlight captured by `showMenu`) and shopping-list menu rows (pressed fill butter→`surfaceVariant`) no longer flash yellow on press. Resting highlighted/selected rows still paint lime.
- **#7 Inline calendar reveal** — the date-range calendar now eases in via `AnimatedSwitcher` (`SizeTransition` top-anchored + `FadeTransition`, 200ms easeOut) instead of popping in with a blink.
- **#9 Add Ingredient → bottom sheet** — the floating card is replaced by a proper `showModalBottomSheet` titled **Add Ingredients** (grab handle + centred title, `isScrollControlled` so it lifts above the keyboard); same field + lime Add pill + submit callback.

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean. Sim-verified: Add Ingredients sheet renders with handle/title/field/pill over a scrim; overflow menu opens clean; inline calendar reveals correctly (June 2026, day selected) with the eased wrapper.