### PR TITLE
fix(recipe): reorder Starting Guide hub cards to match Figma

### DIFF
--- a/lib/src/features/starting_guide/constants/articles.dart
+++ b/lib/src/features/starting_guide/constants/articles.dart
@@ -331,6 +331,42 @@ const List<GuideArticle> kStartingGuideArticles = [
       ),
     ],
   ),
+  // ── 5 Sign Readiness (Figma 1474:50031) ──────────────────────────────────
+  GuideArticle(
+    slug: 'readiness-signs',
+    title: 'Signs Your Baby Is Ready for Solids',
+    subtitle: 'Every baby develops at their own pace, so these signs are '
+        'generally more important than the calendar.',
+    blocks: [
+      HeroCardBlock(
+        title: '5 Sign Readiness',
+        body: 'Every baby develops at their own pace, so these signs are '
+            'generally more important than the calendar.',
+      ),
+      SectionHeadingBlock('Asther readiness result'),
+      ParagraphBlock(
+        'Most babies are ready at around six months, but these developmental '
+        'signs are the most important indicators.',
+      ),
+      ChecklistCardBlock(
+        title: 'Readiness Signs',
+        score: '3/5',
+        items: [
+          // Long copy kept on a single line per item so the literals are
+          // const (required by the outer `const List` constructor) and the
+          // `no_adjacent_strings_in_list` lint stays happy.
+          // ignore: lines_longer_than_80_chars
+          'Can sit upright with minimal support. Good head and neck control (can hold head steady)',
+          'Sits upright with minimal support',
+          // See the comment above the first item — same reason.
+          // ignore: lines_longer_than_80_chars
+          'Loss of the tongue-thrust reflex (doesn’t automatically push food out).',
+          'Shows interest in food (watching, reaching, opening mouth).',
+          'Can bring objects to their mouth.',
+        ],
+      ),
+    ],
+  ),
   // ── Feeding Principles (Figma 1474:50514) ────────────────────────────────
   GuideArticle(
     slug: 'feeding-principles',
@@ -408,42 +444,6 @@ const List<GuideArticle> kStartingGuideArticles = [
           label: 'Start Introducing Allergens',
           routeName: 'allergen-tracker',
         ),
-      ),
-    ],
-  ),
-  // ── 5 Sign Readiness (Figma 1474:50031) ──────────────────────────────────
-  GuideArticle(
-    slug: 'readiness-signs',
-    title: 'Signs Your Baby Is Ready for Solids',
-    subtitle: 'Every baby develops at their own pace, so these signs are '
-        'generally more important than the calendar.',
-    blocks: [
-      HeroCardBlock(
-        title: '5 Sign Readiness',
-        body: 'Every baby develops at their own pace, so these signs are '
-            'generally more important than the calendar.',
-      ),
-      SectionHeadingBlock('Asther readiness result'),
-      ParagraphBlock(
-        'Most babies are ready at around six months, but these developmental '
-        'signs are the most important indicators.',
-      ),
-      ChecklistCardBlock(
-        title: 'Readiness Signs',
-        score: '3/5',
-        items: [
-          // Long copy kept on a single line per item so the literals are
-          // const (required by the outer `const List` constructor) and the
-          // `no_adjacent_strings_in_list` lint stays happy.
-          // ignore: lines_longer_than_80_chars
-          'Can sit upright with minimal support. Good head and neck control (can hold head steady)',
-          'Sits upright with minimal support',
-          // See the comment above the first item — same reason.
-          // ignore: lines_longer_than_80_chars
-          'Loss of the tongue-thrust reflex (doesn’t automatically push food out).',
-          'Shows interest in food (watching, reaching, opening mouth).',
-          'Can bring objects to their mouth.',
-        ],
       ),
     ],
   ),

--- a/test/features/starting_guide/starting_guide_hub_screen_test.dart
+++ b/test/features/starting_guide/starting_guide_hub_screen_test.dart
@@ -121,11 +121,14 @@ void main() {
       },
     );
 
-    testWidgets('renders the hub header title and subtitle', (tester) async {
+    testWidgets('renders the hub header title (no subtitle, per Figma)', (
+      tester,
+    ) async {
       await pump(tester);
 
+      // Figma 971:8642 — the hub header is title-only; there is no subtitle.
       expect(find.text('Starting Guide'), findsWidgets);
-      expect(find.textContaining('Bite-sized reads'), findsOneWidget);
+      expect(find.textContaining('Bite-sized reads'), findsNothing);
     });
   });
 


### PR DESCRIPTION
## What
Swap positions 3 & 4 of the Starting Guide hub so the card order matches Figma 971:8642:

```
Baby's First Nibbles → Introductions → Signs Your Baby Is Ready for Solids → Important Feeding Principles
```

Previously `Important Feeding Principles` rendered before `Signs Your Baby Is Ready for Solids`.

Also drops a stale hub-header subtitle assertion (`Bite-sized reads`) — the Figma hub header is title-only, the screen correctly has no subtitle.

## Verify
- Reordered `kStartingGuideArticles` (list order drives card order).
- 13/13 `starting_guide` tests pass; `flutter analyze --fatal-infos` clean.
- Sim-gated: hub render confirmed against the Figma reference (order now matches).