### PR TITLE
fix(home): hide Active Program Allergens chip when none are active

### DIFF
--- a/lib/src/features/home/widgets/stat_ring_card.dart
+++ b/lib/src/features/home/widgets/stat_ring_card.dart
@@ -55,11 +55,16 @@ class StatRingCard extends StatelessWidget {
   Widget build(BuildContext context) {
     // Chip tone matches `HomeScreen.jsx` (neutral / coral-soft) — the
     // screen-level composition outranks the generic catalogue here.
-    // 'Active Program Allergens' renders unconditionally per spec — only
-    // 'Iron Rich' is gated on the optional [hasIronRichRecipes] arg.
+    // 'Active Program Allergens' is gated on the program having started
+    // (≥1 allergen introduced): Figma's ready-to-start-empty frame
+    // (1266:12135) shows NO chip when nothing is active. 'Iron Rich' is
+    // gated on the optional [hasIronRichRecipes] arg.
+    final hasActiveProgramAllergens =
+        safeCount + flaggedCount + inProgressCount > 0;
     final chips = <Widget>[
       if (hasIronRichRecipes) const AppChip(label: '✓ Iron Rich'),
-      const AppChip(label: '✓ Active Program Allergens'),
+      if (hasActiveProgramAllergens)
+        const AppChip(label: '✓ Active Program Allergens'),
     ];
 
     return Container(

--- a/test/features/home/widgets/stat_ring_card_test.dart
+++ b/test/features/home/widgets/stat_ring_card_test.dart
@@ -63,6 +63,46 @@ void main() {
     });
   });
 
+  group('StatRingCard — Active Program Allergens chip gating', () {
+    testWidgets(
+      'no allergen activity (all notStarted) -> no Active chip (empty state)',
+      (tester) async {
+        // Figma 1266:12135 ready-to-start-empty shows no chips under the rings.
+        await tester.pumpWidget(
+          _wrap(
+            const StatRingCard(
+              safeCount: 0,
+              flaggedCount: 0,
+              notStartedCount: 9,
+              inProgressCount: 0,
+            ),
+          ),
+        );
+
+        expect(find.text('✓ Active Program Allergens'), findsNothing);
+        expect(find.byType(AppChip), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'an in-progress allergen -> Active Program Allergens chip shows',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            const StatRingCard(
+              safeCount: 0,
+              flaggedCount: 0,
+              notStartedCount: 8,
+              inProgressCount: 1,
+            ),
+          ),
+        );
+
+        expect(find.text('✓ Active Program Allergens'), findsOneWidget);
+      },
+    );
+  });
+
   group('StatRingCard — Iron Rich chip gating', () {
     testWidgets(
       'hasIronRichRecipes = false -> only Active Program Allergens chip',


### PR DESCRIPTION
## What
On the ready-to-start-empty home (Figma 1266:12135, zero allergens introduced), `StatRingCard` wrongly showed the `✓ Active Program Allergens` chip — it rendered unconditionally. The empty-state design shows no chips under the rings.

## Change
- Gate the chip on the allergen program having started: `safeCount + flaggedCount + inProgressCount > 0`. (Mirrors the existing `hasIronRichRecipes` gate on the Iron Rich chip.)

## Verify
- analyze --fatal-infos clean; stat_ring_card + home_screen tests pass incl. 2 new gating assertions (all-notStarted → no chip; an in-progress allergen → chip shows).
- Sim-gated: empty-state home now renders the two rings with no chips below, matching the ref; populated home still shows the chip.