### PR TITLE
fix(recipe): detail screen — degrade allergen-read failure to P3 + spinner a11y + token

### DIFF
--- a/lib/src/features/recipe/detail/recipe_detail_controller.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_controller.dart
@@ -27,13 +27,15 @@ class RecipeDetailController extends _$RecipeDetailController {
       allergenSvc.getLogs(babyId),
     ).wait;
 
+    // Only the recipe is essential — without it there is nothing to render.
+    // The allergen program/logs are SECONDARY (they only tint the
+    // "Contains allergens" chips); a failure there must NOT collapse the whole
+    // screen, so they degrade to safe defaults (P3) instead of throwing.
     if (recipeResult.isFailure) throw recipeResult.errorOrNull!;
-    if (programResult.isFailure) throw programResult.errorOrNull!;
-    if (logsResult.isFailure) throw logsResult.errorOrNull!;
 
     final recipe = recipeResult.dataOrNull!;
-    final currentKey = programResult.dataOrNull!.currentAllergenKey;
-    final allLogs = logsResult.dataOrNull!;
+    final currentKey = programResult.dataOrNull?.currentAllergenKey ?? '';
+    final allLogs = logsResult.dataOrNull ?? const <AllergenLog>[];
 
     // Derive status per allergen tag on this recipe.
     final statuses = <String, AllergenStatus>{};

