### PR TITLE
fix(allergen): attachment CTA button-role a11y + repair stale notes-hint test

### DIFF
--- a/lib/src/features/allergen/log/allergen_log_screen.dart
+++ b/lib/src/features/allergen/log/allergen_log_screen.dart
@@ -29,11 +29,7 @@ import 'package:nibbles/src/routing/route_enums.dart';
 /// Pops with a [bool] result — `true` when a log was saved (caller should
 /// invalidate upstream lists).
 class AllergenLogScreen extends ConsumerStatefulWidget {
-  const AllergenLogScreen({
-    required this.allergenKey,
-    this.logId,
-    super.key,
-  });
+  const AllergenLogScreen({required this.allergenKey, this.logId, super.key});
 
   final String allergenKey;
   final String? logId;
@@ -403,8 +399,9 @@ class _DateField extends StatelessWidget {
               borderRadius: BorderRadius.circular(AppSizes.radiusMd),
               border: Border.all(color: AppColors.borderSoft),
             ),
-            padding:
-                const EdgeInsets.symmetric(horizontal: AppSizes.fieldPaddingH),
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.fieldPaddingH,
+            ),
             alignment: Alignment.centerLeft,
             child: Text(
               hasValue ? value! : hint,
@@ -458,10 +455,7 @@ class _NotesField extends StatelessWidget {
 }
 
 class _ReactionToggleRow extends StatelessWidget {
-  const _ReactionToggleRow({
-    required this.hadReaction,
-    required this.onToggle,
-  });
+  const _ReactionToggleRow({required this.hadReaction, required this.onToggle});
 
   final bool hadReaction;
   final VoidCallback onToggle;
@@ -520,19 +514,25 @@ class _AttachmentBlock extends StatelessWidget {
       padding: const EdgeInsets.all(AppSizes.sp12),
       child: SizedBox(
         height: AppSizes.buttonHeight,
-        child: Material(
-          color: AppColors.butter,
-          shape: const StadiumBorder(),
-          child: InkWell(
-            key: const Key('attachment_add_picture'),
-            customBorder: const StadiumBorder(),
-            onTap: onOpenSheet,
-            child: Center(
-              child: Text(
-                hasAttachment ? 'Edit Picture' : 'Add Picture',
-                style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  color: AppColors.greenDeep,
-                  fontWeight: FontWeight.w700,
+        child: Semantics(
+          button: true,
+          label: hasAttachment ? 'Edit Picture' : 'Add Picture',
+          excludeSemantics: true,
+          onTap: onOpenSheet,
+          child: Material(
+            color: AppColors.butter,
+            shape: const StadiumBorder(),
+            child: InkWell(
+              key: const Key('attachment_add_picture'),
+              customBorder: const StadiumBorder(),
+              onTap: onOpenSheet,
+              child: Center(
+                child: Text(
+                  hasAttachment ? 'Edit Picture' : 'Add Picture',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: AppColors.greenDeep,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
               ),
             ),

--- a/test/features/allergen/log/allergen_log_screen_test.dart
+++ b/test/features/allergen/log/allergen_log_screen_test.dart
@@ -44,9 +44,7 @@ void main() {
         _MockAllergenLogController.new,
       ),
     ],
-    child: const MaterialApp(
-      home: AllergenLogScreen(allergenKey: 'peanut'),
-    ),
+    child: const MaterialApp(home: AllergenLogScreen(allergenKey: 'peanut')),
   );
 
   group('AllergenLogScreen (CREATE)', () {
@@ -72,11 +70,12 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('log_date_field')), findsOneWidget);
-      expect(find.text('My baby love it, no reaction'), findsOneWidget);
+      expect(find.text('My baby loves it, no reaction'), findsOneWidget);
     });
 
-    testWidgets('shows Add Picture CTA inside attachment block',
-        (tester) async {
+    testWidgets('shows Add Picture CTA inside attachment block', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
@@ -84,8 +83,21 @@ void main() {
       expect(find.text('Add Picture'), findsOneWidget);
     });
 
-    testWidgets('shows reaction switch wired to controller state',
-        (tester) async {
+    testWidgets('attachment CTA exposes a labelled button (a11y)', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('Add Picture'), findsOneWidget);
+
+      handle.dispose();
+    });
+
+    testWidgets('shows reaction switch wired to controller state', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Audit loop — iteration 12: a11y sweep → allergen-log attachment CTA

Continues the cross-feature a11y button-role sweep (iter8-11). Completes the allergen-log screen's a11y — its `_DateField` + `_ReactionToggleRow` already had button roles; the attachment CTA was the last gap. All lib changes **non-visual** (Semantics only).

### Shipped
- **allergen_log_screen `_AttachmentBlock`** — the "Add Picture" / "Edit Picture" InkWell CTA (dashed attachment container) had no button role. Now wraps in `Semantics(button: true, label: <Add/Edit Picture>, excludeSemantics: true, onTap: onOpenSheet)`. The `attachment_add_picture` key + InkWell are preserved.
- Added a11y test: `find.bySemanticsLabel('Add Picture')` in the existing screen harness.
- **Repaired a pre-existing stale test** (same file): "shows date field and notes hint" asserted the old notes-hint copy `'My baby love it…'`; PR #308 changed it to `'…loves it…'` but the test was never updated (CI runs only `flutter analyze`, not tests, so it went unnoticed). Updated the assertion to the shipped copy.

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` (lib + tests) → clean
- `flutter test test/features/allergen/log/` → **21/21 pass** (was 20/-1 before the stale-test repair)
- Non-visual → no sim gate

### Verified covered / skipped
- recipe/detail sheets (`add_to_meal_plan_sheet`, `add_to_shopping_list_sheet`) — tappables **already** wrapped in `Semantics(button:true)` + `ExcludeSemantics`. No action.

### Remaining sweep targets (one feature/PR)
meal_plan cluster (grep-usage first — may contain dead extractions) · profile/subscription overlays (check already-semantic) · shopping_list `swipe_reveal_row` (Dismissible caution). Shared-DS widgets deferred to owner DS-level pass. Dead-widget ledger (owner: delete-or-wire): `GuideCtaPill`, `TasteSelector`, `PhotoCaptureButton`.