### PR TITLE
feat(recipe): wire detail Utensils/Storage/Texture-Tip/Why-this-meal fields + Supabase migration

### DIFF
--- a/lib/src/common/data/repositories/recipe_repository.dart
+++ b/lib/src/common/data/repositories/recipe_repository.dart
@@ -157,6 +157,7 @@ class RecipeRepositoryImpl implements RecipeRepository {
     final rawIngredients = (row['ingredients'] as List<dynamic>)
         .cast<Map<String, dynamic>>();
     final rawNutritionTags = row['nutrition_tags'] as List<dynamic>?;
+    final rawUtensils = row['utensils'] as List<dynamic>?;
     return Recipe(
       id: row['id'] as String,
       title: row['title'] as String,
@@ -170,6 +171,11 @@ class RecipeRepositoryImpl implements RecipeRepository {
       nutritionTags:
           rawNutritionTags?.map((e) => e as String).toList() ?? <String>[],
       category: row['category'] as String?,
+      utensils: rawUtensils?.cast<String>(),
+      storageNote: row['storage_note'] as String?,
+      freezerNote: row['freezer_note'] as String?,
+      textureTip: row['texture_tip'] as String?,
+      whyThisMeal: row['why_this_meal'] as String?,
     );
   }
 }

--- a/lib/src/common/domain/entities/recipe.dart
+++ b/lib/src/common/domain/entities/recipe.dart
@@ -18,6 +18,11 @@ class Recipe with _$Recipe {
     String? thumbnailUrl,
     @Default(<String>[]) List<String> nutritionTags,
     String? category,
+    List<String>? utensils,
+    String? storageNote,
+    String? freezerNote,
+    String? textureTip,
+    String? whyThisMeal,
   }) = _Recipe;
 
   factory Recipe.fromJson(Map<String, dynamic> json) => _$RecipeFromJson(json);

--- a/lib/src/common/domain/entities/recipe.freezed.dart
+++ b/lib/src/common/domain/entities/recipe.freezed.dart
@@ -32,6 +32,11 @@ mixin _$Recipe {
   String? get thumbnailUrl => throw _privateConstructorUsedError;
   List<String> get nutritionTags => throw _privateConstructorUsedError;
   String? get category => throw _privateConstructorUsedError;
+  List<String>? get utensils => throw _privateConstructorUsedError;
+  String? get storageNote => throw _privateConstructorUsedError;
+  String? get freezerNote => throw _privateConstructorUsedError;
+  String? get textureTip => throw _privateConstructorUsedError;
+  String? get whyThisMeal => throw _privateConstructorUsedError;
 
   /// Serializes this Recipe to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -59,6 +64,11 @@ abstract class $RecipeCopyWith<$Res> {
     String? thumbnailUrl,
     List<String> nutritionTags,
     String? category,
+    List<String>? utensils,
+    String? storageNote,
+    String? freezerNote,
+    String? textureTip,
+    String? whyThisMeal,
   });
 }
 
@@ -88,6 +98,11 @@ class _$RecipeCopyWithImpl<$Res, $Val extends Recipe>
     Object? thumbnailUrl = freezed,
     Object? nutritionTags = null,
     Object? category = freezed,
+    Object? utensils = freezed,
+    Object? storageNote = freezed,
+    Object? freezerNote = freezed,
+    Object? textureTip = freezed,
+    Object? whyThisMeal = freezed,
   }) {
     return _then(
       _value.copyWith(
@@ -135,6 +150,26 @@ class _$RecipeCopyWithImpl<$Res, $Val extends Recipe>
                 ? _value.category
                 : category // ignore: cast_nullable_to_non_nullable
                       as String?,
+            utensils: freezed == utensils
+                ? _value.utensils
+                : utensils // ignore: cast_nullable_to_non_nullable
+                      as List<String>?,
+            storageNote: freezed == storageNote
+                ? _value.storageNote
+                : storageNote // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            freezerNote: freezed == freezerNote
+                ? _value.freezerNote
+                : freezerNote // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            textureTip: freezed == textureTip
+                ? _value.textureTip
+                : textureTip // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            whyThisMeal: freezed == whyThisMeal
+                ? _value.whyThisMeal
+                : whyThisMeal // ignore: cast_nullable_to_non_nullable
+                      as String?,
           )
           as $Val,
     );
@@ -161,6 +196,11 @@ abstract class _$$RecipeImplCopyWith<$Res> implements $RecipeCopyWith<$Res> {
     String? thumbnailUrl,
     List<String> nutritionTags,
     String? category,
+    List<String>? utensils,
+    String? storageNote,
+    String? freezerNote,
+    String? textureTip,
+    String? whyThisMeal,
   });
 }
 
