### PR TITLE
chore(infra): test automation foundations

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -64,6 +64,10 @@ Generated files (`*.freezed.dart`, `*.g.dart`) ARE committed to source control.
 | `make clean` | `flutter clean && flutter pub get` |
 | `make fix` | `dart fix --apply && dart format .` |
 
+## Simulator (UI verification)
+
+Canonical sim: **iPhone 17 / iOS 26.0** — the only sim with `com.aydev.nibbles.dev` installed. Resolve UDID by name (`xcrun simctl list devices | grep "iPhone 17 ("`), don't hardcode it. Drive UI with `axe`: coordinates from `describe-ui` frames (point space), tap at frame center, verify every action with a screenshot — axe exit 0 only means the gesture was delivered. Dev test account for automated flows: see `.env.dev` (`TEST_ACCOUNT_EMAIL` / `TEST_ACCOUNT_PASSWORD`).
+
 ---
 
 ## Agent Roles

--- a/.claude/agents/nibbles-backend.md
+++ b/.claude/agents/nibbles-backend.md
@@ -1,7 +1,7 @@
 ---
 name: nibbles-backend
 description: Agent-Backend for Nibbles. Owns the entire data layer: repositories, services, Supabase queries, Hive local storage, mappers, DTOs, and domain entities. Use for any task touching lib/src/common/data/, lib/src/common/domain/, lib/src/common/services/, or supabase/.
-tools: [read, write, edit, glob, grep, bash, mcp]
+tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, ToolSearch
 ---
 
 # Nibbles — Agent-Backend

--- a/.claude/agents/nibbles-frontend.md
+++ b/.claude/agents/nibbles-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: nibbles-frontend
 description: Agent-Frontend for Nibbles. Implements all Flutter screens, widgets, UI state (AsyncNotifier controllers), and navigation. Use for any task touching lib/src/features/, lib/src/common/components/, or lib/src/routing/.
-tools: [read, write, edit, glob, grep, bash, mcp]
+tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, ToolSearch
 ---
 
 # Nibbles — Agent-Frontend

--- a/.claude/agents/nibbles-infra.md
+++ b/.claude/agents/nibbles-infra.md
@@ -1,7 +1,7 @@
 ---
 name: nibbles-infra
 description: Agent-Infra for Nibbles. Owns project setup, dev/prod flavors, Firebase config, RevenueCat config, deep links, runner.dart bootstrap, pubspec.yaml, and store preparation. Use for M0 infrastructure tasks and any platform-level setup.
-tools: [read, write, edit, glob, grep, bash, mcp]
+tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, ToolSearch
 ---
 
 # Nibbles — Agent-Infra

--- a/.claude/agents/nibbles-qa.md
+++ b/.claude/agents/nibbles-qa.md
@@ -1,7 +1,7 @@
 ---
 name: nibbles-qa
 description: Agent-QA for Nibbles. Writes and maintains unit tests (services, repos, controllers), widget tests (key screens), and integration tests (critical user paths). Use after any feature implementation is complete.
-tools: [read, write, edit, glob, grep, bash, mcp]
+tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, ToolSearch
 ---
 
 # Nibbles — Agent-QA

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,14 @@
       "Bash(git commit:*)",
       "Bash(git push:*)",
       "Bash(git checkout:*)",
-      "Bash(gh pr create:*)"
+      "Bash(gh pr create:*)",
+      "Bash(axe:*)",
+      "Bash(xcrun simctl:*)",
+      "Bash(applesimutils:*)",
+      "Bash(make gen:*)",
+      "Bash(flutter analyze:*)",
+      "Bash(flutter test:*)",
+      "Bash(dart format:*)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ android/key.properties
 .claude/context/
 
 # Tool-generated / temp
+.claude/worktrees/
+.claude/scheduled_tasks.lock
 .superset/
 supabase/.temp/
 supabase/.branches/

