### PR TITLE
chore(qa): unit tests for subscription_success_controller

### DIFF
--- a/test/features/subscription/success/subscription_success_controller_test.dart
+++ b/test/features/subscription/success/subscription_success_controller_test.dart
@@ -1,0 +1,196 @@
+// ignore_for_file: depend_on_referenced_packages // fake_async is a transitive dep
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/services/subscription_service.dart';
+import 'package:nibbles/src/features/subscription/success/subscription_success_controller.dart';
+import 'package:nibbles/src/features/subscription/success/subscription_success_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../../support/fake_analytics.dart';
+
+class _InactiveSubscriptionService extends SubscriptionService {
+  @override
+  bool build() => false;
+}
+
+class _ActiveSubscriptionService extends SubscriptionService {
+  @override
+  bool build() => true;
+}
+
+ProviderContainer _makeContainer({bool startActive = false}) {
+  final c = ProviderContainer(
+    overrides: [
+      subscriptionServiceProvider.overrideWith(
+        startActive
+            ? _ActiveSubscriptionService.new
+            : _InactiveSubscriptionService.new,
+      ),
+      analyticsProvider.overrideWithValue(FakeAnalytics()),
+    ],
+  );
+  addTearDown(c.dispose);
+  return c;
+}
+
+/// Keeps the auto-dispose provider alive while fake timers advance.
+/// Without this, Riverpod's GC microtask disposes the provider (and cancels
+/// its timer) before async.elapse() can fire it.
+ProviderSubscription<SubscriptionSuccessPhase> _listen(
+  ProviderContainer c,
+) => c.listen(subscriptionSuccessControllerProvider, (_, __) {});
+
+void main() {
+  group('SubscriptionSuccessController — fast path (isActive=true)', () {
+    test('initial state is loading', () {
+      fakeAsync((async) {
+        final c = _makeContainer(startActive: true);
+        _listen(c);
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.loading,
+        );
+      });
+    });
+
+    test('does not flip before loadingMinDwell', () {
+      fakeAsync((async) {
+        final c = _makeContainer(startActive: true);
+        _listen(c);
+        async.elapse(const Duration(milliseconds: 1199));
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.loading,
+        );
+      });
+    });
+
+    test('flips to success at loadingMinDwell', () {
+      fakeAsync((async) {
+        final c = _makeContainer(startActive: true);
+        _listen(c);
+        async.elapse(SubscriptionSuccessController.loadingMinDwell);
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.success,
+        );
+      });
+    });
+  });
+
+  group('SubscriptionSuccessController — slow path timeout', () {
+    test('initial state is loading when inactive', () {
+      fakeAsync((async) {
+        final c = _makeContainer();
+        _listen(c);
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.loading,
+        );
+      });
+    });
+
+    test('stays loading before loadingTimeout fires', () {
+      fakeAsync((async) {
+        final c = _makeContainer();
+        _listen(c);
+        async.elapse(const Duration(seconds: 3, milliseconds: 999));
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.loading,
+        );
+      });
+    });
+
+    test('flips to success at loadingTimeout + loadingMinDwell', () {
+      // _flipAfter uses DateTime.now() (not faked), so elapsed≈0ms in tests.
+      // A second timer fires after another loadingMinDwell.
+      fakeAsync((async) {
+        final c = _makeContainer();
+        _listen(c);
+        async.elapse(
+          SubscriptionSuccessController.loadingTimeout +
+              SubscriptionSuccessController.loadingMinDwell,
+        );
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.success,
+        );
+      });
+    });
+  });
+
+  group('SubscriptionSuccessController — slow path listener', () {
+    test('state is loading before subscription activates', () {
+      fakeAsync((async) {
+        final c = _makeContainer();
+        _listen(c);
+        async.elapse(const Duration(milliseconds: 500));
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.loading,
+        );
+      });
+    });
+
+    test('flips to success after sub activates', () {
+      // Activate at T=500ms. _flipAfter schedules Timer(≈loadingMinDwell)
+      // since DateTime.now() is not faked (elapsed≈0ms in tests).
+      fakeAsync((async) {
+        final c = _makeContainer();
+        _listen(c);
+        async.elapse(const Duration(milliseconds: 500));
+        c.read(subscriptionServiceProvider.notifier).setActive(value: true);
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.loading,
+        );
+        async.elapse(SubscriptionSuccessController.loadingMinDwell);
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.success,
+        );
+      });
+    });
+
+    test('listener activation cancels the timeout timer', () {
+      fakeAsync((async) {
+        final c = _makeContainer();
+        _listen(c);
+        async.elapse(const Duration(milliseconds: 500));
+        c.read(subscriptionServiceProvider.notifier).setActive(value: true);
+        // Past the original 4s timeout — state must remain success.
+        async
+          ..elapse(SubscriptionSuccessController.loadingMinDwell)
+          ..elapse(
+            SubscriptionSuccessController.loadingTimeout +
+                SubscriptionSuccessController.loadingMinDwell,
+          );
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.success,
+        );
+      });
+    });
+  });
+
+  group('SubscriptionSuccessController — idempotency', () {
+    test('_flipToSuccess is a no-op when state is already success', () {
+      fakeAsync((async) {
+        final c = _makeContainer(startActive: true);
+        _listen(c);
+        async.elapse(SubscriptionSuccessController.loadingMinDwell);
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.success,
+        );
+        async.elapse(const Duration(seconds: 10));
+        expect(
+          c.read(subscriptionSuccessControllerProvider),
+          SubscriptionSuccessPhase.success,
+        );
+      });
+    });
+  });
+}

