### PR TITLE
fix(onboarding): readiness/result/consent Figma fidelity + cleanup

### DIFF
--- a/lib/src/features/onboarding/consent/onboarding_consent_screen.dart
+++ b/lib/src/features/onboarding/consent/onboarding_consent_screen.dart
@@ -43,7 +43,6 @@ class _OnboardingConsentScreenState
     extends ConsumerState<OnboardingConsentScreen> {
   // Default to the safer 2-checkbox path when DOB is missing (spec step 2).
   static const int _defaultAgeMonths = 6;
-  static const int _earlySolidsThresholdMonths = 6;
 
   late List<bool> _checks;
 
@@ -56,7 +55,7 @@ class _OnboardingConsentScreenState
   }
 
   int _countFor(int ageMonths) =>
-      ageMonths >= _earlySolidsThresholdMonths ? 2 : 3;
+      ageMonths >= onboardingEarlySolidsThresholdMonths ? 2 : 3;
 
   bool get _allChecked => _checks.every((c) => c);
 
@@ -104,79 +103,88 @@ class _OnboardingConsentScreenState
       // prevent racing the createBaby call with orphaned baby rows.
       canPop: !isSubmitting,
       child: Scaffold(
-      backgroundColor: AppColors.background,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
-            vertical: AppSizes.pagePaddingV,
+        // Grad-1 wash — every onboarding screen carries it.
+        body: Container(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [AppColors.butterSoft, Color(0xFFF5F5F5)],
+            ),
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text(
-                'Before we start, some housekeeping',
-                textAlign: TextAlign.center,
-                style: textTheme.displaySmall,
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.pagePaddingH,
+                vertical: AppSizes.pagePaddingV,
               ),
-              const SizedBox(height: AppSizes.lg),
-              // Figma audit calls the cluster at 220x220; we render at 180
-              // so the 3-checkbox <6mo variant still fits without scrolling on
-              // ~5.5" devices (the cluster scales linearly via [PetalBlob]).
-              const Center(child: PetalBlob(size: 180)),
-              const SizedBox(height: AppSizes.xl),
-              Expanded(
-                child: SingleChildScrollView(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      for (var i = 0; i < _checks.length; i++) ...[
-                        _ConsentCheckboxRow(
-                          key: Key('onboarding_consent_checkbox_$i'),
-                          label: _labelFor(i),
-                          value: _checks[i],
-                          onChanged: (v) => _toggle(i, value: v),
-                        ),
-                        if (i < _checks.length - 1)
-                          const SizedBox(height: AppSizes.sm),
-                      ],
-                      if (errorMessage != null) ...[
-                        const SizedBox(height: AppSizes.md),
-                        _InlineError(
-                          key: const Key('onboarding_consent_error'),
-                          message: errorMessage,
-                          onRetry: canConfirm ? _onConfirm : null,
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: AppSizes.md),
-              Row(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  AppRoundButton(
-                    key: const Key('onboarding_consent_back'),
-                    icon: const Icon(Icons.arrow_back_rounded),
-                    tone: AppRoundButtonTone.butter,
-                    semanticLabel: 'Back',
-                    // Gate back during submit to prevent orphan-baby race.
-                    onPressed: isSubmitting ? null : _onBack,
+                  Text(
+                    'Before we start, some housekeeping',
+                    textAlign: TextAlign.center,
+                    // Figma Title 1/Bold 22 (sibling onboarding titles also 22).
+                    style: textTheme.titleLarge,
                   ),
-                  const SizedBox(width: AppSizes.sp12),
+                  const SizedBox(height: AppSizes.lg),
+                  // Figma cluster is 220x220; rendered at 180 so the 3-box
+                  // <6mo variant fits without scrolling on ~5.5" devices.
+                  const Center(child: PetalBlob(size: 180)),
+                  const SizedBox(height: AppSizes.xl),
                   Expanded(
-                    child: AppPillButton(
-                      key: const Key('onboarding_consent_submit'),
-                      label: ctaLabel,
-                      onPressed: canConfirm ? _onConfirm : null,
+                    child: SingleChildScrollView(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          for (var i = 0; i < _checks.length; i++) ...[
+                            _ConsentCheckboxRow(
+                              key: Key('onboarding_consent_checkbox_$i'),
+                              label: _labelFor(i),
+                              value: _checks[i],
+                              onChanged: (v) => _toggle(i, value: v),
+                            ),
+                            if (i < _checks.length - 1)
+                              const SizedBox(height: AppSizes.sm),
+                          ],
+                          if (errorMessage != null) ...[
+                            const SizedBox(height: AppSizes.md),
+                            _InlineError(
+                              key: const Key('onboarding_consent_error'),
+                              message: errorMessage,
+                              onRetry: canConfirm ? _onConfirm : null,
+                            ),
+                          ],
+                        ],
+                      ),
                     ),
+                  ),
+                  const SizedBox(height: AppSizes.md),
+                  Row(
+                    children: [
+                      AppRoundButton(
+                        key: const Key('onboarding_consent_back'),
+                        icon: const Icon(Icons.arrow_back_rounded),
+                        tone: AppRoundButtonTone.butter,
+                        semanticLabel: 'Back',
+                        // Gate back during submit to prevent orphan-baby race.
+                        onPressed: isSubmitting ? null : _onBack,
+                      ),
+                      const SizedBox(width: AppSizes.sp12),
+                      Expanded(
+                        child: AppPillButton(
+                          key: const Key('onboarding_consent_submit'),
+                          label: ctaLabel,
+                          onPressed: canConfirm ? _onConfirm : null,
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ),
-            ],
+            ),
           ),
         ),
-      ),
       ),
     );
   }
