### PR TITLE
fix(recipe): button-role a11y on grid card + read-guide CTA (library a11y sweep)

### DIFF
--- a/lib/src/features/recipe/library/widgets/read_guide_banner.dart
+++ b/lib/src/features/recipe/library/widgets/read_guide_banner.dart
@@ -52,10 +52,7 @@ class ReadGuideBanner extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const Text(
-            'New to Starting Solids?',
-            style: _bannerTitleStyle,
-          ),
+          const Text('New to Starting Solids?', style: _bannerTitleStyle),
           const SizedBox(height: AppSizes.sp12),
           Text(
             'Start your baby’s food journey the right way with simple '
@@ -103,22 +100,25 @@ class _ReadGuideCta extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      borderRadius: BorderRadius.circular(AppSizes.lg),
-      child: InkWell(
+    return Semantics(
+      button: true,
+      label: 'Read Guide',
+      excludeSemantics: true,
+      onTap: onTap,
+      child: Material(
+        color: Colors.transparent,
         borderRadius: BorderRadius.circular(AppSizes.lg),
-        onTap: onTap,
-        child: Container(
-          padding: const EdgeInsets.all(AppSizes.radiusMd),
-          decoration: BoxDecoration(
-            border: Border.all(color: AppColors.cream),
-            borderRadius: BorderRadius.circular(AppSizes.lg),
-          ),
-          alignment: Alignment.center,
-          child: const Text(
-            'Read Guide',
-            style: _ctaLabelStyle,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppSizes.lg),
+          onTap: onTap,
+          child: Container(
+            padding: const EdgeInsets.all(AppSizes.radiusMd),
+            decoration: BoxDecoration(
+              border: Border.all(color: AppColors.cream),
+              borderRadius: BorderRadius.circular(AppSizes.lg),
+            ),
+            alignment: Alignment.center,
+            child: const Text('Read Guide', style: _ctaLabelStyle),
           ),
         ),
       ),

--- a/lib/src/features/recipe/library/widgets/recipe_grid_card.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_grid_card.dart
@@ -41,46 +41,52 @@ class RecipeGridCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final isUnsafe = _hasUnsafeAllergen;
 
-    return GestureDetector(
+    return Semantics(
+      button: true,
+      label: isUnsafe ? '${recipe.title}, not safe' : recipe.title,
+      excludeSemantics: true,
       onTap: onTap,
-      child: Opacity(
-        opacity: isUnsafe ? 0.85 : 1,
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-          child: ColoredBox(
-            color: AppColors.cream,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _CardThumbnail(url: recipe.thumbnailUrl, isUnsafe: isUnsafe),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.all(AppSizes.sp12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        SizedBox(
-                          height: _titleBlockHeight,
-                          child: Text(
-                            recipe.title,
-                            style: const TextStyle(
-                              fontFamily: FontFamily.parkinsans,
-                              fontSize: 13,
-                              fontWeight: FontWeight.w600,
-                              height: 20 / 13,
-                              color: AppColors.fgStrong,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Opacity(
+          opacity: isUnsafe ? 0.85 : 1,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+            child: ColoredBox(
+              color: AppColors.cream,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _CardThumbnail(url: recipe.thumbnailUrl, isUnsafe: isUnsafe),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.all(AppSizes.sp12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          SizedBox(
+                            height: _titleBlockHeight,
+                            child: Text(
+                              recipe.title,
+                              style: const TextStyle(
+                                fontFamily: FontFamily.parkinsans,
+                                fontSize: 13,
+                                fontWeight: FontWeight.w600,
+                                height: 20 / 13,
+                                color: AppColors.fgStrong,
+                              ),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
                             ),
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
                           ),
-                        ),
-                        _NutritionChipRow(tags: recipe.nutritionTags),
-                      ],
+                          _NutritionChipRow(tags: recipe.nutritionTags),
+                        ],
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/test/features/recipe/library/widgets/read_guide_banner_test.dart
+++ b/test/features/recipe/library/widgets/read_guide_banner_test.dart
@@ -1,0 +1,28 @@
+// a11y coverage for `ReadGuideBanner` — the "Read Guide" CTA is styled as a
+// button but was a bare InkWell with no button role; assert it now exposes a
+// labelled button that activates the handler.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/features/recipe/library/widgets/read_guide_banner.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  testWidgets('Read Guide CTA exposes a labelled button + fires onTap', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+    var tapped = false;
+
+    await tester.pumpWidget(_wrap(ReadGuideBanner(onTap: () => tapped = true)));
+    await tester.pump();
+
+    expect(find.bySemanticsLabel('Read Guide'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('Read Guide'));
+    expect(tapped, isTrue);
+
+    handle.dispose();
+  });
+}

--- a/test/features/recipe/library/widgets/recipe_grid_card_test.dart
+++ b/test/features/recipe/library/widgets/recipe_grid_card_test.dart
@@ -1,0 +1,65 @@
+// a11y coverage for `RecipeGridCard` — the tappable card must expose a
+// labelled button role, and a flagged-allergen recipe must surface its
+// "not safe" state in the accessible name (it is otherwise a visual-only
+// chip a screen reader would miss).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/features/recipe/library/widgets/recipe_grid_card.dart';
+
+Recipe _recipe({List<String> allergenTags = const <String>[]}) => Recipe(
+  id: 'r1',
+  title: 'Pea Puree',
+  ageRange: '6+ months',
+  allergenTags: allergenTags,
+  ingredients: const [],
+  steps: const [],
+  howToServe: '',
+);
+
+Widget _wrap(Widget child) => MaterialApp(
+  home: Scaffold(
+    body: Center(child: SizedBox(width: 158, height: 220, child: child)),
+  ),
+);
+
+void main() {
+  testWidgets('exposes a labelled button + fires onTap', (tester) async {
+    final handle = tester.ensureSemantics();
+    var tapped = false;
+
+    await tester.pumpWidget(
+      _wrap(RecipeGridCard(recipe: _recipe(), onTap: () => tapped = true)),
+    );
+    await tester.pump();
+
+    expect(find.bySemanticsLabel('Pea Puree'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('Pea Puree'));
+    expect(tapped, isTrue);
+
+    handle.dispose();
+  });
+
+  testWidgets('flagged-allergen recipe surfaces "not safe" in the label', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      _wrap(
+        RecipeGridCard(
+          recipe: _recipe(allergenTags: const ['peanut']),
+          onTap: () {},
+          flaggedAllergenKeys: const {'peanut'},
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.bySemanticsLabel('Pea Puree, not safe'), findsOneWidget);
+
+    handle.dispose();
+  });
+}


### PR DESCRIPTION
## Audit loop — iteration 9: cross-feature a11y sweep → Recipe Library

Iter8's home a11y pass surfaced a recurring pattern app-wide: tappable `GestureDetector`/`InkWell` targets with no button role / accessible name. This tick scopes the sweep to **Recipe Library** (the largest single-feature cluster of genuine nav/action targets). All changes are **non-visual** (Semantics only — zero pixel change).

### Shipped (2 widgets + 3 tests)
Same proven pattern — `Semantics(button: true, label: <curated>, excludeSemantics: true, onTap: <handler>)`:
- **recipe_grid_card** — the card `GestureDetector` (primary card→recipe-detail nav) → label is the recipe title, **and surfaces the "Not safe" flag** (`'<title>, not safe'`) which was previously a visual-only chip a screen reader would miss.
- **read_guide_banner** — the "Read Guide" CTA (styled as a button but a bare `InkWell`) → `'Read Guide'` button role.

### Tests
Added isolated widget tests (`recipe_grid_card_test`, `read_guide_banner_test`): assert the curated label via `find.bySemanticsLabel` + tap fires the handler; grid card also asserts the flagged-allergen label variant. Portable matchers (no `containsSemantics`/`hasFlag`).

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` (library lib + tests) → clean
- `flutter test test/features/recipe/library/` → all pass (existing screen test's card-tap navigation still green — `excludeSemantics` doesn't break pointer taps)
- Non-visual (Semantics only) → no sim gate

### Sweep status / deferred (cross-feature, NOT done this tick)
The app-wide grep found many more tappable-without-button-role targets — to be picked up in later ticks, one feature per PR (decompose-and-defer):
- **meal_plan** (day_accordion_card, inline_calendar, browse_meal_recipe_card, picked_recipe_row, day_chip_row, recommendation_carousel, header, range sheet)
- **shopping_list** (swipe_reveal_row, shopping_list_menu, add_ingredient_card)
- **allergen/log** (attachment_sheet, photo_capture_button, taste_selector), **starting_guide** (guide_back_button, guide_cta_pill)
- **Shared-DS — owner call (NOT loop-shippable):** app_card, day_chip, app_segmented_control, app_bottom_nav, app_pill_button — these need a DS-level fix so every consumer inherits it.