### PR TITLE
fix(recipe): two-column EVIDENCE INFORMED + No Fluf on First Nibbles

### DIFF
--- a/lib/src/features/starting_guide/constants/articles.dart
+++ b/lib/src/features/starting_guide/constants/articles.dart
@@ -80,6 +80,17 @@ class InfoCardBlock extends GuideBlock {
   final String body;
 }
 
+/// Two [InfoCardBlock]s rendered side by side in one row — equal width, equal
+/// height. Mirrors the "EVIDENCE INFORMED" + "No Fluf" pair on Baby's First
+/// Nibbles (Figma 971:8730), which sits two-up below the full-width
+/// "SIMPLE AND PRACTICAL" card.
+class InfoCardRowBlock extends GuideBlock {
+  const InfoCardRowBlock({required this.left, required this.right});
+
+  final InfoCardBlock left;
+  final InfoCardBlock right;
+}
+
 /// Grid of small icon tiles (e.g. Iron / Minerals / Vitamins / Zinc; or the
 /// 7 iron-rich foods grid on Feeding Principles). Renders as a wrap of
 /// rounded tiles with a green-deep baby-face glyph above each label.
@@ -220,13 +231,15 @@ const List<GuideArticle> kStartingGuideArticles = [
             'Designed for busy parents with realistic recipes and actionable '
             'steps.',
       ),
-      InfoCardBlock(
-        title: 'EVIDENCE INFORMED',
-        body: 'Based on current pediatric nutrition guidelines.',
-      ),
-      InfoCardBlock(
-        title: 'No Fluf',
-        body: 'No overcomplication. Just food that makes sense for you.',
+      InfoCardRowBlock(
+        left: InfoCardBlock(
+          title: 'EVIDENCE INFORMED',
+          body: 'Based on current pediatric nutrition guidelines.',
+        ),
+        right: InfoCardBlock(
+          title: 'No Fluf',
+          body: 'No overcomplication. Just food that makes sense for you.',
+        ),
       ),
       SectionHeadingBlock('Nibbles Goals'),
       NumberedListCardBlock(

--- a/lib/src/features/starting_guide/starting_guide_article_screen.dart
+++ b/lib/src/features/starting_guide/starting_guide_article_screen.dart
@@ -181,6 +181,30 @@ Widget _buildBlock(GuideBlock block, ValueChanged<GuideCta> onCta) {
       );
     case InfoCardBlock():
       return GuideInfoCard(title: block.title, body: block.body);
+    case InfoCardRowBlock():
+      // Two equal-width, equal-height info cards side by side (Figma 971:8730).
+      // IntrinsicHeight bounds the row so `stretch` can equalise card heights
+      // inside the unbounded-height scroll view.
+      return IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: GuideInfoCard(
+                title: block.left.title,
+                body: block.left.body,
+              ),
+            ),
+            const SizedBox(width: AppSizes.md),
+            Expanded(
+              child: GuideInfoCard(
+                title: block.right.title,
+                body: block.right.body,
+              ),
+            ),
+          ],
+        ),
+      );
     case IconTileGridBlock():
       return GuideIconTileGrid(labels: block.labels);
     case ChipGridCardBlock():

--- a/test/features/starting_guide/starting_guide_article_screen_test.dart
+++ b/test/features/starting_guide/starting_guide_article_screen_test.dart
@@ -181,6 +181,25 @@ void main() {
     );
 
     testWidgets(
+      "'first-nibbles' lays EVIDENCE INFORMED + No Fluf side by side",
+      (tester) async {
+        await _pump(tester, slug: 'first-nibbles');
+
+        final evidence = find.text('EVIDENCE INFORMED');
+        final noFluf = find.text('No Fluf');
+        expect(evidence, findsOneWidget);
+        expect(noFluf, findsOneWidget);
+
+        // Figma 971:8730 — the two cards share a row: same top edge, No Fluf
+        // sits to the right of EVIDENCE INFORMED.
+        final ePos = tester.getTopLeft(evidence);
+        final nPos = tester.getTopLeft(noFluf);
+        expect(ePos.dy, nPos.dy);
+        expect(nPos.dx, greaterThan(ePos.dx));
+      },
+    );
+
+    testWidgets(
       "'first-nibbles' primary CTA → routes to recipe-library",
       (tester) async {
         const slug = 'first-nibbles';


### PR DESCRIPTION
## What
On the **Baby's First Nibbles** guide article, Figma 971:8730 lays the second and third info cards (`EVIDENCE INFORMED` + `No Fluf`) **side by side** in one row, below the full-width `SIMPLE AND PRACTICAL` card. The code rendered all three full-width stacked.

## Change
- New `InfoCardRowBlock` (sealed `GuideBlock`) → renders two `GuideInfoCard`s equal-width / equal-height (`IntrinsicHeight` + `Row(stretch)`).
- Article data pairs the two cards into one `InfoCardRowBlock`.
- `_buildBlock` switch handles the new block.

## Verify
- analyze --fatal-infos clean; starting_guide tests pass (added a side-by-side assertion: same dy, No Fluf right of EVIDENCE).
- Sim-gated: article render confirmed against the Figma ref — SIMPLE full-width, EVIDENCE | No Fluf two-up, Nibbles Goals + both CTAs intact.