### PR TITLE
chore(subscription): repository + mapper tests [NIB-98]

### DIFF
--- a/test/common/domain/entities/subscription_plan_test.dart
+++ b/test/common/domain/entities/subscription_plan_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/domain/entities/subscription_plan.dart';
+
+void main() {
+  group('SubscriptionPlanPeriod.analyticsValue', () {
+    test('monthly maps to the snake-case analytics token "monthly"', () {
+      expect(SubscriptionPlanPeriod.monthly.analyticsValue, 'monthly');
+    });
+
+    test('annual maps to the snake-case analytics token "annual"', () {
+      expect(SubscriptionPlanPeriod.annual.analyticsValue, 'annual');
+    });
+
+    test('every enum value has a stable analytics token', () {
+      for (final period in SubscriptionPlanPeriod.values) {
+        expect(period.analyticsValue, isNotEmpty);
+      }
+    });
+  });
+
+  group('SubscriptionPlan defaults', () {
+    test('isRecommended defaults to false when omitted', () {
+      const plan = SubscriptionPlan(
+        id: 'monthly_4_99',
+        title: 'Monthly',
+        priceLabel: r'$4.99 monthly',
+        period: SubscriptionPlanPeriod.monthly,
+      );
+
+      expect(plan.isRecommended, isFalse);
+    });
+
+    test('holds the opaque package id verbatim for the purchase pipeline', () {
+      const plan = SubscriptionPlan(
+        id: 'annual_29_99',
+        title: 'Annual',
+        priceLabel: r'$29.99 yearly',
+        period: SubscriptionPlanPeriod.annual,
+        isRecommended: true,
+      );
+
+      expect(plan.id, 'annual_29_99');
+      expect(plan.isRecommended, isTrue);
+    });
+  });
+}

--- a/test/common/services/subscription_service_test.dart
+++ b/test/common/services/subscription_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
@@ -154,6 +155,48 @@ void main() {
 
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<UnknownException>());
+    });
+  });
+
+  group('SubscriptionService.openManagementPage — platform URL', () {
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    Future<Uri> capturedUri(TargetPlatform platform) async {
+      debugDefaultTargetPlatformOverride = platform;
+      late Uri launched;
+      final c = _makeContainer(
+        launchUrl: (uri, {mode = LaunchMode.platformDefault}) async {
+          launched = uri;
+          return true;
+        },
+      );
+      await c.read(subscriptionServiceProvider.notifier).openManagementPage();
+      return launched;
+    }
+
+    test('launches the App Store subscriptions URL on iOS', () async {
+      final uri = await capturedUri(TargetPlatform.iOS);
+      expect(uri.toString(), iosManagementUrl);
+    });
+
+    test('launches the Play Store subscriptions URL on Android', () async {
+      final uri = await capturedUri(TargetPlatform.android);
+      expect(uri.toString(), androidManagementUrl);
+    });
+
+    test('opens the management page externally, not in-app', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      late LaunchMode launchedMode;
+      final c = _makeContainer(
+        launchUrl: (uri, {mode = LaunchMode.platformDefault}) async {
+          launchedMode = mode;
+          return true;
+        },
+      );
+
+      await c.read(subscriptionServiceProvider.notifier).openManagementPage();
+
+      expect(launchedMode, LaunchMode.externalApplication);
     });
   });
 }


### PR DESCRIPTION
## NIB-98 — Subscription tests: assessment + gap fill

### TL;DR
The ticket's headline ask — **RevenueCat mapper + repository tests** — is **not implementable yet**: there is no subscription repository and no mapper in the codebase. `SubscriptionService` is an explicit **stub** (RevenueCat / `purchases_flutter` wiring is deferred to **NIB-18**). Rather than fabricate production infra to test against, this PR fills the two genuine, currently-uncovered gaps in the subscription **service + domain** layer.

### What was ALREADY covered (not touched)
Comprehensive, passing coverage already exists — no duplication added:
- `test/common/services/subscription_service_test.dart` — build/setActive, `info` (both branches), `loadOfferings`, `purchaseDefault`, `restore` (no-active Failure), `openManagementPage` (success / false / throws). Result Success/Failure branches at the current RC seam.
- `test/features/subscription/paywall/*` — controller + paywall_sheet + all_plans_sheet widgets.
- `test/features/subscription/{cancel,manage,success}/*` — controllers + screens/overlays.

### Why no repository/mapper tests
- No `subscription_repository.dart` exists; RevenueCat is only referenced in `runner.dart` (`Purchases.configure`) and `auth_service.dart` (`Purchases.logOut`).
- `SubscriptionService` returns hardcoded placeholders — no `Purchases.getOfferings/purchasePackage/restorePurchases/customerInfo` calls, no `CustomerInfo`/`Offering` DTO → entity mapping code to test.
- Writing those tests would require first authoring the RC repository + mapper (production infra owned by NIB-18 / infra agent), out of QA scope. Flagged, not fabricated.

### What this PR ADDS (2 real gaps)
1. `test/common/domain/entities/subscription_plan_test.dart` (5 tests) — locks the `SubscriptionPlanPeriod.analyticsValue` contract (`monthly`/`annual` tokens emitted to the `plan_selected` analytics event) + `SubscriptionPlan` defaults. Previously the analytics token mapping was asserted nowhere.
2. `subscription_service_test.dart` — new `openManagementPage — platform URL` group (3 tests): asserts the App Store URL on iOS vs the Play Store URL on Android (the `_managementUrl` platform switch was untested) + external launch mode.

### Gate
- `flutter analyze --fatal-infos`: **No issues found!**
- `flutter test` (full suite): **+1039 passed, ~1 skipped, All tests passed!**

### Follow-up
When NIB-18 wires `purchases_flutter` (repository + `CustomerInfo`/`Offering`/`Package` mappers), add the boundary mapper + `purchases_flutter`-mocked repository tests then. Tracking that as the remaining NIB-98 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
