### PR TITLE
fix(recipe): restore 'big 11' allergen copy (match Figma brand)

### DIFF
--- a/lib/src/features/recipe/detail/widgets/contains_allergens_card.dart
+++ b/lib/src/features/recipe/detail/widgets/contains_allergens_card.dart
@@ -67,7 +67,7 @@ class ContainsAllergensCard extends StatelessWidget {
           ),
           const SizedBox(height: AppSizes.xs),
           Text(
-            'This recipe contains the following of the big 9 allergens',
+            'This recipe contains the following of the big 11 allergens',
             style: theme.textTheme.bodyMedium?.copyWith(
               color: AppColors.fgDefault,
             ),


### PR DESCRIPTION
## What
Reverts the copy change in #304. During an audit I changed recipe-detail 'big 11' → 'big 9' assuming 9 was canonical — but the **design brands it 'The Big 11'**: the Starting Guide article enumerates 11 individual allergens, the Figma frames are named 'Big 11', and the tracker has a 'Big 11' tab. Per the owner, **'Big 11' is canonical** (match Figma), so recipe-detail copy is restored to 'big 11'.

The `/9` ring + `kAllergenKeys` reflect the 9 *grouped* categories the app tracks (tree_nuts, shellfish, dairy…) — a separate, known product mismatch (11 individual vs 9 grouped) that is **not** reconciled here.

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean. Sim-verified: recipe-detail reads 'the big 11 allergens'.