### PR TITLE
fix(shopping-list): audit pass — error scoping, spacing, radius token, heading weight

### DIFF
--- a/lib/src/features/shopping_list/shopping_list_controller.dart
+++ b/lib/src/features/shopping_list/shopping_list_controller.dart
@@ -49,9 +49,15 @@ class ShoppingListController extends _$ShoppingListController {
       throw result.errorOrNull!;
     }
 
-    // Reload to replace placeholder with server-assigned ID
+    // Reload to swap the placeholder id for the server-assigned id. The write
+    // already succeeded, so a refetch read-failure is P3 (background) — don't
+    // let it re-enter the add path and surface a false P2 "add failed" toast.
     ref.invalidateSelf();
-    await future;
+    try {
+      await future;
+    } on Exception catch (_) {
+      // Keep the optimistic row; the list reconciles on the next load.
+    }
   }
 
   Future<void> check(String itemId) async {

--- a/lib/src/features/shopping_list/shopping_list_screen.dart
+++ b/lib/src/features/shopping_list/shopping_list_screen.dart
@@ -416,7 +416,7 @@ class _ItemsList extends StatelessWidget {
     return ListView.separated(
       padding: const EdgeInsets.only(bottom: AppSizes.md),
       itemCount: items.length,
-      separatorBuilder: (_, __) => const SizedBox(height: AppSizes.sm),
+      separatorBuilder: (_, __) => const SizedBox(height: AppSizes.sp12),
       itemBuilder: (_, index) {
         final item = items[index];
         // Optimistic placeholder id=='' would collide if multiple are pending;
@@ -606,7 +606,8 @@ class _EmptyState extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           const Quatrefoil(size: 153),
-          const SizedBox(height: AppSizes.sm),
+          // Figma 971:9989 empty-state gap-[10px] (no 10px spacing token).
+          const SizedBox(height: 10),
           Text(
             "You don't have any list yet",
             textAlign: TextAlign.center,

--- a/lib/src/features/shopping_list/widgets/add_ingredient_card.dart
+++ b/lib/src/features/shopping_list/widgets/add_ingredient_card.dart
@@ -21,7 +21,9 @@ Future<void> showAddIngredientSheet(
     barrierColor: Colors.black.withValues(alpha: 0.5),
     isScrollControlled: true,
     shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(top: Radius.circular(30)),
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppSizes.radius3xl),
+      ),
     ),
     builder: (_) => _AddIngredientSheet(
       controller: controller,
@@ -162,9 +164,7 @@ class _AddPillButton extends StatelessWidget {
         ),
         child: Text(
           'Add',
-          style: AppTypography.headline.copyWith(
-            color: AppColors.greenDeep,
-          ),
+          style: AppTypography.headline.copyWith(color: AppColors.greenDeep),
         ),
       ),
     );

--- a/lib/src/features/shopping_list/widgets/clear_all_confirm_sheet.dart
+++ b/lib/src/features/shopping_list/widgets/clear_all_confirm_sheet.dart
@@ -20,7 +20,9 @@ Future<bool?> showClearAllConfirmSheet(BuildContext context) {
     barrierColor: Colors.black.withValues(alpha: 0.5),
     isScrollControlled: true,
     shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(top: Radius.circular(30)),
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppSizes.radius3xl),
+      ),
     ),
     builder: (_) => const _ClearAllConfirmSheet(),
   );
@@ -50,7 +52,10 @@ class _ClearAllConfirmSheet extends StatelessWidget {
                 child: Text(
                   'Are you sure you want to delete?',
                   textAlign: TextAlign.center,
-                  style: AppTypography.textTheme.titleSmall,
+                  // Figma 971:9982 — Parkinsans Bold 17 (titleSmall is w600).
+                  style: AppTypography.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Shopping-list audit pass (autonomous per-feature audit loop — iteration 1)

Deep audit of the shopping-list feature across flow, component choice, layout/spacing, code quality, Figma fidelity, and best-practice. 5 concrete, verified fixes; 16 owner-questions deferred (not changed); 15 lateral findings rejected.

### Fixes
1. **Add false-error (correctness — P3 vs P2):** `addManual` let a *post-success* refetch read-failure propagate into the add path → a false "Couldn't add items" toast even though the write landed. Now scoped so a refetch read-failure stays P3 (keep the optimistic row). `shopping_list_controller.dart`
2. **Row spacing:** inter-row gap 8→12 to match Figma column gap-12 (971:9851); the screen already uses 12 for its sibling gaps. `shopping_list_screen.dart`
3. **Empty-state spacing:** flower→caption gap 8→10 (Figma 971:9989 gap-[10px]). `shopping_list_screen.dart`
4. **Radius token (DRY):** hardcoded `Radius.circular(30)` → `AppSizes.radius3xl` (token authored for this exact frame, already consumed by `recipe_grid_card`). `add_ingredient_card.dart`, `clear_all_confirm_sheet.dart`
5. **Confirm heading weight:** w600 → w700 to match Figma 971:9982 (Parkinsans Bold 17; the widget's own doc-comment already specified Bold 17). `clear_all_confirm_sheet.dart`

### Verification
- `flutter analyze --fatal-infos --fatal-warnings` — clean
- Visual gate on iOS simulator (QA-bypass): populated list (#2), clear-all confirm sheet (#4), and empty state (#5) all render correctly vs the Figma specs — no layout breakage.

### Deferred to owner (not changed)
Header-title weight (app-wide DS token), Bought-tab empty copy, add-sheet-vs-inline-card surface (NIB-81), Copy-to-Clipboard icon, segmented-control shared-token color/height/weight (kit-vs-Figma), persistent header "+" chip, empty-state illustration asset — all product/DS-ownership decisions per the section_report open questions.