--- a/integration_test/login_flow_test.dart
+++ b/integration_test/login_flow_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nibbles/src/app/config/flavor_config.dart';
+import 'package:nibbles/src/app/runner.dart';
+import 'package:nibbles/src/common/components/components.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+Future<void> pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 30),
+}) async {
+  final end = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(end)) {
+    await tester.pump(const Duration(milliseconds: 250));
+    if (finder.evaluate().isNotEmpty) return;
+  }
+  fail('Timed out after $timeout waiting for $finder');
+}
+
+Future<void> seedOnboardingFlags() async {
+  await Hive.initFlutter();
+  final flags = await Hive.openBox<dynamic>('local_flags');
+  await flags.putAll(<String, dynamic>{
+    'app_has_launched': true,
+    'onboarding_readiness_done': true,
+    'onboarding_baby_setup_done': true,
+    'onboarding_done': true,
+  });
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('login with seeded test account reaches home', (tester) async {
+    await seedOnboardingFlags();
+    await bootstrap(flavor: Flavor.dev);
+
+    final auth = Supabase.instance.client.auth;
+    if (auth.currentSession != null) {
+      await auth.signOut();
+    }
+
+    final email = dotenv.env['TEST_ACCOUNT_EMAIL'];
+    final password = dotenv.env['TEST_ACCOUNT_PASSWORD'];
+    expect(
+      email,
+      isNotNull,
+      reason: 'TEST_ACCOUNT_EMAIL missing from .env.dev',
+    );
+    expect(
+      password,
+      isNotNull,
+      reason: 'TEST_ACCOUNT_PASSWORD missing from .env.dev',
+    );
+
+    final emailField = find.byKey(const Key('login_email_field'));
+    await pumpUntilFound(tester, emailField);
+
+    await tester.enterText(emailField, email!);
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const Key('login_password_field')),
+      password!,
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('login_submit_button')));
+
+    await pumpUntilFound(
+      tester,
+      find.byType(AppBottomNav),
+      timeout: const Duration(seconds: 45),
+    );
+
+    expect(auth.currentSession, isNotNull);
+    expect(auth.currentUser?.email, email);
+  });
+}

--- a/integration_test/smoke_test.dart
+++ b/integration_test/smoke_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('harness smoke check', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: Text('smoke'))),
+    );
+    expect(find.text('smoke'), findsOneWidget);
+  });
+}

--- a/lib/src/common/components/buttons/app_pill_button.dart
+++ b/lib/src/common/components/buttons/app_pill_button.dart
@@ -20,6 +20,7 @@ class AppPillButton extends StatelessWidget {
     this.size = AppPillButtonSize.full,
     this.expand = true,
     this.leading,
+    this.identifier,
     super.key,
   });
 
@@ -33,6 +34,10 @@ class AppPillButton extends StatelessWidget {
 
   /// Optional leading widget (e.g. a `+` icon for "Add" buttons).
   final Widget? leading;
+
+  /// Stable semantics identifier for UI automation (maps to
+  /// accessibilityIdentifier on iOS).
+  final String? identifier;
 
   bool get _isSmall => size == AppPillButtonSize.small;
 
@@ -88,31 +93,30 @@ class AppPillButton extends StatelessWidget {
           const SizedBox(width: AppSizes.xs),
         ],
         Flexible(
-          child: Text(
-            label,
-            style: textStyle,
-            overflow: TextOverflow.ellipsis,
-          ),
+          child: Text(label, style: textStyle, overflow: TextOverflow.ellipsis),
         ),
       ],
     );
 
-    return Material(
-      color: _background(variant),
-      shape: StadiumBorder(
-        side: isSecondary && !_disabled
-            ? const BorderSide(color: AppColors.greenDeep, width: 1.5)
-            : BorderSide.none,
-      ),
-      child: InkWell(
-        onTap: onPressed,
-        customBorder: const StadiumBorder(),
-        child: SizedBox(
-          height: height,
-          width: expand ? double.infinity : null,
-          child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: hPad),
-            child: Center(child: child),
+    return Semantics(
+      identifier: identifier,
+      child: Material(
+        color: _background(variant),
+        shape: StadiumBorder(
+          side: isSecondary && !_disabled
+              ? const BorderSide(color: AppColors.greenDeep, width: 1.5)
+              : BorderSide.none,
+        ),
+        child: InkWell(
+          onTap: onPressed,
+          customBorder: const StadiumBorder(),
+          child: SizedBox(
+            height: height,
+            width: expand ? double.infinity : null,
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: hPad),
+              child: Center(child: child),
+            ),
           ),
         ),
       ),

--- a/lib/src/common/components/buttons/social_auth_button.dart
+++ b/lib/src/common/components/buttons/social_auth_button.dart
@@ -21,6 +21,7 @@ class SocialAuthButton extends StatelessWidget {
     required this.label,
     required this.onPressed,
     this.isLoading = false,
+    this.identifier,
     super.key,
   });
 
