### PR TITLE
refactor(allergen): centralize allergen display names (DRY)

### DIFF
--- a/lib/src/features/home/widgets/ongoing_introduced_card.dart
+++ b/lib/src/features/home/widgets/ongoing_introduced_card.dart
@@ -46,19 +46,13 @@ class OngoingIntroducedCard extends StatelessWidget {
     return null;
   }
 
-  String _displayName(String key) =>
-      key.replaceAll('_', ' ').split(' ').map(_capitalize).join(' ');
-
-  String _capitalize(String word) =>
-      word.isEmpty ? word : '${word[0].toUpperCase()}${word.substring(1)}';
-
   @override
   Widget build(BuildContext context) {
     final key = _ongoingKey;
     if (key == null) return const SizedBox.shrink();
 
     final emoji = AllergenEmoji.get(key);
-    final name = _displayName(key);
+    final name = AllergenEmoji.displayName(key);
     final filled = (logCounts[key] ?? 0).clamp(0, _target);
 
     return Column(

--- a/lib/src/features/recipe/detail/widgets/contains_allergens_card.dart
+++ b/lib/src/features/recipe/detail/widgets/contains_allergens_card.dart
@@ -23,14 +23,6 @@ class ContainsAllergensCard extends StatelessWidget {
   final List<String> allergenTags;
   final Map<String, AllergenStatus> statuses;
 
-  String _humanize(String raw) {
-    return raw
-        .split('_')
-        .where((w) => w.isNotEmpty)
-        .map((w) => '${w[0].toUpperCase()}${w.substring(1)}')
-        .join(' ');
-  }
-
   AppChipTone _toneFor(String tag) {
     final status = statuses[tag] ?? AllergenStatus.notStarted;
     return switch (status) {
@@ -79,7 +71,7 @@ class ContainsAllergensCard extends StatelessWidget {
             children: [
               for (final tag in allergenTags)
                 AppChip(
-                  label: _humanize(tag),
+                  label: AllergenEmoji.displayName(tag),
                   tone: _toneFor(tag),
                   emoji: AllergenEmoji.get(tag),
                 ),

--- a/lib/src/features/recipe/library/recipe_library_screen.dart
+++ b/lib/src/features/recipe/library/recipe_library_screen.dart
@@ -196,10 +196,8 @@ class _RecipeContent extends StatelessWidget {
   final VoidCallback onReadGuideTap;
   final Future<void> Function() onRefresh;
 
-  List<Recipe> get _allRecipes => state.recipesByCategory.values
-      .expand((rs) => rs)
-      .toSet()
-      .toList();
+  List<Recipe> get _allRecipes =>
+      state.recipesByCategory.values.expand((rs) => rs).toSet().toList();
 
   List<Recipe> get _recommendations {
     final key = state.ongoingAllergenKey;
@@ -241,7 +239,9 @@ class _RecipeContent extends StatelessWidget {
             ReadGuideBanner(onTap: onReadGuideTap),
           if (ongoingKey != null && recommendations.isNotEmpty)
             RecipeCategoryRow(
-              title: 'Recommendation for ${_displayName(ongoingKey)} '
+              title:
+                  'Recommendation for '
+                  '${AllergenEmoji.displayName(ongoingKey)} '
                   '${AllergenEmoji.get(ongoingKey)}',
               recipes: recommendations,
               flaggedAllergenKeys: state.flaggedAllergenKeys,
@@ -258,20 +258,6 @@ class _RecipeContent extends StatelessWidget {
       ),
     );
   }
-
-  static const _allergenNames = {
-    'peanut': 'Peanut',
-    'egg': 'Egg',
-    'dairy': 'Dairy',
-    'tree_nuts': 'Tree Nuts',
-    'sesame': 'Sesame',
-    'soy': 'Soy',
-    'wheat': 'Wheat',
-    'fish': 'Fish',
-    'shellfish': 'Shellfish',
-  };
-
-  static String _displayName(String key) => _allergenNames[key] ?? key;
 }
 
 class _ErrorView extends StatelessWidget {


### PR DESCRIPTION
## What
Owner-greenlit DRY cleanup. Three sites duplicated allergen-name humanizing, all producing the same proper-cased output as the canonical `AllergenEmoji.displayName` (added in #307):
- `contains_allergens_card._humanize`
- `ongoing_introduced_card._displayName` + `_capitalize`
- `recipe_library_screen._allergenNames` map + `_displayName`

Migrated all three to `AllergenEmoji.displayName`, removed the local helpers. **Carefully left `recipe_banner_card._humanize` untouched** — it humanizes *nutrition* tags (not allergens), which aren't in the allergen name map, so routing it through `displayName` would regress it to lowercase.

## Gate
`flutter analyze --fatal-infos --fatal-warnings` → clean; `dart format` clean. **Zero visual change** — each removed helper's output was verified byte-identical to `displayName` for the 9 allergen keys, and #307 already sim-confirmed `displayName` renders correct capitalized names.