### PR TITLE
chore(qa): unit tests for allergen_service

### DIFF
--- a/test/common/services/allergen_service_test.dart
+++ b/test/common/services/allergen_service_test.dart
@@ -393,6 +393,35 @@ void main() {
         verifyNever(() => mockRepo.advanceProgramState(any(), any(), any()));
       },
     );
+
+    test('returns failure when getProgramState fails', () async {
+      when(
+        () => mockRepo.getProgramState(any()),
+      ).thenAnswer(
+        (_) async => const Result.failure(NetworkException('offline')),
+      );
+
+      final result = await sut.advanceToNextAllergen(_babyId);
+
+      expect(result.isFailure, isTrue);
+      verifyNever(() => mockRepo.getAllergens());
+    });
+
+    test('returns failure when getAllergens fails', () async {
+      when(
+        () => mockRepo.getProgramState(any()),
+      ).thenAnswer((_) async => Result.success(_makeProgramState()));
+      when(
+        () => mockRepo.getAllergens(),
+      ).thenAnswer(
+        (_) async => const Result.failure(NetworkException('offline')),
+      );
+
+      final result = await sut.advanceToNextAllergen(_babyId);
+
+      expect(result.isFailure, isTrue);
+      verifyNever(() => mockRepo.advanceProgramState(any(), any(), any()));
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Coverage

`lib/src/common/services/allergen_service.dart`: **93.0% → 94.8%**

Adds 2 failure-path tests for `advanceToNextAllergen`:
- `getProgramState` failure → returns `Result.failure`, skips `getAllergens`
- `getAllergens` failure (after `getProgramState` succeeds) → returns `Result.failure`, skips `advanceProgramState`

These lines (247, 252) were the only testable missed lines; remaining misses (338, 342, 344, 349–351) are Firebase crash recorder body + Riverpod provider factory — structurally untestable.

Ticket: NIB-219