### PR TITLE
chore(shopping-list): extend widget tests for redesigned flows [NIB-97]

### DIFF
--- a/test/features/shopping_list/shopping_list_screen_test.dart
+++ b/test/features/shopping_list/shopping_list_screen_test.dart
@@ -349,4 +349,179 @@ void main() {
           });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Add flow via the "+" chip → Add Ingredients sheet — Figma 971:9872
+  //   Optimistic insert (appears immediately) then reconcile with the server,
+  //   and P2 toast on add failure.
+  // ---------------------------------------------------------------------------
+
+  group('ShoppingListScreen - add', () {
+    testWidgets('adding via the sheet inserts optimistically then reconciles', (
+      tester,
+    ) async {
+      final backing = <ShoppingListItem>[];
+      when(
+        () => mockService.getItems(any()),
+      ).thenAnswer((_) async => Result.success(List.of(backing)));
+      when(() => mockService.addManualItem(any(), any())).thenAnswer((_) async {
+        backing.add(_makeItem(id: 'server-1', name: 'Carrots'));
+        return const Result.success(null);
+      });
+
+      await tester.pumpWidget(_buildSut(mockService));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'Carrots');
+      await tester.tap(find.text('Add'));
+
+      // Optimistic: the row is present before the server refetch settles.
+      await tester.pump();
+      expect(find.text('Carrots'), findsOneWidget);
+
+      // Reconciled: still present after the invalidate/refetch resolves.
+      await tester.pumpAndSettle();
+      expect(find.text('Carrots'), findsOneWidget);
+      verify(() => mockService.addManualItem(_babyId, 'Carrots')).called(1);
+    });
+
+    testWidgets('add failure surfaces P2 toast', (tester) async {
+      when(() => mockService.addManualItem(any(), any())).thenAnswer(
+        (_) async => const Result.failure(UnknownException('boom')),
+      );
+
+      await tester.pumpWidget(_buildSut(mockService));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'Carrots');
+      await tester.tap(find.text('Add'));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Couldn't add items. Try again."), findsOneWidget);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Check / uncheck moves items between the List and Bought tabs
+  //   (optimistic — no refetch; state.listItems / boughtItems re-partition).
+  // ---------------------------------------------------------------------------
+
+  group('ShoppingListScreen - check/uncheck moves between tabs', () {
+    testWidgets('checking an item moves it from List to Bought', (
+      tester,
+    ) async {
+      when(
+        () => mockService.getItems(any()),
+      ).thenAnswer((_) async => Result.success([_makeItem()]));
+      when(
+        () => mockService.checkItem(any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      await tester.pumpWidget(_buildSut(mockService));
+      await tester.pumpAndSettle();
+
+      final rowBox = tester.getRect(find.text('Apples'));
+      await tester.tapAt(Offset(rowBox.left - 24, rowBox.center.dy));
+      await tester.pumpAndSettle();
+
+      // Gone from the List tab.
+      expect(find.text('Apples'), findsNothing);
+
+      // Present on the Bought tab.
+      await tester.tap(find.text('Bought'));
+      await tester.pumpAndSettle();
+      expect(find.text('Apples'), findsOneWidget);
+    });
+
+    testWidgets('unchecking a Bought item calls uncheck and moves it to List', (
+      tester,
+    ) async {
+      when(
+        () => mockService.getItems(any()),
+      ).thenAnswer((_) async => Result.success([_makeItem(isChecked: true)]));
+      when(
+        () => mockService.uncheckItem(any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      await tester.pumpWidget(_buildSut(mockService));
+      await tester.pumpAndSettle();
+
+      // Item starts on the Bought tab.
+      await tester.tap(find.text('Bought'));
+      await tester.pumpAndSettle();
+
+      final rowBox = tester.getRect(find.text('Apples'));
+      await tester.tapAt(Offset(rowBox.left - 24, rowBox.center.dy));
+      await tester.pumpAndSettle();
+
+      verify(() => mockService.uncheckItem('item-1')).called(1);
+      // Gone from Bought.
+      expect(find.text('Apples'), findsNothing);
+
+      // Back on the List tab.
+      await tester.tap(find.text('List'));
+      await tester.pumpAndSettle();
+      expect(find.text('Apples'), findsOneWidget);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Swipe-to-delete — Figma 971:9915. Drag the row left to reveal the burgundy
+  // Delete pill, then tap it to commit (distinct from the per-row cancel chip).
+  // ---------------------------------------------------------------------------
+
+  group('ShoppingListScreen - swipe to delete', () {
+    testWidgets('swiping a row left reveals the Delete pill which commits', (
+      tester,
+    ) async {
+      when(
+        () => mockService.getItems(any()),
+      ).thenAnswer((_) async => Result.success([_makeItem()]));
+      when(
+        () => mockService.deleteItem(any()),
+      ).thenAnswer((_) async => const Result.success(null));
+
+      await tester.pumpWidget(_buildSut(mockService));
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.text('Apples'), const Offset(-200, 0));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockService.deleteItem('item-1')).called(1);
+      // Direct commit — no confirm dialog for a swipe delete.
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Empty state — Bought tab (List-empty is covered above)
+  // ---------------------------------------------------------------------------
+
+  group('ShoppingListScreen - Bought empty state', () {
+    testWidgets('Bought tab shows the empty-state copy when nothing bought', (
+      tester,
+    ) async {
+      when(
+        () => mockService.getItems(any()),
+      ).thenAnswer((_) async => Result.success([_makeItem()]));
+
+      await tester.pumpWidget(_buildSut(mockService));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Bought'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('You don’t have any list yet'), findsOneWidget);
+      expect(find.text('Apples'), findsNothing);
+    });
+  });
 }


### PR DESCRIPTION
## NIB-97 — Shopping List: extend widget tests for redesigned screen + flows

Coverage already existed for this screen; this PR **extends** the widget suite for the genuinely-uncovered redesigned flows. No existing tests were rewritten or duplicated.

All new tests mock at `shoppingListServiceProvider` (via the existing `_buildSut` / `_makeItem` helpers) and assert real user-visible behavior.

### Already covered (left untouched)
- Segmented List/Bought tab switch
- Items rendering (unchecked → List, checked → Bought)
- Checkbox tap calls `checkItem`
- Per-row cancel-chip delete (+ delete-fail P2 toast)
- Clear-all confirm sheet: open / confirm / cancel
- Copy-to-clipboard: success + failure snackbars
- List-tab empty state

### Added (6 tests)
| # | Test | Checklist item |
|---|------|----------------|
| 1 | Add via sheet inserts optimistically then reconciles | optimistic add (item appears immediately) |
| 2 | Add failure surfaces P2 toast | add fail = P2 toast |
| 3 | Checking moves item List → Bought | check moves item between tabs |
| 4 | Unchecking a Bought item calls `uncheck` and moves it to List | uncheck moves item between tabs |
| 5 | Swipe row left reveals Delete pill which commits | swipe-to-delete (distinct from per-row chip) |
| 6 | Bought tab empty state | empty states (Bought) |

### Gate
- `flutter analyze --fatal-infos`: **No issues found**
- `flutter test` (full suite): **1045 passed, 1 skipped, 0 failed** (+6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPzwgJsJ3BJYDF8PxK31dx
