### PR TITLE
test: green the full suite — NIB-119 auth coverage + stale-test repairs from first-nibbles rebuild

### DIFF
--- a/test/common/services/auth_service_test.dart
+++ b/test/common/services/auth_service_test.dart
@@ -320,6 +320,134 @@ void main() {
     });
   });
 
+  group('AuthService.updateEmail', () {
+    test('delegates to repository and returns its Result', () async {
+      when(
+        () => mockRepo.updateEmail(any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      final result = await sut.updateEmail('new@example.com');
+
+      expect(result.isSuccess, isTrue);
+      verify(() => mockRepo.updateEmail('new@example.com')).called(1);
+    });
+
+    test('surfaces the repository failure message', () async {
+      when(() => mockRepo.updateEmail(any())).thenAnswer(
+        (_) async => const Result.failure(ServerException('Email in use.')),
+      );
+
+      final result = await sut.updateEmail('new@example.com');
+
+      expect(result.isFailure, isTrue);
+      expect(result.errorOrNull!.message, 'Email in use.');
+    });
+  });
+
+  group('AuthService.currentUserEmail', () {
+    test('passes through the repository value', () {
+      when(() => mockRepo.currentUserEmail).thenReturn('jane@example.com');
+
+      expect(sut.currentUserEmail, 'jane@example.com');
+    });
+
+    test('is null when the repository has no session', () {
+      when(() => mockRepo.currentUserEmail).thenReturn(null);
+
+      expect(sut.currentUserEmail, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // NIB-119: backfill gap coverage — remote-profile-not-completed + social
+  // ---------------------------------------------------------------------------
+
+  group('AuthService backfill edge cases', () {
+    test('remote profile NOT completed — queries baby repo but sets no flags',
+        () async {
+      final mockFlagsBackfill = MockLocalFlagService();
+      when(mockFlagsBackfill.isOnboardingBabySetupDone).thenReturn(false);
+
+      final mockBabyRepo = MockBabyProfileRepository();
+      when(mockBabyRepo.isOnboardingCompleted).thenAnswer((_) async => false);
+
+      when(
+        () => mockRepo.signIn(any(), any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      final localContainer = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(mockRepo),
+          localFlagServiceProvider.overrideWithValue(mockFlagsBackfill),
+          babyProfileRepositoryProvider.overrideWithValue(mockBabyRepo),
+        ],
+      );
+      addTearDown(localContainer.dispose);
+
+      await localContainer
+          .read(authServiceProvider.notifier)
+          .signIn('alice@example.com', 'password123');
+
+      verify(mockBabyRepo.isOnboardingCompleted).called(1);
+      verifyNever(mockFlagsBackfill.setOnboardingReadinessDone);
+      verifyNever(mockFlagsBackfill.setOnboardingBabySetupDone);
+    });
+
+    test('signInWithGoogle Success(true) also runs the backfill', () async {
+      final mockFlagsBackfill = MockLocalFlagService();
+      when(mockFlagsBackfill.isOnboardingBabySetupDone).thenReturn(false);
+      when(mockFlagsBackfill.setOnboardingReadinessDone).thenAnswer((_) {});
+      when(mockFlagsBackfill.setOnboardingBabySetupDone).thenAnswer((_) {});
+
+      final mockBabyRepo = MockBabyProfileRepository();
+      when(mockBabyRepo.isOnboardingCompleted).thenAnswer((_) async => true);
+
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(true));
+
+      final localContainer = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(mockRepo),
+          localFlagServiceProvider.overrideWithValue(mockFlagsBackfill),
+          babyProfileRepositoryProvider.overrideWithValue(mockBabyRepo),
+        ],
+      );
+      addTearDown(localContainer.dispose);
+
+      await localContainer
+          .read(authServiceProvider.notifier)
+          .signInWithGoogle();
+
+      verify(mockBabyRepo.isOnboardingCompleted).called(1);
+      verify(mockFlagsBackfill.setOnboardingBabySetupDone).called(1);
+    });
+
+    test('signInWithGoogle Success(false) (cancel) does NOT run the backfill',
+        () async {
+      final mockBabyRepo = MockBabyProfileRepository();
+
+      when(
+        () => mockRepo.signInWithGoogle(),
+      ).thenAnswer((_) async => const Result.success(false));
+
+      final localContainer = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(mockRepo),
+          localFlagServiceProvider.overrideWithValue(mockFlags),
+          babyProfileRepositoryProvider.overrideWithValue(mockBabyRepo),
+        ],
+      );
+      addTearDown(localContainer.dispose);
+
+      await localContainer
+          .read(authServiceProvider.notifier)
+          .signInWithGoogle();
+
+      verifyNever(mockBabyRepo.isOnboardingCompleted);
+    });
+  });
+
   group('AuthService computed properties', () {
     test('isLoggedIn returns current auth state', () {
       expect(sut.isLoggedIn, isFalse);

--- a/test/features/auth/forgot_password/forgot_password_controller_test.dart
+++ b/test/features/auth/forgot_password/forgot_password_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -87,5 +89,44 @@ void main() {
 
     expect(container.read(forgotPasswordControllerProvider).sent, isFalse);
     expect(fakeAnalytics.calls, isEmpty);
+  });
+
+  test('updateEmail clears a prior backend errorMessage', () async {
+    when(() => mockRepo.resetPassword(any())).thenAnswer(
+      (_) async => const Result.failure(ServerException('rate-limited')),
+    );
+
+    readController().updateEmail('jane@example.com');
+    await readController().submit();
+    expect(
+      container.read(forgotPasswordControllerProvider).errorMessage,
+      'rate-limited',
+    );
+
+    readController().updateEmail('jane2@example.com');
+    expect(
+      container.read(forgotPasswordControllerProvider).errorMessage,
+      isNull,
+    );
+  });
+
+  test('concurrent submit while a request is in flight is a no-op (isLoading '
+      'guard) — the repository is hit exactly once', () async {
+    final completer = Completer<Result<void>>();
+    when(
+      () => mockRepo.resetPassword(any()),
+    ).thenAnswer((_) => completer.future);
+
+    readController().updateEmail('jane@example.com');
+
+    final first = readController().submit();
+    // Second call sees isLoading == true and returns before awaiting.
+    final second = readController().submit();
+
+    completer.complete(const Result.success(null));
+    await Future.wait([first, second]);
+    await Future<void>.delayed(Duration.zero);
+
+    verify(() => mockRepo.resetPassword('jane@example.com')).called(1);
   });
 }

--- a/test/features/auth/forgot_password/forgot_password_screen_test.dart
+++ b/test/features/auth/forgot_password/forgot_password_screen_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
-import 'package:nibbles/src/common/components/buttons/app_round_button.dart';
 import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
@@ -70,18 +69,10 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Butter back pill — exactly one AppRoundButton with the back arrow.
-      final backButtonFinder = find.byType(AppRoundButton);
-      expect(backButtonFinder, findsOneWidget);
-      final backBtn = tester.widget<AppRoundButton>(backButtonFinder);
-      expect(backBtn.tone, AppRoundButtonTone.butter);
-      expect(
-        find.descendant(
-          of: backButtonFinder,
-          matching: find.byIcon(Icons.arrow_back_rounded),
-        ),
-        findsOneWidget,
-      );
+      // Back pill — the first-nibbles rebuild renders an InkWell pill with the
+      // back arrow + a 'Back' semantics label (no AppRoundButton).
+      expect(find.bySemanticsLabel('Back'), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_back_rounded), findsOneWidget);
 
       // Email field present.
       expect(find.byKey(const Key('forgot_email_field')), findsOneWidget);
@@ -103,7 +94,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(AppRoundButton));
+    await tester.tap(find.byIcon(Icons.arrow_back_rounded));
     await tester.pumpAndSettle();
 
     // With no back-stack canPop is false, so the screen routes to login.

--- a/test/features/auth/login/login_controller_test.dart
+++ b/test/features/auth/login/login_controller_test.dart
@@ -49,6 +49,58 @@ void main() {
   LoginController readController() =>
       container.read(loginControllerProvider.notifier);
 
+  LoginState readState() => container.read(loginControllerProvider);
+
+  // ---------------------------------------------------------------------------
+  // field mutations
+  // ---------------------------------------------------------------------------
+
+  group('field mutations', () {
+    test('updateEmail marks the email dirty and clears any error', () {
+      readController()
+        ..updatePassword('x') // seed some state
+        ..updateEmail('jane@example.com');
+
+      final state = readState();
+      expect(state.email.value, 'jane@example.com');
+      expect(state.email.isValid, isTrue);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('updatePassword marks the password dirty and clears any error', () {
+      readController().updatePassword('supersecret');
+
+      final state = readState();
+      expect(state.password.value, 'supersecret');
+      expect(state.password.isValid, isTrue);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('toggleObscure flips the obscure flag (default true)', () {
+      expect(readState().obscure, isTrue);
+
+      readController().toggleObscure();
+      expect(readState().obscure, isFalse);
+
+      readController().toggleObscure();
+      expect(readState().obscure, isTrue);
+    });
+
+    test('submit failure stores the backend message in errorMessage and '
+        'clears loading', () async {
+      when(() => mockRepo.signIn(any(), any())).thenAnswer(
+        (_) async =>
+            const Result.failure(ServerException('Invalid login credentials.')),
+      );
+
+      await readController().submit();
+
+      final state = readState();
+      expect(state.errorMessage, 'Invalid login credentials.');
+      expect(state.isLoading, isFalse);
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // submit() — email login
   // ---------------------------------------------------------------------------

--- a/test/features/auth/login/login_screen_test.dart
+++ b/test/features/auth/login/login_screen_test.dart
@@ -31,6 +31,11 @@ GoRouter _routerFor(Widget screen) => GoRouter(
       name: AppRoute.register.name,
       builder: (_, __) => const Scaffold(body: Text('Register stub')),
     ),
+    GoRoute(
+      path: AppRoute.forgotPassword.path,
+      name: AppRoute.forgotPassword.name,
+      builder: (_, __) => const Scaffold(body: Text('Forgot stub')),
+    ),
   ],
 );
 
@@ -71,9 +76,9 @@ void main() {
       await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
       await tester.pumpAndSettle();
 
-      // Brand mark is the Quatrefoil (NIB-107 swapped the lockup for the
-      // bare butter mark per Figma node 1015:13496).
-      expect(find.byType(Quatrefoil), findsOneWidget);
+      // Brand mark — the first-nibbles rebuild renders the Nibbles logo SVG
+      // (Semantics label 'Nibbles') in place of the old Quatrefoil lockup.
+      expect(find.bySemanticsLabel('Nibbles'), findsOneWidget);
 
       // Verbatim copy per Figma — smart apostrophes intentional.
       expect(find.text('Hi, Welcome!'), findsOneWidget);
@@ -85,8 +90,8 @@ void main() {
       expect(find.text('Password'), findsWidgets);
       expect(find.text('Login'), findsOneWidget);
       expect(find.text('Or login with'), findsOneWidget);
-      expect(find.text('Sign in with Google'), findsOneWidget);
-      expect(find.text('Sign in with Apple'), findsOneWidget);
+      expect(find.text('Login with Google'), findsOneWidget);
+      expect(find.text('Login with Apple'), findsOneWidget);
       expect(find.text('Don’t have an account?'), findsOneWidget);
       expect(find.text('Sign Up'), findsOneWidget);
 
@@ -272,5 +277,55 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Register stub'), findsOneWidget);
+  });
+
+  // -------------------------------------------------------------------------
+  // Submit gating (canSubmit)
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'primary CTA is disabled until both email + password are valid',
+    (tester) async {
+      await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+      await tester.pumpAndSettle();
+
+      AppPillButton submitButton() => tester.widget<AppPillButton>(
+        find.byKey(const Key('login_submit_button')),
+      );
+
+      // Empty form — disabled (onPressed == null).
+      expect(submitButton().onPressed, isNull);
+
+      // Valid email but no password — still disabled.
+      await tester.enterText(
+        find.byKey(const Key('login_email_field')),
+        'jane@example.com',
+      );
+      await tester.pump();
+      expect(submitButton().onPressed, isNull);
+
+      // Both valid — enabled.
+      await tester.enterText(
+        find.byKey(const Key('login_password_field')),
+        'supersecret',
+      );
+      await tester.pump();
+      expect(submitButton().onPressed, isNotNull);
+    },
+  );
+
+  testWidgets('Forgot password link navigates to the forgot-password route', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(const LoginScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
+
+    final link = find.text('Forgot password?');
+    await tester.ensureVisible(link);
+    await tester.pumpAndSettle();
+    await tester.tap(link);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Forgot stub'), findsOneWidget);
   });
 }

--- a/test/features/auth/register/register_controller_test.dart
+++ b/test/features/auth/register/register_controller_test.dart
@@ -49,6 +49,81 @@ void main() {
   RegisterController readController() =>
       container.read(registerControllerProvider.notifier);
 
+  RegisterState readState() => container.read(registerControllerProvider);
+
+  // ---------------------------------------------------------------------------
+  // field mutations + derived validity
+  // ---------------------------------------------------------------------------
+
+  group('field mutations', () {
+    test('update* set their fields and clear any error', () {
+      readController()
+        ..updateEmail('jane@example.com')
+        ..updatePassword('password123')
+        ..updateConfirmPassword('password123');
+
+      final state = readState();
+      expect(state.email.value, 'jane@example.com');
+      expect(state.password.value, 'password123');
+      expect(state.confirmPassword, 'password123');
+      expect(state.errorMessage, isNull);
+    });
+
+    test('toggleObscure / toggleObscureConfirm flip independently', () {
+      expect(readState().obscure, isTrue);
+      expect(readState().obscureConfirm, isTrue);
+
+      readController().toggleObscure();
+      expect(readState().obscure, isFalse);
+      expect(readState().obscureConfirm, isTrue);
+
+      readController().toggleObscureConfirm();
+      expect(readState().obscureConfirm, isFalse);
+    });
+  });
+
+  group('derived validity', () {
+    test('passwordsMatch is false until confirm equals a non-empty password',
+        () {
+      final ctrl = readController()..updatePassword('password123');
+      expect(readState().passwordsMatch, isFalse);
+
+      ctrl.updateConfirmPassword('nope');
+      expect(readState().passwordsMatch, isFalse);
+
+      ctrl.updateConfirmPassword('password123');
+      expect(readState().passwordsMatch, isTrue);
+    });
+
+    test('isValid requires valid email + valid password + matching confirm',
+        () {
+      final ctrl = readController()
+        ..updateEmail('not-an-email')
+        ..updatePassword('short')
+        ..updateConfirmPassword('short');
+      expect(readState().isValid, isFalse);
+
+      ctrl
+        ..updateEmail('jane@example.com')
+        ..updatePassword('password123')
+        ..updateConfirmPassword('password123');
+      expect(readState().isValid, isTrue);
+    });
+
+    test('submit failure stores the backend message in errorMessage', () async {
+      when(() => mockRepo.signUp(any(), any())).thenAnswer(
+        (_) async =>
+            const Result.failure(ServerException('Email already in use.')),
+      );
+
+      final ok = await readController().submit();
+
+      expect(ok, isFalse);
+      expect(readState().errorMessage, 'Email already in use.');
+      expect(readState().isLoading, isFalse);
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // submit() — email sign up
   // ---------------------------------------------------------------------------

--- a/test/features/auth/register/register_screen_test.dart
+++ b/test/features/auth/register/register_screen_test.dart
@@ -67,14 +67,15 @@ void main() {
   ];
 
   testWidgets(
-    'renders Quatrefoil logo mark, email + password fields, and submit '
+    'renders Nibbles logo mark, email + password fields, and submit '
     '— NO name field',
     (tester) async {
       await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
       await tester.pumpAndSettle();
 
-      // NIB-112 redesign uses the quatrefoil-only mark (no wordmark BrandLogo).
-      expect(find.byType(Quatrefoil), findsOneWidget);
+      // First-nibbles rebuild renders the Nibbles logo SVG (Semantics label
+      // 'Nibbles') in place of the old quatrefoil-only mark.
+      expect(find.bySemanticsLabel('Nibbles'), findsOneWidget);
       expect(find.text('Start Your Journey'), findsOneWidget);
       expect(find.byKey(const Key('register_email_field')), findsOneWidget);
       expect(find.byKey(const Key('register_password_field')), findsOneWidget);
@@ -230,7 +231,97 @@ void main() {
     await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
     await tester.pumpAndSettle();
 
-    // Submit button is gated on isValid — enter a valid email + 8+ char pw.
+    // Submit button is gated on isValid — needs a valid email, an 8+ char
+    // password AND a matching confirm entry.
+    await tester.enterText(
+      find.byKey(const Key('register_email_field')),
+      'jane@example.com',
+    );
+    await tester.enterText(
+      find.byKey(const Key('register_password_field')),
+      'password123',
+    );
+    await tester.enterText(
+      find.byKey(const Key('register_confirm_field')),
+      'password123',
+    );
+    await tester.pump();
+
+    final submit = find.byKey(const Key('register_submit_button'));
+    await tester.ensureVisible(submit);
+    await tester.pumpAndSettle();
+    await tester.tap(submit);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Email already in use.'), findsOneWidget);
+  });
+
+  // -------------------------------------------------------------------------
+  // Inline validation captions + submit gating
+  // -------------------------------------------------------------------------
+
+  testWidgets('malformed email shows the email-format caption', (tester) async {
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('register_email_field')),
+      'not-an-email',
+    );
+    await tester.pump();
+
+    expect(find.text('Please enter a valid email.'), findsOneWidget);
+  });
+
+  testWidgets('short password shows the min-length caption', (tester) async {
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('register_password_field')),
+      'short',
+    );
+    await tester.pump();
+
+    expect(
+      find.text('Password must be at least 8 characters.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('non-matching confirm shows the mismatch caption', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('register_password_field')),
+      'password123',
+    );
+    await tester.enterText(
+      find.byKey(const Key('register_confirm_field')),
+      'password999',
+    );
+    await tester.pump();
+
+    expect(find.text("Passwords don't match."), findsOneWidget);
+  });
+
+  testWidgets('submit CTA is disabled until email + password + confirm valid', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
+    await tester.pumpAndSettle();
+
+    AppPillButton submitButton() => tester.widget<AppPillButton>(
+      find.byKey(const Key('register_submit_button')),
+    );
+
+    // Empty — disabled.
+    expect(submitButton().onPressed, isNull);
+
+    // Email + password valid but confirm still empty — disabled.
     await tester.enterText(
       find.byKey(const Key('register_email_field')),
       'jane@example.com',
@@ -240,11 +331,28 @@ void main() {
       'password123',
     );
     await tester.pump();
+    expect(submitButton().onPressed, isNull);
 
-    await tester.tap(find.byKey(const Key('register_submit_button')));
+    // Matching confirm — enabled.
+    await tester.enterText(
+      find.byKey(const Key('register_confirm_field')),
+      'password123',
+    );
+    await tester.pump();
+    expect(submitButton().onPressed, isNotNull);
+  });
+
+  testWidgets('Login footer link navigates to the login route', (tester) async {
+    await tester.pumpWidget(_wrap(const RegisterScreen(), buildOverrides()));
     await tester.pumpAndSettle();
 
-    expect(find.text('Email already in use.'), findsOneWidget);
+    final link = find.byKey(const Key('register_login_link'));
+    await tester.ensureVisible(link);
+    await tester.pumpAndSettle();
+    await tester.tap(link);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Login stub'), findsOneWidget);
   });
 
   testWidgets(

--- a/test/features/auth/reset_password/reset_password_screen_test.dart
+++ b/test/features/auth/reset_password/reset_password_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/common/data/repositories/auth_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/services/local_flag_service.dart';
 import 'package:nibbles/src/features/auth/reset_password/reset_password_screen.dart';
@@ -12,6 +13,7 @@ import 'package:nibbles/src/logging/analytics.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
 import '../../../support/fake_analytics.dart';
+import '../../../support/supabase_test_env.dart';
 
 class MockAuthRepository extends Mock implements AuthRepository {}
 
@@ -42,6 +44,11 @@ void main() {
   late MockAuthRepository mockRepo;
   late MockLocalFlagService mockFlags;
   late FakeAnalytics fakeAnalytics;
+
+  // The screen reads `Supabase.instance` directly to pick home vs login after
+  // a successful reset. Boot a no-persistence Supabase singleton so that read
+  // returns a null session (→ login route) instead of throwing.
+  setUpAll(ensureTestSupabaseInitialized);
 
   setUp(() {
     mockRepo = MockAuthRepository();
@@ -180,4 +187,37 @@ void main() {
 
     expect(find.text('Login stub'), findsOneWidget);
   });
+
+  testWidgets(
+    'backend failure (e.g. expired token) surfaces the error message inline '
+    '(P1) and stays on the reset screen',
+    (tester) async {
+      when(() => mockRepo.updatePassword(any())).thenAnswer(
+        (_) async =>
+            const Result.failure(ServerException('Reset link has expired.')),
+      );
+
+      await tester.pumpWidget(
+        _wrap(const ResetPasswordScreen(), buildOverrides()),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('reset_password_new_field')),
+        'password123',
+      );
+      await tester.enterText(
+        find.byKey(const Key('reset_password_confirm_field')),
+        'password123',
+      );
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('reset_password_submit_button')));
+      await tester.pumpAndSettle();
+
+      // Backend message shown verbatim; no navigation away from the screen.
+      expect(find.text('Reset link has expired.'), findsOneWidget);
+      expect(find.text('Login stub'), findsNothing);
+    },
+  );
 }

--- a/test/features/home/widgets/ongoing_introduced_card_test.dart
+++ b/test/features/home/widgets/ongoing_introduced_card_test.dart
@@ -11,6 +11,7 @@ import 'package:firebase_analytics_platform_interface/firebase_analytics_platfor
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
@@ -98,8 +99,8 @@ void main() {
       expect(find.text('Peanut'), findsOneWidget);
       // Verbatim audit subhead (trailing space preserved): "2/3 times ".
       expect(find.text('2/3 times '), findsOneWidget);
-      // Peanut emoji is in the AllergenEmoji constant — renders inside thumb.
-      expect(find.text('🥜'), findsOneWidget);
+      // Thumb is now an allergen-specific SVG icon (design), not an emoji.
+      expect(find.byType(SvgPicture), findsWidgets);
     },
   );
 

--- a/test/features/onboarding/dob/onboarding_dob_screen_test.dart
+++ b/test/features/onboarding/dob/onboarding_dob_screen_test.dart
@@ -62,6 +62,8 @@ Future<void> _pumpScreen(
   WidgetTester tester, {
   required ProviderContainer container,
 }) async {
+  await tester.binding.setSurfaceSize(const Size(390, 844));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
   await tester.pumpWidget(
     UncontrolledProviderScope(
       container: container,

--- a/test/features/recipe/library/widgets/read_guide_banner_test.dart
+++ b/test/features/recipe/library/widgets/read_guide_banner_test.dart
@@ -3,8 +3,8 @@
 // labelled button that activates the handler.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:nibbles/src/common/components/brand/quatrefoil.dart';
 import 'package:nibbles/src/features/recipe/library/widgets/read_guide_banner.dart';
 
 Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
@@ -28,14 +28,14 @@ void main() {
   });
 
   testWidgets(
-    'renders the decorative brand quatrefoil blobs (Figma 1015:6820)',
+    'renders the baked banner SVG asset at the design aspect ratio',
     (tester) async {
       await tester.pumpWidget(_wrap(ReadGuideBanner(onTap: () {})));
       await tester.pump();
 
-      // Two clipped sage blobs sit in the banner's top-right per the design.
-      expect(find.byType(Quatrefoil), findsNWidgets(2));
-      expect(find.byType(ClipRRect), findsWidgets);
+      // The whole banner (green card, blobs, title, CTA) is one baked SVG.
+      expect(find.byType(SvgPicture), findsOneWidget);
+      expect(find.byType(AspectRatio), findsOneWidget);
     },
   );
 }

--- a/test/features/starting_guide/starting_guide_article_screen_test.dart
+++ b/test/features/starting_guide/starting_guide_article_screen_test.dart
@@ -229,21 +229,10 @@ void main() {
       }
     });
 
-    testWidgets("'feeding-principles' renders 'The Big 11' allergen chips", (
-      tester,
-    ) async {
-      await _pump(tester, slug: 'feeding-principles');
-
-      // Sample a few chips from The Big 11. 'Egg' is also in the iron-rich
-      // grid as 'Eggs' (plural) — checking distinct labels avoids overlap.
-      for (final label in ['Almond', 'Cashew', 'Wallnut', 'Sesame']) {
-        expect(
-          find.text(label),
-          findsWidgets,
-          reason: 'allergen chip "$label" missing',
-        );
-      }
-    });
+    // NOTE: the 'feeding-principles' slug is special-cased in routing to the
+    // dedicated FeedingPrinciplesScreen (which owns the Big 11 chips), not the
+    // generic article screen — so that coverage belongs in a dedicated
+    // FeedingPrinciplesScreen test, not here.
 
     testWidgets(
       "'readiness-signs' renders the bespoke signs card (no baby -> 0/6)",

--- a/test/support/supabase_test_env.dart
+++ b/test/support/supabase_test_env.dart
@@ -1,0 +1,42 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// In-memory PKCE storage so [Supabase.initialize] does not reach for
+/// SharedPreferences (which needs a platform channel) under the test runner.
+class _InMemoryGotrueAsyncStorage extends GotrueAsyncStorage {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> getItem({required String key}) async => _store[key];
+
+  @override
+  Future<void> setItem({required String key, required String value}) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> removeItem({required String key}) async {
+    _store.remove(key);
+  }
+}
+
+bool _initialized = false;
+
+/// Boots a no-persistence Supabase singleton for widget tests whose screens
+/// read `Supabase.instance` directly (e.g. reset-password's session check).
+///
+/// [EmptyLocalStorage] disables session persistence, so `currentSession` is
+/// always `null` — no network is touched. Safe to call multiple times per
+/// isolate; only the first call initializes.
+Future<void> ensureTestSupabaseInitialized() async {
+  if (_initialized) return;
+  _initialized = true;
+  await Supabase.initialize(
+    url: 'http://localhost:54321',
+    anonKey: 'test-anon-key',
+    authOptions: FlutterAuthClientOptions(
+      localStorage: const EmptyLocalStorage(),
+      pkceAsyncStorage: _InMemoryGotrueAsyncStorage(),
+      autoRefreshToken: false,
+    ),
+  );
+}


### PR DESCRIPTION
Greens `main`'s test suite (was red — 16 stale tests from the June-23 first-nibbles rebuild).

## NIB-119 — auth redesign coverage (primary)
- 26 new widget/unit tests for the redesigned login/register/forgot/reset + social/no-name flows; 6 stale auth tests repaired. New `test/support/supabase_test_env.dart` helper.

## Stale-test repairs to green CI (folded in — same rebuild root cause)
- **DOB screen test**: pump at a real device size (390×844) instead of Flutter's default 800×600, so the picker Column no longer overflows by 12px. Test-only; screen untouched.
- **ongoing-introduced card**: assert the allergen SVG icon (design) instead of the removed `🥜` emoji.
- **read-guide banner**: assert the baked banner SVG asset instead of the removed `Quatrefoil` blobs.
- **starting-guide article**: drop the obsolete 'feeding-principles' sub-test — that slug is routed to the dedicated `FeedingPrinciplesScreen` now.

## Gate
- `flutter analyze`: No issues found.
- `flutter test`: **+1031 ~1: All tests passed!**

## Follow-ups (noted, not in scope here)
- Add a dedicated `FeedingPrinciplesScreen` test to cover the Big-11 chips (coverage moved there).
- `reset_password_screen.dart` reads `Supabase.instance` directly in the widget layer (violates the no-Supabase-in-Screen rule) — route through AuthService/Repository.