### PR TITLE
fix(onboarding): atomic createBaby via RPC + UNIQUE(user_id) — REVIEW (DB migration)

### DIFF
--- a/lib/src/common/data/repositories/baby_profile_repository.dart
+++ b/lib/src/common/data/repositories/baby_profile_repository.dart
@@ -47,18 +47,22 @@ class BabyProfileRepositoryImpl implements BabyProfileRepository {
     Gender gender = Gender.preferNotToSay,
   ]) async {
     try {
-      final data = await _supabase
-          .from('babies')
-          .insert({
-            'user_id': _userId,
-            'name': name,
-            'date_of_birth': dob.toIso8601String().split('T').first,
-            'gender': gender.toJson(),
-            'onboarding_completed': true,
-          })
-          .select()
-          .single();
-      return Result.success(BabyResponse.fromJson(data).toDomain());
+      // Atomic: the `create_baby_with_program` RPC inserts the baby row AND its
+      // allergen_program_state row in one transaction (migration
+      // 20260605000001). Replaces the old two-write sequence that could orphan
+      // a baby row and duplicate it on retry.
+      final res = await _supabase.rpc<dynamic>(
+        'create_baby_with_program',
+        params: {
+          'p_name': name,
+          'p_date_of_birth': dob.toIso8601String().split('T').first,
+          'p_gender': gender.toJson(),
+        },
+      );
+      final row = res is List
+          ? res.first as Map<String, dynamic>
+          : res as Map<String, dynamic>;
+      return Result.success(BabyResponse.fromJson(row).toDomain());
     } on AppException catch (e) {
       return Result.failure(e);
     } on PostgrestException catch (e) {

--- a/lib/src/common/services/baby_profile_service.dart
+++ b/lib/src/common/services/baby_profile_service.dart
@@ -12,8 +12,12 @@ class BabyProfileService {
 
   final BabyProfileRepository _repo;
 
-  /// Creates baby row + allergen_program_state row atomically (sequential).
-  /// If allergen_program_state insert fails, returns Failure.
+  /// Creates the baby row + its allergen_program_state row ATOMICALLY.
+  ///
+  /// Atomicity lives at the repository/DB layer: the repository's `createBaby`
+  /// calls the `create_baby_with_program` Postgres RPC, which does both inserts
+  /// in a single transaction. A failure can therefore never orphan a baby row
+  /// or duplicate it on retry (unlike the old app-side two-write sequence).
   ///
   /// Gender is optional — the redesigned onboarding (NIB-120) drops the
   /// selector. Defaults to [Gender.preferNotToSay] when omitted.
@@ -21,18 +25,7 @@ class BabyProfileService {
     String name,
     DateTime dob, [
     Gender gender = Gender.preferNotToSay,
-  ]) async {
-    final babyResult = await _repo.createBaby(name, dob, gender);
-    if (babyResult.isFailure) return babyResult;
-
-    final baby = babyResult.dataOrNull!;
-    final programResult = await _repo.createAllergenProgramState(baby.id);
-    if (programResult.isFailure) {
-      return Result.failure(programResult.errorOrNull!);
-    }
-
-    return Result.success(baby);
-  }
+  ]) => _repo.createBaby(name, dob, gender);
 
   Future<Baby?> getBaby() => _repo.getBaby();
 

--- a/supabase/migrations/20260605000001_create_baby_with_program_rpc.sql
+++ b/supabase/migrations/20260605000001_create_baby_with_program_rpc.sql
@@ -1,0 +1,48 @@
+-- Atomic baby creation (fixes the onboarding orphan/duplicate-baby bug).
+--
+-- Previously the app created the baby row and its allergen_program_state row in
+-- TWO separate writes from the service layer. If the second write failed, the
+-- baby row was already committed (and never rolled back), and the user's retry
+-- created a SECOND baby row. This RPC performs both inserts inside a single
+-- plpgsql function body — which runs in one transaction — so either both rows
+-- commit or neither does.
+--
+-- One baby per user is the real invariant. The UNIQUE(user_id) constraint
+-- enforces it and makes a retry idempotent.
+-- NOTE: this ALTER fails if duplicate user_id rows already exist. The app is
+-- pre-launch, so none are expected; if any exist in an environment, de-duplicate
+-- the babies table before applying this migration.
+ALTER TABLE babies
+  ADD CONSTRAINT babies_user_id_key UNIQUE (user_id);
+
+-- SECURITY INVOKER (default): the inserts run as the calling user, so RLS still
+-- applies (WITH CHECK auth.uid() = user_id passes; the just-inserted baby is
+-- visible to the allergen_program_state RLS EXISTS check within the same txn).
+-- search_path is pinned to avoid resolution hijacking.
+CREATE OR REPLACE FUNCTION create_baby_with_program(
+  p_name TEXT,
+  p_date_of_birth DATE,
+  p_gender TEXT
+)
+RETURNS babies
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_baby babies;
+BEGIN
+  INSERT INTO babies (user_id, name, date_of_birth, gender, onboarding_completed)
+  VALUES (auth.uid(), p_name, p_date_of_birth, p_gender, true)
+  RETURNING * INTO v_baby;
+
+  INSERT INTO allergen_program_state (
+    baby_id, current_allergen_key, current_sequence_order, status
+  )
+  VALUES (v_baby.id, 'peanut', 1, 'in_progress');
+
+  RETURN v_baby;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_baby_with_program(TEXT, DATE, TEXT) TO authenticated;

--- a/test/common/services/baby_profile_service_test.dart
+++ b/test/common/services/baby_profile_service_test.dart
@@ -32,16 +32,13 @@ void main() {
     sut = BabyProfileService(mockRepo);
   });
 
