### PR TITLE
refactor(allergen): AL-03 detail cleanup — dead babyId/refresh() + sp2 token

### DIFF
--- a/lib/src/features/allergen/detail/allergen_detail_controller.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_controller.dart
@@ -49,16 +49,10 @@ class AllergenDetailController extends _$AllergenDetailController {
       allergen: allergen,
       logs: logs,
       status: status,
-      babyId: baby.id,
       babyName: baby.name,
       firstIntroduced: firstIntroduced,
       lastGiven: lastGiven,
     );
-  }
-
-  Future<void> refresh() async {
-    ref.invalidateSelf();
-    await future;
   }
 
   void _throwIfFailure<T>(Result<T> result) {

--- a/lib/src/features/allergen/detail/allergen_detail_state.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_state.dart
@@ -11,7 +11,6 @@ class AllergenDetailState with _$AllergenDetailState {
     required Allergen allergen,
     required List<AllergenLog> logs,
     required AllergenStatus status,
-    required String babyId,
     required String babyName,
     // First introduced = min(logDate), Last given = max(logDate).
     // Null when there are 0 logs.

--- a/lib/src/features/allergen/detail/allergen_detail_state.freezed.dart
+++ b/lib/src/features/allergen/detail/allergen_detail_state.freezed.dart
@@ -20,7 +20,6 @@ mixin _$AllergenDetailState {
   Allergen get allergen => throw _privateConstructorUsedError;
   List<AllergenLog> get logs => throw _privateConstructorUsedError;
   AllergenStatus get status => throw _privateConstructorUsedError;
-  String get babyId => throw _privateConstructorUsedError;
   String get babyName =>
       throw _privateConstructorUsedError; // First introduced = min(logDate), Last given = max(logDate).
   // Null when there are 0 logs.
@@ -45,7 +44,6 @@ abstract class $AllergenDetailStateCopyWith<$Res> {
     Allergen allergen,
     List<AllergenLog> logs,
     AllergenStatus status,
-    String babyId,
     String babyName,
     DateTime? firstIntroduced,
     DateTime? lastGiven,
@@ -72,7 +70,6 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
     Object? allergen = null,
     Object? logs = null,
     Object? status = null,
-    Object? babyId = null,
     Object? babyName = null,
     Object? firstIntroduced = freezed,
     Object? lastGiven = freezed,
@@ -91,10 +88,6 @@ class _$AllergenDetailStateCopyWithImpl<$Res, $Val extends AllergenDetailState>
                 ? _value.status
                 : status // ignore: cast_nullable_to_non_nullable
                       as AllergenStatus,
-            babyId: null == babyId
-                ? _value.babyId
-                : babyId // ignore: cast_nullable_to_non_nullable
-                      as String,
             babyName: null == babyName
                 ? _value.babyName
                 : babyName // ignore: cast_nullable_to_non_nullable
@@ -136,7 +129,6 @@ abstract class _$$AllergenDetailStateImplCopyWith<$Res>
     Allergen allergen,
     List<AllergenLog> logs,
     AllergenStatus status,
-    String babyId,
     String babyName,
     DateTime? firstIntroduced,
     DateTime? lastGiven,
@@ -163,7 +155,6 @@ class __$$AllergenDetailStateImplCopyWithImpl<$Res>
     Object? allergen = null,
     Object? logs = null,
     Object? status = null,
-    Object? babyId = null,
     Object? babyName = null,
     Object? firstIntroduced = freezed,
     Object? lastGiven = freezed,
@@ -182,10 +173,6 @@ class __$$AllergenDetailStateImplCopyWithImpl<$Res>
             ? _value.status
             : status // ignore: cast_nullable_to_non_nullable
                   as AllergenStatus,
-        babyId: null == babyId
-            ? _value.babyId
-            : babyId // ignore: cast_nullable_to_non_nullable
-                  as String,
         babyName: null == babyName
             ? _value.babyName
             : babyName // ignore: cast_nullable_to_non_nullable
@@ -210,7 +197,6 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
     required this.allergen,
     required final List<AllergenLog> logs,
     required this.status,
-    required this.babyId,
     required this.babyName,
     this.firstIntroduced,
     this.lastGiven,
@@ -229,8 +215,6 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
   @override
   final AllergenStatus status;
   @override
-  final String babyId;
-  @override
   final String babyName;
   // First introduced = min(logDate), Last given = max(logDate).
   // Null when there are 0 logs.
@@ -241,7 +225,7 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
 
   @override
   String toString() {
-    return 'AllergenDetailState(allergen: $allergen, logs: $logs, status: $status, babyId: $babyId, babyName: $babyName, firstIntroduced: $firstIntroduced, lastGiven: $lastGiven)';
+    return 'AllergenDetailState(allergen: $allergen, logs: $logs, status: $status, babyName: $babyName, firstIntroduced: $firstIntroduced, lastGiven: $lastGiven)';
   }
 
   @override
@@ -253,7 +237,6 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
                 other.allergen == allergen) &&
             const DeepCollectionEquality().equals(other._logs, _logs) &&
             (identical(other.status, status) || other.status == status) &&
-            (identical(other.babyId, babyId) || other.babyId == babyId) &&
             (identical(other.babyName, babyName) ||
                 other.babyName == babyName) &&
             (identical(other.firstIntroduced, firstIntroduced) ||
@@ -268,7 +251,6 @@ class _$AllergenDetailStateImpl implements _AllergenDetailState {
     allergen,
     const DeepCollectionEquality().hash(_logs),
     status,
-    babyId,
     babyName,
     firstIntroduced,
     lastGiven,
@@ -291,7 +273,6 @@ abstract class _AllergenDetailState implements AllergenDetailState {
     required final Allergen allergen,
     required final List<AllergenLog> logs,
     required final AllergenStatus status,
-    required final String babyId,
     required final String babyName,
     final DateTime? firstIntroduced,
     final DateTime? lastGiven,
@@ -303,8 +284,6 @@ abstract class _AllergenDetailState implements AllergenDetailState {
   List<AllergenLog> get logs;
   @override
   AllergenStatus get status;
-  @override
-  String get babyId;
   @override
   String get babyName; // First introduced = min(logDate), Last given = max(logDate).
   // Null when there are 0 logs.

--- a/lib/src/features/allergen/detail/widgets/detail_header_card.dart
+++ b/lib/src/features/allergen/detail/widgets/detail_header_card.dart
@@ -62,7 +62,7 @@ class DetailHeaderCard extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
-                const SizedBox(height: 2),
+                const SizedBox(height: AppSizes.sp2),
                 Text(
                   _subtext,
                   style: textTheme.bodySmall?.copyWith(


### PR DESCRIPTION
## Audit loop — iteration 6: Allergen Detail (AL-03)

Per-feature deep audit of the allergen-detail screen. Shipping only the concrete, owner-unambiguous code-quality fixes; everything visual/contested is deferred to the owner (below).

### Shipped (3 fixes)
- Remove dead `babyId` field from `AllergenDetailState` (never read; `baby.id` is sourced live in the controller for `getLogs`). Regenerated `*.freezed.dart`.
- Remove dead `refresh()` method from `AllergenDetailController` (no callers).
- `SizedBox(height: 2)` → `SizedBox(height: AppSizes.sp2)` in `detail_header_card.dart` (token, visually identical).

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` → clean
- `flutter test test/features/allergen/detail/` → 5/5 pass
- Non-visual (dead-code + identical token) → no sim gate required
- `.g.dart` hash-noise reverted; diff is 4 files, +2/-30

### Deferred to owner (NOT shipped — visual/contested/product calls)
These surfaced during the audit but are owner decisions, not concrete violations:
- **Segment bar colour** — audit internally contradicted itself (coral vs green for in-progress). Needs Figma source-of-truth.
- **Add-button gating** — whether the "+" log button should be disabled at safe/flagged is a product call.
- **AppBar title "Details Allergen"** — grammar/UX wording tradeoff.
- **Status-pill colours/contrast** — DS tokens vs Figma values diverge; needs designer.
- **Gradient background** vs flat — Figma fidelity question.
- **Flagged-state segment + banner copy** — verbatim vs reworded.

No Linear ticket exists for any of the above; logged to the loop memory for owner triage.