### PR TITLE
fix(home): populated dashboard fidelity (dashed meals container + real thumbnails)

### DIFF
--- a/lib/src/common/components/cards/app_card.dart
+++ b/lib/src/common/components/cards/app_card.dart
@@ -16,6 +16,9 @@ class AppCard extends StatelessWidget {
       vertical: AppSizes.sp12,
     ),
     this.onTap,
+    this.borderColor = AppColors.borderMuted,
+    this.borderWidth = 1.5,
+    this.cornerRadius = AppSizes.radiusXl,
     super.key,
   });
 
@@ -23,6 +26,15 @@ class AppCard extends StatelessWidget {
   final AppCardVariant variant;
   final EdgeInsetsGeometry padding;
   final VoidCallback? onTap;
+
+  /// Dashed-border stroke color (only used by [AppCardVariant.dashed]).
+  final Color borderColor;
+
+  /// Dashed-border stroke width (only used by [AppCardVariant.dashed]).
+  final double borderWidth;
+
+  /// Corner radius for the surface and dashed border.
+  final double cornerRadius;
 
   Color get _background {
     switch (variant) {
@@ -37,7 +49,7 @@ class AppCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final radius = BorderRadius.circular(AppSizes.radiusXl);
+    final radius = BorderRadius.circular(cornerRadius);
 
     Widget content = Container(
       decoration: BoxDecoration(color: _background, borderRadius: radius),
@@ -47,9 +59,10 @@ class AppCard extends StatelessWidget {
 
     if (variant == AppCardVariant.dashed) {
       content = CustomPaint(
-        painter: const _DashedBorderPainter(
-          color: AppColors.borderMuted,
-          radius: AppSizes.radiusXl,
+        painter: _DashedBorderPainter(
+          color: borderColor,
+          radius: cornerRadius,
+          strokeWidth: borderWidth,
         ),
         child: content,
       );
@@ -58,11 +71,7 @@ class AppCard extends StatelessWidget {
     if (onTap != null) {
       return Material(
         color: Colors.transparent,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: radius,
-          child: content,
-        ),
+        child: InkWell(onTap: onTap, borderRadius: radius, child: content),
       );
     }
     return content;
@@ -71,17 +80,22 @@ class AppCard extends StatelessWidget {
 
 /// Paints a 1.5px dashed rounded-rect border (kit `.card--dashed`).
 class _DashedBorderPainter extends CustomPainter {
-  const _DashedBorderPainter({required this.color, required this.radius});
+  const _DashedBorderPainter({
+    required this.color,
+    required this.radius,
+    this.strokeWidth = 1.5,
+  });
 
   final Color color;
   final double radius;
+  final double strokeWidth;
 
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
       ..color = color
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.5;
+      ..strokeWidth = strokeWidth;
 
     final rrect = RRect.fromRectAndRadius(
       Offset.zero & size,
@@ -94,10 +108,7 @@ class _DashedBorderPainter extends CustomPainter {
     for (final metric in path.computeMetrics()) {
       var distance = 0.0;
       while (distance < metric.length) {
-        canvas.drawPath(
-          metric.extractPath(distance, distance + dash),
-          paint,
-        );
+        canvas.drawPath(metric.extractPath(distance, distance + dash), paint);
         distance += dash + gap;
       }
     }
@@ -105,5 +116,7 @@ class _DashedBorderPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_DashedBorderPainter oldDelegate) =>
-      oldDelegate.color != color || oldDelegate.radius != radius;
+      oldDelegate.color != color ||
+      oldDelegate.radius != radius ||
+      oldDelegate.strokeWidth != strokeWidth;
 }

--- a/lib/src/features/home/widgets/helpful_guidance_card.dart
+++ b/lib/src/features/home/widgets/helpful_guidance_card.dart
@@ -83,7 +83,7 @@ class _GuidanceTipCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.surface,
         borderRadius: BorderRadius.circular(AppSizes.radiusXl),
-        boxShadow: AppSizes.shadowCard,
+        boxShadow: const [BoxShadow(color: Color(0x33EAEC8C), blurRadius: 5)],
       ),
       padding: const EdgeInsets.symmetric(
         horizontal: AppSizes.md - 2,

--- a/lib/src/features/home/widgets/todays_meals_card.dart
+++ b/lib/src/features/home/widgets/todays_meals_card.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/cards/app_card.dart';
 import 'package:nibbles/src/common/components/chips/app_chip.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
@@ -85,16 +87,28 @@ class TodaysMealsCard extends StatelessWidget {
               if (todaysMeals.isEmpty)
                 const _NoMealsInline()
               else
-                ...List<Widget>.generate(todaysMeals.length, (i) {
-                  final entry = todaysMeals[i];
-                  return Padding(
-                    padding: EdgeInsets.only(top: i == 0 ? 0 : AppSizes.sm),
-                    child: _MealRow(
-                      entry: entry,
-                      recipe: recipes[entry.recipeId],
-                    ),
-                  );
-                }),
+                AppCard(
+                  variant: AppCardVariant.dashed,
+                  borderColor: AppColors.lime,
+                  borderWidth: 2,
+                  cornerRadius: AppSizes.radiusMd,
+                  padding: const EdgeInsets.all(AppSizes.sp12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: List<Widget>.generate(todaysMeals.length, (i) {
+                      final entry = todaysMeals[i];
+                      return Padding(
+                        padding: EdgeInsets.only(
+                          top: i == 0 ? 0 : AppSizes.sp12,
+                        ),
+                        child: _MealRow(
+                          entry: entry,
+                          recipe: recipes[entry.recipeId],
+                        ),
+                      );
+                    }),
+                  ),
+                ),
             ],
           ),
         ),
@@ -149,6 +163,7 @@ class _GreatJobBanner extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.butterSoft,
         borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+        border: Border.all(color: AppColors.lime),
       ),
       padding: const EdgeInsets.symmetric(
         horizontal: AppSizes.md - 2,
@@ -236,23 +251,7 @@ class _MealRow extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Container(
-                width: 56,
-                height: 56,
-                decoration: BoxDecoration(
-                  gradient: const LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [AppColors.tanBase, AppColors.coral],
-                  ),
-                  borderRadius: BorderRadius.circular(AppSizes.radiusLg - 2),
-                ),
-                alignment: Alignment.center,
-                child: const Text(
-                  '🍲',
-                  style: TextStyle(fontSize: 26, height: 1),
-                ),
-              ),
+              _MealThumbnail(url: recipe?.thumbnailUrl),
               const SizedBox(width: AppSizes.sp12),
               Expanded(
                 child: Column(
@@ -278,6 +277,45 @@ class _MealRow extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Meal-row thumbnail — real recipe photo at the Figma size (90x76, r10)
+/// with an emoji fallback. Mirrors browse_meal_recipe_card._Thumbnail.
+class _MealThumbnail extends StatelessWidget {
+  const _MealThumbnail({this.url});
+
+  final String? url;
+
+  static const double _w = 90;
+  static const double _h = 76;
+
+  Widget _fallback() => Container(
+    width: _w,
+    height: _h,
+    color: AppColors.surfaceVariant,
+    alignment: Alignment.center,
+    child: const Text('🍲', style: TextStyle(fontSize: 26, height: 1)),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final radius = BorderRadius.circular(AppSizes.radiusMd);
+    if (url == null || url!.isEmpty) {
+      return ClipRRect(borderRadius: radius, child: _fallback());
+    }
+    return ClipRRect(
+      borderRadius: radius,
+      child: CachedNetworkImage(
+        imageUrl: url!,
+        width: _w,
+        height: _h,
+        fit: BoxFit.cover,
+        placeholder: (_, __) =>
+            Container(width: _w, height: _h, color: AppColors.surfaceVariant),
+        errorWidget: (_, __, ___) => _fallback(),
       ),
     );
   }


### PR DESCRIPTION
## What
Backlog #11 — populated Home dashboard to Figma 1242:10567 fidelity (exact tokens read live via Figma MCP). Edits kept OUT of home_screen.dart (a prior PR owns it).

- **Dashed lime container** — today's meal rows now sit in a dashed `AppCard` with a lime (#EAEC98) ~2px border, radius 10. AppCard gains optional `borderColor`/`borderWidth`/`cornerRadius`, each defaulting to the current hardcoded values so `HomeNoMealsState`'s grey dashed border does NOT regress.
- **Real thumbnails** — `_MealRow` emoji/gradient placeholder → `CachedNetworkImage(recipe.thumbnailUrl)` at 90×76 r10 with an emoji fallback (mirrors browse_meal_recipe_card._Thumbnail).
- **Great-job banner** — gains a 1px lime border (fill already butterSoft).
- **Guidance tip cards** — shadow tinted to a soft lime glow (`Color(0x33EAEC8C)`, blur 5) per Figma; const literal avoids the withOpacity deprecation.

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean; `dart format` clean. **Sim-verified on a freshly-onboarded populated account**: the 2/2 today's-meals card renders the dashed lime container with real-photo thumbnails and the Great-job banner with its lime border (screenshot diffed vs Figma 1242:10567). HomeNoMealsState default border preserved.