### PR TITLE
fix(onboarding): Back animates as reverse pop, not forward push

### DIFF
--- a/lib/src/features/onboarding/name/onboarding_name_screen.dart
+++ b/lib/src/features/onboarding/name/onboarding_name_screen.dart
@@ -90,7 +90,9 @@ class _OnboardingNameScreenState extends ConsumerState<OnboardingNameScreen> {
     final last = _lastTrimmed;
     final joined = last.isEmpty ? first : '$first $last';
     ref.read(onboardingControllerProvider.notifier).updateName(joined);
-    context.goNamed(AppRoute.onboardingDob.name);
+    // Push (not go) so DOB's back button gets a real reverse pop. Safe: name +
+    // dob share phase A, so popping dob->name is not bounced by the redirect.
+    context.pushNamed(AppRoute.onboardingDob.name);
   }
 
   @override

--- a/lib/src/features/onboarding/result/onboarding_result_screen.dart
+++ b/lib/src/features/onboarding/result/onboarding_result_screen.dart
@@ -143,8 +143,11 @@ class OnboardingResultScreen extends ConsumerWidget {
                       child: AppPillButton(
                         key: const Key('onboarding_result_next'),
                         label: 'Next',
+                        // Push (not go) so consent's back button gets a real
+                        // reverse pop. Safe: result + consent share phase C, so
+                        // popping consent->result is not redirect-bounced.
                         onPressed: () =>
-                            context.goNamed(AppRoute.onboardingConsent.name),
+                            context.pushNamed(AppRoute.onboardingConsent.name),
                       ),
                     ),
                   ],


### PR DESCRIPTION
## Problem

Onboarding screens navigate forward with `context.goNamed` (REPLACE — no back stack). On the consent screen, `context.canPop()` is therefore false, so `_onBack` falls through to `context.goNamed(onboardingResult)` — a **forward push transition** instead of a back/pop. The Back button visually slides the wrong way.

Every onboarding back handler already uses the `if (canPop()) pop(); else goNamed(...)` pattern — they were written to use the back stack, but it was never populated because forward nav replaced instead of pushed.

## Fix

Switch the two **same-phase** forward transitions from `goNamed` → `pushNamed`, so a back stack exists and `context.pop()` gives a real reverse animation:

- `result → consent` (both in redirect phase C) — fixes #4
- `name → dob` (both in redirect phase A) — same class, gives DOB a real back pop

## Why the other two transitions stay `goNamed`

`dob → readiness` and `readiness → result` are **phase boundaries**: each flips a local flag (`babySetupDone` / `readinessDone`) before navigating. The `resolveAppRedirect` phase whitelist would bounce a lower-phase pop back forward (e.g. popping readiness → dob redirects to readiness), breaking the kill/resume contract. Keeping `goNamed` (replace) at each boundary blows away the stale lower-phase routes, so no pop can loop.

**Rule applied: push within a phase, `go` (replace) across a phase.**

`resolveAppRedirect` is **untouched** — the redirect matrix is green by construction.

## Tests

All green (50 tests):
- `test/routing/resolve_app_redirect_test.dart`
- `test/features/onboarding/{result,consent,dob,name}/*_screen_test.dart`

Screen tests assert the destination renders (not the nav method), which `pushNamed` satisfies.

## Known limitation (out of scope)

The two **cross-phase** back buttons (readiness-Q1 → dob, result → readiness) cannot be reverse-pops without breaking the resume contract, so they retain a forward-anim. Likewise the kill/resume edge case (relaunch lands on consent with an empty stack; first Back falls through to `goNamed(result)`). Both are intentional and acceptable.

## Visual gate

isVisual = true — the back animation must be confirmed on the simulator (result ⇄ consent and name ⇄ dob should slide as a reverse pop).