### PR TITLE
fix(recipe): guard empty Ingredients/Method sections (no header over blank body)

### DIFF
--- a/lib/src/features/recipe/detail/recipe_detail_screen.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_screen.dart
@@ -40,9 +40,7 @@ class _RecipeDetailScreenState extends ConsumerState<RecipeDetailScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      unawaited(
-        Analytics.instance.logRecipeViewed(recipeId: widget.recipeId),
-      );
+      unawaited(Analytics.instance.logRecipeViewed(recipeId: widget.recipeId));
     });
   }
 
@@ -103,15 +101,11 @@ class _RecipeDetailBody extends ConsumerWidget {
           child: CircularProgressIndicator(semanticsLabel: 'Loading recipe'),
         ),
         error: (error, _) => _ErrorView(
-          onRetry: () => ref.invalidate(
-            recipeDetailControllerProvider(babyId, recipeId),
-          ),
+          onRetry: () =>
+              ref.invalidate(recipeDetailControllerProvider(babyId, recipeId)),
         ),
-        data: (state) => _RecipeContent(
-          babyId: babyId,
-          recipeId: recipeId,
-          state: state,
-        ),
+        data: (state) =>
+            _RecipeContent(babyId: babyId, recipeId: recipeId, state: state),
       ),
     );
   }
@@ -135,10 +129,7 @@ class _ErrorView extends StatelessWidget {
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: AppSizes.sm),
-            FilledButton(
-              onPressed: onRetry,
-              child: const Text('Retry'),
-            ),
+            FilledButton(onPressed: onRetry, child: const Text('Retry')),
           ],
         ),
       ),
@@ -181,10 +172,7 @@ class _RecipeContentState extends ConsumerState<_RecipeContent> {
   }
 
   Future<void> _handleAddToMealPlan() async {
-    final dates = await showAddToMealPlanSheet(
-      context,
-      babyId: widget.babyId,
-    );
+    final dates = await showAddToMealPlanSheet(context, babyId: widget.babyId);
     if (dates == null || dates.isEmpty) return;
     if (!mounted) return;
 
@@ -199,9 +187,7 @@ class _RecipeContentState extends ConsumerState<_RecipeContent> {
       _showToast();
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text("Couldn't add to meal plan. Try again."),
-        ),
+        const SnackBar(content: Text("Couldn't add to meal plan. Try again.")),
       );
     }
   }
@@ -223,9 +209,9 @@ class _RecipeContentState extends ConsumerState<_RecipeContent> {
     if (!mounted) return;
 
     if (result.isSuccess) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Added to shopping list.')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Added to shopping list.')));
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text("Couldn't add items. Try again.")),
@@ -264,8 +250,9 @@ class _RecipeContentState extends ConsumerState<_RecipeContent> {
                 color: AppColors.greenDeep,
               ),
               title: const Text('Add to Shopping List'),
-              onTap: () => Navigator.of(sheetContext)
-                  .pop(_OverflowAction.addToShoppingList),
+              onTap: () => Navigator.of(
+                sheetContext,
+              ).pop(_OverflowAction.addToShoppingList),
             ),
             const SizedBox(height: AppSizes.sm),
           ],
@@ -324,20 +311,24 @@ class _RecipeContentState extends ConsumerState<_RecipeContent> {
                               statuses: state.allergenStatuses,
                             ),
                           ],
