### PR TITLE
fix(ui): recipe-library search single-box + starting-guide Grad-1

### DIFF
--- a/lib/src/common/components/inputs/app_search_field.dart
+++ b/lib/src/common/components/inputs/app_search_field.dart
@@ -52,7 +52,10 @@ class AppSearchField extends StatelessWidget {
               cursorColor: AppColors.greenDeep,
               decoration: InputDecoration(
                 isCollapsed: true,
+                filled: false,
                 border: InputBorder.none,
+                enabledBorder: InputBorder.none,
+                focusedBorder: InputBorder.none,
                 hintText: hintText,
                 hintStyle: theme.textTheme.bodyLarge?.copyWith(
                   color: AppColors.greenSoft,

--- a/lib/src/features/recipe/library/widgets/library_header.dart
+++ b/lib/src/features/recipe/library/widgets/library_header.dart
@@ -125,7 +125,10 @@ class _SearchInput extends StatelessWidget {
                 hintStyle: AppTypography.textTheme.bodyLarge?.copyWith(
                   color: AppColors.fgFaint,
                 ),
+                filled: false,
                 border: InputBorder.none,
+                enabledBorder: InputBorder.none,
+                focusedBorder: InputBorder.none,
                 isDense: true,
                 contentPadding: EdgeInsets.zero,
               ),

--- a/lib/src/features/starting_guide/starting_guide_hub_screen.dart
+++ b/lib/src/features/starting_guide/starting_guide_hub_screen.dart
@@ -81,9 +81,12 @@ class _StartingGuideHubScreenState
       backgroundColor: Colors.transparent,
       body: Container(
         decoration: const BoxDecoration(
+          // Grad-1 (matches profile_screen): CSS
+          // linear-gradient(152.612deg, #FFFCD5 19.168%, #F5F5F5 50%).
           gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
+            begin: Alignment(-0.460, -0.888),
+            end: Alignment(0.460, 0.888),
+            stops: [0.19168, 0.5],
             colors: [AppColors.butterSoft, Color(0xFFF5F5F5)],
           ),
         ),


### PR DESCRIPTION
## What
Backlog items #2, #8 from the on-device UI review.

- **#2 Search double-box** — the recipe-library 'Search recipe' field (and the shared `AppSearchField`) rendered a nested inner box because the `TextField` inherited the global `InputDecorationTheme` (filled + enabled/focused `OutlineInputBorder`) inside its own pill `Container`. Fixed by setting `filled: false` + `enabledBorder`/`focusedBorder: InputBorder.none` so only the outer container draws the box. Fixes every `AppSearchField` consumer too.
- **#8 Starting-guide gradient** — the hub background used a plain `topCenter→bottomCenter` gradient; replaced with the canonical Grad-1 (`152.612deg`, stops `[0.19168, 0.5]`, butterSoft→#F5F5F5) used on other pages.

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean. Sim-verified: search field is a single rounded box (focused + unfocused, no inner border); starting-guide hub now shows the diagonal butter→grey Grad-1 matching Profile.