### PR TITLE
fix(shopping-list): butter-fill the range shoplist toggle button

### DIFF
--- a/lib/src/features/meal_plan/widgets/range_add_to_shoplist_sheet.dart
+++ b/lib/src/features/meal_plan/widgets/range_add_to_shoplist_sheet.dart
@@ -414,11 +414,14 @@ class _BottomActions extends StatelessWidget {
       child: Row(
         children: [
           Expanded(
-            child: OutlinedButton(
+            child: FilledButton(
               onPressed: submitting ? null : onToggleAll,
-              style: OutlinedButton.styleFrom(
+              style: FilledButton.styleFrom(
                 minimumSize: const Size.fromHeight(AppSizes.xxl),
-                side: const BorderSide(color: AppColors.greenDeep),
+                backgroundColor: AppColors.butter,
+                disabledBackgroundColor: AppColors.butter.withValues(
+                  alpha: 0.5,
+                ),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(AppSizes.radius2xl),
                 ),

--- a/test/features/meal_plan/widgets/range_add_to_shoplist_sheet_test.dart
+++ b/test/features/meal_plan/widgets/range_add_to_shoplist_sheet_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/services/meal_plan_service.dart';
@@ -116,6 +117,17 @@ void main() {
       // Baseline = all selected → toggle reads "Unselect All", Add (N=count).
       expect(find.text('Unselect All'), findsOneWidget);
       expect(find.text('Add (${_ingredients.length})'), findsOneWidget);
+      // Figma 971:7908 — the toggle is a butter-filled button (not outlined).
+      final toggleBtn = tester.widget<FilledButton>(
+        find.ancestor(
+          of: find.text('Unselect All'),
+          matching: find.byType(FilledButton),
+        ),
+      );
+      expect(
+        toggleBtn.style?.backgroundColor?.resolve({}),
+        AppColors.butter,
+      );
       // Range fetch invoked with the range bounds.
       verify(
         () =>


### PR DESCRIPTION
## What
The range Add-to-Shoplist sheet (Figma 971:7908) renders the **Select All / Unselect All** toggle as a **butter-filled** button, mirroring the filled `Add (N)` CTA. The code used a transparent `OutlinedButton` (green border, no fill).

## Change
- `_BottomActions` left toggle: `OutlinedButton` → `FilledButton` with `backgroundColor: AppColors.butter`, `foregroundColor: greenDeep`, disabled-state at 50% alpha. Same height/radius.

## Verify
- analyze --fatal-infos clean; 7/7 `range_add_to_shoplist_sheet` tests pass (added a butter-background assertion on the toggle).
- Sim-gated: rendered the populated sheet (seeded meal entries + recipes) — toggle now butter-filled, Add CTA green, header/date-range/rows/safe-area all match the ref.