### PR TITLE
fix(allergen): clear stale isSaved on EDIT re-entry — no phantom save bounce

### DIFF
--- a/lib/src/features/allergen/log/allergen_log_controller.dart
+++ b/lib/src/features/allergen/log/allergen_log_controller.dart
@@ -81,7 +81,15 @@ class AllergenLogController extends _$AllergenLogController {
     required String allergenKey,
     required String logId,
   }) async {
-    if (state.hydrated && state.logId == logId) return;
+    if (state.hydrated && state.logId == logId) {
+      // Re-entering EDIT for the SAME log: clear any stale `isSaved` left by a
+      // previous save of this log. The controller is keepAlive, so without
+      // this the screen's save-listener trips on the first interaction and
+      // bounces the user out — dropping the second edit + returning a phantom
+      // saved=true.
+      if (state.isSaved) state = state.copyWith(isSaved: false);
+      return;
+    }
 
     state = state.copyWith(isLoading: true);
 

--- a/test/features/allergen/log/allergen_log_controller_test.dart
+++ b/test/features/allergen/log/allergen_log_controller_test.dart
@@ -413,5 +413,48 @@ void main() {
         expect(state.logId, isNull);
       },
     );
+
+    test(
+      'hydrateForEdit clears a stale isSaved when re-editing the same log '
+      '(keepAlive — no phantom bounce)',
+      () => runWithAnalyticsGuard(() async {
+        final existing = _makeLog(id: 'log-edit', notes: 'note');
+        when(
+          () => mockService.getLogs(
+            any(),
+            allergenKey: any(named: 'allergenKey'),
+          ),
+        ).thenAnswer((_) async => Result.success([existing]));
+        when(
+          () => mockService.updateAllergenLog(
+            log: any(named: 'log'),
+            newPhotoLocalPath: any(named: 'newPhotoLocalPath'),
+            oldPhotoPath: any(named: 'oldPhotoPath'),
+          ),
+        ).thenAnswer((_) async => Result.success(existing));
+
+        final controller = readController();
+        // First edit + save → isSaved flips true; the keepAlive controller
+        // retains it after the screen pops.
+        await controller.hydrateForEdit(
+          babyId: _babyId,
+          allergenKey: _allergenKey,
+          logId: 'log-edit',
+        );
+        await controller.submit(babyId: _babyId, allergenKey: _allergenKey);
+        expect(readState().isSaved, isTrue);
+
+        // Re-enter EDIT for the SAME log (idempotent short-circuit): the stale
+        // isSaved must be cleared so the screen's save-listener cannot bounce
+        // on the first interaction.
+        await controller.hydrateForEdit(
+          babyId: _babyId,
+          allergenKey: _allergenKey,
+          logId: 'log-edit',
+        );
+        expect(readState().isSaved, isFalse);
+        expect(readState().logId, 'log-edit');
+      }),
+    );
   });
 }


### PR DESCRIPTION
## What
The `AllergenLogController` is `@Riverpod(keepAlive: true)`, so after saving an edit its `isSaved=true` survives screen disposal. Re-editing the **same** log short-circuited `hydrateForEdit` without clearing `isSaved`, so the screen's save-listener tripped on the first interaction — bouncing the user out, dropping the second edit, and returning a phantom `saved=true`.

## Fix
Clear the stale `isSaved` inside the idempotent short-circuit when re-entering EDIT for the same log.

## Test
Adds a test reproducing the re-edit bounce: hydrate → submit (success → isSaved=true) → re-hydrate same log → asserts `isSaved==false` and `logId` retained. Full controller suite: 7/7 green.

## Risk
Controller-only logic change, no visual change. `flutter analyze --fatal-infos --fatal-warnings` clean.