### PR TITLE
feat(onboarding): animated You all set celebration (rotate + pulse)

### DIFF
--- a/lib/src/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen.dart
+++ b/lib/src/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen.dart
@@ -5,7 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
-import 'package:nibbles/src/common/components/brand/petal_blob.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 import 'package:nibbles/src/features/onboarding/baby_setup_loading/baby_setup_loading_controller.dart';
 import 'package:nibbles/src/features/onboarding/baby_setup_loading/baby_setup_loading_state.dart';
 import 'package:nibbles/src/logging/analytics.dart';
@@ -18,10 +18,13 @@ import 'package:nibbles/src/routing/route_enums.dart';
 /// a static petal-blob frame for [BabySetupLoadingController.minDwell] and
 /// then auto-pushes /home.
 ///
-/// Visuals (Figma node 971:10246 — `.figma-audit/onboarding/baby-setup-loading`):
+/// Visuals (Figma node 1290:10122 — "You all set!" celebration):
 ///   - Solid cream (#FFFCD5 — `AppColors.butterSoft`) background.
-///   - [PetalBlob] cluster center-screen with faint uppercase "LOADING"
-///     caption layered inside (cream-on-cream, low contrast per spec).
+///   - Brand flower cluster center-screen with faint uppercase "LOADING"
+///     caption layered inside (cream-on-cream, low contrast per spec). The
+///     OUTER butter quatrefoil rotates continuously (~9s/rev, linear) while
+///     the CENTER glow dot pulses gently (~1.2s, reverse-repeat). The inner
+///     sage quatrefoil stays static.
 ///   - Footer tagline ("We need several data to know more about your babys")
 ///     anchored ~70% down screen, Figtree SemiBold 15/22, black.
 ///
@@ -38,7 +41,23 @@ class OnboardingBabySetupLoadingScreen extends ConsumerStatefulWidget {
 }
 
 class _OnboardingBabySetupLoadingScreenState
-    extends ConsumerState<OnboardingBabySetupLoadingScreen> {
+    extends ConsumerState<OnboardingBabySetupLoadingScreen>
+    with TickerProviderStateMixin {
+  /// Full revolution of the outer petals — "not fast, not slow" per owner,
+  /// linear so the spin reads as a steady bloom, never a jolt.
+  static const Duration _rotationPeriod = Duration(seconds: 9);
+
+  /// Center-glow pulse half-cycle. Reverse-repeats so the dot breathes
+  /// gently between [_glowPulseMin] and full scale.
+  static const Duration _pulsePeriod = Duration(milliseconds: 1200);
+
+  /// Lower bound of the glow pulse scale (full scale = 1.0).
+  static const double _glowPulseMin = 0.85;
+
+  late final AnimationController _rotationController;
+  late final AnimationController _pulseController;
+  late final Animation<double> _glowPulse;
+
   /// Footer copy — verbatim from the Figma audit (incl. the flagged grammar
   /// issue: "several data" treated singular + missing apostrophe on "babys").
   /// PO has the rewrite "We need some data to learn more about your baby." on
@@ -55,9 +74,28 @@ class _OnboardingBabySetupLoadingScreenState
   @override
   void initState() {
     super.initState();
+    _rotationController = AnimationController(
+      vsync: this,
+      duration: _rotationPeriod,
+    )..repeat();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: _pulsePeriod,
+    );
+    _glowPulse = Tween<double>(begin: 1, end: _glowPulseMin).animate(
+      CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
+    );
+    _pulseController.repeat(reverse: true);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       unawaited(_logScreenView());
     });
