### PR TITLE
fix(allergen): run AL-08 completion gate on log delete

### DIFF
--- a/lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart
+++ b/lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart
@@ -11,7 +11,9 @@ import 'package:nibbles/src/common/components/components.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/allergen/detail/allergen_detail_controller.dart';
 import 'package:nibbles/src/features/allergen/log_detail/allergen_log_detail_controller.dart';
 import 'package:nibbles/src/features/allergen/log_detail/allergen_log_detail_state.dart';
@@ -196,6 +198,36 @@ class _LogDetailViewState extends ConsumerState<_LogDetailView> {
     ref
       ..invalidate(allergenDetailControllerProvider(_allergenKey))
       ..invalidate(allergenTrackerControllerProvider(_state.babyId));
+
+    // AL-08 reachability gate (NIB-128), mirrored from the log capture screen.
+    // Deleting a *reaction* log can flip its allergen flagged → safe (when 3+
+    // clean logs remain), which may complete the program. The save path runs
+    // this same gate after a write; the delete path must too, or the AL-08
+    // completion screen is silently missed. The once-only
+    // `program_completion_shown_{babyId}` flag prevents re-showing it.
+    final babyId = _state.babyId;
+    final flagService = ref.read(localFlagServiceProvider);
+    if (!flagService.isProgramCompletionShown(babyId)) {
+      final statusesResult = await ref
+          .read(allergenServiceProvider)
+          .getAllergenStatuses(babyId);
+      if (!mounted) return;
+      final statuses = statusesResult.dataOrNull;
+      final allSafe =
+          statuses != null &&
+          statuses.isNotEmpty &&
+          statuses.values.every(
+            (AllergenStatus s) => s == AllergenStatus.safe,
+          );
+      if (allSafe) {
+        await flagService.markProgramCompletionShown(babyId);
+        if (!mounted) return;
+        context.goNamed(AppRoute.allergenComplete.name);
+        return;
+      }
+    }
+
+    if (!mounted) return;
     context.pop();
   }
 

--- a/test/features/allergen/log_detail/allergen_log_detail_screen_test.dart
+++ b/test/features/allergen/log_detail/allergen_log_detail_screen_test.dart
@@ -7,10 +7,13 @@ import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/allergen.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/domain/enums/emoji_taste.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/helpers/derive_allergen_status.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/allergen/log_detail/allergen_log_detail_screen.dart';
 import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
@@ -20,6 +23,8 @@ import '../../../support/fake_analytics.dart';
 class _MockAllergenService extends Mock implements AllergenService {}
 
 class _MockBabyProfileService extends Mock implements BabyProfileService {}
+
+class _MockLocalFlagService extends Mock implements LocalFlagService {}
 
 const _babyId = 'baby-001';
 const _allergenKey = 'peanut';
