### PR TITLE
refactor(recipe): category-row title via named headline token

### DIFF
--- a/lib/src/app/themes/app_typography.dart
+++ b/lib/src/app/themes/app_typography.dart
@@ -149,6 +149,15 @@ abstract final class AppTypography {
     color: AppColors.text,
   );
 
+  // headline — Figma Headline/SemiBold (15/22 h1.467). Parkinsans display.
+  static const TextStyle headline = TextStyle(
+    fontFamily: FontFamily.parkinsans,
+    fontSize: 15,
+    fontWeight: FontWeight.w600,
+    height: 22 / 15,
+    color: AppColors.fgStrong,
+  );
+
   // emptyStateTitle — components-empty-state.html .ttl spec:
   // 700 16px/1.2 var(--font-display) color var(--fg-strong).
   static const TextStyle emptyStateTitle = TextStyle(

--- a/lib/src/features/recipe/library/widgets/recipe_category_row.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_category_row.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
@@ -42,15 +41,7 @@ class RecipeCategoryRow extends StatelessWidget {
             AppSizes.pagePaddingH,
             AppSizes.sp12,
           ),
-          child: Text(
-            title,
-            style: AppTypography.textTheme.titleSmall?.copyWith(
-              fontSize: 15,
-              fontWeight: FontWeight.w600,
-              height: 22 / 15,
-              color: AppColors.fgStrong,
-            ),
-          ),
+          child: Text(title, style: AppTypography.headline),
         ),
         SizedBox(
           height: _cardHeight,


### PR DESCRIPTION
## What
Backlog #5 (recipe library) — **PR3**: code-quality. The category-row section title used an ad-hoc `titleSmall.copyWith(fontSize:15, w600, height:22/15, fgStrong)`. Extracted that exact shape into a named `AppTypography.headline` token (Figma 'Headline/SemiBold', Parkinsans 15/22) and used it. Removed the now-unused `app_colors` import.

**Zero visual change** — `headline` reproduces the same style; this is a DRY/token-naming cleanup.

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean; `dart format` clean. Sim-verified: 'Other' category title renders identically.