### PR TITLE
fix(allergen): NIB-153 per-allergen start-introduce identifiers + unmerged pill semantics

### DIFF
--- a/lib/src/common/components/buttons/app_pill_button.dart
+++ b/lib/src/common/components/buttons/app_pill_button.dart
@@ -98,8 +98,14 @@ class AppPillButton extends StatelessWidget {
       ],
     );
 
+    // NIB-153 — container + button so the pill stays its own accessibility
+    // element; without it iOS merges the pill into surrounding row text and
+    // identifier-targeted taps resolve to the row center, missing the button.
     return Semantics(
       identifier: identifier,
+      container: true,
+      button: true,
+      enabled: !_disabled,
       child: Material(
         color: _background(variant),
         shape: StadiumBorder(

--- a/lib/src/features/allergen/tracker/widgets/start_introduce_card.dart
+++ b/lib/src/features/allergen/tracker/widgets/start_introduce_card.dart
@@ -72,7 +72,7 @@ class StartIntroduceCard extends StatelessWidget {
           const SizedBox(width: AppSizes.sm),
           AppPillButton(
             label: 'Start Introduce',
-            identifier: 'allergen_start_introduce_button',
+            identifier: 'allergen_start_introduce_button_${allergen.key}',
             onPressed: onStartIntroduce,
             variant: AppPillButtonVariant.ghost,
             size: AppPillButtonSize.small,

--- a/test/features/allergen/tracker/allergen_tracker_screen_test.dart
+++ b/test/features/allergen/tracker/allergen_tracker_screen_test.dart
@@ -63,22 +63,12 @@ const _allergens = [
   Allergen(key: 'peanut', name: 'Peanut', sequenceOrder: 1, emoji: '🥜'),
   Allergen(key: 'egg', name: 'Egg', sequenceOrder: 2, emoji: '🥚'),
   Allergen(key: 'dairy', name: 'Dairy', sequenceOrder: 3, emoji: '🥛'),
-  Allergen(
-    key: 'tree_nuts',
-    name: 'Tree Nuts',
-    sequenceOrder: 4,
-    emoji: '🌰',
-  ),
+  Allergen(key: 'tree_nuts', name: 'Tree Nuts', sequenceOrder: 4, emoji: '🌰'),
   Allergen(key: 'sesame', name: 'Sesame', sequenceOrder: 5, emoji: '🫘'),
   Allergen(key: 'soy', name: 'Soy', sequenceOrder: 6, emoji: '🫘'),
   Allergen(key: 'wheat', name: 'Wheat', sequenceOrder: 7, emoji: '🌾'),
   Allergen(key: 'fish', name: 'Fish', sequenceOrder: 8, emoji: '🐟'),
-  Allergen(
-    key: 'shellfish',
-    name: 'Shellfish',
-    sequenceOrder: 9,
-    emoji: '🦐',
-  ),
+  Allergen(key: 'shellfish', name: 'Shellfish', sequenceOrder: 9, emoji: '🦐'),
 ];
 
 AllergenLog _makeLog({
@@ -139,10 +129,7 @@ void main() {
     final router = GoRouter(
       initialLocation: '/',
       routes: [
-        GoRoute(
-          path: '/',
-          builder: (_, __) => const AllergenTrackerScreen(),
-        ),
+        GoRoute(path: '/', builder: (_, __) => const AllergenTrackerScreen()),
         GoRoute(
           path: AppRoute.allergenLogCreate.path,
           name: AppRoute.allergenLogCreate.name,
@@ -216,10 +203,7 @@ void main() {
           _makeLog(id: 'd2', allergenKey: 'dairy'),
           _makeLog(id: 'd3', allergenKey: 'dairy'),
         ];
-        stubReads(
-          statuses: statusesEggDairySafePeanutFlagged(),
-          logs: logs,
-        );
+        stubReads(statuses: statusesEggDairySafePeanutFlagged(), logs: logs);
 
         await tester.pumpWidget(buildSubject(_PushRecorder()));
         await tester.pumpAndSettle();
@@ -233,10 +217,7 @@ void main() {
         expect(find.text('Not Tried'), findsNothing);
         // Reaction Log list rendered for the logged entries (may be below
         // the fold depending on test viewport, so allow off-screen).
-        expect(
-          find.text('Reaction Log', skipOffstage: false),
-          findsOneWidget,
-        );
+        expect(find.text('Reaction Log', skipOffstage: false), findsOneWidget);
 
         // Switch to Big 11 tab.
         await tester.tap(find.text('Big 11'));
@@ -252,6 +233,32 @@ void main() {
           find.byType(StartIntroduceCard, skipOffstage: false),
           findsWidgets,
         );
+        // NIB-153 — every Start Introduce CTA carries a per-allergen
+        // identifier so axe --id targeting is unambiguous.
+        final semantics = tester.ensureSemantics();
+        await tester.pump();
+        final startIntroduceIdentifiers = tester
+            .widgetList<StartIntroduceCard>(
+              find.byType(StartIntroduceCard, skipOffstage: false),
+            )
+            .map(
+              (card) =>
+                  'allergen_start_introduce_button_'
+                  '${card.allergen.key}',
+            )
+            .toList();
+        expect(
+          startIntroduceIdentifiers.toSet().length,
+          startIntroduceIdentifiers.length,
+        );
+        for (final id in startIntroduceIdentifiers) {
+          expect(
+            find.bySemanticsIdentifier(id, skipOffstage: false),
+            findsOneWidget,
+            reason: id,
+          );
+        }
+        semantics.dispose();
         // Stat-column labels — Not Safe + Not Tried are unique strings on
         // Big 11.
         expect(find.text('Not Safe'), findsOneWidget);
@@ -277,10 +284,7 @@ void main() {
 
         // Section headers remain visible at zero data (Figma 1089:17373).
         expect(find.text('Allergen Exposure'), findsOneWidget);
-        expect(
-          find.text('Reaction Log', skipOffstage: false),
-          findsOneWidget,
-        );
+        expect(find.text('Reaction Log', skipOffstage: false), findsOneWidget);
         // Per-section placeholders sit inside their sections.
         expect(find.text('No exposures yet'), findsOneWidget);
         expect(
@@ -290,34 +294,31 @@ void main() {
       },
     );
 
-    testWidgets(
-      'Tapping Start Introduce navigates to allergen-log-create '
-      'with the tapped allergen key',
-      (tester) async {
-        stubReads(
-          statuses: {
-            for (final a in _allergens) a.key: AllergenStatus.notStarted,
-          },
-        );
-        final recorder = _PushRecorder();
-        await tester.pumpWidget(buildSubject(recorder));
-        await tester.pumpAndSettle();
+    testWidgets('Tapping Start Introduce navigates to allergen-log-create '
+        'with the tapped allergen key', (tester) async {
+      stubReads(
+        statuses: {
+          for (final a in _allergens) a.key: AllergenStatus.notStarted,
+        },
+      );
+      final recorder = _PushRecorder();
+      await tester.pumpWidget(buildSubject(recorder));
+      await tester.pumpAndSettle();
 
-        // Switch to Big 11 so Start Introduce cards render.
-        await tester.tap(find.text('Big 11'));
-        await tester.pumpAndSettle();
+      // Switch to Big 11 so Start Introduce cards render.
+      await tester.tap(find.text('Big 11'));
+      await tester.pumpAndSettle();
 
-        // Tap the first Start Introduce button.
-        final firstStart = find.text('Start Introduce').first;
-        await tester.ensureVisible(firstStart);
-        await tester.tap(firstStart);
-        await tester.pumpAndSettle();
+      // Tap the first Start Introduce button.
+      final firstStart = find.text('Start Introduce').first;
+      await tester.ensureVisible(firstStart);
+      await tester.tap(firstStart);
+      await tester.pumpAndSettle();
 
-        expect(recorder.lastName, AppRoute.allergenLogCreate.name);
-        // First alphabetically-displayed allergen in sequence order is peanut.
-        expect(recorder.lastPathParams?['allergenKey'], 'peanut');
-      },
-    );
+      expect(recorder.lastName, AppRoute.allergenLogCreate.name);
+      // First alphabetically-displayed allergen in sequence order is peanut.
+      expect(recorder.lastPathParams?['allergenKey'], 'peanut');
+    });
 
     testWidgets(
       'See All link on Ongoing tab switches segment to Big 11 (no nav)',


### PR DESCRIPTION
## Ticket
[NIB-153](https://linear.app/adithya-workspace/issue/NIB-153) — every Not-Tried row exposed the same `allergen_start_introduce_button` identifier; `axe tap --id` hard-failed with "Multiple (6) accessibility elements matched", forcing the allergen golden flow onto brittle coordinate taps.

## What changed
- **`start_introduce_card.dart`** — identifier is now per-allergen: `allergen_start_introduce_button_${allergen.key}` (mirrors the existing `allergen_card_${key}` pattern on the same screen).
- **`app_pill_button.dart`** — the pill's `Semantics` is now `container: true, button: true, enabled: !_disabled`. Without this, iOS merged the pill into the surrounding row text: the identifier resolved, but the resolved tap point was the ROW center, so id-targeted taps missed the button entirely (found during sim verification of this fix). Affects all pills uniformly; the other identifier users (`login_submit_button`, `register_submit_button`) are standalone CTAs whose behavior is unchanged — auth suites green.

## Tests
- `allergen_tracker_screen_test.dart` — new NIB-153 assertions: all StartIntroduceCard identifiers unique, and each resolves via `find.bySemanticsIdentifier` to exactly one node.
- `flutter analyze --fatal-infos` clean; allergen + auth suites 93/93 green in the worktree.

## Sim verification (QA-Fixer, dev flavor)
`describe-ui` before: one merged StaticText per row, ambiguous id. After: six distinct Button nodes:
```
Button  id=allergen_start_introduce_button_dairy      label=Start Introduce  center=(304,707)
Button  id=allergen_start_introduce_button_tree_nuts  label=Start Introduce  center=(304,787)
Button  id=allergen_start_introduce_button_sesame     label=Start Introduce  center=(304,860)
Button  id=allergen_start_introduce_button_soy / _wheat / _fish (below fold)
```
`axe tap --id allergen_start_introduce_button_dairy` resolved to the pill (x=304, not row center) and opened the Reaction Log create form for Dairy.

| Big 11 — unique ids live | Log form opened via id tap |
|---|---|
| ![big11](https://raw.githubusercontent.com/A-Y-Developments/Nibbles/17e24cfc387db08ab497f36f1007efd8e3a0835a/qa/run-artifacts/NIB-153/01_big11_unique_ids.png) | ![form](https://raw.githubusercontent.com/A-Y-Developments/Nibbles/17e24cfc387db08ab497f36f1007efd8e3a0835a/qa/run-artifacts/NIB-153/02_log_form_via_id_tap.png) |

## Note for the explorer
`allergen.steps` can now replace its coordinate taps with `tap --id allergen_start_introduce_button_<key>` — left to the explorer's next authoring pass since the flow file is owned by that loop.