### PR TITLE
refactor(allergen): SizedBox(height:2) → AppSizes.sp2 token

### DIFF
--- a/lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart
+++ b/lib/src/features/allergen/log_detail/allergen_log_detail_screen.dart
@@ -479,7 +479,7 @@ class _AttachmentBlock extends ConsumerWidget {
                       ),
                     if (description != null && description.isNotEmpty) ...[
                       if (title != null && title.isNotEmpty)
-                        const SizedBox(height: 2),
+                        const SizedBox(height: AppSizes.sp2),
                       Text(
                         description,
                         style: GoogleFonts.figtree(

--- a/lib/src/features/allergen/tracker/widgets/allergen_progress_card.dart
+++ b/lib/src/features/allergen/tracker/widgets/allergen_progress_card.dart
@@ -93,7 +93,7 @@ class AllergenProgressCard extends StatelessWidget {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(allergen.name, style: textTheme.titleSmall),
-                    const SizedBox(height: 2),
+                    const SizedBox(height: AppSizes.sp2),
                     Text(
                       // Figma verbatim: keeps the trailing space on "N/3 times ".
                       '$clamped/3 times ',

--- a/lib/src/features/allergen/tracker/widgets/start_introduce_card.dart
+++ b/lib/src/features/allergen/tracker/widgets/start_introduce_card.dart
@@ -59,7 +59,7 @@ class StartIntroduceCard extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 Text(allergen.name, style: textTheme.titleSmall),
-                const SizedBox(height: 2),
+                const SizedBox(height: AppSizes.sp2),
                 Text(
                   'Not Tried',
                   style: textTheme.bodyMedium?.copyWith(


### PR DESCRIPTION
## What
Three hardcoded `const SizedBox(height: 2)` gaps in allergen widgets swapped to the `AppSizes.sp2` design token:
- `tracker/widgets/allergen_progress_card.dart` (name → progress-count gap)
- `tracker/widgets/start_introduce_card.dart` (name → 'Not Tried' gap)
- `log_detail/allergen_log_detail_screen.dart` (attachment title → description gap)

## Byte-identical (no sim)
`AppSizes.sp2` is `static const double sp2 = 2`, and each call site was already `const SizedBox(height: 2)` → the swap compiles to the identical const. Provably no visual change, so no sim gate. Full allergen suite (45 tests) green.

## Left untouched
- `taste_selector.dart` `width: 2` — dead widget (zero usages, owner delete-or-wire ledger); don't edit dead extractions.
- `log_detail` `vertical: AppSizes.sm + 2` — deliberate composite offset, not a standalone token.

## Risk
Pure token-DRY swap, byte-identical. `flutter analyze --fatal-infos` clean.