+  }
+
+  @override
+  void dispose() {
+    _rotationController.dispose();
+    _pulseController.dispose();
+    super.dispose();
   }
 
   Future<void> _logScreenView() async {
@@ -113,8 +151,12 @@ class _OnboardingBabySetupLoadingScreenState
                     child: Stack(
                       alignment: Alignment.center,
                       children: [
-                        const PetalBlob(
-                          key: Key('onboarding_baby_setup_loading_blob'),
+                        _AnimatedPetalBlob(
+                          key: const Key(
+                            'onboarding_baby_setup_loading_blob',
+                          ),
+                          rotation: _rotationController,
+                          glowPulse: _glowPulse,
                         ),
                         Padding(
                           // Nudge the caption slightly below the blob's optical
@@ -165,6 +207,74 @@ class _OnboardingBabySetupLoadingScreenState
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Brand flower for the "You all set!" celebration — a decomposed `PetalBlob`
+/// so the outer petals can rotate independently of the pulsing center.
+///
+/// Geometry mirrors `PetalBlob` byte-for-byte (outer = avatarXl*1.84, inner
+/// ~52% of outer, glow ratio sp12*1.4/outer) so the static frame is visually
+/// identical to the consent screen's cluster.
+///   - Outer butter [Quatrefoil] wrapped in a [RotationTransition].
+///   - Inner sage [Quatrefoil] — static.
+///   - Soft butter glow dot wrapped in a [ScaleTransition] driven by the pulse.
+class _AnimatedPetalBlob extends StatelessWidget {
+  const _AnimatedPetalBlob({
+    required this.rotation,
+    required this.glowPulse,
+    super.key,
+  });
+
+  final Animation<double> rotation;
+  final Animation<double> glowPulse;
+
+  @override
+  Widget build(BuildContext context) {
+    const outerSize = AppSizes.avatarXl * 1.84;
+    const baseInner = AppSizes.avatarXl * 0.96;
+    const baseGlow = AppSizes.sp12 * 1.4;
+    const innerSize = outerSize * (baseInner / outerSize);
+    const glowSize = outerSize * (baseGlow / outerSize);
+
+    return SizedBox(
+      width: outerSize,
+      height: outerSize,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          RotationTransition(
+            turns: rotation,
+            child: const Quatrefoil(
+              size: outerSize,
+              coreColor: AppColors.butter,
+            ),
+          ),
+          const Quatrefoil(
+            size: innerSize,
+            petalColor: AppColors.green,
+            coreColor: AppColors.greenDeep,
+          ),
+          ScaleTransition(
+            scale: glowPulse,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: AppColors.butter,
+                shape: BoxShape.circle,
+                boxShadow: [
+                  BoxShadow(
+                    color: AppColors.butter.withValues(alpha: 0.9),
+                    blurRadius: AppSizes.sm,
+                    spreadRadius: AppSizes.xs,
+                  ),
+                ],
+              ),
+              child: const SizedBox(width: glowSize, height: glowSize),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/test/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen_test.dart
+++ b/test/features/onboarding/baby_setup_loading/onboarding_baby_setup_loading_screen_test.dart
@@ -76,9 +76,12 @@ void main() {
       await tester.pump();
 
       // Advance past the min-dwell so the controller flips to `ready` and
-      // the screen schedules its push to /home.
+      // the screen schedules its push to /home. The celebration animations
+      // repeat() forever, so `pumpAndSettle` would hang — pump explicit frames
+      // to let the GoRouter nav transition settle instead.
       await tester.pump(BabySetupLoadingController.minDwell);
-      await tester.pumpAndSettle();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
 
       expect(find.text('HOME_STUB'), findsOneWidget);
       expect(
@@ -119,12 +122,47 @@ void main() {
       await tester.pumpWidget(_buildSut(router: router));
       await tester.pump();
 
+      // `pumpAndSettle` would hang on the forever-repeating celebration
+      // animations — pump explicit frames to settle the nav transition.
       await tester.pump(BabySetupLoadingController.maxTimeout);
-      await tester.pumpAndSettle();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
 
       expect(
         router.routerDelegate.currentConfiguration.uri.path,
         AppRoute.home.path,
+      );
+    },
+  );
+
+  testWidgets(
+    'celebration animation controllers are running (rotation advances)',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildSut(
+          router: _routerFor(const OnboardingBabySetupLoadingScreen()),
+        ),
+      );
+      await tester.pump();
+
+      final rotation = tester.widget<RotationTransition>(
+        find.descendant(
+          of: find.byKey(const Key('onboarding_baby_setup_loading_blob')),
+          matching: find.byType(RotationTransition),
+        ),
+      );
+      final before = rotation.turns.value;
+
+      // Advance a fraction of the dwell — the looping controller must tick.
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(rotation.turns.value, isNot(equals(before)));
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('onboarding_baby_setup_loading_blob')),
+          matching: find.byType(ScaleTransition),
+        ),
+        findsOneWidget,
       );
     },
   );


### PR DESCRIPTION
## What

Animates the post-consent baby-setup loading screen (consent → baby_setup_loading → /home) to match Figma **1290-10122** ('You all set!' celebration). Previously a static petal-blob frame with no motion.

## Changes
- Decomposed the static `PetalBlob` into `_AnimatedPetalBlob` (same geometry, byte-for-byte ratios) so outer petals can rotate independently of the pulsing center:
  - **Outer** butter quatrefoil → `RotationTransition`, ~9s/revolution, linear, `repeat()` (owner: 'not fast, not slow').
  - **Inner** sage quatrefoil → static.
  - **Center** glow dot → `ScaleTransition` pulsing 1.0 ↔ 0.85, 1.2s, reverse-repeat, easeInOut.
- Two `AnimationController`s via `TickerProviderStateMixin`; both disposed in `dispose()`.
- Preserved controller/state, auto-route-to-/home behaviour, PopScope, min-dwell, LOADING caption, blob `Key`, and Semantics.

## Tests
- Existing tests reworked off `pumpAndSettle` (hangs forever on repeating animations) → explicit `pump(duration)` frames.
- Added a test asserting the rotation controller is running (`turns.value` advances) + the pulse `ScaleTransition` renders.
- All 5 tests pass; `flutter analyze --fatal-infos --fatal-warnings` clean on changed files.

## Flag — footer copy NOT changed
Figma 1290-10122 replaces the footer with **'You all set!'** (the LOADING caption is retained in both frames). The current footer is the verbatim audit copy *'We need several data to know more about your babys'*, which an in-file comment says the PO has on an open-questions list (kept byte-for-byte to keep the visual diff clean). Per task instructions I did **not** swap the copy unilaterally — coordinator/PO to confirm whether the footer should become 'You all set!'.

## Visual
isVisual = true — animations need a rendered sim check (multi-frame capture for the rotate + pulse).