### PR TITLE
fix(home): light up the Iron Rich stat chip from today's meals

### DIFF
--- a/lib/src/features/home/home_screen.dart
+++ b/lib/src/features/home/home_screen.dart
@@ -160,6 +160,13 @@ class _HomeContent extends StatelessWidget {
     final ageMonths = _monthsBetween(baby.dateOfBirth, DateTime.now());
     final variant = state.variant;
 
+    // Light up the '✓ Iron Rich' stat chip when any of today's meals is an
+    // iron-rich recipe (Figma 1242:10567). The StatRingCard param existed but
+    // was never wired — home is the call-site that supplies the data.
+    final hasIronRichRecipes = state.todaysRecipes.values.any(
+      (r) => r.nutritionTags.any((t) => t.toLowerCase().contains('iron')),
+    );
+
     // Lime hero paints to y=0 behind the status bar (top: false), so the
     // scroll content carries the top safe inset itself to clear the notch.
     final topInset = MediaQuery.of(context).padding.top;
@@ -217,6 +224,7 @@ class _HomeContent extends StatelessWidget {
                           inProgressCount: state.inProgressCount,
                           todayMealCount: state.todayMealCount,
                           todayMealTarget: 2,
+                          hasIronRichRecipes: hasIronRichRecipes,
                           onAllergenTap: () => context.pushNamed(
                             AppRoute.allergenTracker.name,
                           ),

--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -43,6 +43,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
@@ -363,6 +364,48 @@ void main() {
       expect(find.text('Breakfast'), findsOneWidget);
       expect(find.text('Lunch'), findsOneWidget);
     });
+
+    testWidgets(
+      "today's iron-rich recipe lights up the '✓ Iron Rich' stat chip",
+      (tester) async {
+        // Figma 1242:10567 — the stat card shows '✓ Iron Rich' when any of
+        // today's meals is an iron-rich recipe. home wires hasIronRichRecipes
+        // from todaysRecipes.
+        final state = _populatedState().copyWith(
+          todaysRecipes: const {
+            'recipe-aaa': Recipe(
+              id: 'recipe-aaa',
+              title: 'Iron Purée',
+              ageRange: '6+ months',
+              allergenTags: [],
+              ingredients: [],
+              steps: [],
+              howToServe: '',
+              nutritionTags: ['iron_rich'],
+            ),
+          },
+        );
+
+        await _pump(
+          tester,
+          overrides: _overridesFor(babyId: _babyId, state: state),
+        );
+
+        expect(find.text('✓ Iron Rich'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      "no iron-rich recipe today -> no '✓ Iron Rich' chip",
+      (tester) async {
+        await _pump(
+          tester,
+          overrides: _overridesFor(babyId: _babyId, state: _populatedState()),
+        );
+
+        expect(find.text('✓ Iron Rich'), findsNothing);
+      },
+    );
   });
 
   group('HomeScreen — readyToStartEmpty variant (baby + no activity)', () {


### PR DESCRIPTION
## What
The populated Home dashboard (Figma 1242:10567) shows a `✓ Iron Rich` chip under the TODAY MEALS ring when today's meals include an iron-rich recipe. `StatRingCard` already had a `hasIronRichRecipes` param gating that chip — but `home_screen.dart` never passed it, so the chip never rendered.

## Change
- `_HomeContent` computes `hasIronRichRecipes` from `state.todaysRecipes` (any recipe with an iron-rich `nutritionTag`) and passes it to `StatRingCard`.

## Verify
- analyze --fatal-infos clean; home tests pass incl. 2 new home-level assertions (iron-rich recipe → chip shows; none → chip hidden).
- Sim-gated: populated home (seeded iron-rich meals) now renders both `✓ Iron Rich` + `✓ Active Program Allergens`, matching the ref.