### PR TITLE
fix(onboarding): readiness content scrolls — no RenderFlex overflow

### DIFF
--- a/lib/src/features/onboarding/readiness/onboarding_readiness_screen.dart
+++ b/lib/src/features/onboarding/readiness/onboarding_readiness_screen.dart
@@ -145,66 +145,79 @@ class _OnboardingReadinessScreenState
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              const SizedBox(height: AppSizes.md),
-              Semantics(
-                liveRegion: true,
-                container: true,
-                label:
-                    'Question ${_currentIndex + 1} of $_readinessTotalSteps',
-                child: Center(
-                  child: Text(
-                    '${_currentIndex + 1} of $_readinessTotalSteps Questions',
-                    key: const Key('onboarding_readiness_counter'),
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: AppColors.fgStrong,
-                      fontWeight: FontWeight.w600,
-                    ),
+              // Scroll the question content so short devices / large text
+              // scales never overflow; the Back/Next footer stays pinned to
+              // the bottom (mirrors the result + consent siblings).
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      const SizedBox(height: AppSizes.md),
+                      Semantics(
+                        liveRegion: true,
+                        container: true,
+                        label:
+                            'Question ${_currentIndex + 1} of '
+                            '$_readinessTotalSteps',
+                        child: Center(
+                          child: Text(
+                            '${_currentIndex + 1} of '
+                            '$_readinessTotalSteps Questions',
+                            key: const Key('onboarding_readiness_counter'),
+                            style: textTheme.bodyMedium?.copyWith(
+                              color: AppColors.fgStrong,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: AppSizes.sm),
+                      ReadinessProgressBar(
+                        stepCount: _readinessTotalSteps,
+                        currentIndex: _currentIndex,
+                      ),
+                      const SizedBox(height: AppSizes.xl),
+                      Text(
+                        title,
+                        textAlign: TextAlign.center,
+                        style: textTheme.titleLarge,
+                      ),
+                      const SizedBox(height: AppSizes.md),
+                      Text(
+                        step.body,
+                        textAlign: TextAlign.center,
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: AppColors.fgMuted,
+                        ),
+                      ),
+                      const SizedBox(height: AppSizes.lg),
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Expanded(
+                            child: ReadinessChoiceCard(
+                              key: const Key('readiness_choice_yes'),
+                              label: step.yesLabel,
+                              selected: currentAnswer ?? false,
+                              onTap: () => _recordAnswer(isYes: true),
+                            ),
+                          ),
+                          const SizedBox(width: AppSizes.md),
+                          Expanded(
+                            child: ReadinessChoiceCard(
+                              key: const Key('readiness_choice_unsure'),
+                              label: step.noLabel,
+                              selected: currentAnswer == false,
+                              onTap: () => _recordAnswer(isYes: false),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
                   ),
                 ),
               ),
-              const SizedBox(height: AppSizes.sm),
-              ReadinessProgressBar(
-                stepCount: _readinessTotalSteps,
-                currentIndex: _currentIndex,
-              ),
-              const SizedBox(height: AppSizes.xl),
-              Text(
-                title,
-                textAlign: TextAlign.center,
-                style: textTheme.titleLarge,
-              ),
-              const SizedBox(height: AppSizes.md),
-              Text(
-                step.body,
-                textAlign: TextAlign.center,
-                style: textTheme.bodyMedium?.copyWith(
-                  color: AppColors.fgMuted,
-                ),
-              ),
-              const SizedBox(height: AppSizes.lg),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: ReadinessChoiceCard(
-                      key: const Key('readiness_choice_yes'),
-                      label: step.yesLabel,
-                      selected: currentAnswer ?? false,
-                      onTap: () => _recordAnswer(isYes: true),
-                    ),
-                  ),
-                  const SizedBox(width: AppSizes.md),
-                  Expanded(
-                    child: ReadinessChoiceCard(
-                      key: const Key('readiness_choice_unsure'),
-                      label: step.noLabel,
-                      selected: currentAnswer == false,
-                      onTap: () => _recordAnswer(isYes: false),
-                    ),
-                  ),
-                ],
-              ),
-              const Spacer(),
               Padding(
                 padding: const EdgeInsets.only(bottom: AppSizes.pagePaddingV),
                 child: Row(

--- a/test/features/onboarding/readiness/onboarding_readiness_screen_test.dart
+++ b/test/features/onboarding/readiness/onboarding_readiness_screen_test.dart
@@ -215,4 +215,40 @@ void main() {
       expect(state.readinessAnswers[4], isNull);
     },
   );
+
+  testWidgets(
+    'question content scrolls on a short viewport — no RenderFlex overflow, '
+    'Next footer still present',
+    (tester) async {
+      // A short viewport that overflowed the old rigid Column + Spacer layout
+      // (the other tests bump to 420x900 precisely to avoid that overflow).
+      await tester.binding.setSurfaceSize(const Size(360, 480));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(onboardingControllerProvider.notifier).updateName('Lily');
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: _routerFor(const OnboardingReadinessScreen()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Pre-fix this threw a "RenderFlex overflowed" error at this height.
+      expect(tester.takeException(), isNull);
+      // The question content now lives in a scroll view; the footer CTA stays
+      // pinned (rendered outside the scroll view).
+      expect(find.byType(SingleChildScrollView), findsOneWidget);
+      expect(
+        find.byKey(const Key('onboarding_readiness_next')),
+        findsOneWidget,
+      );
+      expect(find.text('1 of 6 Questions'), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION
## What
The readiness questionnaire (`onboarding_readiness_screen.dart`) was a rigid `Column` + `Spacer()` holding `AspectRatio(1)` choice cards. On short devices or with large text scale it threw a **RenderFlex overflow** — the existing widget tests had to bump the surface to 420×900 *specifically* to avoid it (see the helper comment).

## Fix
Wrap the question content (counter, progress bar, title, body, choice cards) in `Expanded → SingleChildScrollView`, and drop the `Spacer()`. The Back/Next footer stays **outside** the scroll view so it remains pinned to the bottom. This mirrors the proven `onboarding_result` / `consent` siblings, which already use this exact pattern.

## Verification (first real sim tick)
- **Widget test**: pumps at a 360×480 viewport (which overflowed pre-fix) and asserts `tester.takeException()` is null, the content is in a `SingleChildScrollView`, and the Next footer is still present. Fails pre-fix. Full suite 6/6 green.
- **Simulator**: built `build-qa-sim`, booted the readiness screen on iPhone 17 via the onboarding-gate, and confirmed the **normal-case render is unchanged** — content top-aligned, Back/Next footer pinned at the bottom (screenshot below). No visual regression from the restructure.

## Risk
Layout restructure on one onboarding screen; normal case byte-equivalent (content fits → same layout), overflow case now scrolls. `flutter analyze --fatal-infos` clean.