### PR TITLE
chore(qa): unit tests for recipe_repository

### DIFF
--- a/test/common/data/repositories/recipe_repository_test.dart
+++ b/test/common/data/repositories/recipe_repository_test.dart
@@ -268,6 +268,55 @@ void main() {
         'r1',
       );
     });
+
+    test(
+      'cache hit triggers unawaited background refresh',
+      () async {
+        final mockSupabase = _MockSupabaseClient();
+        final mockHive = _MockHiveService();
+        final mockRecipesBox = _MockRecipesBox();
+        final mockQb = _MockQueryBuilder();
+
+        const r = Recipe(
+          id: 'r1',
+          title: 'Pea Puree',
+          ageRange: '6m+',
+          allergenTags: [],
+          ingredients: [],
+          steps: [],
+          howToServe: 'Serve.',
+        );
+        final cachedJson = jsonEncode([r.toJson()]);
+
+        when(() => mockHive.recipesBox).thenReturn(mockRecipesBox);
+        when(() => mockRecipesBox.get(any<dynamic>()))
+            .thenReturn(cachedJson);
+        when(() => mockSupabase.from('recipes'))
+            .thenAnswer((_) => mockQb);
+        when(mockQb.select).thenAnswer(
+          (_) => _FakeChain<PostgrestList>(payload: [_row(id: 'r2')]),
+        );
+        when(
+          () => mockRecipesBox.put(
+            any<dynamic>(),
+            any<String>(),
+          ),
+        ).thenAnswer((_) async {});
+
+        final sut = RecipeRepositoryImpl(
+          supabaseClient: mockSupabase,
+          hiveService: mockHive,
+        );
+        await sut.getAllRecipes();
+
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(
+          () => mockRecipesBox.put(any<dynamic>(), any<String>()),
+        ).called(1);
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Coverage

`recipe_repository.dart`: **84.9% → 91.8%** (62/73 → 67/73 lines)

Remaining 6 missed lines:
- Lines 34-35: constructor initializer list defaults (`Supabase.instance.client`,
  `HiveService()`) — requires full Supabase init, untestable in unit tests
- Lines 56-57: cache corruption Crashlytics call — requires Firebase init
- Lines 177, 182: `recipeRepository` provider — requires Supabase init

## What was added

A single test verifying that when `getAllRecipes` returns from Hive cache,
the unawaited `_refreshCache()` background call completes: stubs Supabase
to return fresh data, pumps microtasks with `Future.delayed(Duration.zero)`,
then verifies `recipesBox.put` was called (covering lines 143–149).

## Test plan

- [x] `flutter analyze --fatal-infos` — clean
- [x] `flutter test test/common/data/repositories/recipe_repository_test.dart` — 17/17 passed
- [x] Full `flutter test` suite — all passed