@@ -189,6 +229,11 @@ class __$$RecipeImplCopyWithImpl<$Res>
     Object? thumbnailUrl = freezed,
     Object? nutritionTags = null,
     Object? category = freezed,
+    Object? utensils = freezed,
+    Object? storageNote = freezed,
+    Object? freezerNote = freezed,
+    Object? textureTip = freezed,
+    Object? whyThisMeal = freezed,
   }) {
     return _then(
       _$RecipeImpl(
@@ -236,6 +281,26 @@ class __$$RecipeImplCopyWithImpl<$Res>
             ? _value.category
             : category // ignore: cast_nullable_to_non_nullable
                   as String?,
+        utensils: freezed == utensils
+            ? _value._utensils
+            : utensils // ignore: cast_nullable_to_non_nullable
+                  as List<String>?,
+        storageNote: freezed == storageNote
+            ? _value.storageNote
+            : storageNote // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        freezerNote: freezed == freezerNote
+            ? _value.freezerNote
+            : freezerNote // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        textureTip: freezed == textureTip
+            ? _value.textureTip
+            : textureTip // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        whyThisMeal: freezed == whyThisMeal
+            ? _value.whyThisMeal
+            : whyThisMeal // ignore: cast_nullable_to_non_nullable
+                  as String?,
       ),
     );
   }
@@ -256,10 +321,16 @@ class _$RecipeImpl implements _Recipe {
     this.thumbnailUrl,
     final List<String> nutritionTags = const <String>[],
     this.category,
+    final List<String>? utensils,
+    this.storageNote,
+    this.freezerNote,
+    this.textureTip,
+    this.whyThisMeal,
   }) : _allergenTags = allergenTags,
        _ingredients = ingredients,
        _steps = steps,
-       _nutritionTags = nutritionTags;
+       _nutritionTags = nutritionTags,
+       _utensils = utensils;
 
   factory _$RecipeImpl.fromJson(Map<String, dynamic> json) =>
       _$$RecipeImplFromJson(json);
@@ -311,10 +382,28 @@ class _$RecipeImpl implements _Recipe {
 
   @override
   final String? category;
+  final List<String>? _utensils;
+  @override
+  List<String>? get utensils {
+    final value = _utensils;
+    if (value == null) return null;
+    if (_utensils is EqualUnmodifiableListView) return _utensils;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  final String? storageNote;
+  @override
+  final String? freezerNote;
+  @override
+  final String? textureTip;
+  @override
+  final String? whyThisMeal;
 
   @override
   String toString() {
-    return 'Recipe(id: $id, title: $title, ageRange: $ageRange, allergenTags: $allergenTags, ingredients: $ingredients, steps: $steps, howToServe: $howToServe, notes: $notes, thumbnailUrl: $thumbnailUrl, nutritionTags: $nutritionTags, category: $category)';
+    return 'Recipe(id: $id, title: $title, ageRange: $ageRange, allergenTags: $allergenTags, ingredients: $ingredients, steps: $steps, howToServe: $howToServe, notes: $notes, thumbnailUrl: $thumbnailUrl, nutritionTags: $nutritionTags, category: $category, utensils: $utensils, storageNote: $storageNote, freezerNote: $freezerNote, textureTip: $textureTip, whyThisMeal: $whyThisMeal)';
   }
 
   @override
@@ -345,7 +434,16 @@ class _$RecipeImpl implements _Recipe {
               _nutritionTags,
             ) &&
             (identical(other.category, category) ||
-                other.category == category));
+                other.category == category) &&
+            const DeepCollectionEquality().equals(other._utensils, _utensils) &&
+            (identical(other.storageNote, storageNote) ||
+                other.storageNote == storageNote) &&
+            (identical(other.freezerNote, freezerNote) ||
+                other.freezerNote == freezerNote) &&
+            (identical(other.textureTip, textureTip) ||
+                other.textureTip == textureTip) &&
+            (identical(other.whyThisMeal, whyThisMeal) ||
+                other.whyThisMeal == whyThisMeal));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -363,6 +461,11 @@ class _$RecipeImpl implements _Recipe {
     thumbnailUrl,
     const DeepCollectionEquality().hash(_nutritionTags),
     category,
+    const DeepCollectionEquality().hash(_utensils),
+    storageNote,
+    freezerNote,
+    textureTip,
+    whyThisMeal,
   );
 
   /// Create a copy of Recipe
