### PR TITLE
chore(infra): bump faraday to 1.10.6 (high-severity DoS patch)

### DIFF
--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)


### PR DESCRIPTION
Patches dependabot alert #2 (high): Faraday uncontrolled recursion / stack-exhaustion DoS via deeply nested query params. Bumps the transitive gem in `ios/Gemfile.lock` 1.10.5 → 1.10.6 (patch release, backward-compatible).

- Ruby/fastlane toolchain only — no Flutter/Dart change.
- Verified: `bundle exec fastlane lanes` still loads all lanes (build_only/upload_latest/beta).
- Diff: single line in Gemfile.lock.