### PR TITLE
fix(recipe): library card overflow-safe layout + Figma nutrition chip

### DIFF
--- a/lib/src/features/recipe/library/widgets/recipe_grid_card.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_grid_card.dart
@@ -1,23 +1,23 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/common/components/chips/app_chip.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 
-/// Recipe library / home recommendation card (NIB-53 redesign).
+/// Recipe library card (NIB-53 redesign).
 ///
 /// Visual target is a 158x220 tile per Figma 971:8661 — image-top (117 high,
-/// white surface) + 12px-padded content column containing a 2-line title and
-/// a row of salmon-ghost chips ('Iron Rich' bolt chip + a `+N` overflow
-/// chip). Flagged-allergen recipes show a [AppChipTone.flag] 'Not safe'
-/// chip overlaid on the image and dim the card slightly.
+/// white surface) + 12px-padded content column. The content column fills the
+/// remaining card height and uses space-between to pin the 2-line title to
+/// the top and the salmon-ghost chip row (bolt 'Iron Rich' chip + a `+N`
+/// overflow chip) to the bottom. Flagged-allergen recipes show a
+/// [AppChipTone.flag] 'Not safe' chip overlaid on the image and dim the card.
 ///
-/// The card is width-flexible (parent provides the box) so the same widget
-/// continues to render in the Home carousel (140-wide `SizedBox`) and the
-/// Home recommendations grid (aspect-ratio driven) — only the Library row
-/// pins the box to 158x220.
+/// Library-only: rendered by `RecipeCategoryRow` (horizontal 158x220 row)
+/// and `RecipeSearchResults` (2-column 158x220 grid). Both pin the box.
 class RecipeGridCard extends StatelessWidget {
   const RecipeGridCard({
     required this.recipe,
@@ -33,8 +33,8 @@ class RecipeGridCard extends StatelessWidget {
   bool get _hasUnsafeAllergen =>
       recipe.allergenTags.any(flaggedAllergenKeys.contains);
 
-  // Figma 760:7436 paragraph block (158x117 thumb + 12 padding + 40px
-  // title block + 24px chip row + 12 padding = 220 total).
+  // Figma 760:7436 title block: 2 lines x 20 = 40h. Slack between the title
+  // and the bottom-pinned chip row is absorbed by space-between, not a gap.
   static const double _titleBlockHeight = 40;
 
   @override
@@ -51,36 +51,33 @@ class RecipeGridCard extends StatelessWidget {
             color: AppColors.cream,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
               children: [
-                _CardThumbnail(
-                  url: recipe.thumbnailUrl,
-                  isUnsafe: isUnsafe,
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(AppSizes.sp12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      SizedBox(
-                        height: _titleBlockHeight,
-                        child: Text(
-                          recipe.title,
-                          style: const TextStyle(
-                            fontFamily: FontFamily.parkinsans,
-                            fontSize: 13,
-                            fontWeight: FontWeight.w600,
-                            height: 20 / 13,
-                            color: AppColors.fgStrong,
+                _CardThumbnail(url: recipe.thumbnailUrl, isUnsafe: isUnsafe),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(AppSizes.sp12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        SizedBox(
+                          height: _titleBlockHeight,
+                          child: Text(
+                            recipe.title,
+                            style: const TextStyle(
+                              fontFamily: FontFamily.parkinsans,
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                              height: 20 / 13,
+                              color: AppColors.fgStrong,
+                            ),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
                           ),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
                         ),
-                      ),
-                      const SizedBox(height: AppSizes.sm),
-                      _NutritionChipRow(tags: recipe.nutritionTags),
-                    ],
+                        _NutritionChipRow(tags: recipe.nutritionTags),
+                      ],
+                    ),
                   ),
                 ),
               ],
@@ -122,12 +119,11 @@ class _CardThumbnail extends StatelessWidget {
             CachedNetworkImage(
               imageUrl: url!,
               fit: BoxFit.cover,
-              memCacheWidth:
-                  (158 * MediaQuery.devicePixelRatioOf(context)).round(),
-              memCacheHeight:
-                  (117 * MediaQuery.devicePixelRatioOf(context)).round(),
-              placeholder: (_, __) =>
-                  const ColoredBox(color: AppColors.tan20),
+              memCacheWidth: (158 * MediaQuery.devicePixelRatioOf(context))
+                  .round(),
+              memCacheHeight: (117 * MediaQuery.devicePixelRatioOf(context))
+                  .round(),
+              placeholder: (_, __) => const ColoredBox(color: AppColors.tan20),
               errorWidget: (_, __, ___) => const ColoredBox(
                 color: AppColors.tan20,
                 child: Icon(
@@ -153,10 +149,10 @@ class _CardThumbnail extends StatelessWidget {
   }
 }
 
-/// First nutrition tag as a salmon-ghost chip (Figma 'Iron Rich' label) +
-/// `+N` overflow chip for the rest. Both use [AppChipTone.neutral] so the
-/// chip background and text colour follow the Figma 'LabelContain' token
-/// (salmon-ghost / salmon-dark). When there are no tags, renders a fixed-
+/// First nutrition tag as a salmon-ghost chip (Figma 'Iron Rich' bolt label)
+/// + a `+N` overflow chip for the rest. The label chip is [Flexible] and
+/// ellipsizes so a long tag never overflows the ~134px content width; the
+/// `+N` chip is non-shrinking. When there are no tags, renders a fixed-
 /// height spacer so the card height stays stable across recipes.
 class _NutritionChipRow extends StatelessWidget {
   const _NutritionChipRow({required this.tags});
@@ -172,17 +168,72 @@ class _NutritionChipRow extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Flexible(
-          child: AppChip(
-            label: tags.first,
-            icon: const Icon(Icons.bolt),
-          ),
-        ),
+        Flexible(child: _NutritionChip(label: tags.first)),
         if (extra > 0) ...[
           const SizedBox(width: AppSizes.xs),
-          AppChip(label: '+$extra'),
+          _NutritionChip.overflow(count: extra),
         ],
       ],
+    );
+  }
+}
+
+/// Card-local salmon-ghost nutrition chip (Figma 'LabelContain', node
+/// 1082:7250). bg coralSoft / fg coralDeep, Figtree Regular 10/16, h24,
+/// radius 30. Deliberately NOT the shared [AppChip] (Parkinsans 11/700):
+/// this chip needs the Figtree caption token and a flexible, ellipsizing
+/// label so the row stays overflow-safe on the narrow card.
+class _NutritionChip extends StatelessWidget {
+  const _NutritionChip({required this.label})
+    : count = null,
+      isOverflow = false;
+
+  const _NutritionChip.overflow({required this.count})
+    : label = '',
+      isOverflow = true;
+
+  final String label;
+  final int? count;
+  final bool isOverflow;
+
+  @override
+  Widget build(BuildContext context) {
+    final textStyle = GoogleFonts.figtree(
+      fontSize: 10,
+      fontWeight: FontWeight.w400,
+      height: 16 / 10,
+      color: AppColors.coralDeep,
+    );
+
+    return Container(
+      height: AppSizes.chipHeightSm,
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.md),
+      decoration: BoxDecoration(
+        color: AppColors.coralSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radius3xl),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            isOverflow ? Icons.add : Icons.bolt,
+            size: AppSizes.iconSm,
+            color: AppColors.coralDeep,
+          ),
+          SizedBox(width: isOverflow ? AppSizes.xs : AppSizes.sm),
+          if (isOverflow)
+            Text('${count ?? 0}', style: textStyle)
+          else
+            Flexible(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: textStyle,
+              ),
+            ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## What
Backlog #5 (recipe library) — **PR1 of N**: the core card fix in `recipe_grid_card.dart` (Figma 971:8661, tokens read via the local Figma Dev-Mode bridge).

- **Layout** — content column is now `Expanded` + `MainAxisAlignment.spaceBetween`: the 2-line title pins to the top and the nutrition-chip row to the bottom, filling the 220h card (no dead space, matches Figma justify-between). Both call sites (`RecipeCategoryRow`, `RecipeSearchResults`) pin a bounded 220h box, so `Expanded` is safe.
- **Overflow-safe chips** — replaced the shared `AppChip` (in the row only) with a **card-local `_NutritionChip`**: the label chip is `Flexible` and its inner `Text` ellipsizes, so a long tag can no longer RenderFlex-overflow the ~134px content width; the `+N` chip is non-shrinking. Shared `AppChip` (17 call sites) is untouched.
- **Figma fidelity** — `_NutritionChip` matches the 'LabelContain' token: bg coralSoft (#FDF2EC), fg coralDeep (#C97850), Figtree Regular 10/16 (via the project's `GoogleFonts.figtree`), h24, radius 30, leading bolt icon; `+N` uses an add glyph + count.
- Stale doc-comment fixed (card is library-only, not a Home-carousel widget).

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean; `dart format` clean. **Sim-verified**: the recipe-library category-row cards render in the 220 box with **zero RenderFlex overflow** and correct title/spacing. Note: current seed recipes have no `nutritionTags`, so the chip itself isn't exercised on-device — the empty-tags spacer correctly holds card height; the chip is code-verified against the Figma tokens + the project's Figtree convention.

Follow-ups (later PRs): header sizing (#5 PR2), category-row section-title token (#5 PR3), search-state polish (#5 PR4).