### PR TITLE
fix(allergen): button role + label on attachment photo preview

### DIFF
--- a/lib/src/features/allergen/log/widgets/attachment_sheet.dart
+++ b/lib/src/features/allergen/log/widgets/attachment_sheet.dart
@@ -246,47 +246,57 @@ class _PhotoPreview extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
     final radius = BorderRadius.circular(AppSizes.radiusLg);
 
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        key: const Key('attachment_photo_tap'),
-        onTap: onTap,
-        borderRadius: radius,
-        child: Container(
-          height: 195,
-          width: double.infinity,
-          decoration: BoxDecoration(
-            color: AppColors.bgInput,
-            borderRadius: radius,
-          ),
-          alignment: Alignment.center,
-          child: photoPath != null
-              ? ClipRRect(
-                  borderRadius: radius,
-                  child: Image.file(
-                    File(photoPath!),
-                    fit: BoxFit.cover,
-                    width: double.infinity,
-                    height: 195,
-                  ),
-                )
-              : Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const Icon(
-                      Icons.add_a_photo_outlined,
-                      color: AppColors.fgFaint,
-                      size: AppSizes.iconLg,
+    // Button role + curated label so screen readers announce the tap target
+    // (the inner "Tap to add photo" caption is absent once a photo is set, and
+    // an Image.file alone carries no accessible name). excludeSemantics is safe
+    // here — the InkWell wraps no other interactive children.
+    return Semantics(
+      button: true,
+      label: photoPath != null ? 'Change photo' : 'Add photo',
+      excludeSemantics: true,
+      onTap: onTap,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          key: const Key('attachment_photo_tap'),
+          onTap: onTap,
+          borderRadius: radius,
+          child: Container(
+            height: 195,
+            width: double.infinity,
+            decoration: BoxDecoration(
+              color: AppColors.bgInput,
+              borderRadius: radius,
+            ),
+            alignment: Alignment.center,
+            child: photoPath != null
+                ? ClipRRect(
+                    borderRadius: radius,
+                    child: Image.file(
+                      File(photoPath!),
+                      fit: BoxFit.cover,
+                      width: double.infinity,
+                      height: 195,
                     ),
-                    const SizedBox(height: AppSizes.sm),
-                    Text(
-                      'Tap to add photo',
-                      style: textTheme.bodyMedium?.copyWith(
+                  )
+                : Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(
+                        Icons.add_a_photo_outlined,
                         color: AppColors.fgFaint,
+                        size: AppSizes.iconLg,
                       ),
-                    ),
-                  ],
-                ),
+                      const SizedBox(height: AppSizes.sm),
+                      Text(
+                        'Tap to add photo',
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: AppColors.fgFaint,
+                        ),
+                      ),
+                    ],
+                  ),
+          ),
         ),
       ),
     );

--- a/test/features/allergen/log/widgets/attachment_sheet_test.dart
+++ b/test/features/allergen/log/widgets/attachment_sheet_test.dart
@@ -107,5 +107,27 @@ void main() {
         expect(box.value!.photoPath, isNull);
       },
     );
+
+    testWidgets(
+      'photo preview is an "Add photo" button that opens the source picker',
+      (tester) async {
+        final handle = tester.ensureSemantics();
+        await _openSheet(tester);
+
+        // a11y: the tap target carries a button role + curated label. Pre-fix
+        // the only node was the "Tap to add photo" caption (which vanishes once
+        // a photo is set, and an Image.file alone has no accessible name).
+        expect(find.bySemanticsLabel('Add photo'), findsOneWidget);
+
+        await tester.tap(find.bySemanticsLabel('Add photo'));
+        await tester.pumpAndSettle();
+
+        // Tapping fires _pickPhoto → the Camera/Gallery source sheet.
+        expect(find.text('Camera'), findsOneWidget);
+        expect(find.text('Gallery'), findsOneWidget);
+
+        handle.dispose();
+      },
+    );
   });
 }


### PR DESCRIPTION
## What
The Attachment sheet's `_PhotoPreview` tap target (an `InkWell` that opens the camera/gallery source picker) had **no button role and no accessible name**. A screen reader announced only the inner `Tap to add photo` caption — which disappears once a photo is selected, leaving an `Image.file` with no accessible name at all.

## Fix
Wrap the tap target in the project's standard a11y pattern: `Semantics(button: true, label: photoPath != null ? 'Change photo' : 'Add photo', excludeSemantics: true, onTap: onTap)`. `excludeSemantics` is safe — the InkWell wraps no other interactive children (just an image or an icon+caption). The diff is a +2 reindent of the widget body from the added wrapper; scoped to `_PhotoPreview`, no unrelated reflow.

## Test
Adds a `find.bySemanticsLabel('Add photo')` test (portable matcher) that also taps the labelled node and asserts the Camera/Gallery source picker opens. Fails pre-fix (no such label). Suite: 5/5 attachment_sheet green.

## Note (correction)
The audit ledger pointed at `log_detail/_PhotoPreview` — that one is **display-only** (no tap target), so the real gap was this `attachment_sheet/_PhotoPreview`. Fixed the correct widget.

## Risk
Semantics-only (a11y) change, no visual/behavioural change. `flutter analyze --fatal-infos` clean.