### PR TITLE
fix(subscription): re-entrancy guard on cancel-subscription submit

### DIFF
--- a/lib/src/features/subscription/cancel/cancel_subscription_controller.dart
+++ b/lib/src/features/subscription/cancel/cancel_subscription_controller.dart
@@ -26,6 +26,14 @@ class CancelSubscriptionController extends _$CancelSubscriptionController {
   CancelSubscriptionState build() => const CancelSubscriptionState();
 
   Future<bool> submit(CancelReason reason) async {
+    // Re-entrancy guard: the overlay's Continue CTA disable is presentational
+    // (isSubmitting flips on a next-frame rebuild), so a same-frame double-tap
+    // can re-enter before the button greys out — double-firing the deep-link
+    // launch + both intent analytics events. Mirror PaywallController
+    // (purchaseDefault/restore) + delete-account (PR #337): bail if already in
+    // flight.
+    if (state.isSubmitting) return false;
+
     state = state.copyWith(isSubmitting: true);
 
     // Fire-and-forget intent events BEFORE the deep-link so we capture

--- a/test/features/subscription/cancel/cancel_subscription_controller_test.dart
+++ b/test/features/subscription/cancel/cancel_subscription_controller_test.dart
@@ -7,6 +7,8 @@
 //   4. Resets isSubmitting=false.
 //   5. Returns true on Success, false on Failure.
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nibbles/src/common/services/subscription_service.dart';
@@ -97,6 +99,53 @@ void main() {
       expect(
         container.read(cancelSubscriptionControllerProvider).isSubmitting,
         isFalse,
+      );
+    },
+  );
+
+  test(
+    're-entrancy: a second submit while one is in-flight returns false and '
+    'does NOT launch or re-log the intent events twice',
+    () async {
+      final analytics = FakeAnalytics();
+      final gate = Completer<bool>();
+      var launchCalls = 0;
+      Future<bool> gatedLaunch(
+        Uri uri, {
+        LaunchMode mode = LaunchMode.platformDefault,
+      }) {
+        launchCalls += 1;
+        return gate.future;
+      }
+
+      final container = ProviderContainer(
+        overrides: [
+          analyticsProvider.overrideWithValue(analytics),
+          subscriptionLaunchUrlProvider.overrideWithValue(gatedLaunch),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final controller =
+          container.read(cancelSubscriptionControllerProvider.notifier);
+      // First submit runs synchronously up to the launch await, so
+      // isSubmitting is already true when the second (double-tap) lands.
+      final first = controller.submit(CancelReason.achievedGoal);
+      final second = await controller.submit(CancelReason.achievedGoal);
+
+      // The in-flight guard rejects the second tap immediately.
+      expect(second, isFalse);
+      expect(launchCalls, 1);
+
+      gate.complete(true);
+      expect(await first, isTrue);
+
+      // Exactly one set of intent events despite the double-tap.
+      expect(
+        analytics.calls
+            .where((c) => c.name == 'subscription_cancel_started')
+            .length,
+        1,
       );
     },
   );


### PR DESCRIPTION
## What
`CancelSubscriptionController.submit` set `isSubmitting = true` but never early-returned when a submission was already in flight.

The overlay's Continue CTA disable is **presentational** — `isSubmitting` flips state on a next-frame rebuild, so a same-frame double-tap re-enters `submit()` before the button greys out, firing the `openManagementPage` deep-link **twice** and both intent analytics events (`subscription_cancel_started` + `subscription_cancel_reason`) twice.

## Fix
Add `if (state.isSubmitting) return false;` as the first line of `submit()`. This is an explicit project hard rule (cancel/submit actions must guard re-entrancy) and matches the codebase's own convention: the **sibling** `PaywallController.purchaseDefault`/`restore` already guard (`if (state.action != PaywallAction.none) return`), as do delete-account (PR #337) and `FeedbackController`. Cancel was the lone gap.

## Test
Completer-gated re-entrancy test: a second `submit` while the first is in-flight returns `false`, with exactly one `openManagementPage` launch and one set of intent events. Fails pre-fix. Suite: 4/4 cancel controller green.

## Audit context
Found by a 6-dimension subscription Workflow (confirmed by 3 dims) + manual controller read. Other subscription ship-nonvisual findings queued for follow-up: `_PlanCard` a11y (single-select selected-state invisible to screen readers — but on the all-plans sheet which is currently unreachable behind TODO NIB-61); 4 token dedups in `all_plans_sheet.dart` (`_kSheetTopRadius`/`_kContinueRadius`/`_kPlanCardRadius`/`_kColumnGap` → AppSizes). DEFER: all-plans flow unreachable until NIB-61/NIB-18.

## Risk
One-line control-flow guard on a controller, no visual change. `flutter analyze --fatal-infos` clean.