### PR TITLE
fix(onboarding): DOB screen visual rebuild to Figma 971:10173

### DIFF
--- a/lib/src/common/components/buttons/app_round_button.dart
+++ b/lib/src/common/components/buttons/app_round_button.dart
@@ -3,7 +3,7 @@ import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 
 /// Background tone for [AppRoundButton] — maps to kit `.rbtn--*`.
-enum AppRoundButtonTone { white, ghost, green, butter }
+enum AppRoundButtonTone { white, ghost, green, butter, lime }
 
 /// Sizing for [AppRoundButton]. `regular` = 44 circle, `small` = 32 circle.
 enum AppRoundButtonSize { regular, small }
@@ -39,12 +39,13 @@ class AppRoundButton extends StatelessWidget {
         return AppColors.greenDeep;
       case AppRoundButtonTone.butter:
         return AppColors.butter;
+      case AppRoundButtonTone.lime:
+        return AppColors.lime;
     }
   }
 
-  Color get _foreground => tone == AppRoundButtonTone.green
-      ? AppColors.cream
-      : AppColors.greenDeep;
+  Color get _foreground =>
+      tone == AppRoundButtonTone.green ? AppColors.cream : AppColors.greenDeep;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/features/onboarding/dob/onboarding_dob_screen.dart
+++ b/lib/src/features/onboarding/dob/onboarding_dob_screen.dart
@@ -18,7 +18,7 @@ import 'package:nibbles/src/utils/age_in_months.dart';
 ///   - body subtitle ("We use this to suggest the right foods…")
 ///   - quatrefoil illustration cluster + salmonGhost "X Month" age chip
 ///   - 3-column wheel (Year / Month / Day) with lime selection pill per column
-///   - bottom row: butter back round button + forestDarkn "Next" pill
+///   - bottom row: lime back round button + forestDarkn "Next" pill
 ///
 /// State written to the hoisted [OnboardingController] via `updateDob`. Then
 /// the phase-A flag `onboarding_baby_setup_done` is flipped — the router's
@@ -202,99 +202,110 @@ class _OnboardingDobScreenState extends ConsumerState<OnboardingDobScreen> {
       _maxYear - _minYear + 1,
       (i) => _minYear + i,
     );
