### PR TITLE
fix(auth): disable email autocorrect + a11y parity (Workflow convergence-test deep-dive)

### DIFF
--- a/lib/src/features/auth/forgot_password/forgot_password_screen.dart
+++ b/lib/src/features/auth/forgot_password/forgot_password_screen.dart
@@ -135,6 +135,8 @@ class _InputView extends StatelessWidget {
           key: const Key('forgot_email_field'),
           hintText: 'Email address',
           keyboardType: TextInputType.emailAddress,
+          autocorrect: false,
+          enableSuggestions: false,
           textInputAction: TextInputAction.done,
           onChanged: onEmailChanged,
           onSubmitted: (_) => state.isLoading ? null : onSubmit(),

--- a/lib/src/features/auth/login/login_screen.dart
+++ b/lib/src/features/auth/login/login_screen.dart
@@ -83,6 +83,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   label: 'Email address',
                   hintText: 'Email address',
                   keyboardType: TextInputType.emailAddress,
+                  autocorrect: false,
+                  enableSuggestions: false,
                   textInputAction: TextInputAction.next,
                   focusNode: _emailFocus,
                   onChanged: controller.updateEmail,
@@ -171,24 +173,30 @@ class _LoginLogoMark extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const SizedBox(
-      width: _size,
-      height: _size,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          Quatrefoil(size: _size, coreColor: AppColors.butter),
-          Text(
-            'n',
-            style: TextStyle(
-              fontFamily: FontFamily.parkinsans,
-              fontSize: 70,
-              fontWeight: FontWeight.w800,
-              height: 1,
-              color: AppColors.greenDeep,
-            ),
+    return Semantics(
+      label: 'Nibbles',
+      image: true,
+      child: const ExcludeSemantics(
+        child: SizedBox(
+          width: _size,
+          height: _size,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              Quatrefoil(size: _size, coreColor: AppColors.butter),
+              Text(
+                'n',
+                style: TextStyle(
+                  fontFamily: FontFamily.parkinsans,
+                  fontSize: 70,
+                  fontWeight: FontWeight.w800,
+                  height: 1,
+                  color: AppColors.greenDeep,
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/src/features/auth/register/register_screen.dart
+++ b/lib/src/features/auth/register/register_screen.dart
@@ -85,6 +85,8 @@ class RegisterScreen extends ConsumerWidget {
                   label: 'Email address',
                   hintText: 'Email address',
                   keyboardType: TextInputType.emailAddress,
+                  autocorrect: false,
+                  enableSuggestions: false,
                   textInputAction: TextInputAction.next,
                   onChanged: controller.updateEmail,
                   errorText: emailErrorText,
@@ -263,18 +265,23 @@ class _LoginFooter extends StatelessWidget {
           style: textTheme.bodyLarge?.copyWith(color: AppColors.text),
         ),
         const SizedBox(width: AppSizes.xs),
-        InkWell(
-          key: const Key('register_login_link'),
-          onTap: () => context.goNamed(AppRoute.login.name),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSizes.xs,
-              vertical: AppSizes.xs,
-            ),
-            child: Text(
-              'Login',
-              style: AppTypography.headline.copyWith(
-                color: AppColors.burgundy,
+        Semantics(
+          button: true,
+          label: 'Login',
+          excludeSemantics: true,
+          child: InkWell(
+            key: const Key('register_login_link'),
+            onTap: () => context.goNamed(AppRoute.login.name),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.xs,
+                vertical: AppSizes.xs,
+              ),
+              child: Text(
+                'Login',
+                style: AppTypography.headline.copyWith(
+                  color: AppColors.burgundy,
+                ),
               ),
             ),
           ),

--- a/test/features/auth/forgot_password/forgot_password_screen_test.dart
+++ b/test/features/auth/forgot_password/forgot_password_screen_test.dart
@@ -174,4 +174,20 @@ void main() {
       expect(find.byKey(const Key('forgot_submit_button')), findsNothing);
     },
   );
+
+  testWidgets('email field disables autocorrect + suggestions', (tester) async {
+    await tester.pumpWidget(
+      _wrap(const ForgotPasswordScreen(), buildOverrides()),
+    );
+    await tester.pumpAndSettle();
+
+    final textField = tester.widget<TextField>(
+      find.descendant(
+        of: find.byKey(const Key('forgot_email_field')),
+        matching: find.byType(TextField),
+      ),
+    );
+    expect(textField.autocorrect, isFalse);
+    expect(textField.enableSuggestions, isFalse);
+  });
 }


### PR DESCRIPTION
## Audit loop — iteration 18: auth-flow deep-dive (convergence test)

Workflow audit of the AUTH flow (login/register/forgot/reset, 12 files, 6 dims × adversarial verify). 11 raw → 3 SHIP-nonvisual / 0 SHIP-visual / 2 DEFER / 6 REJECT. **Not converged** — found a real behavioral bug + 2 a11y parity gaps. All shipped changes are **non-visual**.

### Shipped (3 fixes + 1 test)
- **bug — email autocorrect mangling** (`login` / `register` / `forgot_password` screens): all three email `AppTextField`s set `keyboardType: emailAddress` but left `autocorrect`/`enableSuggestions` at their `true` defaults. `AppTextField`'s own docstring says *"Pass false for email fields"*, and the app's only other email field (`profile_edit`) already does. iOS/Android autocorrect silently mutates typed emails → wrong credentials → misleading P1 "invalid login" errors. Added `autocorrect: false` + `enableSuggestions: false` to all three (no change to the shared `AppTextField`). + a test asserting the inner `TextField` has both disabled.
- **a11y — register footer "Login" link**: a bare `InkWell` nav target with no button role. Wrapped in `Semantics(button: true, label: 'Login', excludeSemantics: true)` to mirror login's `_SignUpFooter` (the established convention).
- **a11y — login logo mark**: the decorative `'n'` glyph leaked to the a11y tree (screen reader announced a stray "n"). Wrapped in `Semantics(label: 'Nibbles', image: true, child: ExcludeSemantics(...))` to mirror register's `_SignUpLogoMark`.

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` → clean
- `flutter test` forgot (incl. new email test) + register → all pass; diffs scoped (no `dart format` on pre-existing files)
- Non-visual (input-behavior params + Semantics annotations) → no sim gate

### DEFER (real but owner-ambiguous / needs care — NOT shipped)
- `reset_password` gates its P1 Supabase error display behind a fragile literal-string comparison (swallow risk) — needs careful error-flow review.
- `register_controller.submit`/`_runSocial` lack a `ref.mounted` guard after `await` before touching state/`ref.read` — potential use-after-dispose; verify AsyncNotifier disposal semantics first.

### Pre-existing broken test (NOT my regression, verified on clean main — 5th such file)
`login_screen_test` › "error state — submit failure renders the Supabase error verbatim" fails on clean `main`: expects 2× "Invalid login credentials." but finds 0. Could be a stale test **or** a real P1 error-rendering gap (login errors not surfacing) — worth a dedicated investigation tick. CI never caught it (CI runs only `flutter analyze`). Logged for owner.