### PR TITLE
chore(recipe): unit tests for recipe_detail_controller

### DIFF
--- a/test/features/recipe/detail/recipe_detail_controller_test.dart
+++ b/test/features/recipe/detail/recipe_detail_controller_test.dart
@@ -1,21 +1,26 @@
-// Unit tests for RecipeDetailController.build() error degradation:
-//   * a SECONDARY allergen program/logs read failure must NOT collapse the
-//     screen — the recipe still renders with empty allergen data (P3);
-//   * the recipe read itself is essential — its failure still throws.
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
 import 'package:nibbles/src/common/services/recipe_service.dart';
+import 'package:nibbles/src/common/services/shopping_list_service.dart';
 import 'package:nibbles/src/features/recipe/detail/recipe_detail_controller.dart';
 
 class _MockRecipeService extends Mock implements RecipeService {}
 
 class _MockAllergenService extends Mock implements AllergenService {}
+
+class _MockMealPlanService extends Mock implements MealPlanService {}
+
+class _MockShoppingListService extends Mock implements ShoppingListService {}
 
 const _babyId = 'baby-1';
 const _recipe = Recipe(
@@ -27,14 +32,41 @@ const _recipe = Recipe(
   steps: [],
   howToServe: 'Serve.',
 );
+const _taggedRecipe = Recipe(
+  id: 'r1',
+  title: 'Peanut Puff',
+  ageRange: '6+ months',
+  allergenTags: ['peanut'],
+  ingredients: [],
+  steps: [],
+  howToServe: 'Serve.',
+);
+final _programState = AllergenProgramState(
+  id: 'prog-1',
+  babyId: _babyId,
+  currentAllergenKey: 'peanut',
+  currentSequenceOrder: 1,
+  status: AllergenProgramStatus.inProgress,
+  createdAt: DateTime(2025, 6),
+  updatedAt: DateTime(2025, 6),
+);
 
 void main() {
   late _MockRecipeService recipeSvc;
   late _MockAllergenService allergenSvc;
+  late _MockMealPlanService mealPlanSvc;
+  late _MockShoppingListService shoppingListSvc;
+
+  setUpAll(() {
+    registerFallbackValue(const <RecipeAssignment>[]);
+    registerFallbackValue(const <AllergenLog>[]);
+  });
 
   setUp(() {
     recipeSvc = _MockRecipeService();
     allergenSvc = _MockAllergenService();
+    mealPlanSvc = _MockMealPlanService();
+    shoppingListSvc = _MockShoppingListService();
   });
 
   ProviderContainer container() {
@@ -42,46 +74,176 @@ void main() {
       overrides: [
         recipeServiceProvider.overrideWithValue(recipeSvc),
         allergenServiceProvider.overrideWithValue(allergenSvc),
+        mealPlanServiceProvider.overrideWithValue(mealPlanSvc),
+        shoppingListServiceProvider.overrideWithValue(shoppingListSvc),
       ],
     );
     addTearDown(c.dispose);
     return c;
   }
 
-  test('allergen program/logs read failure still renders the recipe', () async {
+  void stubHappyBuild({Recipe recipe = _recipe}) {
     when(
       () => recipeSvc.getRecipeById(any()),
-    ).thenAnswer((_) async => const Result.success(_recipe));
+    ).thenAnswer((_) async => Result.success(recipe));
+    when(
+      () => allergenSvc.getProgramState(any()),
+    ).thenAnswer((_) async => Result.success(_programState));
+    when(
+      () => allergenSvc.getLogs(any()),
+    ).thenAnswer((_) async => const Result.success(<AllergenLog>[]));
+  }
+
+  void stubFailedBuild() {
+    when(
+      () => recipeSvc.getRecipeById(any()),
+    ).thenAnswer((_) async => const Result.failure(NetworkException()));
     when(
       () => allergenSvc.getProgramState(any()),
     ).thenAnswer((_) async => const Result.failure(NetworkException()));
     when(
       () => allergenSvc.getLogs(any()),
     ).thenAnswer((_) async => const Result.failure(NetworkException()));
+  }
 
-    final state = await container().read(
-      recipeDetailControllerProvider(_babyId, 'r1').future,
-    );
+  group('build() — allergen degradation', () {
+    test('allergen program/logs read failure still renders the recipe', () async {
+      when(
+        () => recipeSvc.getRecipeById(any()),
+      ).thenAnswer((_) async => const Result.success(_recipe));
+      when(
+        () => allergenSvc.getProgramState(any()),
+      ).thenAnswer((_) async => const Result.failure(NetworkException()));
+      when(
+        () => allergenSvc.getLogs(any()),
+      ).thenAnswer((_) async => const Result.failure(NetworkException()));
 
-    expect(state.recipe.id, 'r1');
-    expect(state.currentAllergenKey, '');
-    expect(state.allergenStatuses, isEmpty);
+      final state = await container().read(
+        recipeDetailControllerProvider(_babyId, 'r1').future,
+      );
+
+      expect(state.recipe.id, 'r1');
+      expect(state.currentAllergenKey, '');
+      expect(state.allergenStatuses, isEmpty);
+    });
+
+    test('recipe read failure throws (recipe is essential)', () async {
+      stubFailedBuild();
+
+      await expectLater(
+        container().read(recipeDetailControllerProvider(_babyId, 'r1').future),
+        throwsA(isA<NetworkException>()),
+      );
+    });
   });
 
-  test('recipe read failure still throws (recipe is essential)', () async {
-    when(
-      () => recipeSvc.getRecipeById(any()),
-    ).thenAnswer((_) async => const Result.failure(NetworkException()));
-    when(
-      () => allergenSvc.getProgramState(any()),
-    ).thenAnswer((_) async => const Result.failure(NetworkException()));
-    when(
-      () => allergenSvc.getLogs(any()),
-    ).thenAnswer((_) async => const Result.failure(NetworkException()));
+  group('build() — happy path', () {
+    test('derives allergen statuses per tag', () async {
+      stubHappyBuild(recipe: _taggedRecipe);
+      when(
+        () => allergenSvc.deriveStatus(any()),
+      ).thenReturn(AllergenStatus.inProgress);
 
-    await expectLater(
-      container().read(recipeDetailControllerProvider(_babyId, 'r1').future),
-      throwsA(isA<NetworkException>()),
-    );
+      final state = await container().read(
+        recipeDetailControllerProvider(_babyId, 'r1').future,
+      );
+
+      expect(state.allergenStatuses, {'peanut': AllergenStatus.inProgress});
+      expect(state.currentAllergenKey, 'peanut');
+    });
+
+    test('empty allergenTags yields empty statuses map', () async {
+      stubHappyBuild();
+
+      final state = await container().read(
+        recipeDetailControllerProvider(_babyId, 'r1').future,
+      );
+
+      expect(state.allergenStatuses, isEmpty);
+    });
+  });
+
+  group('assignToMealPlan()', () {
+    test('returns empty list when dates is empty', () async {
+      stubHappyBuild();
+      final c = container();
+      await c.read(recipeDetailControllerProvider(_babyId, 'r1').future);
+
+      final result = await c
+          .read(recipeDetailControllerProvider(_babyId, 'r1').notifier)
+          .assignToMealPlan({});
+
+      expect(result.isSuccess, true);
+      expect(result.dataOrNull, isEmpty);
+    });
+
+    test('propagates service failure', () async {
+      stubHappyBuild();
+      when(
+        () => mealPlanSvc.appendMealsToRange(
+          babyId: any(named: 'babyId'),
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          assignments: any(named: 'assignments'),
+        ),
+      ).thenAnswer((_) async => const Result.failure(NetworkException()));
+
+      final c = container();
+      await c.read(recipeDetailControllerProvider(_babyId, 'r1').future);
+
+      final result = await c
+          .read(recipeDetailControllerProvider(_babyId, 'r1').notifier)
+          .assignToMealPlan({DateTime(2025, 6)});
+
+      expect(result.isFailure, true);
+    });
+
+    test('returns failure when state is null', () async {
+      stubFailedBuild();
+      final c = container();
+      await expectLater(
+        c.read(recipeDetailControllerProvider(_babyId, 'r1').future),
+        throwsA(isA<NetworkException>()),
+      );
+
+      final result = await c
+          .read(recipeDetailControllerProvider(_babyId, 'r1').notifier)
+          .assignToMealPlan({DateTime(2025, 6)});
+
+      expect(result.isFailure, true);
+    });
+  });
+
+  group('addToShoppingList()', () {
+    test('propagates service failure', () async {
+      stubHappyBuild();
+      when(
+        () => shoppingListSvc.addFromRecipe(any(), any(), any()),
+      ).thenAnswer((_) async => const Result.failure(NetworkException()));
+
+      final c = container();
+      await c.read(recipeDetailControllerProvider(_babyId, 'r1').future);
+
+      final result = await c
+          .read(recipeDetailControllerProvider(_babyId, 'r1').notifier)
+          .addToShoppingList(['peanut butter']);
+
+      expect(result.isFailure, true);
+    });
+
+    test('returns failure when state is null', () async {
+      stubFailedBuild();
+      final c = container();
+      await expectLater(
+        c.read(recipeDetailControllerProvider(_babyId, 'r1').future),
+        throwsA(isA<NetworkException>()),
+      );
+
+      final result = await c
+          .read(recipeDetailControllerProvider(_babyId, 'r1').notifier)
+          .addToShoppingList(['peanut butter']);
+
+      expect(result.isFailure, true);
+    });
   });
 }


### PR DESCRIPTION
## Coverage

Target: `lib/src/features/recipe/detail/recipe_detail_controller.dart`

| Metric | Before | After |
|---|---|---|
| Line coverage | 25.5% (13/51) | 84.3% (43/51) |

## Tests added (9 total across 4 groups)

- **build() allergen degradation** — allergen/logs failure still renders; recipe failure throws
- **build() happy path** — allergen statuses derived per tag; empty tags yields empty map
- **assignToMealPlan()** — empty dates → `Success([])`; service failure propagates; null state guard
- **addToShoppingList()** — service failure propagates; null state guard

The 8 uncovered lines are `unawaited(Analytics.instance...)` success-path blocks; these require Firebase initialisation in test and cannot be reached without it.

## Test plan
- [x] `flutter test test/features/recipe/detail/recipe_detail_controller_test.dart` — 9/9 passed
- [x] `flutter analyze --fatal-infos` — no issues