### PR TITLE
refactor(profile,onboarding): remove dead state fields + Supabase-in-controller call

### DIFF
--- a/lib/src/features/onboarding/onboarding_controller.dart
+++ b/lib/src/features/onboarding/onboarding_controller.dart
@@ -99,31 +99,18 @@ class OnboardingController extends _$OnboardingController {
     state = state.copyWith(readinessAnswers: List<bool?>.unmodifiable(next));
   }
 
-  void setReadinessReady({required bool ready}) {
-    state = state.copyWith(readinessReady: ready);
-  }
-
-  /// Derives the readiness-ready flag from current answers, persists the
-  /// local-flag, and updates state. Called from the readiness screen's finish
-  /// step so the flag is flipped inside the controller before the router
-  /// redirect runs — avoids the race between fire-and-forget flag write and
-  /// GoRouter reading the stale value.
+  /// Persists the readiness-done local flag from inside the controller so it is
+  /// flipped before the router redirect runs — avoids the race between a
+  /// fire-and-forget flag write and GoRouter reading the stale value. The
+  /// readiness outcome is derived independently on the result screen (majority
+  /// gate), so no state field is written here.
   void completeReadiness() {
-    final allMet = state.readinessAnswers.every((a) => a ?? false);
-    state = state.copyWith(readinessReady: allMet);
     ref.read(localFlagServiceProvider).setOnboardingReadinessDone();
   }
 
   // ---------------------------------------------------------------------------
   // Consent + submit stage (P1)
   // ---------------------------------------------------------------------------
-
-  void setConsentAccepted({required bool accepted}) {
-    state = state.copyWith(
-      consentAccepted: accepted,
-      submitErrorMessage: null,
-    );
-  }
 
   /// Persists the baby on consent submit. Returns true on success — caller is
   /// expected to set `onboarding_done` and navigate to `/home`. On failure the

--- a/lib/src/features/onboarding/onboarding_state.dart
+++ b/lib/src/features/onboarding/onboarding_state.dart
@@ -32,8 +32,6 @@ class OnboardingState with _$OnboardingState {
     // safely on first build; kept in sync with [readinessQuestionCount].
     @Default(<bool?>[null, null, null, null, null])
     List<bool?> readinessAnswers,
-    @Default(false) bool readinessReady,
-    @Default(false) bool consentAccepted,
     @Default(false) bool isSubmitting,
     String? submitErrorMessage,
   }) = _OnboardingState;

--- a/lib/src/features/onboarding/onboarding_state.freezed.dart
+++ b/lib/src/features/onboarding/onboarding_state.freezed.dart
@@ -25,8 +25,6 @@ mixin _$OnboardingState {
       throw _privateConstructorUsedError; // Seeded as a length-5 nullable list so the readiness screen can index
   // safely on first build; kept in sync with [readinessQuestionCount].
   List<bool?> get readinessAnswers => throw _privateConstructorUsedError;
-  bool get readinessReady => throw _privateConstructorUsedError;
-  bool get consentAccepted => throw _privateConstructorUsedError;
   bool get isSubmitting => throw _privateConstructorUsedError;
   String? get submitErrorMessage => throw _privateConstructorUsedError;
 
@@ -49,8 +47,6 @@ abstract class $OnboardingStateCopyWith<$Res> {
     DateTime? dob,
     bool? pediatricianApproved,
     List<bool?> readinessAnswers,
-    bool readinessReady,
-    bool consentAccepted,
     bool isSubmitting,
     String? submitErrorMessage,
   });
@@ -75,8 +71,6 @@ class _$OnboardingStateCopyWithImpl<$Res, $Val extends OnboardingState>
     Object? dob = freezed,
     Object? pediatricianApproved = freezed,
     Object? readinessAnswers = null,
-    Object? readinessReady = null,
-    Object? consentAccepted = null,
     Object? isSubmitting = null,
     Object? submitErrorMessage = freezed,
   }) {
@@ -98,14 +92,6 @@ class _$OnboardingStateCopyWithImpl<$Res, $Val extends OnboardingState>
                 ? _value.readinessAnswers
                 : readinessAnswers // ignore: cast_nullable_to_non_nullable
                       as List<bool?>,
-            readinessReady: null == readinessReady
-                ? _value.readinessReady
-                : readinessReady // ignore: cast_nullable_to_non_nullable
-                      as bool,
-            consentAccepted: null == consentAccepted
-                ? _value.consentAccepted
-                : consentAccepted // ignore: cast_nullable_to_non_nullable
-                      as bool,
             isSubmitting: null == isSubmitting
                 ? _value.isSubmitting
                 : isSubmitting // ignore: cast_nullable_to_non_nullable
@@ -134,8 +120,6 @@ abstract class _$$OnboardingStateImplCopyWith<$Res>
     DateTime? dob,
     bool? pediatricianApproved,
     List<bool?> readinessAnswers,
-    bool readinessReady,
-    bool consentAccepted,
     bool isSubmitting,
     String? submitErrorMessage,
   });
