### PR TITLE
chore(qa): unit tests for profile_edit_controller

### DIFF
--- a/test/features/profile/edit/profile_edit_controller_test.dart
+++ b/test/features/profile/edit/profile_edit_controller_test.dart
@@ -299,5 +299,23 @@ void main() {
         );
       },
     );
+
+    test(
+      'getBaby returns null during save: sets Baby-not-found errorMessage',
+      () async {
+        final ctrl = await readController();
+        when(
+          () => mockBabyService.getBaby(),
+        ).thenAnswer((_) async => null);
+
+        final result = await ctrl.save();
+
+        expect(result.success, isFalse);
+        final state =
+            container.read(profileEditControllerProvider(_babyId)).requireValue;
+        expect(state.errorMessage, 'Baby profile not found.');
+        expect(state.isLoading, isFalse);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Coverage

**Target:** `lib/src/features/profile/edit/profile_edit_controller.dart`

**Before:** 90.9% (5 missed lines — 20, 24, 35, 93, 94)
**After:** ~95.5% (3 missed — 20/24/35 are untestable: Firebase crash recorder body + Riverpod annotation)

## What was added

One test in `save — failure branches`:
- `getBaby returns null during save` — covers lines 93-94 (`state = AsyncData(current.copyWith(isLoading: false, errorMessage: 'Baby profile not found.'))`) which was the only unexercised path in `save()`.

Pattern: re-stub `mockBabyService.getBaby()` to return `null` after `build()` completes, then call `save()` and assert the error state.