### PR TITLE
chore(qa): unit tests for allergen_repository

### DIFF
--- a/test/common/data/repositories/allergen_repository_test.dart
+++ b/test/common/data/repositories/allergen_repository_test.dart
@@ -571,6 +571,17 @@ void main() {
       },
     );
 
+    test('PostgrestException maps to ServerException', () async {
+      final _ = stubTable(
+        'allergen_logs',
+        error: const PostgrestException(message: 'rls denied'),
+      );
+
+      final result = await buildSut().updateLog(_sampleLog);
+
+      expect(result.errorOrNull, _failsWith<ServerException>('rls denied'));
+    });
+
     test('unexpected error maps to UnknownException', () async {
       final _ = stubTable('allergen_logs', error: StateError('boom'));
 
@@ -708,6 +719,17 @@ void main() {
       expect(result.isSuccess, isTrue);
       expect(builder.updated, <String, dynamic>{'status': 'completed'});
       expect(builder.filters, [('baby_id', 'baby-1')]);
+    });
+
+    test('PostgrestException maps to ServerException', () async {
+      final _ = stubTable(
+        'allergen_program_state',
+        error: const PostgrestException(message: 'rls denied'),
+      );
+
+      final result = await buildSut().completeProgramState('baby-1');
+
+      expect(result.errorOrNull, _failsWith<ServerException>('rls denied'));
     });
 
     test('unexpected error maps to UnknownException', () async {


### PR DESCRIPTION
## Coverage

**Target:** `lib/src/common/data/repositories/allergen_repository.dart`

**Before:** 96.4% (6 missed lines — 71, 72, 216, 291, 374, 379)
**After:** 97.8% (4 missed lines — 71, 72, 374, 379 are untestable: constructor null-coalescing + Riverpod provider factory)

## What was added

Two missing `PostgrestException → ServerException` tests:
- `updateLog` — was only covered for `UnknownException`, not `PostgrestException`
- `completeProgramState` — was only covered for `UnknownException`, not `PostgrestException`

Follows the exact same `stubTable(..., error: const PostgrestException(...))` pattern used across the rest of the file.