### PR TITLE
fix(starting-guide): 'Back' button-role a11y on icon-only back button

### DIFF
--- a/lib/src/features/starting_guide/widgets/guide_back_button.dart
+++ b/lib/src/features/starting_guide/widgets/guide_back_button.dart
@@ -12,19 +12,25 @@ class GuideBackButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      shape: const CircleBorder(),
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        onTap: onTap,
-        child: const SizedBox(
-          width: AppSizes.roundButtonSm,
-          height: AppSizes.roundButtonSm,
-          child: Icon(
-            Icons.arrow_back_rounded,
-            color: AppColors.greenDeep,
-            size: AppSizes.iconMd,
+    return Semantics(
+      button: true,
+      label: 'Back',
+      excludeSemantics: true,
+      onTap: onTap,
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: onTap,
+          child: const SizedBox(
+            width: AppSizes.roundButtonSm,
+            height: AppSizes.roundButtonSm,
+            child: Icon(
+              Icons.arrow_back_rounded,
+              color: AppColors.greenDeep,
+              size: AppSizes.iconMd,
+            ),
           ),
         ),
       ),

--- a/test/features/starting_guide/widgets/guide_back_button_test.dart
+++ b/test/features/starting_guide/widgets/guide_back_button_test.dart
@@ -1,0 +1,26 @@
+// a11y coverage for `GuideBackButton` — an icon-only back button that had no
+// accessible name. Assert it now exposes a "Back" button that fires onTap.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/features/starting_guide/widgets/guide_back_button.dart';
+
+void main() {
+  testWidgets('exposes a "Back" button + fires onTap', (tester) async {
+    final handle = tester.ensureSemantics();
+    var tapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: GuideBackButton(onTap: () => tapped = true)),
+      ),
+    );
+
+    expect(find.bySemanticsLabel('Back'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('Back'));
+    expect(tapped, isTrue);
+
+    handle.dispose();
+  });
+}


### PR DESCRIPTION
## Audit loop — iteration 11: a11y sweep → starting_guide back button

Continues the cross-feature a11y button-role sweep (iter8 home, iter9 recipe-library, iter10 shopping-list). All changes **non-visual** (Semantics only).

### Shipped (1 widget + test)
- **guide_back_button** — `GuideBackButton` was an icon-only InkWell (`arrow_back_rounded`) with **no accessible name at all** (the most severe a11y gap class — a screen reader announced nothing). Now wraps in `Semantics(button: true, label: 'Back', excludeSemantics: true, onTap: onTap)`. Used in the starting-guide hub AppBar `leading` slot.
- Added `guide_back_button_test` — `find.bySemanticsLabel('Back')` + tap fires `onTap`.

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` → clean
- New test passes; non-visual → no sim gate

### Findings logged for owner (NOT in scope of this PR)
- **Dead code (3 extracted-but-unwired widgets, zero usages app-wide):** `GuideCtaPill` (starting_guide), `TasteSelector` + `PhotoCaptureButton` (allergen/log). The live allergen-log UI is inline in `allergen_log_screen.dart`, so these extractions are unused. Owner: delete or wire up.
- **Pre-existing broken test (NOT my regression):** `starting_guide_hub_screen_test.dart` › "renders the hub header title and subtitle" fails on clean `main` — it expects a `'Bite-sized reads'` subtitle that is not in the screen source. Either the test is stale or the **screen is missing intended Figma copy** — owner/Figma call. (It hasn't blocked CI because CI runs only `flutter analyze`, not `flutter test`.)
- **Remaining a11y gap in allergen-log:** `_AttachmentBlock` "Add/Edit Picture" InkWell CTA has no button role (the screen's `_DateField` + `_ReactionToggleRow` already do) — next allergen-log tick.

### Remaining sweep targets (one feature/PR)
meal_plan cluster · recipe/detail sheets (check already-semantic) · profile/subscription overlays · allergen-log `_AttachmentBlock` · shopping_list `swipe_reveal_row` (Dismissible caution). Shared-DS widgets deferred to an owner DS-level pass.