### PR TITLE
fix(onboarding): re-entrancy guard on submit() (prevent duplicate baby rows)

### DIFF
--- a/lib/src/features/onboarding/onboarding_controller.dart
+++ b/lib/src/features/onboarding/onboarding_controller.dart
@@ -122,6 +122,11 @@ class OnboardingController extends _$OnboardingController {
   /// hole, but if any future path lands a user here with missing input we
   /// surface an inline P1 message instead of silently no-op'ing.
   Future<bool> submit() async {
+    // Re-entrancy guard: a second call while a createBaby is already in flight
+    // (e.g. a double-tap before isSubmitting repaints) would issue a second
+    // non-idempotent createBaby and orphan a duplicate baby row.
+    if (state.isSubmitting) return false;
+
     if (state.dob == null || !state.babyName.isValid) {
       state = state.copyWith(
         submitErrorMessage: "We're missing your baby's name or date of birth. "

--- a/test/features/onboarding/onboarding_controller_submit_is_submitting_test.dart
+++ b/test/features/onboarding/onboarding_controller_submit_is_submitting_test.dart
@@ -156,4 +156,31 @@ void main() {
       );
     },
   );
+
+  test(
+    're-entrant submit while in-flight returns false and never calls '
+    'createBaby twice (no orphan baby rows)',
+    () async {
+      final completer = Completer<Result<Baby>>();
+      when(
+        () => babyProfile.createBaby(any(), any()),
+      ).thenAnswer((_) => completer.future);
+
+      final container = _makeContainer(babyProfile);
+      final controller = container.read(onboardingControllerProvider.notifier)
+        ..updateName('Lily')
+        ..updateDob(DateTime(2025, 6));
+
+      // First call is in-flight (isSubmitting=true, awaiting createBaby).
+      final pending = controller.submit();
+      // Second call before the first resolves must be rejected by the guard.
+      final reentrant = await controller.submit();
+      expect(reentrant, isFalse);
+
+      completer.complete(Result.success(_fakeBaby));
+      await pending;
+
+      verify(() => babyProfile.createBaby(any(), any())).called(1);
+    },
+  );
 }


### PR DESCRIPTION
## Audit loop — iteration 19: onboarding flow deep-dive (Workflow)

Workflow audit of the onboarding flow (intro→name→dob→readiness→result→consent→baby_setup, 16 files, 6 dims × adversarial verify). 11 raw → 1 SHIP-nonvisual / 1 SHIP-visual / 3 DEFER / 6 REJECT. Thinner than prior deep-dives (recipe-detail 5, map 6, auth 3) — convergence is approaching — but the one non-visual finding is a real data-integrity bug worth shipping.

### Shipped (1 fix + 1 test)
- **bug — double-submit creates orphan baby rows:** `OnboardingController.submit()` set `isSubmitting = true` then `await createBaby(...)`, but had **no internal re-entrancy guard**. The consent screen's CTA/Retry disable is purely presentational (`isSubmitting` only schedules a *next-frame* rebuild), so a fast double-tap — or taps buffered during a jank/GC pause before the disable repaints — can invoke `submit()` twice; both pass the name/DOB check and both call the **non-idempotent** `createBaby`, orphaning a duplicate baby row. Added `if (state.isSubmitting) return false;` as the first line (matches the existing PopScope comment's stated intent). Failure + success paths still reset `isSubmitting`, so legitimate retries are unaffected.
- Added a controller test: a second `submit()` while the first is in-flight returns `false` and `createBaby` is `verify(...).called(1)`.

### Gates
- `flutter analyze --fatal-infos --fatal-warnings` → clean
- `flutter test` onboarding controller suites → **11/11 pass** (incl. the new re-entrancy test)
- Non-visual (controller guard) → no sim gate. Diff scoped (no `dart format` on pre-existing files).

### Deferred (verified, NOT shipped)
- **SHIP-visual (backlog):** the readiness questionnaire screen is a rigid `Column` (no `SingleChildScrollView`) with `AspectRatio(1)` square cards → **RenderFlex overflow risk** on short devices / large text scale. Both sibling screens (`result`, `consent`) already wrap content in a scroll view; readiness is the lone divergence. Visual restructure → needs the sim gate.
- **DEFER:** `routes.dart` `baby-setup-loading` not whitelisted in the M2 paywall redirect branch (but the subscription guard is **deferred per project rules** — M2 removed — so currently moot/owner). `onboarding_controller.reset()` is unused but its doc says "Reserved for sign-out / test setup" (intentional, not dead). Result 'not met' sign rows reuse the green check-circle styling (Figma question).

CONVERGENCE NOTE: 3 deep-dives still finding real bugs, but the SHIP-nonvisual count is trending down (5→6→3→1). The next near-empty Workflow will trigger a convergence notice + loop downshift.