@@ -28,6 +29,10 @@ class SocialAuthButton extends StatelessWidget {
   final String label;
   final VoidCallback onPressed;
   final bool isLoading;
+
+  /// Stable semantics identifier for UI automation (maps to
+  /// accessibilityIdentifier on iOS).
+  final String? identifier;
 
   static const double _logoSize = 28;
 
@@ -44,30 +49,33 @@ class SocialAuthButton extends StatelessWidget {
         ? const StadiumBorder()
         : const StadiumBorder(side: BorderSide(color: AppColors.borderSoft));
 
-    return Material(
-      color: background,
-      shape: shape,
-      child: InkWell(
-        onTap: disabled ? null : onPressed,
-        customBorder: const StadiumBorder(),
-        child: SizedBox(
-          height: AppSizes.buttonHeight,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              ExcludeSemantics(child: _logo(disabled)),
-              const SizedBox(width: AppSizes.sp12),
-              Text(
-                label,
-                style: TextStyle(
-                  fontFamily: FontFamily.parkinsans,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                  height: 20 / 13,
-                  color: foreground,
+    return Semantics(
+      identifier: identifier,
+      child: Material(
+        color: background,
+        shape: shape,
+        child: InkWell(
+          onTap: disabled ? null : onPressed,
+          customBorder: const StadiumBorder(),
+          child: SizedBox(
+            height: AppSizes.buttonHeight,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                ExcludeSemantics(child: _logo(disabled)),
+                const SizedBox(width: AppSizes.sp12),
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontFamily: FontFamily.parkinsans,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    height: 20 / 13,
+                    color: foreground,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/common/components/inputs/app_text_field.dart
+++ b/lib/src/common/components/inputs/app_text_field.dart
@@ -23,6 +23,7 @@ class AppTextField extends StatefulWidget {
     this.autocorrect = true,
     this.enableSuggestions = true,
     this.textCapitalization = TextCapitalization.none,
+    this.identifier,
     super.key,
   });
 
@@ -57,6 +58,10 @@ class AppTextField extends StatefulWidget {
 
   /// Forwarded to [TextField.textCapitalization].
   final TextCapitalization textCapitalization;
+
+  /// Stable semantics identifier for UI automation (maps to
+  /// accessibilityIdentifier on iOS).
+  final String? identifier;
 
   @override
   State<AppTextField> createState() => _AppTextFieldState();
@@ -118,40 +123,47 @@ class _AppTextFieldState extends State<AppTextField> {
         // container and no hard-edged focus shadow (the previous spreadRadius
         // BoxShadow rendered a phantom second border). Border + fill + error
         // caption + suffix icon are all native decoration slots.
-        TextField(
-          controller: widget.controller,
-          focusNode: _focusNode,
-          enabled: widget.enabled,
-          obscureText: widget.obscureText,
-          keyboardType: widget.keyboardType,
-          textInputAction: widget.textInputAction,
-          onChanged: widget.onChanged,
-          onSubmitted: widget.onSubmitted,
-          autocorrect: widget.autocorrect,
-          enableSuggestions: widget.enableSuggestions,
-          textCapitalization: widget.textCapitalization,
-          style: theme.textTheme.bodyLarge?.copyWith(color: AppColors.fgStrong),
-          cursorColor: AppColors.greenDeep,
-          decoration: InputDecoration(
-            filled: true,
-            fillColor: focused ? AppColors.surface : AppColors.bgInput,
-            isDense: true,
-            contentPadding: const EdgeInsets.symmetric(
-              horizontal: AppSizes.md,
-              vertical: AppSizes.sp12 + 1,
+        Semantics(
+          identifier: widget.identifier,
+          child: TextField(
+            controller: widget.controller,
+            focusNode: _focusNode,
+            enabled: widget.enabled,
+            obscureText: widget.obscureText,
+            keyboardType: widget.keyboardType,
+            textInputAction: widget.textInputAction,
+            onChanged: widget.onChanged,
+            onSubmitted: widget.onSubmitted,
+            autocorrect: widget.autocorrect,
+            enableSuggestions: widget.enableSuggestions,
+            textCapitalization: widget.textCapitalization,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: AppColors.fgStrong,
             ),
-            hintText: widget.hintText,
-            hintStyle: theme.textTheme.bodyLarge?.copyWith(
-              color: AppColors.greenSoft,
+            cursorColor: AppColors.greenDeep,
+            decoration: InputDecoration(
+              filled: true,
+              fillColor: focused ? AppColors.surface : AppColors.bgInput,
+              isDense: true,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.md,
+                vertical: AppSizes.sp12 + 1,
+              ),
+              hintText: widget.hintText,
+              hintStyle: theme.textTheme.bodyLarge?.copyWith(
+                color: AppColors.greenSoft,
+              ),
+              suffixIcon: widget.suffixIcon,
+              enabledBorder: borderOf(AppColors.borderSoft, 1),
+              disabledBorder: borderOf(AppColors.borderSoft, 1),
+              focusedBorder: borderOf(AppColors.greenDeep, 2),
+              errorBorder: borderOf(errorColor, 1),
+              focusedErrorBorder: borderOf(errorColor, 2),
+              errorText: widget.errorText,
+              errorStyle: theme.textTheme.bodySmall?.copyWith(
+                color: errorColor,
+              ),
             ),
-            suffixIcon: widget.suffixIcon,
-            enabledBorder: borderOf(AppColors.borderSoft, 1),
-            disabledBorder: borderOf(AppColors.borderSoft, 1),
-            focusedBorder: borderOf(AppColors.greenDeep, 2),
-            errorBorder: borderOf(errorColor, 1),
-            focusedErrorBorder: borderOf(errorColor, 2),
-            errorText: widget.errorText,
-            errorStyle: theme.textTheme.bodySmall?.copyWith(color: errorColor),
           ),
         ),
       ],

--- a/lib/src/common/components/navigation/app_bottom_nav.dart
+++ b/lib/src/common/components/navigation/app_bottom_nav.dart
@@ -4,10 +4,18 @@ import 'package:nibbles/src/app/themes/app_sizes.dart';
 
 /// One destination in [AppBottomNav].
 class AppBottomNavItem {
-  const AppBottomNavItem({required this.icon, required this.label});
+  const AppBottomNavItem({
+    required this.icon,
+    required this.label,
+    this.identifier,
+  });
 
   final IconData icon;
   final String label;
+
+  /// Stable semantics identifier for UI automation (maps to
+  /// accessibilityIdentifier on iOS).
+  final String? identifier;
 }
 
 /// Canonical bottom nav — the floating rounded-28 card + shadowCard variant
@@ -26,10 +34,26 @@ class AppBottomNav extends StatelessWidget {
   final List<AppBottomNavItem> items;
 
   static const List<AppBottomNavItem> defaultItems = [
-    AppBottomNavItem(icon: Icons.home_outlined, label: 'Home'),
-    AppBottomNavItem(icon: Icons.restaurant_outlined, label: 'Meals'),
-    AppBottomNavItem(icon: Icons.shopping_cart_outlined, label: 'Grocery'),
-    AppBottomNavItem(icon: Icons.menu_book_outlined, label: 'Recipes'),
+    AppBottomNavItem(
+      icon: Icons.home_outlined,
+      label: 'Home',
+      identifier: 'nav_tab_home',
+    ),
+    AppBottomNavItem(
+      icon: Icons.restaurant_outlined,
+      label: 'Meals',
+      identifier: 'nav_tab_meal_plan',
+    ),
+    AppBottomNavItem(
+      icon: Icons.shopping_cart_outlined,
+      label: 'Grocery',
+      identifier: 'nav_tab_shopping_list',
+    ),
+    AppBottomNavItem(
+      icon: Icons.menu_book_outlined,
+      label: 'Recipes',
+      identifier: 'nav_tab_recipe_library',
+    ),
   ];
 
   @override
@@ -69,35 +93,38 @@ class _Tab extends StatelessWidget {
   Widget build(BuildContext context) {
     final fg = active ? AppColors.greenDeep : AppColors.fgFaint;
 
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: onTap,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 150),
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSizes.md - 2,
-          vertical: AppSizes.sm,
-        ),
-        decoration: BoxDecoration(
-          color: active ? AppColors.butter : Colors.transparent,
-          borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(item.icon, size: 22, color: fg),
-            const SizedBox(height: 3),
-            Text(
-              item.label,
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                    fontSize: 10,
-                    fontWeight: FontWeight.w700,
-                    letterSpacing: 0,
-                    height: 1,
-                    color: fg,
-                  ),
-            ),
-          ],
+    return Semantics(
+      identifier: item.identifier,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.md - 2,
+            vertical: AppSizes.sm,
+          ),
+          decoration: BoxDecoration(
+            color: active ? AppColors.butter : Colors.transparent,
+            borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(item.icon, size: 22, color: fg),
+              const SizedBox(height: 3),
+              Text(
+                item.label,
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0,
+                  height: 1,
+                  color: fg,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/allergen/tracker/widgets/allergen_progress_card.dart
+++ b/lib/src/features/allergen/tracker/widgets/allergen_progress_card.dart
@@ -65,58 +65,61 @@ class AllergenProgressCard extends StatelessWidget {
     final trailingChip = _trailingChip();
     final clamped = cleanLogCount.clamp(0, 3);
 
-    return AppCard(
-      onTap: onTap,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Row(
-            children: [
-              Container(
-                width: AppSizes.avatarMd,
-                height: AppSizes.avatarMd,
-                decoration: const BoxDecoration(
-                  color: AppColors.coralSoft,
-                  shape: BoxShape.circle,
+    return Semantics(
+      identifier: 'allergen_card_${allergen.key}',
+      child: AppCard(
+        onTap: onTap,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: AppSizes.avatarMd,
+                  height: AppSizes.avatarMd,
+                  decoration: const BoxDecoration(
+                    color: AppColors.coralSoft,
+                    shape: BoxShape.circle,
+                  ),
+                  alignment: Alignment.center,
+                  child: Text(
+                    allergen.emoji,
+                    style: const TextStyle(fontSize: 24, height: 1),
+                  ),
                 ),
-                alignment: Alignment.center,
-                child: Text(
-                  allergen.emoji,
-                  style: const TextStyle(fontSize: 24, height: 1),
-                ),
-              ),
-              const SizedBox(width: AppSizes.sp12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(allergen.name, style: textTheme.titleSmall),
-                    const SizedBox(height: AppSizes.sp2),
-                    Text(
-                      // Figma verbatim: keeps the trailing space on "N/3 times ".
-                      '$clamped/3 times ',
-                      style: textTheme.bodyMedium?.copyWith(
-                        color: AppColors.fgMuted,
+                const SizedBox(width: AppSizes.sp12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(allergen.name, style: textTheme.titleSmall),
+                      const SizedBox(height: AppSizes.sp2),
+                      Text(
+                        // Figma verbatim: keeps the trailing space on "N/3 times ".
+                        '$clamped/3 times ',
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: AppColors.fgMuted,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              if (trailingChip != null) trailingChip,
-            ],
-          ),
-          const SizedBox(height: AppSizes.sp12),
-          AppSegmentedProgressBar(filledCount: clamped, tone: _barTone),
-          if (totalLogCount > cleanLogCount) ...[
-            const SizedBox(height: AppSizes.xs),
-            Text(
-              '$totalLogCount log${totalLogCount == 1 ? '' : 's'} total',
-              style: textTheme.bodySmall,
+                if (trailingChip != null) trailingChip,
+              ],
             ),
+            const SizedBox(height: AppSizes.sp12),
+            AppSegmentedProgressBar(filledCount: clamped, tone: _barTone),
+            if (totalLogCount > cleanLogCount) ...[
+              const SizedBox(height: AppSizes.xs),
+              Text(
+                '$totalLogCount log${totalLogCount == 1 ? '' : 's'} total',
+                style: textTheme.bodySmall,
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/lib/src/features/allergen/tracker/widgets/start_introduce_card.dart
+++ b/lib/src/features/allergen/tracker/widgets/start_introduce_card.dart
@@ -72,6 +72,7 @@ class StartIntroduceCard extends StatelessWidget {
           const SizedBox(width: AppSizes.sm),
           AppPillButton(
             label: 'Start Introduce',
+            identifier: 'allergen_start_introduce_button',
             onPressed: onStartIntroduce,
             variant: AppPillButtonVariant.ghost,
             size: AppPillButtonSize.small,

--- a/lib/src/features/auth/login/login_screen.dart
+++ b/lib/src/features/auth/login/login_screen.dart
@@ -80,6 +80,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 const SizedBox(height: AppSizes.xl),
                 AppTextField(
                   key: const Key('login_email_field'),
+                  identifier: 'login_email_field',
                   label: 'Email address',
                   hintText: 'Email address',
                   keyboardType: TextInputType.emailAddress,
@@ -94,6 +95,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 const SizedBox(height: AppSizes.md),
                 AppTextField(
                   key: const Key('login_password_field'),
+                  identifier: 'login_password_field',
                   label: 'Password',
                   hintText: 'Password',
                   obscureText: state.obscure,
@@ -113,16 +115,19 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 const SizedBox(height: AppSizes.xs),
                 Align(
                   alignment: Alignment.centerRight,
-                  child: TextButton(
-                    onPressed: () =>
-                        context.goNamed(AppRoute.forgotPassword.name),
-                    child: const Text(
-                      'Forgot password?',
-                      style: TextStyle(
-                        fontFamily: FontFamily.parkinsans,
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.burgundy,
+                  child: Semantics(
+                    identifier: 'login_forgot_password_link',
+                    child: TextButton(
+                      onPressed: () =>
+                          context.goNamed(AppRoute.forgotPassword.name),
+                      child: const Text(
+                        'Forgot password?',
+                        style: TextStyle(
+                          fontFamily: FontFamily.parkinsans,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.burgundy,
+                        ),
                       ),
                     ),
                   ),
@@ -130,6 +135,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 const SizedBox(height: AppSizes.md),
                 AppPillButton(
                   key: const Key('login_submit_button'),
+                  identifier: 'login_submit_button',
                   label: state.isLoading ? 'Logging in…' : 'Login',
                   onPressed: (state.isLoading || !canSubmit)
                       ? null
@@ -140,6 +146,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 const SizedBox(height: AppSizes.md),
                 SocialAuthButton(
                   key: const Key('login_google_button'),
+                  identifier: 'login_google_button',
                   provider: SocialAuthProvider.google,
                   label: 'Login with Google',
                   isLoading: state.isLoading,
@@ -148,6 +155,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                 const SizedBox(height: AppSizes.md),
                 SocialAuthButton(
                   key: const Key('login_apple_button'),
+                  identifier: 'login_apple_button',
                   provider: SocialAuthProvider.apple,
                   label: 'Login with Apple Account',
                   isLoading: state.isLoading,
@@ -266,15 +274,14 @@ class _SignUpFooter extends StatelessWidget {
         Semantics(
           button: true,
           label: 'Sign up',
+          identifier: 'login_signup_link',
           excludeSemantics: true,
           child: TextButton(
             key: const Key('login_signup_link'),
             onPressed: () => context.goNamed(AppRoute.register.name),
             child: Text(
               'Sign Up',
-              style: AppTypography.headline.copyWith(
-                color: AppColors.burgundy,
-              ),
+              style: AppTypography.headline.copyWith(color: AppColors.burgundy),
             ),
           ),
         ),

--- a/lib/src/features/auth/register/register_screen.dart
+++ b/lib/src/features/auth/register/register_screen.dart
@@ -82,6 +82,7 @@ class RegisterScreen extends ConsumerWidget {
                 const SizedBox(height: AppSizes.xl),
                 AppTextField(
                   key: const Key('register_email_field'),
+                  identifier: 'register_email_field',
                   label: 'Email address',
                   hintText: 'Email address',
                   keyboardType: TextInputType.emailAddress,
@@ -102,6 +103,7 @@ class RegisterScreen extends ConsumerWidget {
                 const SizedBox(height: AppSizes.md),
                 AppTextField(
                   key: const Key('register_password_field'),
+                  identifier: 'register_password_field',
                   label: 'Password',
                   hintText: 'Password',
                   obscureText: state.obscure,
@@ -117,6 +119,7 @@ class RegisterScreen extends ConsumerWidget {
                 const SizedBox(height: AppSizes.lg),
                 AppPillButton(
                   key: const Key('register_submit_button'),
+                  identifier: 'register_submit_button',
                   label: state.isLoading ? 'Signing up…' : 'Sign Up',
                   onPressed: (!state.isValid || state.isLoading)
                       ? null
@@ -132,6 +135,7 @@ class RegisterScreen extends ConsumerWidget {
                 const SizedBox(height: AppSizes.md),
                 SocialAuthButton(
                   key: const Key('register_google_button'),
+                  identifier: 'register_google_button',
                   provider: SocialAuthProvider.google,
                   label: 'Sign Up with Google',
                   isLoading: state.isLoading,
@@ -145,6 +149,7 @@ class RegisterScreen extends ConsumerWidget {
                 const SizedBox(height: AppSizes.md),
                 SocialAuthButton(
                   key: const Key('register_apple_button'),
+                  identifier: 'register_apple_button',
                   provider: SocialAuthProvider.apple,
                   label: 'Sign Up with Apple Account',
                   isLoading: state.isLoading,
@@ -268,6 +273,7 @@ class _LoginFooter extends StatelessWidget {
         Semantics(
           button: true,
           label: 'Login',
+          identifier: 'register_login_link',
           excludeSemantics: true,
           child: InkWell(
             key: const Key('register_login_link'),

--- a/lib/src/features/home/widgets/home_header.dart
+++ b/lib/src/features/home/widgets/home_header.dart
@@ -113,6 +113,7 @@ class _HeaderAvatar extends StatelessWidget {
     return Semantics(
       button: true,
       label: 'Profile',
+      identifier: 'home_profile_avatar',
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: onTap,

--- a/lib/src/features/home/widgets/ongoing_introduced_card.dart
+++ b/lib/src/features/home/widgets/ongoing_introduced_card.dart
@@ -75,6 +75,7 @@ class OngoingIntroducedCard extends StatelessWidget {
         Semantics(
           button: true,
           label: '$name, introduced $filled of $_target times',
+          identifier: 'home_allergen_tracker_card',
           excludeSemantics: true,
           onTap: handleTap,
           child: Material(

--- a/lib/src/features/recipe/library/widgets/recipe_grid_card.dart
+++ b/lib/src/features/recipe/library/widgets/recipe_grid_card.dart
@@ -44,6 +44,7 @@ class RecipeGridCard extends StatelessWidget {
     return Semantics(
       button: true,
       label: isUnsafe ? '${recipe.title}, not safe' : recipe.title,
+      identifier: 'recipe_card_${recipe.id}',
       excludeSemantics: true,
       onTap: onTap,
       child: GestureDetector(

--- a/test_driver/integration_test.dart
+++ b/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
## What
- **Semantic identifiers** (`Semantics(identifier:)` → iOS accessibilityIdentifier) on auth fields/buttons, bottom-nav tabs, home avatar, allergen cards (`allergen_card_<key>`), recipe cards (`recipe_card_<id>`) — verified live via `axe describe-ui` (surface as `AXUniqueId`).
- **Integration tests**: `integration_test/login_flow_test.dart` (real login with the seeded dev test account → home) + `smoke_test.dart` harness canary + `test_driver/` for `flutter drive`.
- **Tooling**: sim-tool permission allowlist, canonical sim + test-account docs in CLAUDE.md, fixed `tools:` frontmatter in all four `nibbles-*` agent definitions (lowercase tool names made agents spawn tool-less).

## Verification
- `flutter analyze`: clean.
- E2E login verified on the iPhone 17 / iOS 26 sim via axe using the identifiers (login → authenticated → past login screen).
- Known limitation: `flutter test`/`flutter drive` on iOS sims hang at "loading" on this toolchain (fvm Flutter 3.38.8 + Xcode 26) — reproduced with a minimal smoke test on iOS 26 and 18.3 runtimes, with/without `--no-dds`; `flutter run` attaches fine. The smoke test doubles as the canary: when it passes, the login test is runnable as-is.