### PR TITLE
fix(profile): re-entrancy guard on delete-account submit

### DIFF
--- a/lib/src/features/profile/delete/delete_account_controller.dart
+++ b/lib/src/features/profile/delete/delete_account_controller.dart
@@ -64,6 +64,13 @@ class DeleteAccountController extends _$DeleteAccountController {
   DeleteAccountState build() => const DeleteAccountState();
 
   Future<bool> submit(String reason) async {
+    // Re-entrancy guard: the overlay's Continue CTA disable is presentational
+    // (isSubmitting flips on a next-frame rebuild), so a fast double-tap can
+    // fire submit() twice before the button greys out — and this op is
+    // DESTRUCTIVE. Mirror feedback_controller + onboarding (PR #330): bail if a
+    // submission is already in flight so deleteAccount can't run twice.
+    if (state.isSubmitting) return false;
+
     state = state.copyWith(isSubmitting: true, errorMessage: null);
 
     final result = await ref

--- a/test/features/profile/delete/delete_account_controller_test.dart
+++ b/test/features/profile/delete/delete_account_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -177,6 +179,33 @@ void main() {
         // {isSubmitting: true, errorMessage: null}.
         final state = container.read(deleteAccountControllerProvider);
         expect(state.errorMessage, isNull);
+      },
+    );
+
+    test(
+      're-entrancy: a second submit while one is in-flight returns false and '
+      'does NOT fire the destructive deleteAccount twice',
+      () async {
+        final gate = Completer<Result<void>>();
+        when(() => mockAccountRepo.requestAccountDeletion(any()))
+            .thenAnswer((_) => gate.future);
+
+        final controller = readController();
+        // First submit runs synchronously up to the deleteAccount await, so
+        // isSubmitting is already true when the second (double-tap) lands.
+        final first = controller.submit('Other');
+        final second = await controller.submit('Other');
+
+        // The in-flight guard rejects the second tap immediately.
+        expect(second, isFalse);
+
+        gate.complete(const Result.success(null));
+        expect(await first, isTrue);
+
+        // Exactly one destructive RPC despite the double-tap.
+        verify(
+          () => mockAccountRepo.requestAccountDeletion('Other'),
+        ).called(1);
       },
     );
   });


### PR DESCRIPTION
## What
`DeleteAccountController.submit` set `isSubmitting = true` but never early-returned when a submission was already in flight.

The overlay's Continue CTA disable is **presentational** — `isSubmitting` flips state on a next-frame rebuild, so a fast double-tap (or taps buffered during jank/GC) can fire `submit()` twice before the button greys out. Because this op is **destructive**, that fires the `deleteAccount` RPC twice.

## Fix
Add `if (state.isSubmitting) return false;` as the first line of `submit()`. This mirrors the codebase's own convention: `FeedbackController.submit` already has this 'belt-and-braces' guard, and onboarding got the same fix in PR #330 (the createBaby double-submit). Delete-account was the missing one — and the most dangerous.

## Test
Adds a Completer-gated re-entrancy test: a second `submit` while the first is in-flight returns `false` immediately and `requestAccountDeletion` is called exactly once. Fails pre-fix. Suite: 4/4 delete-account controller green.

## Audit context
This was found by a 6-dimension Workflow deep-dive of the profile feature + manual controller read. Other profile findings logged for follow-up: stale ValueNotifier comment in delete_account_overlay (comment-only); `_kFormPaddingH`→`AppSizes.md` dedup; and two owner-gated DEFERs (clearAll-throw wedges the sheet; getBaby() collapses 401→null masking a P0 sign-out).

## Risk
One-line control-flow guard on a controller, no visual change. `flutter analyze --fatal-infos` clean.