@@ -159,8 +143,6 @@ class __$$OnboardingStateImplCopyWithImpl<$Res>
     Object? dob = freezed,
     Object? pediatricianApproved = freezed,
     Object? readinessAnswers = null,
-    Object? readinessReady = null,
-    Object? consentAccepted = null,
     Object? isSubmitting = null,
     Object? submitErrorMessage = freezed,
   }) {
@@ -182,14 +164,6 @@ class __$$OnboardingStateImplCopyWithImpl<$Res>
             ? _value._readinessAnswers
             : readinessAnswers // ignore: cast_nullable_to_non_nullable
                   as List<bool?>,
-        readinessReady: null == readinessReady
-            ? _value.readinessReady
-            : readinessReady // ignore: cast_nullable_to_non_nullable
-                  as bool,
-        consentAccepted: null == consentAccepted
-            ? _value.consentAccepted
-            : consentAccepted // ignore: cast_nullable_to_non_nullable
-                  as bool,
         isSubmitting: null == isSubmitting
             ? _value.isSubmitting
             : isSubmitting // ignore: cast_nullable_to_non_nullable
@@ -217,8 +191,6 @@ class _$OnboardingStateImpl implements _OnboardingState {
       null,
       null,
     ],
-    this.readinessReady = false,
-    this.consentAccepted = false,
     this.isSubmitting = false,
     this.submitErrorMessage,
   }) : _readinessAnswers = readinessAnswers;