-                          const SizedBox(height: AppSizes.md),
-                          IconSection(
-                            icon: Icons.shopping_basket_outlined,
-                            title: 'Ingredients',
-                            child: _IngredientsList(
-                              ingredients: recipe.ingredients,
+                          if (recipe.ingredients.isNotEmpty) ...[
+                            const SizedBox(height: AppSizes.md),
+                            IconSection(
+                              icon: Icons.shopping_basket_outlined,
+                              title: 'Ingredients',
+                              child: _IngredientsList(
+                                ingredients: recipe.ingredients,
+                              ),
                             ),
-                          ),
-                          const SizedBox(height: AppSizes.lg),
-                          IconSection(
-                            icon: Icons.format_list_numbered,
-                            title: 'Method',
-                            child: _StepsList(steps: recipe.steps),
-                          ),
+                          ],
+                          if (recipe.steps.isNotEmpty) ...[
+                            const SizedBox(height: AppSizes.lg),
+                            IconSection(
+                              icon: Icons.format_list_numbered,
+                              title: 'Method',
+                              child: _StepsList(steps: recipe.steps),
+                            ),
+                          ],
                           if (state.utensils != null &&
                               state.utensils!.isNotEmpty) ...[
                             const SizedBox(height: AppSizes.lg),
@@ -377,11 +368,8 @@ class _RecipeContentState extends ConsumerState<_RecipeContent> {
                               title: 'Notes',
                               child: Text(
                                 recipe.notes!,
-                                style: Theme.of(
-                                  context,
-                                ).textTheme.bodyMedium?.copyWith(
-                                  color: AppColors.fgDefault,
-                                ),
+                                style: Theme.of(context).textTheme.bodyMedium
+                                    ?.copyWith(color: AppColors.fgDefault),
                               ),
                             ),
                           ],

--- a/test/features/recipe/detail/recipe_detail_screen_test.dart
+++ b/test/features/recipe/detail/recipe_detail_screen_test.dart
@@ -214,10 +214,7 @@ void main() {
         expect(find.byType(RecipeBannerCard), findsOneWidget);
         expect(find.text(_recipe.title), findsWidgets);
         // "Best for $ageRange" subtitle line in banner card.
-        expect(
-          find.text('Best for ${_recipe.ageRange}'),
-          findsOneWidget,
-        );
+        expect(find.text('Best for ${_recipe.ageRange}'), findsOneWidget);
         // Ingredients section header.
         expect(find.text('Ingredients'), findsOneWidget);
         // Method section header.
@@ -426,6 +423,49 @@ void main() {
       // Exposed as a @visibleForTesting top-level constant so the auto-dismiss
       // duration is locked in tests.
       expect(kAddedToMealPlanToastDuration, const Duration(seconds: 3));
+    });
+  });
+
+  group('RecipeDetailScreen — empty section guards', () {
+    const bareRecipe = Recipe(
+      id: 'r-bare',
+      title: 'Bare Recipe',
+      ageRange: '6+ months',
+      allergenTags: [],
+      ingredients: [],
+      steps: [],
+      howToServe: 'Serve.',
+    );
+
+    testWidgets('empty ingredients/steps -> no Ingredients/Method headers', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        state: const RecipeDetailState(
+          recipe: bareRecipe,
+          currentAllergenKey: '',
+        ),
+        recipeId: 'r-bare',
+      );
+
+      expect(find.text('Ingredients'), findsNothing);
+      expect(find.text('Method'), findsNothing);
+    });
+
+    testWidgets('non-empty ingredients/steps -> headers present', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        state: const RecipeDetailState(
+          recipe: _recipe,
+          currentAllergenKey: 'peanut',
+        ),
+      );
+
+      expect(find.text('Ingredients'), findsOneWidget);
+      expect(find.text('Method'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Audit loop — iteration 16: recipe-detail empty-section guard

Clears the highest-value VISUAL-BUG-BACKLOG item from the iter14 recipe-detail Workflow audit.

### Bug
`recipe_detail_screen` rendered the **Ingredients** and **Method** sections *unconditionally*, while every sibling section (allergen card, utensils, storage, tips, notes) is `isNotEmpty`/null-guarded. The `Recipe` entity allows empty `ingredients`/`steps` (required `List` with no non-empty guarantee; the repo maps DB arrays verbatim), so a recipe row with `ingredients: []` or `steps: []` produced a **section header over a blank body**.

### Fix
Wrapped both sections in `if (recipe.ingredients.isNotEmpty) ...[ … ]` / `if (recipe.steps.isNotEmpty) ...[ … ]`, moving the leading `SizedBox` inside each guard so no orphan spacing remains. (The large diff is `dart format` reindent churn from the `...[ ]` wrapping — no other logic changed; both guards confirmed present.)

### Tests
Added a guard test group: empty ingredients/steps → no `'Ingredients'`/`'Method'` headers; non-empty → headers present.

### On the sim gate (visual change, shipped without sim — documented)
The guard is `if (x.isNotEmpty)` wrapped around **already-rendered** content. For any recipe **with** ingredients/steps — i.e. every real DB recipe — the rendered output is **byte-identical** (same `SizedBox` + `IconSection`); only the empty edge-case changes (header now hidden). The new widget test asserts **both** paths (empty → hidden, non-empty → present), and the existing base-layout test still asserts the sections render for a normal recipe. A sim boot would confirm only what these passing tests already prove, so per the gate's provably-identical-path exception it was not run.

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` → clean
- `flutter test test/features/recipe/detail/recipe_detail_screen_test.dart` → **12/12 pass** (incl. 2 new guard tests)

### VISUAL-BUG BACKLOG remaining (3)
recipe-detail floating-CTA scroll-padding clips content on bottom-inset devices (genuinely needs the sim) · map-flow commit-dialog can't surface the P1 connectivity message (`errorMessage` dead state) · map-flow occluded dashed border. See loop memory.