### PR TITLE
fix(recipe): allergen card copy 'big 11' -> 'big 9'

### DIFF
--- a/lib/src/features/recipe/detail/widgets/contains_allergens_card.dart
+++ b/lib/src/features/recipe/detail/widgets/contains_allergens_card.dart
@@ -67,7 +67,7 @@ class ContainsAllergensCard extends StatelessWidget {
           ),
           const SizedBox(height: AppSizes.xs),
           Text(
-            'This recipe contains the following of the big 11 allergens',
+            'This recipe contains the following of the big 9 allergens',
             style: theme.textTheme.bodyMedium?.copyWith(
               color: AppColors.fgDefault,
             ),


### PR DESCRIPTION
## What
Proactive audit of the **recipe-detail body** (post-backlog). Found one real defect: the 'Contains allergens' card said *'This recipe contains the following of the big **11** allergens'*, but the app's allergen domain is **9** (`kAllergenKeys`) and every other surface — the paywall feature list, the Read Guide banner, the home `/9` stat — says **'big 9'**. Fixed the inconsistency (`big 11` → `big 9`).

Rest of the recipe-detail body (hero, banner, allergens card, Ingredients/Method/Notes icon-sections, CTA) audited and is faithful — no other changes.

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean. Sim-verified: the card now reads 'the big 9 allergens'.