-  group('BabyProfileService.createBaby', () {
+  group('BabyProfileService.createBaby (atomic via repo RPC)', () {
     test(
-      'returns Result.success(baby) and calls both repo methods on success',
+      'delegates to repo.createBaby and never does the old 2nd write',
       () async {
         when(
           () => mockRepo.createBaby(any(), any(), any()),
         ).thenAnswer((_) async => Result.success(_fakeBaby));
-        when(
-          () => mockRepo.createAllergenProgramState(any()),
-        ).thenAnswer((_) async => const Result.success(null));
 
         final result = await sut.createBaby(
           'Lily',
@@ -54,34 +51,13 @@ void main() {
         verify(
           () => mockRepo.createBaby('Lily', DateTime(2024, 6), Gender.female),
         ).called(1);
-        verify(() => mockRepo.createAllergenProgramState('baby-001')).called(1);
+        // Atomicity now lives in the RPC; the service must NOT issue the old
+        // separate program-state write (the source of the orphan/dup bug).
+        verifyNever(() => mockRepo.createAllergenProgramState(any()));
       },
     );
 
-    test(
-      'returns Result.failure when createAllergenProgramState fails',
-      () async {
-        when(
-          () => mockRepo.createBaby(any(), any(), any()),
-        ).thenAnswer((_) async => Result.success(_fakeBaby));
-        when(() => mockRepo.createAllergenProgramState(any())).thenAnswer(
-          (_) async => const Result.failure(
-            ServerException('Failed to create program state'),
-          ),
-        );
-
-        final result = await sut.createBaby(
-          'Lily',
-          DateTime(2024, 6),
-          Gender.female,
-        );
-
-        expect(result.isFailure, isTrue);
-      },
-    );
-
-    test('returns Result.failure without calling createAllergenProgramState '
-        'when baby creation fails', () async {
+    test('propagates a repo.createBaby failure', () async {
       when(() => mockRepo.createBaby(any(), any(), any())).thenAnswer(
         (_) async => const Result.failure(ServerException('DB error')),
       );
@@ -97,15 +73,11 @@ void main() {
     });
 
     test(
-      'succeeds with NO gender argument — defaults to preferNotToSay '
-      'and remains atomic',
+      'defaults gender to preferNotToSay when omitted',
       () async {
         when(
           () => mockRepo.createBaby(any(), any(), any()),
         ).thenAnswer((_) async => Result.success(_fakeBaby));
-        when(
-          () => mockRepo.createAllergenProgramState(any()),
-        ).thenAnswer((_) async => const Result.success(null));
 
         final result = await sut.createBaby('Lily', DateTime(2024, 6));
 
@@ -114,13 +86,13 @@ void main() {
           () => mockRepo.createBaby(
             'Lily',
             DateTime(2024, 6),
-            // Explicit Gender.preferNotToSay is the assertion of this test —
-            // mocktail needs the literal value to match the captured argument.
+            // Explicit value is the assertion of this test — mocktail needs the
+            // literal to match the captured argument.
             // ignore: avoid_redundant_argument_values
             Gender.preferNotToSay,
           ),
         ).called(1);
-        verify(() => mockRepo.createAllergenProgramState('baby-001')).called(1);
+        verifyNever(() => mockRepo.createAllergenProgramState(any()));
       },
     );
   });


### PR DESCRIPTION
## ⚠️ NEEDS YOUR REVIEW — do not let the loop auto-merge this

This carries a **DB migration**, so it must be reviewed + the migration applied to Supabase, and code+DB shipped together. CI here only runs `flutter analyze` — it does NOT execute the SQL or test the RPC against the database.

## What this fixes (residual bug #1 — you picked option A)
`baby_profile_service.createBaby` did **two separate DB writes** (the `babies` row, then `allergen_program_state`). If the 2nd write failed, the baby row was already committed and never rolled back → **orphan baby row**; the user's retry then created a **duplicate** (the table had no `UNIQUE(user_id)`, and `getBaby()` does `.limit(1).maybeSingle()` so it silently picks one).

## The fix (option A — true atomicity)
- **Migration `20260605000001_create_baby_with_program_rpc.sql`:**
  - `create_baby_with_program(p_name, p_date_of_birth, p_gender) RETURNS babies` — a `plpgsql` function that does **both inserts in one transaction** (`SECURITY INVOKER`, `search_path=public`, granted to `authenticated`). Inserts `babies` (`user_id = auth.uid()`, `onboarding_completed = true`) then `allergen_program_state` (`peanut`/`1`/`in_progress`, matching the old repo values), and returns the baby row.
  - `ALTER TABLE babies ADD CONSTRAINT babies_user_id_key UNIQUE (user_id)` — enforces one-baby-per-user and makes retries idempotent.
- **Repo** `createBaby` → calls the RPC instead of the raw insert; maps the returned row via `BabyResponse.fromJson`.
- **Service** `createBaby` → now a single delegating call (the 2-write logic is gone); doc comment corrected (was falsely "atomically").
- **Tests** — rewrote the `baby_profile_service_test` createBaby group to assert single-delegation + that the old 2nd write is never issued. `flutter analyze --fatal-infos` clean; service + onboarding-controller suites (19 tests, incl. the iter19 re-entrancy test) pass.

## ❗ Before you merge — please verify (I can't, from here)
1. **`UNIQUE(user_id)` will fail to apply if duplicate `babies` rows already exist.** Pre-launch this should be none; if any env has dupes, de-dup first. (Noted in the migration.)
2. **RPC ↔ Dart shape:** the function `RETURNS babies` (single row). The repo defensively handles both a `Map` and a single-element `List` from `supabase.rpc(...)` — worth a quick check against your Supabase that the RPC returns/maps the row as expected (it's the first `.rpc` in this codebase).
3. **Ship code + migration together:** once merged, the app expects the RPC to exist — apply the migration to Supabase (dev then prod) as part of the same release, or onboarding will fail with "function not found".
4. RLS: `SECURITY INVOKER` keeps RLS active; the just-inserted baby is visible to the `allergen_program_state` RLS `EXISTS` check within the same txn. Please sanity-check on dev.

Note: the now-unused `BabyProfileRepository.createAllergenProgramState` is left in place (still on the interface + QA stub) — a separate cleanup if you want it gone.