--- a/lib/src/features/recipe/detail/recipe_detail_screen.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_screen.dart
@@ -99,7 +99,9 @@ class _RecipeDetailBody extends ConsumerWidget {
     return Scaffold(
       backgroundColor: AppColors.background,
       body: detailAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(
+          child: CircularProgressIndicator(semanticsLabel: 'Loading recipe'),
+        ),
         error: (error, _) => _ErrorView(
           onRetry: () => ref.invalidate(
             recipeDetailControllerProvider(babyId, recipeId),

--- a/lib/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart
+++ b/lib/src/features/recipe/detail/widgets/add_to_shopping_list_sheet.dart
@@ -349,7 +349,7 @@ class _RemoveButton extends StatelessWidget {
       label: 'Remove $name',
       child: InkResponse(
         onTap: onPressed,
-        radius: 24,
+        radius: AppSizes.lg,
         child: const SizedBox(
           width: AppSizes.xxl,
           height: AppSizes.xxl,

--- a/test/features/recipe/detail/recipe_detail_controller_test.dart
+++ b/test/features/recipe/detail/recipe_detail_controller_test.dart
@@ -1,0 +1,87 @@
+// Unit tests for RecipeDetailController.build() error degradation:
+//   * a SECONDARY allergen program/logs read failure must NOT collapse the
+//     screen — the recipe still renders with empty allergen data (P3);
+//   * the recipe read itself is essential — its failure still throws.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/recipe_service.dart';
+import 'package:nibbles/src/features/recipe/detail/recipe_detail_controller.dart';
+
+class _MockRecipeService extends Mock implements RecipeService {}
+
+class _MockAllergenService extends Mock implements AllergenService {}
+
+const _babyId = 'baby-1';
+const _recipe = Recipe(
+  id: 'r1',
+  title: 'Plain Carrot',
+  ageRange: '6+ months',
+  allergenTags: [],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+void main() {
+  late _MockRecipeService recipeSvc;
+  late _MockAllergenService allergenSvc;
+
+  setUp(() {
+    recipeSvc = _MockRecipeService();
+    allergenSvc = _MockAllergenService();
+  });
+
+  ProviderContainer container() {
+    final c = ProviderContainer(
+      overrides: [
+        recipeServiceProvider.overrideWithValue(recipeSvc),
+        allergenServiceProvider.overrideWithValue(allergenSvc),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('allergen program/logs read failure still renders the recipe', () async {
+    when(
+      () => recipeSvc.getRecipeById(any()),
+    ).thenAnswer((_) async => const Result.success(_recipe));
+    when(
+      () => allergenSvc.getProgramState(any()),
+    ).thenAnswer((_) async => const Result.failure(NetworkException()));
+    when(
+      () => allergenSvc.getLogs(any()),
+    ).thenAnswer((_) async => const Result.failure(NetworkException()));
+
+    final state = await container().read(
+      recipeDetailControllerProvider(_babyId, 'r1').future,
+    );
+
+    expect(state.recipe.id, 'r1');
+    expect(state.currentAllergenKey, '');
+    expect(state.allergenStatuses, isEmpty);
+  });
+
+  test('recipe read failure still throws (recipe is essential)', () async {
+    when(
+      () => recipeSvc.getRecipeById(any()),
+    ).thenAnswer((_) async => const Result.failure(NetworkException()));
+    when(
+      () => allergenSvc.getProgramState(any()),
+    ).thenAnswer((_) async => const Result.failure(NetworkException()));
+    when(
+      () => allergenSvc.getLogs(any()),
+    ).thenAnswer((_) async => const Result.failure(NetworkException()));
+
+    await expectLater(
+      container().read(recipeDetailControllerProvider(_babyId, 'r1').future),
+      throwsA(isA<NetworkException>()),
+    );
+  });
+}


### PR DESCRIPTION
## Audit loop — iteration 14: recipe-detail deep-dive (Workflow)

a11y sweep is exhausting, so this tick **pivoted** to a Workflow audit of the recipe-detail feature (RC-02, 13 files, 6 dimensions × adversarial verify). 15 raw findings → 5 SHIP / 8 DEFER / 2 REJECT. Shipping the **3 high-confidence non-visual** fixes; deferring the 2 visual ones to a sim-gated tick.

### Shipped (3 fixes + controller test)
- **error-level bug (P3 violation):** `RecipeDetailController.build()` rethrew on the SECONDARY allergen program/logs reads — so a failure there collapsed the *entire* recipe-detail screen into a blocking error view even when the recipe itself loaded fine (it comes from a read-through cache). Now only the recipe read is essential; program/logs degrade to safe defaults (`currentKey = ''`, `logs = []` → statuses derive to `notStarted` → `ContainsAllergensCard` already renders mute chips). Added `recipe_detail_controller_test` proving (a) allergen-read failure still renders the recipe, (b) recipe-read failure still throws.
- **a11y:** the detail-fetch loading spinner (`recipe_detail_screen.dart:102`) had no `semanticsLabel` while the sibling baby-profile spinner does — added `semanticsLabel: 'Loading recipe'` for parity.
- **token-bypass:** `add_to_shopping_list_sheet` remove-button `InkResponse(radius: 24)` → `AppSizes.lg` (byte-identical; `lg == 24`).

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` → clean
- `flutter test` recipe_detail_controller_test (2) + recipe_detail_screen_test (12) → pass
- Non-visual (error-path robustness + Semantics label + identical token) → no sim gate

### Deferred to a sim-gated tick (visual — verified findings, NOT shipped)
- **Ingredients/Method header over blank body** when the list is empty — both sections render unconditionally while every sibling section is `isNotEmpty`-guarded. Needs a guard + widget test + sim check.
- **Floating CTA scroll-padding < CTA height** on bottom-safe-area devices clips the last content — needs device-inset measurement on the sim.

### DEFER (logged for owner / follow-up, NOT shipped)
- `currentAllergenKey` is write-only dead state (removal needs freezed regen).
- `isAddingToMealPlan/...` reset clobbers state captured before the await (controller:63-90) — needs careful state-capture fix.
- recipe read-failure not logged to Crashlytics (P3 half-met).
- `_dateOnly` duplicated (controller + add_to_meal_plan_sheet) — within-feature DRY.
- bottom-sheet top-radius `radiusXl` vs `radius2xl` inconsistency (Figma question).

### Pre-existing broken tests (NOT my regression, verified on clean main)
`add_to_shopping_list_sheet_test` — 2 tests fail with a `CachingIterable.elementAt` runtime error (not a stale-string fix; needs investigation). CI never caught it because CI runs only `flutter analyze`, not tests. Logged for owner.