-    final days = List<int>.generate(
-      _daysInMonth(_year, _month),
-      (i) => i + 1,
-    );
+    final days = List<int>.generate(_daysInMonth(_year, _month), (i) => i + 1);
 
     return Scaffold(
-      backgroundColor: AppColors.cream,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
-            vertical: AppSizes.pagePaddingV,
+      backgroundColor: Colors.transparent,
+      // Grad-1 background — linear-gradient(~154.4deg, #FFFCD5 19.168%,
+      // #F5F5F5 50%). Same pattern as profile/starting-guide screens.
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment(-0.460, -0.888),
+            end: Alignment(0.460, 0.888),
+            stops: [0.19168, 0.5],
+            colors: [AppColors.butterSoft, Color(0xFFF5F5F5)],
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Center(
-                child: Text.rich(
-                  TextSpan(
-                    style: textTheme.titleLarge,
-                    children: [
-                      const TextSpan(text: 'When was '),
-                      TextSpan(
-                        text: firstName,
-                        style: textTheme.titleLarge?.copyWith(
-                          color: AppColors.coral,
+        ),
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.pagePaddingH,
+              vertical: AppSizes.pagePaddingV,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Center(
+                  child: Text.rich(
+                    TextSpan(
+                      style: textTheme.titleLarge,
+                      children: [
+                        const TextSpan(text: 'When was '),
+                        TextSpan(
+                          text: firstName,
+                          style: textTheme.titleLarge?.copyWith(
+                            color: AppColors.coral,
+                          ),
                         ),
-                      ),
-                      const TextSpan(text: ' born?'),
-                    ],
+                        const TextSpan(text: ' born?'),
+                      ],
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.sm),
+                Text(
+                  'We use this to suggest the right foods at the right time.',
+                  style: textTheme.bodyLarge?.copyWith(
+                    color: AppColors.fgMuted,
                   ),
                   textAlign: TextAlign.center,
                 ),
-              ),
-              const SizedBox(height: AppSizes.sm),
-              Text(
-                'We use this to suggest the right foods at the right time.',
-                style: textTheme.bodyLarge?.copyWith(color: AppColors.fgMuted),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: AppSizes.xl),
-              const Center(child: Quatrefoil()),
-              const SizedBox(height: AppSizes.md),
-              Center(
-                child: _AgeChip(
-                  key: const Key('onboarding_dob_age_label'),
-                  label: _ageLabel(_selected),
+                const SizedBox(height: AppSizes.xl),
+                const Center(child: Quatrefoil()),
+                const SizedBox(height: AppSizes.md),
+                Center(
+                  child: _AgeChip(
+                    key: const Key('onboarding_dob_age_label'),
+                    label: _ageLabel(_selected),
+                  ),
                 ),
-              ),
-              const SizedBox(height: AppSizes.lg),
-              _DateWheelRow(
-                yearCtrl: _yearCtrl,
-                monthCtrl: _monthCtrl,
-                dayCtrl: _dayCtrl,
-                years: years,
-                months: _monthAbbr,
-                days: days,
-                selectedYearIndex: _year - _minYear,
-                selectedMonthIndex: _month - 1,
-                selectedDayIndex: _day - 1,
-                wheelHeight: _wheelHeight,
-                itemExtent: _wheelItemExtent,
-                onYearChanged: _onYearChanged,
-                onMonthChanged: _onMonthChanged,
-                onDayChanged: _onDayChanged,
-              ),
-              const Spacer(),
-              Row(
-                children: [
-                  AppRoundButton(
-                    key: const Key('onboarding_dob_back'),
-                    tone: AppRoundButtonTone.butter,
-                    icon: const Icon(Icons.arrow_back_rounded),
-                    semanticLabel: 'Back',
-                    onPressed: () {
-                      if (context.canPop()) {
-                        context.pop();
-                      } else {
-                        context.goNamed(AppRoute.onboardingName.name);
-                      }
-                    },
-                  ),
-                  const SizedBox(width: AppSizes.sm),
-                  Expanded(
-                    child: AppPillButton(
-                      key: const Key('onboarding_dob_next'),
-                      label: 'Next',
-                      onPressed: _onNext,
+                const SizedBox(height: AppSizes.lg),
+                _DateWheelRow(
+                  yearCtrl: _yearCtrl,
+                  monthCtrl: _monthCtrl,
+                  dayCtrl: _dayCtrl,
+                  years: years,
+                  months: _monthAbbr,
+                  days: days,
+                  selectedYearIndex: _year - _minYear,
+                  selectedMonthIndex: _month - 1,
+                  selectedDayIndex: _day - 1,
+                  wheelHeight: _wheelHeight,
+                  itemExtent: _wheelItemExtent,
+                  onYearChanged: _onYearChanged,
+                  onMonthChanged: _onMonthChanged,
+                  onDayChanged: _onDayChanged,
+                ),
+                const Spacer(),
+                Row(
+                  children: [
+                    AppRoundButton(
+                      key: const Key('onboarding_dob_back'),
+                      tone: AppRoundButtonTone.lime,
+                      icon: const Icon(Icons.arrow_back_rounded),
+                      semanticLabel: 'Back',
+                      onPressed: () {
+                        if (context.canPop()) {
+                          context.pop();
+                        } else {
+                          context.goNamed(AppRoute.onboardingName.name);
+                        }
+                      },
                     ),
-                  ),
-                ],
-              ),
-            ],
+                    const SizedBox(width: AppSizes.sm),
+                    Expanded(
+                      child: AppPillButton(
+                        key: const Key('onboarding_dob_next'),
+                        label: 'Next',
+                        onPressed: _onNext,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -443,7 +454,7 @@ class _DateWheelColumn extends StatelessWidget {
       children: [
         Text(
           header,
-          style: textTheme.labelMedium?.copyWith(color: AppColors.fgStrong),
+          style: textTheme.labelMedium?.copyWith(color: AppColors.fgFaint),
         ),
         const SizedBox(height: AppSizes.sm),
         SizedBox(
@@ -452,13 +463,14 @@ class _DateWheelColumn extends StatelessWidget {
             scrollController: controller,
             itemExtent: itemExtent,
             squeeze: 1.1,
-            backgroundColor: AppColors.cream,
-            selectionOverlay: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: AppSizes.xs),
+            backgroundColor: Colors.transparent,
+            selectionOverlay: Center(
               child: Container(
+                width: 70,
+                height: AppSizes.chipHeight,
                 decoration: BoxDecoration(
-                  color: AppColors.butter,
-                  borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+                  color: AppColors.lime,
+                  borderRadius: BorderRadius.circular(AppSizes.radiusLg),
                 ),
               ),
             ),
@@ -468,12 +480,8 @@ class _DateWheelColumn extends StatelessWidget {
               return Center(
                 child: Text(
                   itemBuilder(i),
-                  style: textTheme.labelLarge?.copyWith(
-                    color: isSelected
-                        ? AppColors.greenDeep
-                        : AppColors.fgFaint,
-                    fontWeight:
-                        isSelected ? FontWeight.w700 : FontWeight.w600,
+                  style: textTheme.labelMedium?.copyWith(
+                    color: isSelected ? AppColors.greenDeep : AppColors.fgFaint,
                   ),
                 ),
               );


### PR DESCRIPTION
## What
Backlog #12 — onboarding date-of-birth screen, visual-only rebuild to Figma 971:10173 (exact tokens read live via Figma MCP).

- **Background**: flat cream → canonical Grad-1 gradient (butterSoft→#F5F5F5, same LinearGradient as profile_screen + starting_guide_hub). CupertinoPicker bg cream→transparent so the gradient shows through the wheel.
- **Selection pill**: butter→**lime**, radiusFull→radiusLg(16), and constrained to a centered ~70px×36px pill that hugs the value (was a full-column band) — matches the 3 per-column lime pills in Figma.
- **Back button**: butter→**lime** tone (new `AppRoundButtonTone.lime` = lime bg + forest-dark arrow).
- **Headers** Year/Month/Date: fgStrong→fgFaint (#969696). **Wheel text**: labelLarge(Figtree 17)→labelMedium(Parkinsans SemiBold 13) per Figma; selected greenDeep, off-rows fgFaint.
- Keeps the CupertinoPicker wheel + all DOB/default/future-clamp logic and the load-bearing `setOnboardingBabySetupDone` flag untouched (visual-only).

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean; `dart format` clean. **Note:** merged on code-confidence (user-approved) — the live sim visual gate was not run because the DOB screen sits behind a fresh-account onboarding flow that isn't reachable on the current sim. Edits faithfully apply the exact Figma tokens and reuse the Grad-1/lime patterns already sim-verified on profile + starting-guide.