### PR TITLE
fix(ui): AppChip content-sized in Wrap, not full-width stacked

### DIFF
--- a/lib/src/common/components/chips/app_chip.dart
+++ b/lib/src/common/components/chips/app_chip.dart
@@ -79,7 +79,6 @@ class AppChip extends StatelessWidget {
         color: _background,
         borderRadius: BorderRadius.circular(AppSizes.radiusFull),
       ),
-      alignment: Alignment.center,
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/test/common/components/chips/app_chip_test.dart
+++ b/test/common/components/chips/app_chip_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+
+void main() {
+  testWidgets(
+    'AppChip is content-sized inside a Wrap — not stretched to full width',
+    (tester) async {
+      // A Wrap hands its children loose-bounded constraints. A previous stray
+      // `alignment: Alignment.center` made the chip greedily fill that width,
+      // so chips stacked full-width instead of flowing inline. This pins the
+      // chip to its intrinsic width.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              child: Wrap(
+                children: [AppChip(label: 'Iron Rich')],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final chipWidth = tester.getSize(find.byType(AppChip)).width;
+      expect(chipWidth, lessThan(160));
+    },
+  );
+
+  testWidgets('two short chips flow on the same Wrap line (inline)', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            child: Wrap(
+              children: [
+                AppChip(label: 'Iron Rich'),
+                AppChip(label: 'Protein'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final chips = tester.widgetList<AppChip>(find.byType(AppChip)).toList();
+    final a = tester.getTopLeft(find.byWidget(chips[0]));
+    final b = tester.getTopLeft(find.byWidget(chips[1]));
+    // Same line → identical dy; second chip sits to the right of the first.
+    expect(a.dy, b.dy);
+    expect(b.dx, greaterThan(a.dx));
+  });
+}


### PR DESCRIPTION
## What
On the Recipe Detail screen the banner nutrition chips (Iron Rich / Omega-3 / Protein) and the contains-allergens chips (Fish / Egg) rendered as **full-width bars stacked one per line** instead of small inline chips — a clear mismatch vs the Figma (971:9849), and the owner flagged Recipe Detail as 'still not good'.

## Root cause
`AppChip`'s `Container` had `alignment: Alignment.center`. A `Container` with an alignment **expands to fill** its parent's bounded constraints — and a `Wrap` (or stretch `Column`) hands children bounded width. So every `AppChip` in a `Wrap` filled the row → full-width → stacked.

## Fix
Remove the stray `alignment` (the inner `Row` is already `mainAxisSize.min`, so the chip sizes to its content). This is a **no-op** in content-sized contexts (e.g. inside a `Row`) and **fixes** every `Wrap` usage app-wide (33 `AppChip` call sites).

## Verification
- Sim-gated on Recipe Detail: nutrition + allergen chips now flow inline (screenshot in the sweep). 
- Full suite: 646 pass; the 5 failures are pre-existing (starting_guide subtitle + add_to_shopping_list ×2 + …), **no new failures**, **0 RenderFlex overflows**. Chip-heavy dirs (recipe-detail, home, allergen) all green.
- +regression tests (chip is <160px in a 400px Wrap; two chips share a line).

Part of the Recipe Library cluster fidelity sweep (screen 2/9, Recipe Detail).