@@ -65,10 +70,12 @@ AllergenLog _makeLog({
 void main() {
   late _MockAllergenService mockService;
   late _MockBabyProfileService mockBabyService;
+  late _MockLocalFlagService mockFlags;
 
   setUp(() {
     mockService = _MockAllergenService();
     mockBabyService = _MockBabyProfileService();
+    mockFlags = _MockLocalFlagService();
     when(() => mockBabyService.getBaby()).thenAnswer((_) async => _baby);
     when(
       () => mockService.getAllergens(),
@@ -76,6 +83,11 @@ void main() {
     when(
       () => mockService.getSignedPhotoUrl(any()),
     ).thenAnswer((_) async => const Result.success('https://photo.test/p.jpg'));
+    // Default: AL-08 already shown → the post-delete gate short-circuits and
+    // the screen just pops (the behaviour the non-completion tests expect).
+    when(
+      () => mockFlags.isProgramCompletionShown(any()),
+    ).thenReturn(true);
   });
 
   void stubLogs(List<AllergenLog> logs) {
@@ -109,6 +121,11 @@ void main() {
           name: AppRoute.allergenLogEdit.name,
           builder: (_, __) => const Scaffold(body: Text('EDIT_STUB')),
         ),
+        GoRoute(
+          path: AppRoute.allergenComplete.path,
+          name: AppRoute.allergenComplete.name,
+          builder: (_, __) => const Scaffold(body: Text('AL08_STUB')),
+        ),
       ],
     );
 
@@ -116,6 +133,7 @@ void main() {
       overrides: [
         allergenServiceProvider.overrideWithValue(mockService),
         babyProfileServiceProvider.overrideWithValue(mockBabyService),
+        localFlagServiceProvider.overrideWithValue(mockFlags),
         analyticsProvider.overrideWithValue(FakeAnalytics()),
       ],
       child: MaterialApp.router(routerConfig: router),
@@ -292,6 +310,50 @@ void main() {
             logId: _logId,
             photoPath: 'allergen-attachments/$_babyId/p.jpg',
           ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'Deleting a log that completes the program (all allergens safe, AL-08 '
+      'not yet shown) flips the once-only flag + routes to AL-08, not pop',
+      (tester) async {
+        // A reaction log whose deletion flips its allergen flagged → safe,
+        // completing the program (every allergen derives to safe post-delete).
+        stubLogs([_makeLog(hadReaction: true, notes: 'Rash on cheek')]);
+        when(
+          () => mockService.deleteAllergenLog(
+            logId: any(named: 'logId'),
+            photoPath: any(named: 'photoPath'),
+          ),
+        ).thenAnswer((_) async => const Result.success(null));
+        when(
+          () => mockFlags.isProgramCompletionShown(any()),
+        ).thenReturn(false);
+        when(
+          () => mockFlags.markProgramCompletionShown(any()),
+        ).thenAnswer((_) async {});
+        when(() => mockService.getAllergenStatuses(any())).thenAnswer(
+          (_) async => Result.success({
+            for (final key in kAllergenKeys) key: AllergenStatus.safe,
+          }),
+        );
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('log_detail_menu')));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const Key('log_actions_menu_delete')));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const Key('delete_log_confirm_button')));
+        await tester.pumpAndSettle();
+
+        // Routed to AL-08 instead of popping back to the detail's parent.
+        expect(find.text('AL08_STUB'), findsOneWidget);
+        expect(find.text('ROOT_STUB'), findsNothing);
+        verify(
+          () => mockFlags.markProgramCompletionShown(_babyId),
         ).called(1);
       },
     );


### PR DESCRIPTION
## What
The log-detail **delete** path (`_confirmAndDelete`) popped unconditionally and never ran the **AL-08 program-completion gate** that the log-capture (save) screen runs after a write.

This is a real omission, not cosmetic: `deriveStatusForLogs` marks an allergen `flagged` if **any** log has a reaction. Deleting that reaction log (when 3+ clean logs remain) flips the allergen `flagged → safe`. If it was the last non-safe allergen, the deletion **completes the program** — but the AL-08 completion screen was silently skipped.

## Fix
Mirror the save-path gate inline in `_confirmAndDelete`, **between the existing invalidations and the pop**: re-derive statuses via `getAllergenStatuses` (reads logs fresh from Supabase — allergen logs are not Hive-cached, so the post-delete state is seen); if all allergens are `safe` **and** the once-only `program_completion_shown_{babyId}` flag is unset, flip the flag and `goNamed(allergenComplete)` instead of popping. Otherwise pop as before. Invalidations are preserved on every path.

Inlined (not extracted to a shared helper) deliberately: the save→AL-08 listener is a critical path and CI does not run widget tests (analyze-only), so I kept the proven save-path code untouched. A DRY extraction of the gate is logged as an owner follow-up.

## Product note (completion-is-completion)
This makes a deletion able to route the user into the full-screen AL-08 completion celebration. That is the intended reading: the program genuinely **is** all-safe after the delete, and the once-only flag prevents any re-show. If product wants completion to fire **only** on a positive log (never on a deletion), this is a one-line gate-removal — flagging for owner awareness.

## Test
Adds a delete→AL-08 routing test (all-safe + flag unset → flips flag + routes to AL-08, not pop); fails pre-fix. Existing delete/render tests updated to override `localFlagServiceProvider` (default flag=shown → gate short-circuits → pop, preserving their behaviour). Suite: 8/8 log_detail + 4/4 save-path al_08_gate green. `flutter analyze --fatal-infos` clean.

## Risk
Non-visual control-flow on the delete path; save path untouched.