### PR TITLE
fix(home): button-role a11y on allergen ring + ongoing/meal-row tap targets

### DIFF
--- a/lib/src/features/home/widgets/ongoing_introduced_card.dart
+++ b/lib/src/features/home/widgets/ongoing_introduced_card.dart
@@ -55,6 +55,13 @@ class OngoingIntroducedCard extends StatelessWidget {
     final name = AllergenEmoji.displayName(key);
     final filled = (logCounts[key] ?? 0).clamp(0, _target);
 
+    void handleTap() {
+      unawaited(
+        Analytics.instance.logHomeOngoingAllergenTapped(allergenKey: key),
+      );
+      context.pushNamed(AppRoute.allergenTracker.name);
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -65,62 +72,61 @@ class OngoingIntroducedCard extends StatelessWidget {
           ),
         ),
         const SizedBox(height: AppSizes.sm),
-        Material(
-          color: AppColors.surface,
-          borderRadius: BorderRadius.circular(AppSizes.radiusXl),
-          child: InkWell(
+        Semantics(
+          button: true,
+          label: '$name, introduced $filled of $_target times',
+          excludeSemantics: true,
+          onTap: handleTap,
+          child: Material(
+            color: AppColors.surface,
             borderRadius: BorderRadius.circular(AppSizes.radiusXl),
-            onTap: () {
-              unawaited(
-                Analytics.instance.logHomeOngoingAllergenTapped(
-                  allergenKey: key,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+              onTap: handleTap,
+              child: Ink(
+                decoration: BoxDecoration(
+                  color: AppColors.surface,
+                  borderRadius: BorderRadius.circular(AppSizes.radiusXl),
+                  boxShadow: AppSizes.shadowCard,
                 ),
-              );
-              context.pushNamed(AppRoute.allergenTracker.name);
-            },
-            child: Ink(
-              decoration: BoxDecoration(
-                color: AppColors.surface,
-                borderRadius: BorderRadius.circular(AppSizes.radiusXl),
-                boxShadow: AppSizes.shadowCard,
-              ),
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSizes.md - 2,
-                vertical: AppSizes.sp12,
-              ),
-              child: Row(
-                children: [
-                  _CoralThumb(emoji: emoji),
-                  const SizedBox(width: AppSizes.sp12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(name, style: AppTypography.emptyStateTitle),
-                        const SizedBox(height: AppSizes.sp2),
-                        Text(
-                          '$filled/$_target times ',
-                          style: AppTypography.caption.copyWith(
-                            color: AppColors.fgFaint,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.md - 2,
+                  vertical: AppSizes.sp12,
+                ),
+                child: Row(
+                  children: [
+                    _CoralThumb(emoji: emoji),
+                    const SizedBox(width: AppSizes.sp12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(name, style: AppTypography.emptyStateTitle),
+                          const SizedBox(height: AppSizes.sp2),
+                          Text(
+                            '$filled/$_target times ',
+                            style: AppTypography.caption.copyWith(
+                              color: AppColors.fgFaint,
+                            ),
                           ),
-                        ),
-                        const SizedBox(height: AppSizes.sm),
-                        AppSegmentedProgressBar(
-                          filledCount: filled,
-                          tone: AppSegmentedProgressTone.coral,
-                          height: 6,
-                        ),
-                      ],
+                          const SizedBox(height: AppSizes.sm),
+                          AppSegmentedProgressBar(
+                            filledCount: filled,
+                            tone: AppSegmentedProgressTone.coral,
+                            height: 6,
+                          ),
+                        ],
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: AppSizes.sm),
-                  const Icon(
-                    Icons.chevron_right,
-                    size: AppSizes.iconMd,
-                    color: AppColors.fgFaint,
-                  ),
-                ],
+                    const SizedBox(width: AppSizes.sm),
+                    const Icon(
+                      Icons.chevron_right,
+                      size: AppSizes.iconMd,
+                      color: AppColors.fgFaint,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/src/features/home/widgets/stat_ring_card.dart
+++ b/lib/src/features/home/widgets/stat_ring_card.dart
@@ -87,15 +87,23 @@ class StatRingCard extends StatelessWidget {
               ),
               const SizedBox(width: AppSizes.sp12),
               Expanded(
-                child: GestureDetector(
-                  behavior: HitTestBehavior.opaque,
+                child: Semantics(
+                  button: onAllergenTap != null,
+                  label:
+                      'Allergen progress, $safeCount of '
+                      '$_allergenTotal safe',
+                  excludeSemantics: true,
                   onTap: onAllergenTap,
-                  child: _StatRing(
-                    label: 'ALLERGEN',
-                    value: '$safeCount',
-                    max: '/$_allergenTotal',
-                    numerator: safeCount,
-                    denominator: _allergenTotal,
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: onAllergenTap,
+                    child: _StatRing(
+                      label: 'ALLERGEN',
+                      value: '$safeCount',
+                      max: '/$_allergenTotal',
+                      numerator: safeCount,
+                      denominator: _allergenTotal,
+                    ),
                   ),
                 ),
               ),

--- a/lib/src/features/home/widgets/todays_meals_card.dart
+++ b/lib/src/features/home/widgets/todays_meals_card.dart
@@ -233,48 +233,54 @@ class _MealRow extends StatelessWidget {
         _TagChipData(label: tag, icon: Icons.bolt),
     ];
 
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-        onTap: () {
-          unawaited(
-            Analytics.instance.logRecipeViewed(recipeId: entry.recipeId),
-          );
-          context.pushNamed(
-            AppRoute.recipeDetail.name,
-            pathParameters: {'recipeId': entry.recipeId},
-          );
-        },
-        child: Padding(
-          padding: const EdgeInsets.all(AppSizes.xs),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _MealThumbnail(url: recipe?.thumbnailUrl),
-              const SizedBox(width: AppSizes.sp12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      title,
-                      style: AppTypography.textTheme.labelLarge?.copyWith(
-                        fontWeight: FontWeight.w700,
-                        color: AppColors.fgStrong,
+    void handleTap() {
+      unawaited(Analytics.instance.logRecipeViewed(recipeId: entry.recipeId));
+      context.pushNamed(
+        AppRoute.recipeDetail.name,
+        pathParameters: {'recipeId': entry.recipeId},
+      );
+    }
+
+    return Semantics(
+      button: true,
+      label: 'Meal, $title',
+      excludeSemantics: true,
+      onTap: handleTap,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+          onTap: handleTap,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSizes.xs),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _MealThumbnail(url: recipe?.thumbnailUrl),
+                const SizedBox(width: AppSizes.sp12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        title,
+                        style: AppTypography.textTheme.labelLarge?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.fgStrong,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
                       ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    if (tags.isNotEmpty) ...[
-                      const SizedBox(height: AppSizes.xs),
-                      _TagChipsRow(tags: tags),
+                      if (tags.isNotEmpty) ...[
+                        const SizedBox(height: AppSizes.xs),
+                        _TagChipsRow(tags: tags),
+                      ],
                     ],
-                  ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/test/features/home/widgets/ongoing_introduced_card_test.dart
+++ b/test/features/home/widgets/ongoing_introduced_card_test.dart
@@ -190,4 +190,25 @@ void main() {
 
     expect(find.text('TRACKER_STUB'), findsOneWidget);
   });
+
+  testWidgets('exposes a labelled button via Semantics (a11y)', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      _wrap(
+        const OngoingIntroducedCard(
+          allergenStatuses: {'peanut': AllergenStatus.inProgress},
+          logCounts: {'peanut': 2},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.bySemanticsLabel('Peanut, introduced 2 of 3 times'),
+      findsOneWidget,
+    );
+
+    handle.dispose();
+  });
 }

--- a/test/features/home/widgets/stat_ring_card_test.dart
+++ b/test/features/home/widgets/stat_ring_card_test.dart
@@ -104,4 +104,38 @@ void main() {
       expect(find.text('✓ Active Program Allergens'), findsOneWidget);
     });
   });
+
+  group('StatRingCard — allergen ring a11y', () {
+    testWidgets(
+      'tappable ALLERGEN ring exposes a labelled button + fires onAllergenTap',
+      (tester) async {
+        final handle = tester.ensureSemantics();
+        var tapped = false;
+
+        await tester.pumpWidget(
+          _wrap(
+            StatRingCard(
+              safeCount: 3,
+              flaggedCount: 0,
+              notStartedCount: 6,
+              inProgressCount: 0,
+              onAllergenTap: () => tapped = true,
+            ),
+          ),
+        );
+
+        expect(
+          find.bySemanticsLabel('Allergen progress, 3 of 9 safe'),
+          findsOneWidget,
+        );
+
+        await tester.tap(
+          find.bySemanticsLabel('Allergen progress, 3 of 9 safe'),
+        );
+        expect(tapped, isTrue);
+
+        handle.dispose();
+      },
+    );
+  });
 }

--- a/test/features/home/widgets/todays_meals_card_test.dart
+++ b/test/features/home/widgets/todays_meals_card_test.dart
@@ -321,4 +321,36 @@ void main() {
       expect(find.text("TODAY'S MEALS"), findsOneWidget);
     });
   });
+
+  group('TodaysMealsCard — meal row a11y', () {
+    testWidgets(
+      'meal row exposes a labelled button + tap navigates to recipe detail',
+      (tester) async {
+        tester.view.physicalSize = const Size(1080, 2400);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        final handle = tester.ensureSemantics();
+
+        await tester.pumpWidget(
+          _wrap(
+            TodaysMealsCard(
+              todaysMeals: [_entry('m1', 'r1')],
+              recipes: {'r1': _recipe()},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        const label = 'Meal, Chicken Liver, Apple & Sweet Potato Purée';
+        expect(find.bySemanticsLabel(label), findsOneWidget);
+
+        await tester.tap(find.bySemanticsLabel(label));
+        await tester.pumpAndSettle();
+        expect(find.text('RECIPE_STUB:r1'), findsOneWidget);
+
+        handle.dispose();
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Audit loop — iteration 8: Home dashboard a11y pass

Completes the iter7 deferred a11y items. Three tappable home targets had no button role / accessible name for screen readers; this adds one. All changes are **non-visual** (Semantics annotations only — zero pixel change).

### Shipped (3 widgets + tests)
Each tappable target now wraps in `Semantics(button: true, label: <curated>, excludeSemantics: true, onTap: <handler>)`:
- **stat_ring_card** — ALLERGEN ring (a bare `GestureDetector`) → `'Allergen progress, N of 9 safe'`. `button` is gated on `onAllergenTap != null` (the ring is only interactive when wired).
- **ongoing_introduced_card** — the whole-card `InkWell` → `'<Allergen>, introduced N of 3 times'`.
- **todays_meals_card** `_MealRow` — the row `InkWell` → `'Meal, <recipe title>'`.

**Why `excludeSemantics` + explicit `Semantics.onTap` (not bare MergeSemantics):** an InkWell already emits a tap *action* but no button *role*; wrapping it in a plain `Semantics(button:true)` would leave two nodes. `excludeSemantics: true` collapses the noisy descendant text into one node, and duplicating the handler on `Semantics.onTap` preserves assistive-tech activation while the InkWell/GestureDetector still handles pointer taps. Result: one clean, curated, activatable button node per target.

### Tests (meaningful assertions, portable matchers)
Added one a11y test per widget — asserts the curated label via `find.bySemanticsLabel(...)` (+ tap fires the handler / navigates). Uses the portable finder, **not** the version-skewed `containsSemantics`/`hasFlag` matchers.

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` (home lib + tests) → clean
- `flutter test test/features/home/` → **48/48 pass** (+3 new; existing navigation taps still green — excludeSemantics doesn't break pointer taps)
- Non-visual (Semantics only) → no sim gate

### Deferred (unchanged from iter7, not re-flagged)
- avatar `person_outline` vs baby-name initial (Figma question)
- `_shortMonths` duplicated across 3 widgets / age-in-months dup / `day_chip_row` reimplements shared `DayChip` (multi-file DRY)
- `StatRingCard` unused `flaggedCount`/`notStartedCount`/`inProgressCount` (NIB-86 signature parity)