### PR TITLE
fix(recipe): read-guide banner decorative blobs (Figma fidelity)

### DIFF
--- a/lib/src/features/recipe/library/widgets/read_guide_banner.dart
+++ b/lib/src/features/recipe/library/widgets/read_guide_banner.dart
@@ -3,6 +3,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:nibbles/gen/fonts.gen.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 
 /// First-launch 'New to Starting Solids?' banner for the Recipe Library
 /// (Figma 971:8644 → 1015:6820). Forest-green card with white title, white
@@ -34,10 +35,6 @@ class ReadGuideBanner extends StatelessWidget {
         AppSizes.pagePaddingH,
         0,
       ),
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSizes.sp12,
-        vertical: AppSizes.lg,
-      ),
       decoration: BoxDecoration(
         color: AppColors.green,
         borderRadius: BorderRadius.circular(AppSizes.sp12),
@@ -49,19 +46,55 @@ class ReadGuideBanner extends StatelessWidget {
           ),
         ],
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          const Text('New to Starting Solids?', style: _bannerTitleStyle),
-          const SizedBox(height: AppSizes.sp12),
-          Text(
-            'Start your baby’s food journey the right way with simple '
-            'basics.',
-            style: _bannerBodyStyle,
-          ),
-          const SizedBox(height: AppSizes.sp12),
-          _ReadGuideCta(onTap: onTap),
-        ],
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppSizes.sp12),
+        child: Stack(
+          children: [
+            // Decorative brand quatrefoil blobs (Figma 1015:6820) — lighter
+            // sage shapes clustered at the banner's top-right, clipped.
+            const Positioned(
+              top: -30,
+              right: -22,
+              child: Quatrefoil(
+                size: 104,
+                petalColor: AppColors.greenSoft,
+                coreColor: AppColors.greenSoft,
+              ),
+            ),
+            const Positioned(
+              top: 26,
+              right: -44,
+              child: Quatrefoil(
+                size: 76,
+                petalColor: AppColors.greenSoft,
+                coreColor: AppColors.greenSoft,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.sp12,
+                vertical: AppSizes.lg,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const Text(
+                    'New to Starting Solids?',
+                    style: _bannerTitleStyle,
+                  ),
+                  const SizedBox(height: AppSizes.sp12),
+                  Text(
+                    'Start your baby’s food journey the right way with simple '
+                    'basics.',
+                    style: _bannerBodyStyle,
+                  ),
+                  const SizedBox(height: AppSizes.sp12),
+                  _ReadGuideCta(onTap: onTap),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/test/features/recipe/library/widgets/read_guide_banner_test.dart
+++ b/test/features/recipe/library/widgets/read_guide_banner_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 import 'package:nibbles/src/features/recipe/library/widgets/read_guide_banner.dart';
 
 Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
@@ -24,5 +25,15 @@ void main() {
     expect(tapped, isTrue);
 
     handle.dispose();
+  });
+
+  testWidgets('renders the decorative brand quatrefoil blobs (Figma 1015:6820)',
+      (tester) async {
+    await tester.pumpWidget(_wrap(ReadGuideBanner(onTap: () {})));
+    await tester.pump();
+
+    // Two clipped sage blobs sit in the banner's top-right per the design.
+    expect(find.byType(Quatrefoil), findsNWidgets(2));
+    expect(find.byType(ClipRRect), findsWidgets);
   });
 }


### PR DESCRIPTION
## What
The Recipe Library 'New to Starting Solids?' read-guide banner was a flat green card. The Figma (971:8644 → 1015:6820) shows decorative brand **quatrefoil blobs** clustered at the banner's **top-right**.

## Fix
Wrap the banner content in a `Stack` + `ClipRRect`, with two `Quatrefoil` shapes (sage `greenSoft`) positioned top-right and clipped to the banner's rounded corner — matching the design's decorative flourish. Content/copy/CTA unchanged.

## Sim-gated
Rendered on the sim (fresh install so the first-launch banner shows): the blobs now appear top-right, matching the reference. +widget test asserting the 2 blobs render. analyze clean.

Part of the Recipe Library cluster fidelity sweep.