### PR TITLE
fix(onboarding): DOB picker selection band behind the value, not over it

### DIFF
--- a/lib/src/features/onboarding/dob/onboarding_dob_screen.dart
+++ b/lib/src/features/onboarding/dob/onboarding_dob_screen.dart
@@ -421,9 +421,9 @@ class _DateWheelRow extends StatelessWidget {
   }
 }
 
-/// A single column: header label + CupertinoPicker with a lime rounded pill
-/// `selectionOverlay`. Selected row text rendered in forestDarkn; off-rows in
-/// muted neutral per the Figma render.
+/// A single column: header label + CupertinoPicker stacked over a centered
+/// lime rounded pill band. The band renders behind the text so the selected
+/// row (greenDeep) stays legible; off-rows muted neutral per the Figma render.
 class _DateWheelColumn extends StatelessWidget {
   const _DateWheelColumn({
     required this.header,
@@ -459,13 +459,10 @@ class _DateWheelColumn extends StatelessWidget {
         const SizedBox(height: AppSizes.sm),
         SizedBox(
           height: height,
-          child: CupertinoPicker(
-            scrollController: controller,
-            itemExtent: itemExtent,
-            squeeze: 1.1,
-            backgroundColor: Colors.transparent,
-            selectionOverlay: Center(
-              child: Container(
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              Container(
                 width: 70,
                 height: AppSizes.chipHeight,
                 decoration: BoxDecoration(
@@ -473,19 +470,28 @@ class _DateWheelColumn extends StatelessWidget {
                   borderRadius: BorderRadius.circular(AppSizes.radiusLg),
                 ),
               ),
-            ),
-            onSelectedItemChanged: onSelectedItemChanged,
-            children: List<Widget>.generate(itemCount, (i) {
-              final isSelected = i == selectedIndex;
-              return Center(
-                child: Text(
-                  itemBuilder(i),
-                  style: textTheme.labelMedium?.copyWith(
-                    color: isSelected ? AppColors.greenDeep : AppColors.fgFaint,
-                  ),
-                ),
-              );
-            }),
+              CupertinoPicker(
+                scrollController: controller,
+                itemExtent: itemExtent,
+                squeeze: 1.1,
+                backgroundColor: Colors.transparent,
+                selectionOverlay: const SizedBox.shrink(),
+                onSelectedItemChanged: onSelectedItemChanged,
+                children: List<Widget>.generate(itemCount, (i) {
+                  final isSelected = i == selectedIndex;
+                  return Center(
+                    child: Text(
+                      itemBuilder(i),
+                      style: textTheme.labelMedium?.copyWith(
+                        color: isSelected
+                            ? AppColors.greenDeep
+                            : AppColors.fgFaint,
+                      ),
+                    ),
+                  );
+                }),
+              ),
+            ],
           ),
         ),
       ],

--- a/test/features/onboarding/dob/onboarding_dob_screen_test.dart
+++ b/test/features/onboarding/dob/onboarding_dob_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/common/components/components.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/onboarding/dob/onboarding_dob_screen.dart';
@@ -222,4 +223,44 @@ void main() {
       isNotNull,
     );
   });
+
+  testWidgets(
+    'selection lime band renders BEHIND the picker text, not over it '
+    '(no opaque selectionOverlay)',
+    (tester) async {
+      final container = _makeContainer(flags: flags);
+      await _pumpScreen(tester, container: container);
+
+      final wheel = find.byKey(const Key('onboarding_dob_year_wheel'));
+
+      // The CupertinoPicker no longer paints an opaque selectionOverlay —
+      // it is an empty SizedBox so the value text stays legible.
+      final picker = tester.widget<CupertinoPicker>(
+        find.descendant(of: wheel, matching: find.byType(CupertinoPicker)),
+      );
+      expect(picker.selectionOverlay, isA<SizedBox>());
+
+      // A lime band Container sits inside the same column as a sibling of the
+      // picker (the background pill). Match by its lime decoration color.
+      final limeBand = find.descendant(
+        of: wheel,
+        matching: find.byWidgetPredicate(
+          (w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration! as BoxDecoration).color == AppColors.lime,
+        ),
+      );
+      expect(limeBand, findsOneWidget);
+
+      // The selected value text (greenDeep) still renders.
+      final selectedText = find.descendant(
+        of: wheel,
+        matching: find.byWidgetPredicate(
+          (w) => w is Text && w.style?.color == AppColors.greenDeep,
+        ),
+      );
+      expect(selectedText, findsWidgets);
+    },
+  );
 }


### PR DESCRIPTION
## Problem
On the onboarding DOB screen, `_DateWheelColumn` set the `CupertinoPicker.selectionOverlay` to an opaque centered lime `Container`. `selectionOverlay` paints **in front of** the wheel text, so the selected value was hidden behind a solid lime blob.

## Fix
Wrap the `CupertinoPicker` in a `Stack` (`alignment: center`):
1. Background child: the centered lime band `Container` (width 70, height `AppSizes.chipHeight`, `radiusLg`).
2. Foreground child: the `CupertinoPicker` with `selectionOverlay: const SizedBox.shrink()` and `backgroundColor: Colors.transparent`.

The selected value text (`greenDeep`) now renders crisply **on top of** the lime band. `itemExtent`, `squeeze`, `scrollController`, and `onSelectedItemChanged` are unchanged.

## Test
Extended `onboarding_dob_screen_test.dart` with a case asserting:
- `selectionOverlay` is now a `SizedBox` (no opaque overlay),
- a lime-decorated band `Container` is present inside the wheel,
- the selected value `Text` (greenDeep) still renders.

All 7 widget tests pass; `flutter analyze --fatal-infos --fatal-warnings` clean on changed files.

## Visual
isVisual=true — needs a sim render to confirm the value is legible on the band before merge.