### PR TITLE
chore(qa): unit tests for allergen_complete_controller

### DIFF
--- a/test/features/allergen/complete/allergen_complete_controller_test.dart
+++ b/test/features/allergen/complete/allergen_complete_controller_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/allergen.dart';
+import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
+import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
+import 'package:nibbles/src/common/domain/enums/gender.dart';
+import 'package:nibbles/src/common/services/allergen_service.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
+import 'package:nibbles/src/common/services/local_flag_service.dart';
+import 'package:nibbles/src/features/allergen/complete/allergen_complete_controller.dart';
+
+class _MockAllergenService extends Mock implements AllergenService {}
+
+class _MockBabyProfileService extends Mock implements BabyProfileService {}
+
+class _MockLocalFlagService extends Mock implements LocalFlagService {}
+
+const _babyId = 'baby-001';
+
+final _baby = Baby(
+  id: _babyId,
+  userId: 'user-001',
+  name: 'Lily',
+  dateOfBirth: DateTime(2025, 6),
+  gender: Gender.female,
+  onboardingCompleted: true,
+);
+
+const _peanut = Allergen(
+  key: 'peanut',
+  name: 'Peanut',
+  sequenceOrder: 1,
+  emoji: '🥜',
+);
+
+const _egg = Allergen(
+  key: 'egg',
+  name: 'Egg',
+  sequenceOrder: 2,
+  emoji: '🥚',
+);
+
+AllergenBoardItem _boardItem(Allergen allergen) => AllergenBoardItem(
+  allergen: allergen,
+  logs: const [],
+  status: AllergenStatus.safe,
+);
+
+void main() {
+  late _MockAllergenService allergenSvc;
+  late _MockBabyProfileService babySvc;
+  late _MockLocalFlagService localFlags;
+
+  setUp(() {
+    allergenSvc = _MockAllergenService();
+    babySvc = _MockBabyProfileService();
+    localFlags = _MockLocalFlagService();
+    when(() => babySvc.getBaby()).thenAnswer((_) async => _baby);
+  });
+
+  ProviderContainer makeContainer() {
+    final c = ProviderContainer(
+      overrides: [
+        allergenServiceProvider.overrideWithValue(allergenSvc),
+        babyProfileServiceProvider.overrideWithValue(babySvc),
+        localFlagServiceProvider.overrideWithValue(localFlags),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('build()', () {
+    test('returns state with correct babyName and babyId', () async {
+      when(
+        () => allergenSvc.getAllergenBoardSummary(any()),
+      ).thenAnswer(
+        (_) async => Result.success([_boardItem(_peanut)]),
+      );
+
+      final state = await makeContainer()
+          .read(allergenCompleteControllerProvider.future);
+
+      expect(state.babyName, 'Lily');
+      expect(state.babyId, _babyId);
+      expect(state.allergens, [_peanut]);
+    });
+
+    test('sorts allergens by sequenceOrder ascending', () async {
+      when(
+        () => allergenSvc.getAllergenBoardSummary(any()),
+      ).thenAnswer(
+        (_) async =>
+            Result.success([_boardItem(_egg), _boardItem(_peanut)]),
+      );
+
+      final state = await makeContainer()
+          .read(allergenCompleteControllerProvider.future);
+
+      expect(state.allergens.first.sequenceOrder, 1);
+      expect(state.allergens.last.sequenceOrder, 2);
+    });
+
+    test('enters error state when baby is null', () async {
+      when(() => babySvc.getBaby()).thenAnswer((_) async => null);
+
+      final c = makeContainer();
+      await expectLater(
+        c.read(allergenCompleteControllerProvider.notifier).future,
+        throwsA(isA<UnknownException>()),
+      );
+
+      expect(
+        c.read(allergenCompleteControllerProvider).hasError,
+        isTrue,
+      );
+    });
+
+    test('enters error state on getAllergenBoardSummary failure', () async {
+      const error = ServerException('service unavailable');
+      when(
+        () => allergenSvc.getAllergenBoardSummary(any()),
+      ).thenAnswer(
+        (_) async => const Result.failure(error),
+      );
+
+      final c = makeContainer();
+      await expectLater(
+        c.read(allergenCompleteControllerProvider.notifier).future,
+        throwsA(isA<ServerException>()),
+      );
+
+      expect(
+        c.read(allergenCompleteControllerProvider).hasError,
+        isTrue,
+      );
+    });
+  });
+
+  group('markShown()', () {
+    test('calls setProgramCompletionShown with babyId', () async {
+      when(
+        () => allergenSvc.getAllergenBoardSummary(any()),
+      ).thenAnswer(
+        (_) async => Result.success([_boardItem(_peanut)]),
+      );
+      when(
+        () => localFlags.setProgramCompletionShown(any()),
+      ).thenAnswer((_) {});
+
+      final c = makeContainer();
+      await c.read(allergenCompleteControllerProvider.future);
+      c
+          .read(allergenCompleteControllerProvider.notifier)
+          .markShown();
+
+      verify(
+        () => localFlags.setProgramCompletionShown(_babyId),
+      ).called(1);
+    });
+
+    test('is a no-op when build errored', () async {
+      when(() => babySvc.getBaby()).thenAnswer((_) async => null);
+
+      final c = makeContainer();
+      await expectLater(
+        c.read(allergenCompleteControllerProvider.notifier).future,
+        throwsA(isA<Object>()),
+      );
+
+      c
+          .read(allergenCompleteControllerProvider.notifier)
+          .markShown();
+
+      verifyNever(
+        () => localFlags.setProgramCompletionShown(any()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Coverage
`lib/src/features/allergen/complete/allergen_complete_controller.dart`

- Before: **0%** (0/19 lines)
- After: **57.9%** (11/19 lines)

## Tests added
`test/features/allergen/complete/allergen_complete_controller_test.dart` — 6 tests

| Group | Cases |
|---|---|
| `build()` | happy path (babyName/babyId), sort order ascending, baby null → error, summary failure → error |
| `markShown()` | calls `setProgramCompletionShown` with correct babyId, no-op when build errored |

## Notes
Analytics call wrapped in `try { } on Object catch (_) {}` — happy path fully testable.