@@ -248,19 +220,13 @@ class _$OnboardingStateImpl implements _OnboardingState {
 
   @override
   @JsonKey()
-  final bool readinessReady;
-  @override
-  @JsonKey()
-  final bool consentAccepted;
-  @override
-  @JsonKey()
   final bool isSubmitting;
   @override
   final String? submitErrorMessage;
 
   @override
   String toString() {
-    return 'OnboardingState(babyName: $babyName, dob: $dob, pediatricianApproved: $pediatricianApproved, readinessAnswers: $readinessAnswers, readinessReady: $readinessReady, consentAccepted: $consentAccepted, isSubmitting: $isSubmitting, submitErrorMessage: $submitErrorMessage)';
+    return 'OnboardingState(babyName: $babyName, dob: $dob, pediatricianApproved: $pediatricianApproved, readinessAnswers: $readinessAnswers, isSubmitting: $isSubmitting, submitErrorMessage: $submitErrorMessage)';
   }
 
   @override
@@ -277,10 +243,6 @@ class _$OnboardingStateImpl implements _OnboardingState {
               other._readinessAnswers,
               _readinessAnswers,
             ) &&
-            (identical(other.readinessReady, readinessReady) ||
-                other.readinessReady == readinessReady) &&
-            (identical(other.consentAccepted, consentAccepted) ||
-                other.consentAccepted == consentAccepted) &&
             (identical(other.isSubmitting, isSubmitting) ||
                 other.isSubmitting == isSubmitting) &&
             (identical(other.submitErrorMessage, submitErrorMessage) ||
@@ -294,8 +256,6 @@ class _$OnboardingStateImpl implements _OnboardingState {
     dob,
     pediatricianApproved,
     const DeepCollectionEquality().hash(_readinessAnswers),
-    readinessReady,
-    consentAccepted,
     isSubmitting,
     submitErrorMessage,
   );
@@ -318,8 +278,6 @@ abstract class _OnboardingState implements OnboardingState {
     final DateTime? dob,
     final bool? pediatricianApproved,
     final List<bool?> readinessAnswers,
-    final bool readinessReady,
-    final bool consentAccepted,
     final bool isSubmitting,
     final String? submitErrorMessage,
   }) = _$OnboardingStateImpl;
@@ -334,10 +292,6 @@ abstract class _OnboardingState implements OnboardingState {
   // safely on first build; kept in sync with [readinessQuestionCount].
   @override
   List<bool?> get readinessAnswers;
-  @override
-  bool get readinessReady;
-  @override
-  bool get consentAccepted;
   @override
   bool get isSubmitting;
   @override

--- a/lib/src/features/profile/profile_controller.dart
+++ b/lib/src/features/profile/profile_controller.dart
@@ -1,7 +1,6 @@
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/profile/profile_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 part 'profile_controller.g.dart';
 
@@ -15,7 +14,6 @@ class ProfileController extends _$ProfileController {
   @override
   Future<ProfileState> build(String babyId) async {
     final baby = await ref.read(babyProfileServiceProvider).getBaby();
-    final email = Supabase.instance.client.auth.currentUser?.email;
 
     // SubscriptionService is M2-deferred (NIB-73). Stub the label until the
     // paywall ships.
@@ -23,7 +21,6 @@ class ProfileController extends _$ProfileController {
 
     return ProfileState(
       baby: baby,
-      email: email,
       subscriptionLabel: subscriptionLabel,
     );
   }

--- a/lib/src/features/profile/profile_state.dart
+++ b/lib/src/features/profile/profile_state.dart
@@ -7,7 +7,6 @@ part 'profile_state.freezed.dart';
 class ProfileState with _$ProfileState {
   const factory ProfileState({
     Baby? baby,
-    String? email,
     String? subscriptionLabel,
   }) = _ProfileState;
 }

--- a/lib/src/features/profile/profile_state.freezed.dart
+++ b/lib/src/features/profile/profile_state.freezed.dart
@@ -18,7 +18,6 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$ProfileState {
   Baby? get baby => throw _privateConstructorUsedError;
-  String? get email => throw _privateConstructorUsedError;
   String? get subscriptionLabel => throw _privateConstructorUsedError;
 
   /// Create a copy of ProfileState
@@ -35,7 +34,7 @@ abstract class $ProfileStateCopyWith<$Res> {
     $Res Function(ProfileState) then,
   ) = _$ProfileStateCopyWithImpl<$Res, ProfileState>;
   @useResult
-  $Res call({Baby? baby, String? email, String? subscriptionLabel});
+  $Res call({Baby? baby, String? subscriptionLabel});
 
   $BabyCopyWith<$Res>? get baby;
 }
@@ -54,21 +53,13 @@ class _$ProfileStateCopyWithImpl<$Res, $Val extends ProfileState>
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? baby = freezed,
-    Object? email = freezed,
-    Object? subscriptionLabel = freezed,
-  }) {
+  $Res call({Object? baby = freezed, Object? subscriptionLabel = freezed}) {
     return _then(
       _value.copyWith(
             baby: freezed == baby
                 ? _value.baby
                 : baby // ignore: cast_nullable_to_non_nullable
                       as Baby?,
-            email: freezed == email
-                ? _value.email
-                : email // ignore: cast_nullable_to_non_nullable
-                      as String?,
             subscriptionLabel: freezed == subscriptionLabel
                 ? _value.subscriptionLabel
                 : subscriptionLabel // ignore: cast_nullable_to_non_nullable
@@ -102,7 +93,7 @@ abstract class _$$ProfileStateImplCopyWith<$Res>
   ) = __$$ProfileStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({Baby? baby, String? email, String? subscriptionLabel});
+  $Res call({Baby? baby, String? subscriptionLabel});
 
   @override
   $BabyCopyWith<$Res>? get baby;
@@ -121,21 +112,13 @@ class __$$ProfileStateImplCopyWithImpl<$Res>
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? baby = freezed,
-    Object? email = freezed,
-    Object? subscriptionLabel = freezed,
-  }) {
+  $Res call({Object? baby = freezed, Object? subscriptionLabel = freezed}) {
     return _then(
       _$ProfileStateImpl(
         baby: freezed == baby
             ? _value.baby
             : baby // ignore: cast_nullable_to_non_nullable
                   as Baby?,
-        email: freezed == email
-            ? _value.email
-            : email // ignore: cast_nullable_to_non_nullable
-                  as String?,
         subscriptionLabel: freezed == subscriptionLabel
             ? _value.subscriptionLabel
             : subscriptionLabel // ignore: cast_nullable_to_non_nullable
@@ -148,18 +131,16 @@ class __$$ProfileStateImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$ProfileStateImpl implements _ProfileState {
-  const _$ProfileStateImpl({this.baby, this.email, this.subscriptionLabel});
+  const _$ProfileStateImpl({this.baby, this.subscriptionLabel});
 
   @override
   final Baby? baby;
-  @override
-  final String? email;
   @override
   final String? subscriptionLabel;
 
   @override
   String toString() {
-    return 'ProfileState(baby: $baby, email: $email, subscriptionLabel: $subscriptionLabel)';
+    return 'ProfileState(baby: $baby, subscriptionLabel: $subscriptionLabel)';
   }
 
   @override
@@ -168,13 +149,12 @@ class _$ProfileStateImpl implements _ProfileState {
         (other.runtimeType == runtimeType &&
             other is _$ProfileStateImpl &&
             (identical(other.baby, baby) || other.baby == baby) &&
-            (identical(other.email, email) || other.email == email) &&
             (identical(other.subscriptionLabel, subscriptionLabel) ||
                 other.subscriptionLabel == subscriptionLabel));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, baby, email, subscriptionLabel);
+  int get hashCode => Object.hash(runtimeType, baby, subscriptionLabel);
 
   /// Create a copy of ProfileState
   /// with the given fields replaced by the non-null parameter values.
@@ -188,14 +168,11 @@ class _$ProfileStateImpl implements _ProfileState {
 abstract class _ProfileState implements ProfileState {
   const factory _ProfileState({
     final Baby? baby,
-    final String? email,
     final String? subscriptionLabel,
   }) = _$ProfileStateImpl;
 
   @override
   Baby? get baby;
-  @override
-  String? get email;
   @override
   String? get subscriptionLabel;
 

--- a/test/features/onboarding/onboarding_controller_test.dart
+++ b/test/features/onboarding/onboarding_controller_test.dart
@@ -133,15 +133,14 @@ void main() {
       expect(state.dob, DateTime(2025, 6));
     });
 
-    test('setReadinessAnswers + setReadinessReady update state', () {
+    test('setReadinessAnswers updates state', () {
       final container = _makeContainer(_MockBabyProfileService());
-      container.read(onboardingControllerProvider.notifier)
-        ..setReadinessAnswers(<bool?>[true, false, null])
-        ..setReadinessReady(ready: true);
+      container
+          .read(onboardingControllerProvider.notifier)
+          .setReadinessAnswers(<bool?>[true, false, null]);
 
       final state = container.read(onboardingControllerProvider);
       expect(state.readinessAnswers, [true, false, null]);
-      expect(state.readinessReady, isTrue);
     });
 
     test(
@@ -168,16 +167,5 @@ void main() {
       },
     );
 
-    test('setConsentAccepted toggles consent flag and clears submit error', () {
-      final container = _makeContainer(_MockBabyProfileService());
-      container
-          .read(onboardingControllerProvider.notifier)
-          .setConsentAccepted(accepted: true);
-
-      expect(
-        container.read(onboardingControllerProvider).consentAccepted,
-        isTrue,
-      );
-    });
   });
 }

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -83,13 +83,12 @@ final _fakeBaby = Baby(
 
 ProfileState _populatedState() => ProfileState(
       baby: _fakeBaby,
-      email: 'lily@example.com',
       subscriptionLabel: 'No Subscription',
     );
 
 // ---------------------------------------------------------------------------
-// Fake ProfileController — bypasses the Supabase.instance.client.auth call
-// the real notifier makes inside build().
+// Fake ProfileController — returns a fixed state so the test doesn't depend on
+// the real notifier's baby-profile service read inside build().
 // ---------------------------------------------------------------------------
 
 class _FakeProfileController extends ProfileController {


### PR DESCRIPTION
## Dead-field cleanup batch (autonomous loop — iteration 4)

Removes three audit-discovered dead in-memory `@freezed` state fields (written but read by no UI), batched into one `make gen`. Non-visual — analyze + tests only.

### Changes
- **profile `ProfileState.email`** *(HIGH)* — `ProfileController.build` filled it via a **direct Supabase call** (`Supabase.instance.client.auth.currentUser?.email`), violating the "never call Supabase outside the Repository layer" hard rule, to populate a field no screen reads. Removed the field, the call, and the now-unused `supabase_flutter` import.
- **onboarding `readinessReady`** — `completeReadiness` set it via an **all-5** rule that contradicted the result screen's settled **majority-3** gate (`signsMet >= readinessReadyThreshold`), and nothing read it. Removed the field + `setReadinessReady`; `completeReadiness` keeps only the local-flag write (the outcome is derived independently on the result screen).
- **onboarding `consentAccepted`** — consent is ephemeral (the screen tracks local `_checks`); `setConsentAccepted` was never called in production. Removed the field + setter.

### Verification
- `flutter analyze --fatal-infos --fatal-warnings` — clean (whole project)
- `flutter test` (onboarding controller + profile screen + readiness threshold) — all pass
- `make gen` regenerated `onboarding_state.freezed.dart` + `profile_state.freezed.dart`; reverted incidental riverpod hash-only churn in 3 unrelated `*.g.dart` (generator-version drift, not part of this change).

No behavior change — every removed field had no production reader; the kept `readinessReadyThreshold` majority gate and `completeReadiness` flag write are unaffected.