### PR TITLE
refactor(profile): edit-screen labels use AppTypography.headline token

### DIFF
--- a/lib/src/features/profile/edit/profile_edit_screen.dart
+++ b/lib/src/features/profile/edit/profile_edit_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
 import 'package:nibbles/src/common/components/inputs/app_text_field.dart';
@@ -159,7 +160,7 @@ class _ProfileEditFormState extends ConsumerState<_ProfileEditForm> {
   Widget build(BuildContext context) {
     final formState =
         ref.watch(profileEditControllerProvider(widget.babyId)).valueOrNull ??
-            widget.formState;
+        widget.formState;
     final controller = ref.read(
       profileEditControllerProvider(widget.babyId).notifier,
     );
@@ -172,12 +173,9 @@ class _ProfileEditFormState extends ConsumerState<_ProfileEditForm> {
 
     void goBack() => context.canPop() ? context.pop() : context.go('/home');
 
-    final labelStyle = theme.textTheme.titleSmall?.copyWith(
-      fontSize: 15,
-      fontWeight: FontWeight.w600,
-      height: 22 / 15,
-      color: AppColors.fgStrong,
-    );
+    // Figma field label = Headline/SemiBold (Parkinsans 15/22) — the
+    // shared AppTypography.headline token (NIB token consolidation).
+    const labelStyle = AppTypography.headline;
 
     return _ProfileEditScaffold(
       body: SafeArea(
@@ -211,8 +209,9 @@ class _ProfileEditFormState extends ConsumerState<_ProfileEditForm> {
                           focusNode: _firstNameFocus,
                           onChanged: controller.updateFirstName,
                           textInputAction: TextInputAction.next,
-                          onSubmitted: (_) => FocusScope.of(context)
-                              .requestFocus(_lastNameFocus),
+                          onSubmitted: (_) => FocusScope.of(
+                            context,
+                          ).requestFocus(_lastNameFocus),
                         ),
                       ),
                     ),
@@ -229,8 +228,8 @@ class _ProfileEditFormState extends ConsumerState<_ProfileEditForm> {
                           focusNode: _lastNameFocus,
                           onChanged: controller.updateLastName,
                           textInputAction: TextInputAction.next,
-                          onSubmitted: (_) => FocusScope.of(context)
-                              .requestFocus(_emailFocus),
+                          onSubmitted: (_) =>
+                              FocusScope.of(context).requestFocus(_emailFocus),
                         ),
                       ),
                     ),
@@ -306,9 +305,9 @@ class _ProfileEditFormState extends ConsumerState<_ProfileEditForm> {
     final message = result.emailChanged
         ? 'Please check your inbox to confirm the new email.'
         : 'Profile updated.';
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message)),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
     context.pop();
   }
 }


### PR DESCRIPTION
## What
Proactive audit of **profile-edit (PR-02)**. The screen is visually faithful (header clears notch, fields match the Figma spec — 16px inset, 17px field gap, 143px avatar, Grad-1 bg, clean AppTextField boxes). One real code-quality finding: the field `labelStyle` hand-rolled `titleSmall.copyWith(15, w600, 22/15, fgStrong)` — the exact `AppTypography.headline` token from #303. Now uses the token. **Zero visual change.**

## Broader finding (flagged, not fixed here)
The `Parkinsans 15/22 w600` 'headline' style is hand-rolled inline in **~12 more files** (auth, subscription, recipe banner, profile widgets, allergen log-detail), and several files also have **redundant** `bodyLarge.copyWith(fontSize:15, height:22/15)` (restating bodyLarge's own values). A proper consolidation is a dedicated, careful per-site refactor (not all sites are the same style) — left for a follow-up so this PR stays scoped to the audited screen.

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean; `dart format` clean. Sim-verified: profile-edit labels render identically.