### PR TITLE
chore(infra): unit tests for local_flag_service

### DIFF
--- a/test/common/services/local_flag_service_test.dart
+++ b/test/common/services/local_flag_service_test.dart
@@ -62,4 +62,49 @@ void main() {
       expect(sut.isAccountDeleted(), isTrue);
     });
   });
+
+  group('LocalFlagService.resetOnboardingProgress', () {
+    test('clears all three onboarding flags', () {
+      sut
+        ..setOnboardingReadinessDone()
+        ..setOnboardingBabySetupDone()
+        ..setOnboardingDone();
+      expect(sut.isOnboardingReadinessDone(), isTrue);
+      expect(sut.isOnboardingBabySetupDone(), isTrue);
+      expect(sut.isOnboardingDone(), isTrue);
+
+      sut.resetOnboardingProgress();
+
+      expect(sut.isOnboardingReadinessDone(), isFalse);
+      expect(sut.isOnboardingBabySetupDone(), isFalse);
+      expect(sut.isOnboardingDone(), isFalse);
+    });
+
+    test('does not affect unrelated flags', () {
+      sut
+        ..setHasLaunched()
+        ..setOnboardingReadinessDone()
+        ..resetOnboardingProgress();
+
+      expect(sut.hasLaunched(), isTrue);
+    });
+  });
+
+  group('LocalFlagService.markProgramCompletionShown', () {
+    test('awaitable variant flips the per-baby flag durably', () async {
+      const babyId = 'baby-abc';
+      expect(sut.isProgramCompletionShown(babyId), isFalse);
+
+      await sut.markProgramCompletionShown(babyId);
+
+      expect(sut.isProgramCompletionShown(babyId), isTrue);
+    });
+
+    test('scoped to babyId — other babies remain unaffected', () async {
+      await sut.markProgramCompletionShown('baby-1');
+
+      expect(sut.isProgramCompletionShown('baby-1'), isTrue);
+      expect(sut.isProgramCompletionShown('baby-2'), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## Coverage

**File:** `lib/src/common/services/local_flag_service.dart`
**Before:** 57.1% (12/21 lines)
**After:** ~90.5% (19/21 lines)

## What's new

- `resetOnboardingProgress` — verifies all three onboarding flags are cleared; also confirms unrelated flags survive the reset
- `markProgramCompletionShown` — awaitable variant flips the per-baby flag; scoping test ensures other baby IDs are unaffected

## Untestable lines

Lines 116, 119 — Riverpod provider function calls `Hive.box<dynamic>()` directly (requires platform init). Excluded per convention.