@@ -392,6 +495,11 @@ abstract class _Recipe implements Recipe {
     final String? thumbnailUrl,
     final List<String> nutritionTags,
     final String? category,
+    final List<String>? utensils,
+    final String? storageNote,
+    final String? freezerNote,
+    final String? textureTip,
+    final String? whyThisMeal,
   }) = _$RecipeImpl;
 
   factory _Recipe.fromJson(Map<String, dynamic> json) = _$RecipeImpl.fromJson;
@@ -418,6 +526,16 @@ abstract class _Recipe implements Recipe {
   List<String> get nutritionTags;
   @override
   String? get category;
+  @override
+  List<String>? get utensils;
+  @override
+  String? get storageNote;
+  @override
+  String? get freezerNote;
+  @override
+  String? get textureTip;
+  @override
+  String? get whyThisMeal;
 
   /// Create a copy of Recipe
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/src/common/domain/entities/recipe.g.dart
+++ b/lib/src/common/domain/entities/recipe.g.dart
@@ -26,6 +26,13 @@ _$RecipeImpl _$$RecipeImplFromJson(Map<String, dynamic> json) => _$RecipeImpl(
           .toList() ??
       const <String>[],
   category: json['category'] as String?,
+  utensils: (json['utensils'] as List<dynamic>?)
+      ?.map((e) => e as String)
+      .toList(),
+  storageNote: json['storageNote'] as String?,
+  freezerNote: json['freezerNote'] as String?,
+  textureTip: json['textureTip'] as String?,
+  whyThisMeal: json['whyThisMeal'] as String?,
 );
 
 Map<String, dynamic> _$$RecipeImplToJson(_$RecipeImpl instance) =>
@@ -41,4 +48,9 @@ Map<String, dynamic> _$$RecipeImplToJson(_$RecipeImpl instance) =>
       'thumbnailUrl': instance.thumbnailUrl,
       'nutritionTags': instance.nutritionTags,
       'category': instance.category,
+      'utensils': instance.utensils,
+      'storageNote': instance.storageNote,
+      'freezerNote': instance.freezerNote,
+      'textureTip': instance.textureTip,
+      'whyThisMeal': instance.whyThisMeal,
     };

--- a/lib/src/features/recipe/detail/recipe_detail_state.dart
+++ b/lib/src/features/recipe/detail/recipe_detail_state.dart
@@ -17,22 +17,21 @@ class RecipeDetailState with _$RecipeDetailState {
 
   const RecipeDetailState._();
 
-  /// Optional list of utensils for this recipe. Returns null until the
-  /// `Recipe` entity surfaces a utensils field (NIB-129 only added
-  /// `nutritionTags` + `category`; the rest is pending). Routed through a
-  /// getter so callers stay compile-clean and the UI conditionally hides
-  /// the section.
-  List<String>? get utensils => null;
+  /// Optional list of utensils for this recipe, sourced from the entity.
+  /// Returns null when the recipe has no utensils (null or empty) so the UI
+  /// conditionally hides the section.
+  List<String>? get utensils =>
+      (recipe.utensils?.isEmpty ?? true) ? null : recipe.utensils;
 
-  /// Optional fridge storage note. Null until backed by the entity.
-  String? get storageNote => null;
+  /// Optional fridge storage note, sourced from the entity.
+  String? get storageNote => recipe.storageNote;
 
-  /// Optional freezer storage note. Null until backed by the entity.
-  String? get freezerNote => null;
+  /// Optional freezer storage note, sourced from the entity.
+  String? get freezerNote => recipe.freezerNote;
 
-  /// Optional "Texture Tip" body copy. Null until backed by the entity.
-  String? get textureTip => null;
+  /// Optional "Texture Tip" body copy, sourced from the entity.
+  String? get textureTip => recipe.textureTip;
 
-  /// Optional "Why this meal" body copy. Null until backed by the entity.
-  String? get whyThisMeal => null;
+  /// Optional "Why this meal" body copy, sourced from the entity.
+  String? get whyThisMeal => recipe.whyThisMeal;
 }

--- a/supabase/migrations/20260606100136_recipe_detail_fields.sql
+++ b/supabase/migrations/20260606100136_recipe_detail_fields.sql
@@ -1,0 +1,19 @@
+-- Recipe Detail fields: surface the Utensils / Storage / Texture-Tip /
+-- Why-this-meal sections on RC-02 (UI already built but data-starved).
+--
+-- utensils:      text[] of utensils / appliances (e.g. {'Spoon','Steamer'}).
+-- storage_note:  fridge storage guidance copy.
+-- freezer_note:  freezer storage guidance copy.
+-- texture_tip:   "Texture Tip" body copy.
+-- why_this_meal: "Why this meal" body copy.
+--
+-- All nullable for back-compat — legacy rows have null and the client
+-- conditionally hides each section. Per-recipe CONTENT is populated
+-- separately by the owner.
+
+ALTER TABLE recipes
+  ADD COLUMN IF NOT EXISTS utensils TEXT[],
+  ADD COLUMN IF NOT EXISTS storage_note TEXT,
+  ADD COLUMN IF NOT EXISTS freezer_note TEXT,
+  ADD COLUMN IF NOT EXISTS texture_tip TEXT,
+  ADD COLUMN IF NOT EXISTS why_this_meal TEXT;

