### PR TITLE
fix(meal-plan): map-flow a11y + no-op fontSize cleanup (Workflow deep-dive)

### DIFF
--- a/lib/src/features/meal_plan/map/widgets/day_chip_row.dart
+++ b/lib/src/features/meal_plan/map/widgets/day_chip_row.dart
@@ -78,8 +78,7 @@ class DayChipRow extends StatelessWidget {
         itemBuilder: (context, index) {
           final day = days[index];
           final isSelected = _isSameDay(day, selectedDay);
-          final isFilled =
-              filledDays.any((d) => _isSameDay(d, day));
+          final isFilled = filledDays.any((d) => _isSameDay(d, day));
           return _DayChip(
             day: day,
             isSelected: isSelected,
@@ -127,45 +126,47 @@ class _DayChip extends StatelessWidget {
       borderColor = AppColors.borderSoft;
     }
 
-    return GestureDetector(
+    return Semantics(
+      button: true,
+      selected: isSelected,
+      label: '$abbrev ${day.day} $monthAbbrev',
+      excludeSemantics: true,
       onTap: onTap,
-      child: Container(
-        width: AppSizes.dayChipW,
-        decoration: BoxDecoration(
-          color: bg,
-          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-          border: Border.all(color: borderColor),
-        ),
-        padding: const EdgeInsets.symmetric(
-          vertical: AppSizes.sm,
-          horizontal: AppSizes.xs,
-        ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (isFilled && !isSelected)
-              Icon(
-                Icons.check,
-                color: fg,
-                size: AppSizes.iconSm,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          width: AppSizes.dayChipW,
+          decoration: BoxDecoration(
+            color: bg,
+            borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+            border: Border.all(color: borderColor),
+          ),
+          padding: const EdgeInsets.symmetric(
+            vertical: AppSizes.sm,
+            horizontal: AppSizes.xs,
+          ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isFilled && !isSelected)
+                Icon(Icons.check, color: fg, size: AppSizes.iconSm),
+              Text(
+                abbrev,
+                style: AppTypography.caption.copyWith(
+                  color: fg,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
-            Text(
-              abbrev,
-              style: AppTypography.caption.copyWith(
-                color: fg,
-                fontWeight: FontWeight.w600,
+              Text(
+                '${day.day} $monthAbbrev',
+                style: AppTypography.caption.copyWith(
+                  color: fg,
+                  fontWeight: FontWeight.w700,
+                ),
               ),
-            ),
-            Text(
-              '${day.day} $monthAbbrev',
-              style: AppTypography.caption.copyWith(
-                color: fg,
-                fontWeight: FontWeight.w700,
-                fontSize: 12,
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/meal_plan/map/widgets/picked_recipe_row.dart
+++ b/lib/src/features/meal_plan/map/widgets/picked_recipe_row.dart
@@ -26,59 +26,68 @@ class PickedRecipeRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
+    final label = assignedLabel == null
+        ? recipe.title
+        : '${recipe.title}, assigned to $assignedLabel';
+    return Semantics(
+      button: true,
+      label: label,
+      excludeSemantics: true,
       onTap: onTap,
-      borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-      child: Container(
-        padding: const EdgeInsets.all(AppSizes.sp12),
-        decoration: BoxDecoration(
-          color: AppColors.surface,
-          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-          border: Border.all(color: AppColors.borderSoft),
-        ),
-        child: Row(
-          children: [
-            _Thumbnail(url: recipe.thumbnailUrl),
-            const SizedBox(width: AppSizes.sp12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    recipe.title,
-                    style: AppTypography.bodyBold,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  if (recipe.allergenTags.isNotEmpty) ...[
-                    const SizedBox(height: AppSizes.xs),
-                    _TagsRow(tags: recipe.allergenTags),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        child: Container(
+          padding: const EdgeInsets.all(AppSizes.sp12),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+            border: Border.all(color: AppColors.borderSoft),
+          ),
+          child: Row(
+            children: [
+              _Thumbnail(url: recipe.thumbnailUrl),
+              const SizedBox(width: AppSizes.sp12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      recipe.title,
+                      style: AppTypography.bodyBold,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (recipe.allergenTags.isNotEmpty) ...[
+                      const SizedBox(height: AppSizes.xs),
+                      _TagsRow(tags: recipe.allergenTags),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-            if (assignedLabel != null) ...[
-              const SizedBox(width: AppSizes.sm),
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppSizes.sm,
-                  vertical: AppSizes.xs,
-                ),
-                decoration: BoxDecoration(
-                  color: AppColors.greenTint,
-                  borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-                ),
-                child: Text(
-                  assignedLabel!,
-                  style: AppTypography.caption.copyWith(
-                    color: AppColors.greenDeep,
-                    fontWeight: FontWeight.w700,
+              if (assignedLabel != null) ...[
+                const SizedBox(width: AppSizes.sm),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSizes.sm,
+                    vertical: AppSizes.xs,
+                  ),
+                  decoration: BoxDecoration(
+                    color: AppColors.greenTint,
+                    borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+                  ),
+                  child: Text(
+                    assignedLabel!,
+                    style: AppTypography.caption.copyWith(
+                      color: AppColors.greenDeep,
+                      fontWeight: FontWeight.w700,
+                    ),
                   ),
                 ),
-              ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart
+++ b/lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart
@@ -115,6 +115,7 @@ class _AssignedRecipeCard extends StatelessWidget {
           const SizedBox(width: AppSizes.sm),
           IconButton(
             onPressed: onRemove,
+            tooltip: 'Remove from day',
             icon: const Icon(
               Icons.delete_outline,
               color: AppColors.fgMuted,

--- a/test/features/meal_plan/map/widgets/day_chip_row_test.dart
+++ b/test/features/meal_plan/map/widgets/day_chip_row_test.dart
@@ -1,0 +1,39 @@
+// a11y coverage for the map-flow day chip — the bare GestureDetector now
+// exposes a single-select button (label = day, selected: state) and fires
+// onSelect on tap.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/features/meal_plan/map/widgets/day_chip_row.dart';
+
+void main() {
+  testWidgets('day chip exposes a labelled button + fires onSelect', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+    DateTime? selected;
+    final day = DateTime(2026, 5, 30);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DayChipRow(
+            startDate: day,
+            endDate: day,
+            selectedDay: day,
+            onSelect: (d) => selected = d,
+          ),
+        ),
+      ),
+    );
+
+    // Single-day range → exactly one chip, labelled "<weekday> 30 May".
+    final chip = find.bySemanticsLabel(RegExp('30 May'));
+    expect(chip, findsOneWidget);
+
+    await tester.tap(chip);
+    expect(selected, day);
+
+    handle.dispose();
+  });
+}

--- a/test/features/meal_plan/map/widgets/picked_recipe_row_test.dart
+++ b/test/features/meal_plan/map/widgets/picked_recipe_row_test.dart
@@ -1,0 +1,55 @@
+// a11y coverage for PickedRecipeRow — the bare InkWell tap-to-assign target
+// now exposes a labelled button; the assigned-day badge is surfaced in the
+// accessible name (excludeSemantics would otherwise drop it).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/features/meal_plan/map/widgets/picked_recipe_row.dart';
+
+const _recipe = Recipe(
+  id: 'r1',
+  title: 'Pea Puree',
+  ageRange: '6m+',
+  allergenTags: [],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  testWidgets('exposes a labelled button + fires onTap', (tester) async {
+    final handle = tester.ensureSemantics();
+    var tapped = false;
+
+    await tester.pumpWidget(
+      _wrap(PickedRecipeRow(recipe: _recipe, onTap: () => tapped = true)),
+    );
+
+    expect(find.bySemanticsLabel('Pea Puree'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('Pea Puree'));
+    expect(tapped, isTrue);
+
+    handle.dispose();
+  });
+
+  testWidgets('assignedLabel is surfaced in the button label', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      _wrap(
+        PickedRecipeRow(recipe: _recipe, onTap: () {}, assignedLabel: 'Tue 3'),
+      ),
+    );
+
+    expect(
+      find.bySemanticsLabel('Pea Puree, assigned to Tue 3'),
+      findsOneWidget,
+    );
+
+    handle.dispose();
+  });
+}

--- a/test/features/meal_plan/map/widgets/selected_day_slot_list_test.dart
+++ b/test/features/meal_plan/map/widgets/selected_day_slot_list_test.dart
@@ -1,0 +1,42 @@
+// a11y coverage for SelectedDaySlotList — the icon-only unassign button now
+// carries a "Remove from day" tooltip (which also serves as its screen-reader
+// label) and fires onRemove with the recipe id.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/features/meal_plan/map/widgets/selected_day_slot_list.dart';
+
+const _recipe = Recipe(
+  id: 'r1',
+  title: 'Pea Puree',
+  ageRange: '6m+',
+  allergenTags: [],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+
+void main() {
+  testWidgets('remove button has a tooltip label + fires onRemove with id', (
+    tester,
+  ) async {
+    String? removed;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SelectedDaySlotList(
+            recipes: const [_recipe],
+            onRemove: (id) => removed = id,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byTooltip('Remove from day'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Remove from day'));
+    expect(removed, 'r1');
+  });
+}


### PR DESCRIPTION
## Audit loop — iteration 15: meal_plan MAP flow deep-dive (Workflow)

Workflow audit of the multi-step recipe→day assignment flow (`meal_plan/map`, 6 files, 6 dims × adversarial verify). 12 raw → 4 SHIP-nonvisual / 2 SHIP-visual / 3 DEFER / 3 REJECT. Shipping the 4 **non-visual** fixes; deferring the 2 visual ones to a sim/owner tick.

### Shipped (3 widgets + 3 tests, all non-visual)
- **a11y — day chip** (`day_chip_row` `_DayChip`): a single-select GestureDetector with no button role and no selected signal (selection was colour-only). Now `Semantics(button: true, selected: isSelected, label: '<weekday> <day> <month>', excludeSemantics: true)`.
- **a11y — picked recipe row** (`picked_recipe_row`): the tap-to-assign InkWell had no button role. Now `Semantics(button: true, label: <title>, ...)` — and surfaces the assigned-day badge in the label (`'<title>, assigned to <day>'`) which `excludeSemantics` would otherwise drop.
- **a11y — remove button** (`selected_day_slot_list`): the icon-only unassign `IconButton` had no tooltip/label (its sibling back button does). Added `tooltip: 'Remove from day'`.
- **token/dead-code** (`day_chip_row`): removed a no-op `fontSize: 12` override on `AppTypography.caption` (caption is already `fontSize: 12` — byte-identical).

Added isolated widget tests (`find.bySemanticsLabel` + tap / `find.byTooltip` + fires-with-id).

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` → clean
- `flutter test test/features/meal_plan/map/` → **17/17 pass** (13 existing + 4 new)
- Non-visual (Semantics/tooltip/no-op removal) → no sim gate

### Deferred to a sim/owner tick (VISUAL or contested — verified, NOT shipped)
- **bug:** the commit-failure retry dialog hardcodes its text and never reads `state.errorMessage` — so the required **P1 "No internet connection"** message can never surface, and `errorMessage` is effectively dead state. Fixing it is a behavioural + visual (dialog copy) change tied to the error-level decision → owner/sim tick.
- **component:** populated day-slot dashed border is occluded by its own opaque fill (CustomPaint painter behind child) → visual, needs sim.
- **DEFER:** `errorMessage` dead-state removal (freezed regen); the P2-vs-P1 error-string rule question; the "Drag & drop" helper copy promises drag-and-drop but the flow is tap-only (Figma/product question).

Remaining sweep/audit targets and the standing ledgers (dead widgets, pre-existing broken tests) unchanged — see loop memory.