--- a/test/features/subscription/success/subscription_success_screen_test.dart
+++ b/test/features/subscription/success/subscription_success_screen_test.dart
@@ -27,6 +27,12 @@ class _ActiveSubscriptionService extends SubscriptionService {
   bool build() => true;
 }
 
+/// Starts inactive; call [setActive] on the notifier to simulate provisioning.
+class _InactiveSubscriptionService extends SubscriptionService {
+  @override
+  bool build() => false;
+}
+
 GoRouter _routerFor(Widget screen) => GoRouter(
   initialLocation: AppRoute.subscriptionSuccess.path,
   routes: [
@@ -44,9 +50,16 @@ GoRouter _routerFor(Widget screen) => GoRouter(
   ],
 );
 
-Widget _buildSut({required GoRouter router}) => ProviderScope(
+Widget _buildSut({
+  required GoRouter router,
+  bool startActive = true,
+}) => ProviderScope(
   overrides: [
-    subscriptionServiceProvider.overrideWith(_ActiveSubscriptionService.new),
+    subscriptionServiceProvider.overrideWith(
+      startActive
+          ? _ActiveSubscriptionService.new
+          : _InactiveSubscriptionService.new,
+    ),
   ],
   child: MaterialApp.router(routerConfig: router),
 );
@@ -143,6 +156,37 @@ void main() {
       expect(
         router.routerDelegate.currentConfiguration.uri.path,
         AppRoute.home.path,
+      );
+    },
+  );
+
+  testWidgets(
+    'slow path: flips to success after loadingTimeout + min-dwell',
+    (tester) async {
+      final router = _routerFor(const SubscriptionSuccessScreen());
+      await tester.pumpWidget(_buildSut(router: router, startActive: false));
+      await tester.pump();
+
+      expect(
+        _opacityOf(
+          tester,
+          const Key('subscription_success_done_label'),
+        ),
+        0.0,
+      );
+
+      // Timeout fires _flipAfter; since DateTime.now() is not faked,
+      // remaining≈loadingMinDwell and a second timer is scheduled.
+      await tester.pump(SubscriptionSuccessController.loadingTimeout);
+      await tester.pump(SubscriptionSuccessController.loadingMinDwell);
+      await tester.pump();
+
+      expect(
+        _opacityOf(
+          tester,
+          const Key('subscription_success_done_label'),
+        ),
+        1.0,
       );
     },
   );


### PR DESCRIPTION
## Coverage
`lib/src/features/subscription/success/subscription_success_controller.dart`: **56% → 96%** (24/25 lines)

The one uncovered line is the immediate-flip branch inside `_flipAfter` (`if (remaining <= Duration.zero)`), which requires `DateTime.now()` to advance with the fake clock — `fakeAsync` and `tester.pump` only patch `Timer`, not `DateTime.now()`. All other branches are covered.

## What's tested
- **Fast path** (isActive=true): initial `loading`, no-flip before `loadingMinDwell`, flip to `success` at `loadingMinDwell`
- **Slow path timeout**: stays `loading` before `loadingTimeout`, flips after `loadingTimeout + loadingMinDwell` (second timer from `_flipAfter`)
- **Slow path listener**: state `loading` before activation, flips after sub activates + `loadingMinDwell`, listener cancels the timeout timer
- **Idempotency**: `_flipToSuccess` guard — no-op when already `success`
- **Widget test** (extended): slow path screen test verifying success state after `loadingTimeout + loadingMinDwell`

## Notes
- Uses `c.listen()` to prevent auto-dispose GC from cancelling timers before `fakeAsync.elapse()` fires them
- `// ignore_for_file: depend_on_referenced_packages` for `fake_async` (transitive dep)