--- a/test/common/data/repositories/recipe_repository_test.dart
+++ b/test/common/data/repositories/recipe_repository_test.dart
@@ -49,6 +49,11 @@ Map<String, dynamic> _row({
   String? thumbnailUrl,
   List<dynamic>? nutritionTags,
   String? category,
+  List<dynamic>? utensils,
+  String? storageNote,
+  String? freezerNote,
+  String? textureTip,
+  String? whyThisMeal,
 }) => <String, dynamic>{
   'id': id,
   'title': title,
@@ -61,6 +66,11 @@ Map<String, dynamic> _row({
   'thumbnail_url': thumbnailUrl,
   'nutrition_tags': nutritionTags,
   'category': category,
+  'utensils': utensils,
+  'storage_note': storageNote,
+  'freezer_note': freezerNote,
+  'texture_tip': textureTip,
+  'why_this_meal': whyThisMeal,
 };
 
 void main() {
@@ -120,6 +130,29 @@ void main() {
         expect(roundtripped.category, 'Purees');
       },
     );
+
+    test('roundtrip preserves detail fields (utensils + storage/tip copy)', () {
+      const original = Recipe(
+        id: 'r1',
+        title: 'Pea Puree',
+        ageRange: '6m+',
+        allergenTags: [],
+        ingredients: [],
+        steps: [],
+        howToServe: 'Serve.',
+        utensils: ['Spoon', 'Steamer'],
+        storageNote: 'Fridge 3 days.',
+        freezerNote: 'Freeze 1 month.',
+        textureTip: 'Mash well.',
+        whyThisMeal: 'Iron-rich first food.',
+      );
+      final roundtripped = Recipe.fromJson(original.toJson());
+      expect(roundtripped.utensils, ['Spoon', 'Steamer']);
+      expect(roundtripped.storageNote, 'Fridge 3 days.');
+      expect(roundtripped.freezerNote, 'Freeze 1 month.');
+      expect(roundtripped.textureTip, 'Mash well.');
+      expect(roundtripped.whyThisMeal, 'Iron-rich first food.');
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -196,6 +229,36 @@ void main() {
         expect(recipe.category, isNull);
       },
     );
+
+    test(
+      'row with detail fields → entity carries utensils + storage/tip copy',
+      () async {
+        final recipe = await runRowMap(
+          _row(
+            id: 'r-detail',
+            utensils: ['Spoon', 'Steamer'],
+            storageNote: 'Fridge 3 days.',
+            freezerNote: 'Freeze 1 month.',
+            textureTip: 'Mash well.',
+            whyThisMeal: 'Iron-rich first food.',
+          ),
+        );
+        expect(recipe!.utensils, ['Spoon', 'Steamer']);
+        expect(recipe.storageNote, 'Fridge 3 days.');
+        expect(recipe.freezerNote, 'Freeze 1 month.');
+        expect(recipe.textureTip, 'Mash well.');
+        expect(recipe.whyThisMeal, 'Iron-rich first food.');
+      },
+    );
+
+    test('detail fields null → entity has null detail fields', () async {
+      final recipe = await runRowMap(_row());
+      expect(recipe!.utensils, isNull);
+      expect(recipe.storageNote, isNull);
+      expect(recipe.freezerNote, isNull);
+      expect(recipe.textureTip, isNull);
+      expect(recipe.whyThisMeal, isNull);
+    });
   });
 }
 

