### PR TITLE
fix(meal-plan): day-card recipe-row button a11y + repair stale tag-case tests

### DIFF
--- a/lib/src/features/meal_plan/widgets/day_accordion_card.dart
+++ b/lib/src/features/meal_plan/widgets/day_accordion_card.dart
@@ -306,52 +306,66 @@ class _RecipeRow extends StatelessWidget {
     final visible = tags.take(_maxVisibleTags).toList();
     final overflow = tags.length - visible.length;
 
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+    final flaggedNames = tags
+        .where(flaggedAllergenKeys.contains)
+        .map(AllergenEmoji.displayName)
+        .toList();
+    final semanticsLabel = flaggedNames.isEmpty
+        ? title
+        : '$title, flagged: ${flaggedNames.join(', ')}';
+
+    return Semantics(
+      button: true,
+      label: semanticsLabel,
+      excludeSemantics: true,
       onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSizes.sp12,
-          vertical: AppSizes.sm,
-        ),
-        decoration: BoxDecoration(
-          color: AppColors.butterSoft,
-          borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-        ),
-        child: Row(
-          children: [
-            _Thumbnail(url: recipe?.thumbnailUrl),
-            const SizedBox(width: AppSizes.sp12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    title,
-                    style: AppTypography.textTheme.labelMedium,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  if (tags.isNotEmpty) ...[
-                    const SizedBox(height: AppSizes.xs),
-                    Wrap(
-                      spacing: AppSizes.xs,
-                      runSpacing: AppSizes.xs,
-                      children: [
-                        for (final tag in visible)
-                          _AllergenTagChip(
-                            tag: tag,
-                            flagged: flaggedAllergenKeys.contains(tag),
-                          ),
-                        if (overflow > 0) _OverflowChip(count: overflow),
-                      ],
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.sp12,
+            vertical: AppSizes.sm,
+          ),
+          decoration: BoxDecoration(
+            color: AppColors.butterSoft,
+            borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+          ),
+          child: Row(
+            children: [
+              _Thumbnail(url: recipe?.thumbnailUrl),
+              const SizedBox(width: AppSizes.sp12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      title,
+                      style: AppTypography.textTheme.labelMedium,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
+                    if (tags.isNotEmpty) ...[
+                      const SizedBox(height: AppSizes.xs),
+                      Wrap(
+                        spacing: AppSizes.xs,
+                        runSpacing: AppSizes.xs,
+                        children: [
+                          for (final tag in visible)
+                            _AllergenTagChip(
+                              tag: tag,
+                              flagged: flaggedAllergenKeys.contains(tag),
+                            ),
+                          if (overflow > 0) _OverflowChip(count: overflow),
+                        ],
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/test/features/meal_plan/widgets/day_accordion_card_test.dart
+++ b/test/features/meal_plan/widgets/day_accordion_card_test.dart
@@ -38,6 +38,7 @@ Future<void> _pumpCard(
   required bool isExpanded,
   VoidCallback? onToggle,
   VoidCallback? onAdd,
+  ValueChanged<String>? onRecipeTap,
   Set<String> flaggedAllergenKeys = const {},
 }) {
   return tester.pumpWidget(
@@ -51,7 +52,7 @@ Future<void> _pumpCard(
           isExpanded: isExpanded,
           onToggle: onToggle ?? () {},
           onAdd: onAdd ?? () {},
-          onRecipeTap: (_) {},
+          onRecipeTap: onRecipeTap ?? (_) {},
           onMenuSelected: (_) {},
         ),
       ),
@@ -77,28 +78,25 @@ void main() {
       expect(find.text('No meal plan yet.'), findsNothing);
     });
 
-    testWidgets(
-      'expanded + entries: recipe row renders with title + tag chips '
-      '+ Add pill',
-      (tester) async {
-        await _pumpCard(
-          tester,
-          entries: [_entry()],
-          recipes: {
-            'r-1': _recipe(tags: const ['peanut', 'egg']),
-          },
-          isExpanded: true,
-        );
+    testWidgets('expanded + entries: recipe row renders with title + tag chips '
+        '+ Add pill', (tester) async {
+      await _pumpCard(
+        tester,
+        entries: [_entry()],
+        recipes: {
+          'r-1': _recipe(tags: const ['peanut', 'egg']),
+        },
+        isExpanded: true,
+      );
 
-        expect(find.text('Peanut Butter Toast'), findsOneWidget);
-        expect(find.text('Add'), findsOneWidget);
-        // Tag chips render with replaced underscore labels.
-        expect(find.text('peanut'), findsOneWidget);
-        expect(find.text('egg'), findsOneWidget);
-        // No empty-state hint.
-        expect(find.text('No meal plan yet.'), findsNothing);
-      },
-    );
+      expect(find.text('Peanut Butter Toast'), findsOneWidget);
+      expect(find.text('Add'), findsOneWidget);
+      // Tag chips render with replaced underscore labels.
+      expect(find.text('Peanut'), findsOneWidget);
+      expect(find.text('Egg'), findsOneWidget);
+      // No empty-state hint.
+      expect(find.text('No meal plan yet.'), findsNothing);
+    });
 
     testWidgets(
       'expanded + entries: 3+ tags renders +N overflow chip after first 2',
@@ -113,13 +111,13 @@ void main() {
         );
 
         // First 2 tags visible.
-        expect(find.text('peanut'), findsOneWidget);
-        expect(find.text('egg'), findsOneWidget);
+        expect(find.text('Peanut'), findsOneWidget);
+        expect(find.text('Egg'), findsOneWidget);
         // 4 - 2 = +2 overflow chip.
         expect(find.text('+2'), findsOneWidget);
         // Hidden tags should not render their labels.
-        expect(find.text('dairy'), findsNothing);
-        expect(find.text('soy'), findsNothing);
+        expect(find.text('Dairy'), findsNothing);
+        expect(find.text('Soy'), findsNothing);
       },
     );
 
@@ -168,6 +166,48 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(added, 1);
+    });
+
+    testWidgets('recipe row exposes a labelled button + fires onRecipeTap', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      String? tappedRecipeId;
+      await _pumpCard(
+        tester,
+        entries: [_entry()],
+        recipes: {'r-1': _recipe()},
+        isExpanded: true,
+        onRecipeTap: (id) => tappedRecipeId = id,
+      );
+
+      expect(find.bySemanticsLabel('Peanut Butter Toast'), findsOneWidget);
+
+      await tester.tap(find.bySemanticsLabel('Peanut Butter Toast'));
+      await tester.pumpAndSettle();
+      expect(tappedRecipeId, 'r-1');
+
+      handle.dispose();
+    });
+
+    testWidgets('flagged allergen is surfaced in the row button label', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await _pumpCard(
+        tester,
+        entries: [_entry()],
+        recipes: {'r-1': _recipe()},
+        isExpanded: true,
+        flaggedAllergenKeys: const {'peanut'},
+      );
+
+      expect(
+        find.bySemanticsLabel('Peanut Butter Toast, flagged: Peanut'),
+        findsOneWidget,
+      );
+
+      handle.dispose();
     });
   });
 }


### PR DESCRIPTION
## Audit loop — iteration 13: a11y sweep → meal-plan day card

Continues the cross-feature a11y sweep (iter8-12). Targets the populated meal-plan `DayAccordionCard`. All lib changes **non-visual** (Semantics only).

### Shipped
- **day_accordion_card `_RecipeRow`** — the recipe row (taps to recipe detail) was a bare `GestureDetector` with no button role. Now wraps in `Semantics(button: true, label: <curated>, excludeSemantics: true, onTap: onTap)`. The label is the recipe title, and — following the recipe_grid_card precedent — **surfaces flagged allergens** (`'<title>, flagged: <names>'`) so the safety signal isn't lost to `excludeSemantics`.
- Added 2 a11y tests: button label + tap fires `onRecipeTap('r-1')`; flagged-allergen label variant. (Extended the existing `_pumpCard` helper with an `onRecipeTap` param.)
- **Repaired 2 pre-existing stale tests** (same file, verified pre-existing on clean main): they asserted lowercase allergen tag text (`'peanut'`, `'egg'`, …), but PR #307 capitalized tag chips via `AllergenEmoji.displayName` (`'Peanut'`, `'Egg'`). Updated to the shipped casing. (CI runs only `flutter analyze`, never tests, so these went unnoticed.)

### Deferred (NOT shipped this tick)
- **`_Header` toggle** GestureDetector — wraps a `PopupMenuButton` (which has its own button semantics + 'More' tooltip); an `excludeSemantics` wrap would clobber it. Accordion-header semantics + nested popup needs careful handling → separate tick.
- **`_DayCardChip` chevron** — shared private widget (used for both the popup trigger and the chevron); labeling needs a signature change → defer.

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` (lib + test) → clean
- `flutter test test/features/meal_plan/` → **all pass** (8 day-card incl. 2 new + 2 repaired; 33 across widgets + screen, incl. the 7-card populated screen test)
- Non-visual → no sim gate

### Remaining sweep targets
meal_plan: `_Header`/chevron toggle (above), `picked_recipe_row`, browse/recommendation sheets, `inline_calendar` · profile/subscription overlays (check already-semantic) · shopping_list `swipe_reveal_row` (Dismissible caution). Dead-widget ledger (owner): `GuideCtaPill`, `TasteSelector`, `PhotoCaptureButton`. Still-broken: `starting_guide_hub` 'Bite-sized reads' subtitle test (owner/Figma).