### PR TITLE
fix(allergen): reaction-log Notes hint grammar ('love' -> 'loves')

### DIFF
--- a/lib/src/features/allergen/log/allergen_log_screen.dart
+++ b/lib/src/features/allergen/log/allergen_log_screen.dart
@@ -449,7 +449,7 @@ class _NotesField extends StatelessWidget {
         decoration: InputDecoration(
           isCollapsed: true,
           border: InputBorder.none,
-          hintText: 'My baby love it, no reaction',
+          hintText: 'My baby loves it, no reaction',
           hintStyle: textTheme.bodyLarge?.copyWith(color: AppColors.fgFaint),
         ),
       ),


### PR DESCRIPTION
## What
Audit of the reaction-log (AL-06). Form is faithful; one copy finding: the Notes hint read **'My baby love it, no reaction'** (subject-verb: 'loves'). Owner confirmed this is a typo (not an intentionally-preserved verbatim Figma string). Fixed to **'My baby loves it, no reaction'**.

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean. Sim-verified: the Notes field hint now reads 'My baby loves it, no reaction'.