### PR TITLE
fix(subscription): cancel overlay radius token + reason-chip a11y (parity with delete-account)

### DIFF
--- a/lib/src/features/subscription/cancel/cancel_subscription_overlay.dart
+++ b/lib/src/features/subscription/cancel/cancel_subscription_overlay.dart
@@ -36,7 +36,7 @@ Future<void> showCancelSubscriptionOverlay(BuildContext context) {
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(
         // Figma sheet top corner radius = 30.
-        top: Radius.circular(30),
+        top: Radius.circular(AppSizes.radius3xl),
       ),
     ),
     builder: (_) => const _CancelSubscriptionSheet(),
@@ -231,7 +231,9 @@ class _SheetHeader extends StatelessWidget {
           constraints: const BoxConstraints(minWidth: 34, minHeight: 33),
           style: IconButton.styleFrom(
             shape: const RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(Radius.circular(30)),
+              borderRadius: BorderRadius.all(
+                Radius.circular(AppSizes.radius3xl),
+              ),
             ),
           ),
         ),
@@ -331,9 +333,7 @@ class _CancelButton extends StatelessWidget {
           child: Center(
             child: Text(
               'Cancel',
-              style: AppTypography.headline.copyWith(
-                color: fg,
-              ),
+              style: AppTypography.headline.copyWith(color: fg),
             ),
           ),
         ),

--- a/lib/src/features/subscription/cancel/widgets/cancel_reason_chip.dart
+++ b/lib/src/features/subscription/cancel/widgets/cancel_reason_chip.dart
@@ -33,24 +33,31 @@ class CancelReasonChip extends StatelessWidget {
         ? const BorderSide(color: AppColors.green, width: 1.5)
         : BorderSide.none;
 
-    return Material(
-      color: fill,
-      shape: RoundedRectangleBorder(
-        side: border,
-        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-      ),
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-        child: SizedBox(
-          width: double.infinity,
-          child: Padding(
-            // Figma: padding 12 on all sides.
-            padding: const EdgeInsets.all(AppSizes.sp12),
-            child: Text(
-              label,
-              style: AppTypography.headline.copyWith(
-                color: fg,
+    // Single-select choice: expose selected + button role so a screen reader
+    // announces which reason is picked (mirrors ReasonChoiceRow / SettingsRow).
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      child: ExcludeSemantics(
+        child: Material(
+          color: fill,
+          shape: RoundedRectangleBorder(
+            side: border,
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          ),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            child: SizedBox(
+              width: double.infinity,
+              child: Padding(
+                // Figma: padding 12 on all sides.
+                padding: const EdgeInsets.all(AppSizes.sp12),
+                child: Text(
+                  label,
+                  style: AppTypography.headline.copyWith(color: fg),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Subscription audit pass (autonomous loop — iteration 5)

Audited manage-subscription (subscribed + no-plan) + cancel overlay. 13 confirmed findings dedup to **2 fixes** — both non-visual, both bringing the cancel flow to parity with the delete-account overlay (the two are structural twins). 21 owner-questions deferred. The **Manage Subscription screen audited clean**.

### Fixes
- **Radius token (DRY):** `cancel_subscription_overlay` hardcoded `Radius.circular(30)` ×2 (sheet top corner + close-button shape) → `AppSizes.radius3xl`. Same token-bypass already fixed on the delete-account twin (#312/#314); value-identical (30), zero pixel change.
- **A11y parity:** `CancelReasonChip` (the 6 cancel-reason chips) had no selected/button semantics — a screen reader couldn't tell which reason was picked. Wrapped in `Semantics(button:, selected:, label:)` + `ExcludeSemantics`, exactly mirroring the `ReasonChoiceRow` fix from #314.

### Verification
- `flutter analyze --fatal-infos --fatal-warnings` — clean
- `flutter test` (cancel controller + overlay + manage screen) — all 16 pass
- Non-visual (radius 30→30 identical; Semantics is a zero-layout proxy) → no sim gate required.

### Deferred / owner-questions (21)
Cancel reason copy — trailing spaces + "I subscribed by  accident" double-space — are **deliberately preserved verbatim per Figma + ticket AC** (with clean analytics keys), like the app's other verbatim-Figma quirks; not bugs. Plus single-vs-multi-select reasons, a "selected" *visual* variant (vs this a11y-only fix), an "Are you sure?" confirmation step, date format/placeholder, "You all set!" exit path, the dual delete/cancel sheet reuse — all product/design decisions. Hand-rolled `_CancelButton` → a new `AppPillButton` "plain" variant remains the shared-DS deferral (same as delete-account).