### PR TITLE
fix(meal-plan): capitalize allergen tag names (AllergenEmoji.displayName)

### DIFF
--- a/lib/src/app/constants/allergen_emoji.dart
+++ b/lib/src/app/constants/allergen_emoji.dart
@@ -19,4 +19,24 @@ abstract final class AllergenEmoji {
 
   /// Returns the emoji for [allergenKey], or an empty string if not found.
   static String get(String allergenKey) => map[allergenKey] ?? '';
+
+  /// Proper-cased display name per allergen key (e.g. 'tree_nuts' →
+  /// 'Tree Nuts'). Single source of truth so casing stays consistent
+  /// app-wide — use instead of ad-hoc `key.replaceAll('_', ' ')`.
+  static const Map<String, String> nameMap = {
+    'peanut': 'Peanut',
+    'egg': 'Egg',
+    'dairy': 'Dairy',
+    'tree_nuts': 'Tree Nuts',
+    'sesame': 'Sesame',
+    'soy': 'Soy',
+    'wheat': 'Wheat',
+    'fish': 'Fish',
+    'shellfish': 'Shellfish',
+  };
+
+  /// Display name for [allergenKey]; falls back to a humanized key
+  /// (underscores → spaces) for any unmapped key.
+  static String displayName(String allergenKey) =>
+      nameMap[allergenKey] ?? allergenKey.replaceAll('_', ' ');
 }

--- a/lib/src/features/meal_plan/map/widgets/picked_recipe_row.dart
+++ b/lib/src/features/meal_plan/map/widgets/picked_recipe_row.dart
@@ -132,7 +132,7 @@ class _TagsRow extends StatelessWidget {
           .take(3)
           .map(
             (t) => AppChip(
-              label: t.replaceAll('_', ' '),
+              label: AllergenEmoji.displayName(t),
               emoji: AllergenEmoji.get(t),
             ),
           )

--- a/lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart
+++ b/lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart
@@ -39,10 +39,7 @@ class SelectedDaySlotList extends StatelessWidget {
 
 /// Cream-tinted dashed container holding the assigned recipe rows.
 class _PopulatedDayContainer extends StatelessWidget {
-  const _PopulatedDayContainer({
-    required this.recipes,
-    required this.onRemove,
-  });
+  const _PopulatedDayContainer({required this.recipes, required this.onRemove});
 
   final List<Recipe> recipes;
   final ValueChanged<String> onRemove;
@@ -179,7 +176,7 @@ class _TagsRow extends StatelessWidget {
           .take(3)
           .map(
             (t) => AppChip(
-              label: t.replaceAll('_', ' '),
+              label: AllergenEmoji.displayName(t),
               emoji: AllergenEmoji.get(t),
             ),
           )

--- a/lib/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart
+++ b/lib/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart
@@ -29,9 +29,7 @@ class BrowseMealRecipeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    final borderColor = selected
-        ? AppColors.primary
-        : AppColors.borderSoft;
+    final borderColor = selected ? AppColors.primary : AppColors.borderSoft;
 
     return Opacity(
       opacity: unsafe ? 0.5 : 1,
@@ -166,11 +164,7 @@ class _SelectIndicator extends StatelessWidget {
         ),
       ),
       child: selected
-          ? const Icon(
-              Icons.check,
-              size: 16,
-              color: AppColors.onPrimary,
-            )
+          ? const Icon(Icons.check, size: 16, color: AppColors.onPrimary)
           : null,
     );
   }
@@ -180,10 +174,7 @@ class _UnsafeBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.sm,
-        vertical: 2,
-      ),
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.sm, vertical: 2),
       decoration: BoxDecoration(
         color: AppColors.destructiveSoft,
         borderRadius: BorderRadius.circular(AppSizes.radiusFull),
@@ -326,11 +317,8 @@ class _RowThumbnail extends StatelessWidget {
       width: size,
       height: size,
       fit: BoxFit.cover,
-      placeholder: (_, __) => Container(
-        width: size,
-        height: size,
-        color: AppColors.surfaceVariant,
-      ),
+      placeholder: (_, __) =>
+          Container(width: size, height: size, color: AppColors.surfaceVariant),
       errorWidget: (_, __, ___) => Container(
         width: size,
         height: size,
@@ -346,7 +334,7 @@ class _RowThumbnail extends StatelessWidget {
 }
 
 String _formatFlaggedTags(List<String> tags) => tags
-    .map((t) => '${AllergenEmoji.get(t)} ${t.replaceAll('_', ' ')}')
+    .map((t) => '${AllergenEmoji.get(t)} ${AllergenEmoji.displayName(t)}')
     .join(', ');
 
 class _RowSelectIndicator extends StatelessWidget {
@@ -370,11 +358,7 @@ class _RowSelectIndicator extends StatelessWidget {
         border: Border.all(color: border),
       ),
       child: selected
-          ? const Icon(
-              Icons.check,
-              size: 16,
-              color: AppColors.onPrimary,
-            )
+          ? const Icon(Icons.check, size: 16, color: AppColors.onPrimary)
           : null,
     );
   }

--- a/lib/src/features/meal_plan/widgets/day_accordion_card.dart
+++ b/lib/src/features/meal_plan/widgets/day_accordion_card.dart
@@ -144,10 +144,7 @@ class _Header extends StatelessWidget {
       child: Row(
         children: [
           Expanded(
-            child: Text(
-              dateLabel,
-              style: AppTypography.textTheme.titleMedium,
-            ),
+            child: Text(dateLabel, style: AppTypography.textTheme.titleMedium),
           ),
           // Green-filled rounded-square overflow button (Figma 971:8619).
           PopupMenuButton<DayCardMenuAction>(
@@ -413,7 +410,7 @@ class _AllergenTagChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final emoji = AllergenEmoji.get(tag);
-    final name = tag.replaceAll('_', ' ');
+    final name = AllergenEmoji.displayName(tag);
     return AppChip(
       label: name,
       emoji: emoji,


### PR DESCRIPTION
## What
Audit of the **meal-plan** feature (populated day-accordion). The screen is faithful, but found a real, user-visible inconsistency: the meal-plan feature renders allergen tags **lowercase** ('peanut', 'wheat') via ad-hoc `tag.replaceAll('_', ' ')`, while **recipe-detail, recipe-library, recipe-banner, and home** all **capitalize** them ('Peanut', 'Tree Nuts', 'Dairy').

Fix: added a canonical `AllergenEmoji.displayName(key)` (single source of truth, proper-cased name map) to the shared `AllergenEmoji` constant, and used it in the 4 meal-plan tag-pill renderers (`day_accordion_card`, `picked_recipe_row`, `selected_day_slot_list`, `browse_meal_recipe_card`). Now casing is consistent app-wide. (Not a brand decision like Big 11 — plain formatting consistency; the capitalized form is the app majority + the polished convention.)

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean; `dart format` clean. Sim-verified: the populated day-accordion now shows '🥜 Peanut' / '🌾 Wheat' (was lowercase), matching recipe-detail.

Follow-up candidate: the duplicated `_humanize`/`_capitalize` in recipe-detail/banner/home + the private `_allergenNames` map in recipe-library could also migrate to `AllergenEmoji.displayName` (DRY) — flagged, not done here.