### PR TITLE
fix(auth): left-align forgot-password confirmation badge

### DIFF
--- a/lib/src/features/auth/forgot_password/forgot_password_screen.dart
+++ b/lib/src/features/auth/forgot_password/forgot_password_screen.dart
@@ -165,18 +165,24 @@ class _ConfirmationView extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Container(
-          width: AppSizes.iconXl + AppSizes.md,
-          height: AppSizes.iconXl + AppSizes.md,
-          decoration: const BoxDecoration(
-            color: AppColors.butter,
-            shape: BoxShape.circle,
-          ),
-          alignment: Alignment.center,
-          child: const Icon(
-            Icons.mark_email_read_outlined,
-            size: AppSizes.iconLg,
-            color: AppColors.greenDeep,
+        // Left-align the badge to match the left-aligned title/body below;
+        // a bare Container in a stretch column would be forced full-width
+        // and the circle would render centered.
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Container(
+            width: AppSizes.iconXl + AppSizes.md,
+            height: AppSizes.iconXl + AppSizes.md,
+            decoration: const BoxDecoration(
+              color: AppColors.butter,
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: const Icon(
+              Icons.mark_email_read_outlined,
+              size: AppSizes.iconLg,
+              color: AppColors.greenDeep,
+            ),
           ),
         ),
         const SizedBox(height: AppSizes.lg),


### PR DESCRIPTION
## Problem
On the forgot-password **"Check your email"** confirmation state, the butter email-icon badge rendered **horizontally centered** while the back button, title, and body are all **left-aligned** — a visible inconsistency.

Root cause: the badge `Container` lives in a `CrossAxisAlignment.stretch` Column, which forces it to a tight full-width constraint. `BoxShape.circle` then paints the circle centered within that full-width box.

## Fix
Wrap the badge in `Align(alignment: Alignment.centerLeft)` so it left-aligns with the rest of the screen. One-widget, contained change.

## Verification
- `flutter analyze --fatal-infos --fatal-warnings` → No issues found!
- Sim render (iPhone 16 Pro, dev flavor): badge now sits left-aligned under the back button, matching the left-aligned title/body.

Before: centered badge over left-aligned text · After: badge left-aligned.