### PR TITLE
fix(profile): delete-account + feedback audit fixes (radius token, a11y, CTA height)

### DIFF
--- a/lib/src/features/profile/delete/delete_account_overlay.dart
+++ b/lib/src/features/profile/delete/delete_account_overlay.dart
@@ -35,7 +35,7 @@ Future<void> showDeleteAccountOverlay(BuildContext context) {
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(
         // Figma sheet top corner radius = 30.
-        top: Radius.circular(30),
+        top: Radius.circular(AppSizes.radius3xl),
       ),
     ),
     // isDismissible and enableDrag are wired dynamically inside the sheet
@@ -231,7 +231,9 @@ class _SheetHeader extends StatelessWidget {
           constraints: const BoxConstraints(minWidth: 34, minHeight: 33),
           style: IconButton.styleFrom(
             shape: const RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(Radius.circular(30)),
+              borderRadius: BorderRadius.all(
+                Radius.circular(AppSizes.radius3xl),
+              ),
             ),
           ),
         ),
@@ -326,9 +328,7 @@ class _CancelButton extends StatelessWidget {
           child: Center(
             child: Text(
               'Cancel',
-              style: AppTypography.headline.copyWith(
-                color: fg,
-              ),
+              style: AppTypography.headline.copyWith(color: fg),
             ),
           ),
         ),

--- a/lib/src/features/profile/delete/widgets/reason_choice_row.dart
+++ b/lib/src/features/profile/delete/widgets/reason_choice_row.dart
@@ -29,23 +29,30 @@ class ReasonChoiceRow extends StatelessWidget {
     final fill = selected ? AppColors.butter : AppColors.butterSoft;
     final fg = selected ? AppColors.greenDeep : AppColors.text;
 
-    return Material(
-      color: fill,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-      ),
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-        child: SizedBox(
-          width: double.infinity,
-          child: Padding(
-            // Figma: padding 12 on all sides.
-            padding: const EdgeInsets.all(AppSizes.sp12),
-            child: Text(
-              label,
-              style: AppTypography.headline.copyWith(
-                color: fg,
+    // Single-select choice: expose selected + button role so a screen reader
+    // announces which reason is picked (mirrors SettingsRow / RadioPill).
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      child: ExcludeSemantics(
+        child: Material(
+          color: fill,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          ),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            child: SizedBox(
+              width: double.infinity,
+              child: Padding(
+                // Figma: padding 12 on all sides.
+                padding: const EdgeInsets.all(AppSizes.sp12),
+                child: Text(
+                  label,
+                  style: AppTypography.headline.copyWith(color: fg),
+                ),
               ),
             ),
           ),

--- a/lib/src/features/profile/feedback/feedback_screen.dart
+++ b/lib/src/features/profile/feedback/feedback_screen.dart
@@ -186,6 +186,9 @@ class _FeedbackEntryScreen extends StatelessWidget {
                 key: const Key('feedback_send_button'),
                 label: 'Send Feedback',
                 variant: AppPillButtonVariant.ghost,
+                // Figma 1207:15287 = h42; small(40) is the closest token and
+                // matches the delete-overlay Continue CTA.
+                size: AppPillButtonSize.small,
                 onPressed: canSubmit ? onSubmit : null,
               ),
             ),


### PR DESCRIPTION
## Profile audit pass (autonomous loop — iteration 3)

Deep audit of profile PR-01 + delete-account overlay + give-feedback. 10 findings confirmed; this PR ships **3 clean, scoped fixes**. The rest are deferred (shared-component changes, freezed regen) or are owner-questions.

### Fixes
- **Radius token (DRY):** delete sheet hardcoded `Radius.circular(30)` ×2 (top corner + close pill) → `AppSizes.radius3xl` (the same token-bypass the shopping-list pass flagged; value-identical, zero pixel change). `delete_account_overlay.dart`
- **A11y:** `ReasonChoiceRow` (the 6 deletion-reason chips) had no selected/button semantics — a screen reader couldn't tell which reason was picked. Wrapped in `Semantics(selected:, button:, label:)` + `ExcludeSemantics`, mirroring `SettingsRow`/`RadioPill`. Zero visual change. `reason_choice_row.dart`
- **CTA height:** feedback Send button defaulted to `full` (52px); Figma `1207:15287` is 42px and the sibling delete-overlay Continue CTA already uses `small` (40px). Set `size: AppPillButtonSize.small`. `feedback_screen.dart`

### Verification
- `flutter analyze --fatal-infos --fatal-warnings` — clean
- Visual gate on iOS sim (QA-bypass + temp subscription fake → /home → profile → Give Feedback): Send CTA now renders **h=40, w=370** (was 52) ✓. Radius + a11y changes are pixel-identical / non-visual.

### Deferred
- **ProfileController reads Supabase directly** for a dead `ProfileState.email` field (HIGH — violates "no Supabase outside Repository") → batched with other dead-field removals that need freezed regen.
- Continue/Cancel CTA heights (40 vs 42), Cancel → new `AppPillButton` "plain" variant, feedback textarea → `AppTextField` multiline — all touch the **shared DS component** (and an out-of-feature allergen consumer) → owner-scoped, regression surface beyond profile.
- `_BrandLockup` grey placeholders (NIB-78 — wordmark/mascot SVGs not in repo; `BrandLogo` is a different composition) → owner.
- 32 owner-questions (sign-out `AlertDialog` off-DS, single-vs-multi-select reasons, deletion confirmation/reauth flow, feedback char-limit, etc.).

### Explicitly NOT changed (verified trap)
`settings_row` title looks like a hand-rolled `AppTypography.headline` and was flagged for migration — but `theme.textTheme.titleSmall` inherits Material-2021's `letterSpacing: 0.1` (ThemeData merges the provided textTheme onto the M3 Typography baseline), which `AppTypography.headline` lacks. Migrating would silently drop 0.1px. Confirmed via `app_theme.dart` + `app_typography.dart`; left as-is (matches the PR #310 exclusion).