@@ -237,12 +245,9 @@ class _ConsentCheckboxRow extends StatelessWidget {
               Padding(
                 // Nudge the checkbox down so it visually aligns with the first
                 // line of label text.
-                padding: const EdgeInsets.only(top: 2),
+                padding: const EdgeInsets.only(top: AppSizes.sp2),
                 child: ExcludeSemantics(
-                  child: AppCheckbox(
-                    value: value,
-                    onChanged: onChanged,
-                  ),
+                  child: AppCheckbox(value: value, onChanged: onChanged),
                 ),
               ),
               const SizedBox(width: AppSizes.sp12),
@@ -267,11 +272,7 @@ class _ConsentCheckboxRow extends StatelessWidget {
 /// Retry is null while submit is in-flight or the boxes are unchecked so the
 /// user can't fire a duplicate submit mid-request.
 class _InlineError extends StatelessWidget {
-  const _InlineError({
-    required this.message,
-    required this.onRetry,
-    super.key,
-  });
+  const _InlineError({required this.message, required this.onRetry, super.key});
 
   final String message;
   final VoidCallback? onRetry;

--- a/lib/src/features/onboarding/readiness/widgets/readiness_choice_card.dart
+++ b/lib/src/features/onboarding/readiness/widgets/readiness_choice_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 
 /// Large square choice card used in the NIB-83 readiness questionnaire.
@@ -32,9 +33,9 @@ class ReadinessChoiceCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
     final borderColor = selected ? AppColors.greenDeep : AppColors.green;
-    final borderWidth = selected ? 2.5 : 1.5;
+    // Figma readiness-check forest stroke is 2; selected 2.5 is kit-derived.
+    final borderWidth = selected ? 2.5 : 2.0;
     final surface = selected ? AppColors.butterSoft : AppColors.cream;
 
     return Semantics(
@@ -66,9 +67,9 @@ class ReadinessChoiceCard extends StatelessWidget {
                     child: Text(
                       label,
                       textAlign: TextAlign.center,
-                      style: textTheme.bodyMedium?.copyWith(
+                      // Figma card label = Headline/SemiBold (Parkinsans 15/22).
+                      style: AppTypography.headline.copyWith(
                         color: AppColors.greenDeep,
-                        fontWeight: FontWeight.w600,
                       ),
                     ),
                   ),
@@ -94,10 +95,7 @@ class _NibbleIcon extends StatelessWidget {
       child: Stack(
         alignment: Alignment.center,
         children: [
-          Quatrefoil(
-            size: AppSizes.xxl,
-            coreColor: AppColors.butter,
-          ),
+          Quatrefoil(size: AppSizes.xxl, coreColor: AppColors.butter),
           Icon(
             Icons.cancel_outlined,
             size: AppSizes.iconMd,

--- a/lib/src/features/onboarding/readiness/widgets/readiness_progress_bar.dart
+++ b/lib/src/features/onboarding/readiness/widgets/readiness_progress_bar.dart
@@ -10,8 +10,8 @@ import 'package:nibbles/src/app/themes/app_sizes.dart';
 /// (.figma-audit/onboarding/readiness-check-{1..6}/screenshot.png):
 ///
 ///   step 0 (Q1)  -> coral peach   (gate / intro)
-///   step 1 (Q2)  -> destructive   (burgundy)
-///   step 2 (Q3)  -> destructive   (burgundy)
+///   step 1 (Q2)  -> burgundy
+///   step 2 (Q3)  -> burgundy
 ///   step 3 (Q4)  -> coral         (salmon)
 ///   step 4 (Q5)  -> butter        (lime)
 ///   step 5 (Q6)  -> green         (forest)
@@ -37,8 +37,8 @@ class ReadinessProgressBar extends StatelessWidget {
   /// the NIB-83 stepCount (6).
   static const List<Color> _stepFillColors = <Color>[
     AppColors.coral,
-    AppColors.destructive,
-    AppColors.destructive,
+    AppColors.burgundy,
+    AppColors.burgundy,
     AppColors.coral,
     AppColors.butter,
     AppColors.green,
@@ -78,14 +78,13 @@ class ReadinessProgressBar extends StatelessWidget {
           width: double.infinity,
           child: Stack(
             children: [
-              const ColoredBox(
-                color: trackColor,
-                child: SizedBox.expand(),
-              ),
+              const ColoredBox(color: trackColor, child: SizedBox.expand()),
               TweenAnimationBuilder<double>(
                 duration: const Duration(milliseconds: 320),
                 curve: Curves.easeOut,
-                tween: Tween<double>(begin: fraction, end: fraction),
+                // end-only so width tweens from the prior fraction to the new
+                // one on step change (begin==end would snap with no motion).
+                tween: Tween<double>(end: fraction),
                 builder: (context, value, _) => FractionallySizedBox(
                   widthFactor: value.clamp(0.0, 1.0),
                   child: TweenAnimationBuilder<Color?>(

--- a/lib/src/features/onboarding/result/onboarding_result_screen.dart
+++ b/lib/src/features/onboarding/result/onboarding_result_screen.dart
@@ -72,75 +72,85 @@ class OnboardingResultScreen extends ConsumerWidget {
     final firstName = _firstToken(babyNameRaw);
     final signsMet = answers.where((a) => a ?? false).length;
     final ready = signsMet >= readinessReadyThreshold;
+    final outcomeTitle = ready
+        ? '$firstName is ready for solids at this time'
+        : '$firstName is not ready for solids at this time';
 
     final textTheme = Theme.of(context).textTheme;
 
     return Scaffold(
-      backgroundColor: AppColors.background,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.pagePaddingH,
-            vertical: AppSizes.pagePaddingV,
+      // Grad-1 wash (butterSoft → grey) — every onboarding screen carries it.
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [AppColors.butterSoft, Color(0xFFF5F5F5)],
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Expanded(
-                child: SingleChildScrollView(
-                  child: Column(
-                    children: [
-                      if (ready) ...[
+        ),
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.pagePaddingH,
+              vertical: AppSizes.pagePaddingV,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        if (ready) ...[
+                          Text(
+                            'New Journey Unlock!',
+                            textAlign: TextAlign.center,
+                            style: textTheme.titleSmall?.copyWith(
+                              color: AppColors.fgStrong,
+                            ),
+                          ),
+                          const SizedBox(height: AppSizes.sm),
+                        ],
                         Text(
-                          'New Journey Unlock!',
+                          outcomeTitle,
                           textAlign: TextAlign.center,
-                          style: textTheme.titleSmall?.copyWith(
+                          style: textTheme.headlineSmall?.copyWith(
                             color: AppColors.fgStrong,
                           ),
                         ),
-                        const SizedBox(height: AppSizes.sm),
-                      ],
-                      Text(
-                        ready
-                            ? '$firstName is ready for solids at this time'
-                            : '$firstName is not ready for solids at this time',
-                        textAlign: TextAlign.center,
-                        style: textTheme.headlineSmall?.copyWith(
-                          color: AppColors.fgStrong,
+                        const SizedBox(height: AppSizes.xl),
+                        _HeroCard(
+                          signsMet: signsMet,
+                          answers: answers,
+                          ready: ready,
                         ),
-                      ),
-                      const SizedBox(height: AppSizes.xl),
-                      _HeroCard(
-                        signsMet: signsMet,
-                        answers: answers,
-                        ready: ready,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: AppSizes.md),
-              Row(
-                children: [
-                  AppRoundButton(
-                    key: const Key('onboarding_result_back'),
-                    icon: const Icon(Icons.arrow_back_rounded),
-                    tone: AppRoundButtonTone.butter,
-                    semanticLabel: 'Back',
-                    onPressed: () => _onBack(context),
-                  ),
-                  const SizedBox(width: AppSizes.sp12),
-                  Expanded(
-                    child: AppPillButton(
-                      key: const Key('onboarding_result_next'),
-                      label: 'Next',
-                      onPressed: () =>
-                          context.goNamed(AppRoute.onboardingConsent.name),
+                      ],
                     ),
                   ),
-                ],
-              ),
-            ],
+                ),
+                const SizedBox(height: AppSizes.md),
+                Row(
+                  children: [
+                    AppRoundButton(
+                      key: const Key('onboarding_result_back'),
+                      icon: const Icon(Icons.arrow_back_rounded),
+                      tone: AppRoundButtonTone.butter,
+                      semanticLabel: 'Back',
+                      onPressed: () => _onBack(context),
+                    ),
+                    const SizedBox(width: AppSizes.sp12),
+                    Expanded(
+                      child: AppPillButton(
+                        key: const Key('onboarding_result_next'),
+                        label: 'Next',
+                        onPressed: () =>
+                            context.goNamed(AppRoute.onboardingConsent.name),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -180,7 +190,8 @@ class _HeroCard extends StatelessWidget {
   final List<bool?> answers;
   final bool ready;
 
-  static const double _heroSize = 96;
+  // Figma readiness-ready/not-ready hero "Group 78" is 154x154.
+  static const double _heroSize = 154;
 
   @override
   Widget build(BuildContext context) {
@@ -194,7 +205,7 @@ class _HeroCard extends StatelessWidget {
           padding: const EdgeInsets.only(top: overlap),
           child: _SignsCard(signsMet: signsMet, answers: answers, ready: ready),
         ),
-        const Quatrefoil(coreColor: AppColors.greenSoft),
+        const Quatrefoil(size: _heroSize, coreColor: AppColors.greenSoft),
       ],
     );
   }


### PR DESCRIPTION
## Onboarding readiness/result/consent audit pass (autonomous loop — iteration 2)

Deep audit of the readiness questionnaire, result, and consent screens. 14 findings confirmed; this PR ships **9 one-tick-safe fixes** (7 visual fidelity + 2 code-quality). Remaining confirmed findings + 14 owner-questions are deferred (see below).

### Visual fidelity (sim-gated vs Figma)
- **readiness card label**: Figtree `bodyMedium`(14) → Parkinsans `AppTypography.headline`(15) — Figma card label is Headline/SemiBold
- **readiness card border**: resting `1.5` → `2.0` (Figma forest border 2)
- **progress-bar burgundy**: `AppColors.destructive` #851E1E → `AppColors.burgundy` #77393B (was using the semantic error-red as a decorative fill)
- **progress-bar width tween**: was a no-op (`begin == end`) → `end`-only so the documented width animation actually runs
- **result hero**: quatrefoil `96` → `154` (Figma "Group 78" 154×154); size now passed explicitly so the mark, overlap, and card top-padding scale from one source
- **result + consent background**: solid → Grad-1 gradient (the gradient every other onboarding screen already carries; readiness/dob/intro use it)
- **consent title**: `displaySmall`(28) → `titleLarge`(22) — Figma Title 1/Bold; 28 was the lone outlier vs the 22px readiness/result/name/dob titles

### Code quality
- **consent 6-month threshold**: dropped the duplicated local `6` literal, now references the controller's exported `onboardingEarlySolidsThresholdMonths` (UI checkbox count + DB consent record now share one source)
- **consent checkbox nudge**: `top: 2` → `AppSizes.sp2` token

### Verification
- `flutter analyze --fatal-infos --fatal-warnings` — clean
- Visual gate on iOS sim (QA-bypass routed into onboarding): readiness Q1–Q2, result (ready variant), and consent all render correctly vs Figma — burgundy progress fill, 2px card border, Parkinsans labels, 154px hero overlap, gradient backgrounds, 22px consent title — no layout breakage.

### Deferred (follow-up onboarding tick)
- Dead in-memory state fields `readinessReady` / `consentAccepted` + setters (need freezed regen + test updates)
- Triplicated `_firstToken` → shared `firstNameOrFallback` util (touches the dob screen too)
- `_ScoreChip` → shared `AppChip` (would shrink the chip type 13→11 — needs an `AppChip` size variant to stay faithful)
- 14 owner-questions (progress-bar colour-ramp intent, score-chip denominator/ready-variant rows, consent checkbox/cluster sizes, duplicated sign copy, etc.) — product/design decisions, not unilateral changes.

Note: the large consent/result line counts are gradient-wrap re-indentation (a gradient requires a `Container` wrapper).