### PR TITLE
fix(allergen): invalidate tracker on detail return — no stale status after log add

### DIFF
--- a/lib/src/features/allergen/tracker/allergen_tracker_screen.dart
+++ b/lib/src/features/allergen/tracker/allergen_tracker_screen.dart
@@ -268,7 +268,8 @@ class _TrackerContent extends ConsumerWidget {
             statuses: state.statuses,
             logs: state.logs,
             onStartIntroduce: onStartIntroduce,
-            onAllergenTap: (a) => _openAllergenDetail(context, a.key),
+            onAllergenTap: (a) =>
+                unawaited(_openAllergenDetail(context, ref, a.key)),
           )
         else
           _OngoingList(
@@ -277,7 +278,8 @@ class _TrackerContent extends ConsumerWidget {
             allergens: state.allergens,
             statuses: state.statuses,
             logs: state.logs,
-            onAllergenTap: (a) => _openAllergenDetail(context, a.key),
+            onAllergenTap: (a) =>
+                unawaited(_openAllergenDetail(context, ref, a.key)),
             onSeeAll: onSeeAll,
           ),
         const SliverToBoxAdapter(child: SizedBox(height: AppSizes.xl)),
@@ -285,11 +287,21 @@ class _TrackerContent extends ConsumerWidget {
     );
   }
 
-  void _openAllergenDetail(BuildContext context, String allergenKey) {
-    context.pushNamed(
+  Future<void> _openAllergenDetail(
+    BuildContext context,
+    WidgetRef ref,
+    String allergenKey,
+  ) async {
+    await context.pushNamed(
       AppRoute.allergenDetail.name,
       pathParameters: {'allergenKey': allergenKey},
     );
+    // Adding a log inside the detail screen changes this allergen's derived
+    // status; detail invalidates only its own provider, so refresh the tracker
+    // on return to avoid showing a stale per-allergen status.
+    if (context.mounted) {
+      ref.invalidate(allergenTrackerControllerProvider(babyId));
+    }
   }
 }
 

--- a/test/features/allergen/tracker/allergen_tracker_screen_test.dart
+++ b/test/features/allergen/tracker/allergen_tracker_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/allergen/tracker/allergen_tracker_screen.dart';
+import 'package:nibbles/src/features/allergen/tracker/widgets/allergen_progress_card.dart';
 import 'package:nibbles/src/features/allergen/tracker/widgets/start_introduce_card.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
@@ -159,7 +160,13 @@ void main() {
             recorder
               ..lastName = AppRoute.allergenDetail.name
               ..lastPathParams = st.pathParameters;
-            return const Scaffold(body: Text('DETAIL_STUB'));
+            // Poppable so the "refresh on return" test can navigate back.
+            return Scaffold(
+              body: TextButton(
+                onPressed: ctx.pop,
+                child: const Text('DETAIL_STUB'),
+              ),
+            );
           },
         ),
         GoRoute(
@@ -337,6 +344,52 @@ void main() {
         // After tapping See All, Big 11 sections are shown.
         expect(find.text('Already Tried'), findsOneWidget);
         expect(find.text('Allergen Exposure'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'Tapping an allergen tile navigates to detail; returning refreshes '
+      'the tracker so per-allergen status is not stale',
+      (tester) async {
+        stubReads(
+          statuses: {
+            'peanut': AllergenStatus.safe,
+            for (final a in _allergens.skip(1))
+              a.key: AllergenStatus.notStarted,
+          },
+          logs: [
+            _makeLog(id: 'p1', allergenKey: 'peanut'),
+            _makeLog(id: 'p2', allergenKey: 'peanut'),
+            _makeLog(id: 'p3', allergenKey: 'peanut'),
+          ],
+        );
+        final recorder = _PushRecorder();
+        await tester.pumpWidget(buildSubject(recorder));
+        await tester.pumpAndSettle();
+
+        // Big 11 renders an AllergenProgressCard for the tried (safe) peanut.
+        await tester.tap(find.text('Big 11'));
+        await tester.pumpAndSettle();
+
+        // Initial load fetched statuses exactly once (segment switch is local).
+        verify(() => mockService.getAllergenStatuses(any())).called(1);
+
+        final card = find.byType(AllergenProgressCard).first;
+        await tester.ensureVisible(card);
+        await tester.tap(card);
+        await tester.pumpAndSettle();
+
+        // Navigated to allergen-detail with the tapped key.
+        expect(recorder.lastName, AppRoute.allergenDetail.name);
+        expect(recorder.lastPathParams?['allergenKey'], 'peanut');
+        expect(find.text('DETAIL_STUB'), findsOneWidget);
+
+        // Return to the tracker → it must re-fetch (detail may have added a
+        // log that changed this allergen's derived status).
+        await tester.tap(find.text('DETAIL_STUB'));
+        await tester.pumpAndSettle();
+
+        verify(() => mockService.getAllergenStatuses(any())).called(1);
       },
     );
   });


### PR DESCRIPTION
## What
`_TrackerContent._openAllergenDetail` navigated to the allergen-detail screen **fire-and-forget** — it never awaited the push nor refreshed the tracker on return.

The detail screen lets the user add a log (`_onAddPressed`), which invalidates **only its own** provider (`allergenDetailControllerProvider`). So after adding a log and popping back, the tracker board showed a **stale per-allergen status** (e.g. a just-completed allergen still rendered as in-progress).

## Fix
Mirror the existing `_startIntroduce` pattern: make `_openAllergenDetail` async, `await` the push, and `ref.invalidate(allergenTrackerControllerProvider(babyId))` on return (guarded by `context.mounted` since `_TrackerContent` is a `ConsumerWidget`). Call sites wrapped in `unawaited(...)`.

## Test
Adds a test: tap an allergen tile → asserts nav to detail with the right key → pop back → `verify` the tracker re-fetched statuses on return. Full tracker suite: 5/5 green. Pre-fix this test fails (no re-fetch).

## Risk
Screen-only nav/refresh logic, no visual change. `flutter analyze --fatal-infos --fatal-warnings` clean.