### PR TITLE
fix(shopping-list): button-role a11y on overflow menu + add pill (a11y sweep)

### DIFF
--- a/lib/src/features/shopping_list/widgets/add_ingredient_card.dart
+++ b/lib/src/features/shopping_list/widgets/add_ingredient_card.dart
@@ -151,20 +151,26 @@ class _AddPillButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    return Semantics(
+      button: true,
+      label: 'Add',
+      excludeSemantics: true,
       onTap: onTap,
-      child: Container(
-        width: 77,
-        height: 30,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: AppColors.butter,
-          borderRadius: BorderRadius.circular(AppSizes.radius2xl),
-        ),
-        child: Text(
-          'Add',
-          style: AppTypography.headline.copyWith(color: AppColors.greenDeep),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          width: 77,
+          height: 30,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: AppColors.butter,
+            borderRadius: BorderRadius.circular(AppSizes.radius2xl),
+          ),
+          child: Text(
+            'Add',
+            style: AppTypography.headline.copyWith(color: AppColors.greenDeep),
+          ),
         ),
       ),
     );

--- a/lib/src/features/shopping_list/widgets/shopping_list_menu.dart
+++ b/lib/src/features/shopping_list/widgets/shopping_list_menu.dart
@@ -81,10 +81,16 @@ class _ShoppingListOverflowMenuState extends State<ShoppingListOverflowMenu> {
             ],
           );
         },
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
+        child: Semantics(
+          button: true,
+          label: 'More options',
+          excludeSemantics: true,
           onTap: _toggle,
-          child: widget.child,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: _toggle,
+            child: widget.child,
+          ),
         ),
       ),
     );