--- a/test/features/recipe/detail/recipe_detail_state_test.dart
+++ b/test/features/recipe/detail/recipe_detail_state_test.dart
@@ -1,0 +1,81 @@
+// Unit tests for [RecipeDetailState]'s entity-backed detail getters.
+//
+// These exercise the REAL getter logic against a REAL `Recipe` entity (not a
+// fake subclass), pinning the wiring that surfaces the RC-02 Utensils /
+// Storage / Texture-Tip / Why-this-meal sections:
+//   * `utensils` collapses null OR empty → null (so the UI hides the section),
+//     and passes a populated list through unchanged.
+//   * storageNote / freezerNote / textureTip / whyThisMeal pass through from
+//     the entity (null when absent).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/features/recipe/detail/recipe_detail_state.dart';
+
+Recipe _recipe({
+  List<String>? utensils,
+  String? storageNote,
+  String? freezerNote,
+  String? textureTip,
+  String? whyThisMeal,
+}) => Recipe(
+  id: 'r1',
+  title: 'Pea Puree',
+  ageRange: '6m+',
+  allergenTags: const [],
+  ingredients: const [],
+  steps: const [],
+  howToServe: 'Serve.',
+  utensils: utensils,
+  storageNote: storageNote,
+  freezerNote: freezerNote,
+  textureTip: textureTip,
+  whyThisMeal: whyThisMeal,
+);
+
+RecipeDetailState _state(Recipe recipe) =>
+    RecipeDetailState(recipe: recipe, currentAllergenKey: 'peanut');
+
+void main() {
+  group('RecipeDetailState.utensils', () {
+    test('null utensils → null (section hidden)', () {
+      expect(_state(_recipe()).utensils, isNull);
+    });
+
+    test('empty utensils → null (section hidden)', () {
+      expect(_state(_recipe(utensils: const [])).utensils, isNull);
+    });
+
+    test('populated utensils → passes list through', () {
+      expect(
+        _state(_recipe(utensils: const ['Spoon', 'Bowl'])).utensils,
+        ['Spoon', 'Bowl'],
+      );
+    });
+  });
+
+  group('RecipeDetailState detail copy getters', () {
+    test('populated entity → getters surface the values', () {
+      final state = _state(
+        _recipe(
+          storageNote: 'Fridge 3 days.',
+          freezerNote: 'Freeze 1 month.',
+          textureTip: 'Mash well.',
+          whyThisMeal: 'Iron-rich first food.',
+        ),
+      );
+      expect(state.storageNote, 'Fridge 3 days.');
+      expect(state.freezerNote, 'Freeze 1 month.');
+      expect(state.textureTip, 'Mash well.');
+      expect(state.whyThisMeal, 'Iron-rich first food.');
+    });
+
+    test('absent entity fields → getters return null', () {
+      final state = _state(_recipe());
+      expect(state.storageNote, isNull);
+      expect(state.freezerNote, isNull);
+      expect(state.textureTip, isNull);
+      expect(state.whyThisMeal, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The Recipe Detail screen (RC-02) already has the **Utensils / appliances**, **Storage** (fridge + freezer), **Texture Tip**, and **Why this meal** sections built in the UI — but they were **data-starved**: their `RecipeDetailState` getters were hardcoded to `null`, so the sections never rendered.

This wires the full chain: entity -> Supabase row mapping -> state getters, plus a migration to add the backing columns.

## Changes

- **Entity** (`recipe.dart`): 5 new nullable optional fields — `List<String>? utensils`, `String? storageNote`, `String? freezerNote`, `String? textureTip`, `String? whyThisMeal`. Regenerated `recipe.freezed.dart` + `recipe.g.dart` (committed per project rule).
- **Row mapping** (`recipe_repository.dart` `_recipeFromRow`): reads new snake_case columns null-safely — `utensils` (text[] -> List<String>, null when absent), `storage_note`, `freezer_note`, `texture_tip`, `why_this_meal`. Cache round-trips via existing camelCase `toJson`/`fromJson` (no `@JsonKey` — matches `category`/`thumbnailUrl` pattern).
- **State getters** (`recipe_detail_state.dart`): now source from the entity. `utensils` returns null when null OR empty so the section hides; the rest pass through. Doc comments updated (no longer "always null").
- **Migration** (`supabase/migrations/20260606100136_recipe_detail_fields.sql`): `ALTER TABLE recipes ADD COLUMN IF NOT EXISTS` for all 5 columns, all nullable for back-compat.
- **Tests**: new `recipe_detail_state_test.dart` proves the real getters surface entity fields (null -> null, empty -> null, populated -> passes through); extended `recipe_repository_test.dart` with row-mapper + Hive round-trip coverage for the new fields.

## Verification

- `flutter analyze --fatal-infos --fatal-warnings` on all changed files: **clean**.
- `flutter test test/features/recipe/ test/common/`: **225 pass, 2 failures** — both in `add_to_shopping_list_sheet_test.dart` and **pre-existing on clean main** (verified via stash; unrelated widget hit-test issue, not introduced by this change).

## DO NOT MERGE — needs owner review

This PR includes a **DB migration** that is **NOT auto-applied** (no `db push`). It requires owner review before applying. Per-recipe **content** for the new columns must be populated separately by the owner — the migration only adds the (nullable) columns.