### PR TITLE
fix(meal-plan): surface real failure message in map commit retry dialog (P1)

### DIFF
--- a/lib/src/features/meal_plan/map/map_meals_screen.dart
+++ b/lib/src/features/meal_plan/map/map_meals_screen.dart
@@ -176,6 +176,12 @@ class MapMealsScreen extends ConsumerWidget {
   }
 
   Future<void> _showRetryDialog(BuildContext context, WidgetRef ref) async {
+    // Surface the controller's actual failure message (e.g. the P1
+    // "No internet connection..." string on a connectivity failure) rather
+    // than a generic hardcoded line.
+    final message =
+        ref.read(mapMealsControllerProvider(args)).errorMessage ??
+        'Please try again';
     await showDialog<void>(
       context: context,
       barrierDismissible: false,
@@ -190,7 +196,7 @@ class MapMealsScreen extends ConsumerWidget {
             style: AppTypography.sectionTitle,
           ),
           content: Text(
-            'Please try again',
+            message,
             style: AppTypography.textTheme.bodyMedium,
           ),
           actions: [

--- a/test/features/meal_plan/map/map_meals_screen_test.dart
+++ b/test/features/meal_plan/map/map_meals_screen_test.dart
@@ -308,6 +308,33 @@ void main() {
         expect(callCount, 2);
       },
     );
+
+    testWidgets(
+      'commit failure surfaces the failure message in the dialog',
+      (tester) async {
+        when(
+          () => mockMealPlanService.appendMealsToRange(
+            babyId: any(named: 'babyId'),
+            startDate: any(named: 'startDate'),
+            endDate: any(named: 'endDate'),
+            assignments: any(named: 'assignments'),
+          ),
+        ).thenAnswer((_) async => const Result.failure(NetworkException()));
+
+        await pumpMap(tester);
+
+        await tester.tap(find.text(_recipeA.title));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(_recipeB.title));
+        await tester.pumpAndSettle();
+        await tester.tap(find.widgetWithText(FilledButton, 'Complete Mapping'));
+        await tester.pumpAndSettle();
+
+        // The dialog now shows the controller's real failure message (the P1
+        // connectivity string) instead of a generic hardcoded line.
+        expect(find.text('No internet connection.'), findsOneWidget);
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Audit loop — iteration 17: map-flow commit-dialog P1-message bug

Clears the highest-value VISUAL-BUG-BACKLOG item from the iter15 map-flow Workflow audit.

### Bug
`MapMealsScreen._showRetryDialog` hardcoded its content as `'Please try again'` and never read `state.errorMessage`. The controller *already* captures the real failure message (`commit()`: `errorMessage: result.errorOrNull?.message ?? 'Failed to save plan.'`), so on a no-connectivity write the **P1 "No internet connection." message** (error-handling.md: no-connectivity on write = P1) was computed but **could never reach the user**, and `errorMessage` was effectively dead state.

### Fix (screen-only, minimal)
The retry dialog content now renders `state.errorMessage` (falling back to `'Please try again'` when null). The dialog stays the blocking P1 retry dialog; only the message becomes accurate. No controller change needed — it already populates `errorMessage` correctly.

### Test
Added a screen test mirroring the existing commit-failure test but with a `NetworkException` failure → asserts the dialog shows **`'No internet connection.'`** (proving the P1 message now surfaces).

### On the sim gate (shipped without sim — documented)
The change swaps a hardcoded content string for the already-computed `state.errorMessage` — the `AlertDialog` widget tree/layout is unchanged; only the data-driven string differs. The new test pins the surfaced message, and the existing failure test still passes (dialog + Retry behaviour unchanged). A sim boot would confirm only what the tests prove, so per the provably-identical-layout exception it was not run.

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` → clean
- `flutter test test/features/meal_plan/map/` → **18/18 pass** (incl. the new P1-message test)
- (Note: avoided `dart format` on the pre-existing file — it reflows unrelated lines when the file isn't in the local formatter's style; the diff is scoped to the dialog change.)

### VISUAL-BUG BACKLOG remaining (2, genuinely sim-only)
recipe-detail floating-CTA scroll-padding clips content on bottom-inset devices (needs device-inset measurement) · map-flow `_PopulatedDayContainer` dashed border occluded by its own fill (CustomPaint layering). Plus owner-decision items (errorMessage dead-field removal now resolved by this fix; P2-toast-vs-P1-dialog structure still an owner call). See loop memory.