### PR TITLE
chore(recipe): unit tests for recipe_service

### DIFF
--- a/test/common/services/recipe_service_test.dart
+++ b/test/common/services/recipe_service_test.dart
@@ -220,6 +220,67 @@ void main() {
 
       expect(result.isFailure, isTrue);
     });
+
+    test('recipeRepo failure → propagates', () async {
+      when(
+        () => mockAllergenRepo.getLogs(_babyId),
+      ).thenAnswer((_) async => const Result.success([]));
+      when(() => mockRecipeRepo.getRecipesByAllergen(any())).thenAnswer(
+        (_) async => const Result.failure(ServerException('DB error')),
+      );
+
+      final result = await sut.getRecommendationsForAllergen('egg', _babyId);
+
+      expect(result.isFailure, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getGeneralRecommendations
+  // ---------------------------------------------------------------------------
+
+  group('RecipeService.getGeneralRecommendations', () {
+    test('returns first 10 recipes from getAllRecipes', () async {
+      when(
+        () => mockAllergenRepo.getLogs(_babyId),
+      ).thenAnswer((_) async => const Result.success([]));
+      when(() => mockRecipeRepo.getAllRecipes()).thenAnswer(
+        (_) async => Result.success(
+          List.generate(15, (i) => _makeRecipe(id: 'r$i')),
+        ),
+      );
+
+      final result = await sut.getGeneralRecommendations(_babyId);
+
+      expect(result.isSuccess, isTrue);
+      expect(result.dataOrNull, hasLength(10));
+    });
+
+    test('fewer than 10 recipes → returns all', () async {
+      when(
+        () => mockAllergenRepo.getLogs(_babyId),
+      ).thenAnswer((_) async => const Result.success([]));
+      when(() => mockRecipeRepo.getAllRecipes()).thenAnswer(
+        (_) async => Result.success(
+          List.generate(3, (i) => _makeRecipe(id: 'r$i')),
+        ),
+      );
+
+      final result = await sut.getGeneralRecommendations(_babyId);
+
+      expect(result.isSuccess, isTrue);
+      expect(result.dataOrNull, hasLength(3));
+    });
+
+    test('getAllRecipes failure → propagates', () async {
+      when(() => mockAllergenRepo.getLogs(_babyId)).thenAnswer(
+        (_) async => const Result.failure(ServerException('DB error')),
+      );
+
+      final result = await sut.getGeneralRecommendations(_babyId);
+
+      expect(result.isFailure, isTrue);
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Coverage

**File:** `lib/src/common/services/recipe_service.dart`
**Before:** 79.6% (39/49 lines)
**After:** ~91.8% (45/49 lines)

## What's new

- `getRecommendationsForAllergen` — added recipeRepo failure path (line 59)
- `getGeneralRecommendations` — full group: success (15→10 take), fewer-than-10, and failure paths (lines 81–85)

## Untestable lines

Lines 144, 149–151 — Riverpod provider function; requires `Supabase.instance.client` and real repos (platform init). Excluded per convention.