@@ -161,35 +167,41 @@ class _MenuRowState extends State<_MenuRow> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    return Semantics(
+      button: true,
+      label: widget.label,
+      excludeSemantics: true,
       onTap: widget.onTap,
-      onTapDown: (_) => _setPressed(true),
-      onTapCancel: () => _setPressed(false),
-      onTapUp: (_) => _setPressed(false),
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 80),
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSizes.sp12,
-          vertical: 6,
-        ),
-        decoration: BoxDecoration(
-          // Press feedback is a neutral wash, not lime — pressing a row
-          // must not flash yellow (backlog #6).
-          color: _pressed ? AppColors.surfaceVariant : Colors.transparent,
-          borderRadius: BorderRadius.circular(6),
-        ),
-        child: Row(
-          children: [
-            Icon(widget.icon, size: 18, color: AppColors.text),
-            const SizedBox(width: AppSizes.sm),
-            Expanded(
-              child: Text(
-                widget.label,
-                style: AppTypography.textTheme.bodyLarge,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: widget.onTap,
+        onTapDown: (_) => _setPressed(true),
+        onTapCancel: () => _setPressed(false),
+        onTapUp: (_) => _setPressed(false),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 80),
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.sp12,
+            vertical: 6,
+          ),
+          decoration: BoxDecoration(
+            // Press feedback is a neutral wash, not lime — pressing a row
+            // must not flash yellow (backlog #6).
+            color: _pressed ? AppColors.surfaceVariant : Colors.transparent,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Row(
+            children: [
+              Icon(widget.icon, size: 18, color: AppColors.text),
+              const SizedBox(width: AppSizes.sm),
+              Expanded(
+                child: Text(
+                  widget.label,
+                  style: AppTypography.textTheme.bodyLarge,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/test/features/shopping_list/widgets/add_ingredient_card_test.dart
+++ b/test/features/shopping_list/widgets/add_ingredient_card_test.dart
@@ -1,0 +1,50 @@
+// a11y coverage for the Add-ingredient sheet's "Add" pill — a bare
+// GestureDetector with no button role. Assert it exposes a labelled button
+// that fires the onAdd handler.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/features/shopping_list/widgets/add_ingredient_card.dart';
+
+void main() {
+  testWidgets('Add pill exposes a labelled button + fires onAdd', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+    var added = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => Center(
+              child: ElevatedButton(
+                onPressed: () => showAddIngredientSheet(
+                  ctx,
+                  controller: controller,
+                  focusNode: focusNode,
+                  onAdd: () => added = true,
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Add'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('Add'));
+    expect(added, isTrue);
+
+    handle.dispose();
+  });
+}

--- a/test/features/shopping_list/widgets/shopping_list_menu_test.dart
+++ b/test/features/shopping_list/widgets/shopping_list_menu_test.dart
@@ -1,0 +1,44 @@
+// a11y coverage for `ShoppingListOverflowMenu` — the overflow trigger and the
+// two menu rows were bare GestureDetectors with no button role / name. Assert
+// the trigger is a labelled button that opens the menu, and each row is a
+// labelled button that fires its action.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/features/shopping_list/widgets/shopping_list_menu.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+  home: Scaffold(body: Center(child: child)),
+);
+
+void main() {
+  testWidgets('trigger + rows expose labelled buttons; row fires its action', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+    ShoppingListMenuAction? selected;
+
+    await tester.pumpWidget(
+      _wrap(
+        ShoppingListOverflowMenu(
+          onSelected: (a) => selected = a,
+          child: const Icon(Icons.more_horiz),
+        ),
+      ),
+    );
+
+    expect(find.bySemanticsLabel('More options'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('More options'));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Copy to Clipboard'), findsOneWidget);
+    expect(find.bySemanticsLabel('Clear All Shopping List'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('Clear All Shopping List'));
+    await tester.pumpAndSettle();
+    expect(selected, ShoppingListMenuAction.clear);
+
+    handle.dispose();
+  });
+}


### PR DESCRIPTION
## Audit loop — iteration 10: a11y sweep → Shopping List menu + add

Continues the cross-feature a11y button-role sweep (iter8 home, iter9 recipe-library). This tick: the Shopping List overflow menu + add-ingredient pill. All changes **non-visual** (Semantics only).

### Shipped (2 widgets, 3 targets + 2 tests)
Each genuine tap target now wraps in `Semantics(button: true, label: <curated>, excludeSemantics: true, onTap: <handler>)`:
- **shopping_list_menu** — the overflow **trigger** (bare `GestureDetector` around a caller-supplied icon, no name) → `'More options'`; and both **menu rows** (`_MenuRow`) → their action labels (`'Copy to Clipboard'`, `'Clear All Shopping List'`). The tap-outside dismiss **barrier** is deliberately left untouched (it's a scrim, not a button). Row press-state feedback (`onTapDown/Up/Cancel`) is preserved on the inner GestureDetector.
- **add_ingredient_card** — the **"Add" pill** (`_AddPillButton`, bare GestureDetector) → `'Add'`.

### Tests
Isolated widget tests via the public surfaces:
- `shopping_list_menu_test` — taps the `'More options'` button → menu opens → asserts both row labels → tapping `'Clear All Shopping List'` fires `ShoppingListMenuAction.clear`.
- `add_ingredient_card_test` — opens the sheet via `showAddIngredientSheet`, asserts the `'Add'` button label + that tapping it fires `onAdd`.
Portable `find.bySemanticsLabel` + tap (no `containsSemantics`/`hasFlag`).

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` (lib + tests) → clean
- `flutter test test/features/shopping_list/` → all pass (existing screen tests that drive the menu via `find.byIcon`/`find.text` still green — `excludeSemantics` doesn't break pointer taps or widget finders)
- Non-visual → no sim gate

### Sweep status / deferred
- **swipe_reveal_row** (`_DeletePill` + the swipe `GestureDetector`) deferred — Dismissible-style swipe gestures need careful verification that a Semantics wrap doesn't interfere; separate tick.
- New finding (other feature, logged for owner): **`GuideCtaPill` (starting_guide) is dead code** — zero usages app-wide; likely an unwired article-screen CTA. Owner: delete or wire up.
- Remaining a11y-sweep targets (one feature/PR): meal_plan cluster, allergen/log, starting_guide (GuideBackButton), recipe/detail sheets, profile/subscription overlays. Shared-DS widgets (app_card/day_chip/app_segmented_control/app_bottom_nav/app_pill_button) deferred to an owner DS-level pass.