### PR TITLE
chore(qa): unit tests for meal_plan_controller

### DIFF
--- a/test/features/meal_plan/meal_plan_controller_test.dart
+++ b/test/features/meal_plan/meal_plan_controller_test.dart
@@ -404,4 +404,154 @@ void main() {
       ).called(1);
     });
   });
+
+  group('MealPlanController.assignRecipe', () {
+    test('returns true on success and invalidates self', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.assignRecipe(any(), any(), any()),
+      ).thenAnswer((_) async => Result.success(_makeEntry()));
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final ok = await container
+          .read(mealPlanControllerProvider(_babyId).notifier)
+          .assignRecipe(DateTime(2026, 5, 30), 'recipe-001');
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      expect(ok, isTrue);
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(2);
+    });
+
+    test('returns false on failure, does NOT invalidate self', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.assignRecipe(any(), any(), any()),
+      ).thenAnswer(
+        (_) async =>
+            const Result.failure(ServerException('assign failed')),
+      );
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final ok = await container
+          .read(mealPlanControllerProvider(_babyId).notifier)
+          .assignRecipe(DateTime(2026, 5, 30), 'recipe-001');
+
+      expect(ok, isFalse);
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(1);
+    });
+  });
+
+  group('MealPlanController.removeEntry', () {
+    test('returns true on success and invalidates self', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.removeEntry(any()),
+      ).thenAnswer((_) async => const Result<void>.success(null));
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final ok = await container
+          .read(mealPlanControllerProvider(_babyId).notifier)
+          .removeEntry('mp-1');
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      expect(ok, isTrue);
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(2);
+    });
+
+    test('returns false on failure, does NOT invalidate self', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.removeEntry(any()),
+      ).thenAnswer(
+        (_) async =>
+            const Result<void>.failure(ServerException('delete failed')),
+      );
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final ok = await container
+          .read(mealPlanControllerProvider(_babyId).notifier)
+          .removeEntry('mp-1');
+
+      expect(ok, isFalse);
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(1);
+    });
+  });
+
+  group('MealPlanController.clearDay', () {
+    test('returns true on success and invalidates self', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.clearDay(any(), any()),
+      ).thenAnswer((_) async => const Result<void>.success(null));
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final ok = await container
+          .read(mealPlanControllerProvider(_babyId).notifier)
+          .clearDay(DateTime(2026, 5, 30));
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      expect(ok, isTrue);
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(2);
+    });
+
+    test('returns false on failure, does NOT invalidate self', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.clearDay(any(), any()),
+      ).thenAnswer(
+        (_) async =>
+            const Result<void>.failure(ServerException('clear failed')),
+      );
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final ok = await container
+          .read(mealPlanControllerProvider(_babyId).notifier)
+          .clearDay(DateTime(2026, 5, 30));
+
+      expect(ok, isFalse);
+      verify(
+        () => mockMealPlanService.getRolling7(
+          any(),
+          today: any(named: 'today'),
+        ),
+      ).called(1);
+    });
+  });
 }


### PR DESCRIPTION
## Coverage
`lib/src/features/meal_plan/meal_plan_controller.dart`

- Before: **79.5%** (62/78 lines)
- After: **100%** (78/78 lines)

## Tests added (6 new, 14 total in file)
Extended `test/features/meal_plan/meal_plan_controller_test.dart` with three new groups:

| Group | Cases |
|---|---|
| `assignRecipe()` | returns true + invalidates on success; returns false on failure |
| `removeEntry()` | returns true + invalidates on success; returns false on failure |
| `clearDay()` | returns true + invalidates on success; returns false on failure |

Each success test verifies `getRolling7` is called twice (initial build + post-invalidate refetch).