### PR TITLE
feat(shopping-list): analytics events for add/check/delete/clear/copy [NIB-89]

### DIFF
--- a/lib/src/features/shopping_list/shopping_list_controller.dart
+++ b/lib/src/features/shopping_list/shopping_list_controller.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/shopping_list_item.dart';
 import 'package:nibbles/src/common/domain/enums/shopping_list_source.dart';
 import 'package:nibbles/src/common/services/shopping_list_service.dart';
 import 'package:nibbles/src/features/shopping_list/shopping_list_state.dart';
+import 'package:nibbles/src/logging/analytics.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'shopping_list_controller.g.dart';
@@ -49,6 +52,10 @@ class ShoppingListController extends _$ShoppingListController {
       throw result.errorOrNull!;
     }
 
+    _fireAndForget(
+      ref.read(analyticsProvider).logShoppingItemAdded(source: 'manual'),
+    );
+
     // Reload to swap the placeholder id for the server-assigned id. The write
     // already succeeded, so a refetch read-failure is P3 (background) — don't
     // let it re-enter the add path and surface a false P2 "add failed" toast.
@@ -81,6 +88,8 @@ class ShoppingListController extends _$ShoppingListController {
       if (current != null) state = AsyncData(current);
       throw result.errorOrNull!;
     }
+
+    _fireAndForget(ref.read(analyticsProvider).logShoppingItemChecked());
   }
 
   Future<void> uncheck(String itemId) async {
@@ -103,9 +112,13 @@ class ShoppingListController extends _$ShoppingListController {
       if (current != null) state = AsyncData(current);
       throw result.errorOrNull!;
     }
+
+    _fireAndForget(ref.read(analyticsProvider).logShoppingItemUnchecked());
   }
 
-  Future<void> delete(String itemId) async {
+  /// [via] identifies the delete affordance the user tapped: 'swipe' for the
+  /// swipe-to-reveal Delete pill, 'button' for the per-row cancel chip.
+  Future<void> delete(String itemId, {String via = 'button'}) async {
     final current = state.valueOrNull;
     if (current != null) {
       state = AsyncData(
@@ -122,12 +135,18 @@ class ShoppingListController extends _$ShoppingListController {
       if (current != null) state = AsyncData(current);
       throw result.errorOrNull!;
     }
+
+    _fireAndForget(
+      ref.read(analyticsProvider).logShoppingItemDeleted(via: via),
+    );
   }
 
   Future<void> clearAll() async {
     final result = await ref.read(shoppingListServiceProvider).clearAll(babyId);
     if (result.isFailure) throw result.errorOrNull!;
     state = const AsyncData(ShoppingListState(items: []));
+
+    _fireAndForget(ref.read(analyticsProvider).logShoppingListCleared());
   }
 
   /// Returns true if clipboard write succeeded, false otherwise.
@@ -140,9 +159,16 @@ class ShoppingListController extends _$ShoppingListController {
           .read(shoppingListServiceProvider)
           .copyToClipboard(current.listItems);
       await Clipboard.setData(ClipboardData(text: text));
+      _fireAndForget(ref.read(analyticsProvider).logShoppingListCopied());
       return true;
     } on Exception catch (_) {
       return false;
     }
+  }
+
+  /// Analytics is best-effort. Swallow any rejected future so it never blocks
+  /// the write path or escalates to the root zone.
+  void _fireAndForget(Future<void> future) {
+    unawaited(future.catchError((Object _) {}));
   }
 }

--- a/lib/src/features/shopping_list/shopping_list_screen.dart
+++ b/lib/src/features/shopping_list/shopping_list_screen.dart
@@ -132,12 +132,12 @@ class _ShoppingListBodyState extends ConsumerState<_ShoppingListBody> {
       );
   }
 
-  Future<void> _delete(String itemId) async {
+  Future<void> _delete(String itemId, {required String via}) async {
     _swipeController.close();
     try {
       await ref
           .read(shoppingListControllerProvider(widget.babyId).notifier)
-          .delete(itemId);
+          .delete(itemId, via: via);
     } on Exception catch (_) {
       if (!mounted) return;
       _showToast("Couldn't delete item. Try again.");
@@ -419,7 +419,7 @@ class _ItemsList extends StatelessWidget {
   final List<ShoppingListItem> items;
   final SwipeRevealController swipeController;
   final ValueChanged<String> onToggle;
-  final ValueChanged<String> onDelete;
+  final void Function(String itemId, {required String via}) onDelete;
 
   @override
   Widget build(BuildContext context) {
@@ -441,11 +441,11 @@ class _ItemsList extends StatelessWidget {
           key: ValueKey(rowKey),
           rowId: rowKey,
           controller: swipeController,
-          onDelete: () => onDelete(item.id),
+          onDelete: () => onDelete(item.id, via: 'swipe'),
           child: _ShoppingItemRow(
             item: item,
             onToggle: () => onToggle(item.id),
-            onDelete: () => onDelete(item.id),
+            onDelete: () => onDelete(item.id, via: 'button'),
           ),
         );
       },

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -479,6 +479,37 @@ class Analytics {
   }
 
   // ---------------------------------------------------------------------------
+  // Shopping List (NIB-89) — non-PII only: stable enum-string params.
+  // NEVER log item names or baby IDs.
+  // ---------------------------------------------------------------------------
+
+  /// [source] is one of 'manual' / 'recipe' / 'mealPlan'.
+  Future<void> logShoppingItemAdded({required String source}) async {
+    await _logEvent('shopping_item_added', parameters: {'source': source});
+  }
+
+  Future<void> logShoppingItemChecked() async {
+    await _logEvent('shopping_item_checked');
+  }
+
+  Future<void> logShoppingItemUnchecked() async {
+    await _logEvent('shopping_item_unchecked');
+  }
+
+  /// [via] is one of 'swipe' / 'button'.
+  Future<void> logShoppingItemDeleted({required String via}) async {
+    await _logEvent('shopping_item_deleted', parameters: {'via': via});
+  }
+
+  Future<void> logShoppingListCleared() async {
+    await _logEvent('shopping_list_cleared');
+  }
+
+  Future<void> logShoppingListCopied() async {
+    await _logEvent('shopping_list_copied');
+  }
+
+  // ---------------------------------------------------------------------------
   // Screen tracking
   // ---------------------------------------------------------------------------
 

--- a/test/features/shopping_list/shopping_list_controller_test.dart
+++ b/test/features/shopping_list/shopping_list_controller_test.dart
@@ -8,6 +8,9 @@ import 'package:nibbles/src/common/domain/entities/shopping_list_item.dart';
 import 'package:nibbles/src/common/domain/enums/shopping_list_source.dart';
 import 'package:nibbles/src/common/services/shopping_list_service.dart';
 import 'package:nibbles/src/features/shopping_list/shopping_list_controller.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../support/fake_analytics.dart';
 
 class _MockShoppingListService extends Mock implements ShoppingListService {}
 
@@ -29,6 +32,7 @@ ShoppingListItem _item({
 
 void main() {
   late _MockShoppingListService svc;
+  late FakeAnalytics analytics;
 
   setUpAll(() {
     TestWidgetsFlutterBinding.ensureInitialized();
@@ -44,11 +48,15 @@ void main() {
 
   setUp(() {
     svc = _MockShoppingListService();
+    analytics = FakeAnalytics();
   });
 
   ProviderContainer makeContainer() {
     final c = ProviderContainer(
-      overrides: [shoppingListServiceProvider.overrideWithValue(svc)],
+      overrides: [
+        shoppingListServiceProvider.overrideWithValue(svc),
+        analyticsProvider.overrideWithValue(analytics),
+      ],
     );
     addTearDown(c.dispose);
     return c;
@@ -119,6 +127,33 @@ void main() {
 
       final state = c.read(shoppingListControllerProvider(_babyId)).valueOrNull;
       expect(state?.items, reloaded);
+      expect(analytics.eventNames, contains('shopping_item_added'));
+      expect(
+        analytics.calls
+            .firstWhere((e) => e.name == 'shopping_item_added')
+            .parameters['source'],
+        'manual',
+      );
+    });
+
+    test('does not fire analytics when add fails', () async {
+      final initial = [_item()];
+      when(
+        () => svc.getItems(any()),
+      ).thenAnswer((_) async => Result.success(initial));
+      when(() => svc.addManualItem(any(), any())).thenAnswer(
+        (_) async => const Result<void>.failure(NetworkException('fail')),
+      );
+
+      final c = makeContainer();
+      await c.read(shoppingListControllerProvider(_babyId).future);
+
+      await expectLater(
+        notifier(c).addManual('Bread'),
+        throwsA(isA<NetworkException>()),
+      );
+
+      expect(analytics.eventNames, isNot(contains('shopping_item_added')));
     });
 
     test('reverts optimistic insert on failure', () async {
@@ -159,6 +194,7 @@ void main() {
 
       final state = c.read(shoppingListControllerProvider(_babyId)).valueOrNull;
       expect(state?.items.first.isChecked, isTrue);
+      expect(analytics.eventNames, contains('shopping_item_checked'));
     });
 
     test('reverts on failure', () async {
@@ -180,6 +216,7 @@ void main() {
 
       final state = c.read(shoppingListControllerProvider(_babyId)).valueOrNull;
       expect(state?.items.first.isChecked, isFalse);
+      expect(analytics.eventNames, isNot(contains('shopping_item_checked')));
     });
   });
 
@@ -199,6 +236,7 @@ void main() {
 
       final state = c.read(shoppingListControllerProvider(_babyId)).valueOrNull;
       expect(state?.items.first.isChecked, isFalse);
+      expect(analytics.eventNames, contains('shopping_item_unchecked'));
     });
 
     test('reverts on failure', () async {
@@ -220,6 +258,7 @@ void main() {
 
       final state = c.read(shoppingListControllerProvider(_babyId)).valueOrNull;
       expect(state?.items.first.isChecked, isTrue);
+      expect(analytics.eventNames, isNot(contains('shopping_item_unchecked')));
     });
   });
 
@@ -239,6 +278,34 @@ void main() {
 
       final state = c.read(shoppingListControllerProvider(_babyId)).valueOrNull;
       expect(state?.items, isEmpty);
+      expect(analytics.eventNames, contains('shopping_item_deleted'));
+      expect(
+        analytics.calls
+            .firstWhere((e) => e.name == 'shopping_item_deleted')
+            .parameters['via'],
+        'button',
+      );
+    });
+
+    test('records via=swipe when supplied by the call site', () async {
+      final item = _item();
+      when(
+        () => svc.getItems(any()),
+      ).thenAnswer((_) async => Result.success([item]));
+      when(
+        () => svc.deleteItem(any()),
+      ).thenAnswer((_) async => const Result<void>.success(null));
+
+      final c = makeContainer();
+      await c.read(shoppingListControllerProvider(_babyId).future);
+      await notifier(c).delete('item-1', via: 'swipe');
+
+      expect(
+        analytics.calls
+            .firstWhere((e) => e.name == 'shopping_item_deleted')
+            .parameters['via'],
+        'swipe',
+      );
     });
 
     test('reverts removed item on failure', () async {
@@ -260,6 +327,7 @@ void main() {
 
       final state = c.read(shoppingListControllerProvider(_babyId)).valueOrNull;
       expect(state?.items, [item]);
+      expect(analytics.eventNames, isNot(contains('shopping_item_deleted')));
     });
   });
 
@@ -278,6 +346,7 @@ void main() {
 
       final state = c.read(shoppingListControllerProvider(_babyId)).valueOrNull;
       expect(state?.items, isEmpty);
+      expect(analytics.eventNames, contains('shopping_list_cleared'));
     });
 
     test('throws on failure', () async {
@@ -295,6 +364,8 @@ void main() {
         notifier(c).clearAll(),
         throwsA(isA<NetworkException>()),
       );
+
+      expect(analytics.eventNames, isNot(contains('shopping_list_cleared')));
     });
   });
 
@@ -310,6 +381,7 @@ void main() {
 
       final result = await notifier(c).copyToClipboard();
       expect(result, isTrue);
+      expect(analytics.eventNames, contains('shopping_list_copied'));
     });
 
     test('returns false when state is null', () async {
@@ -323,6 +395,7 @@ void main() {
 
       final result = await notifier(c).copyToClipboard();
       expect(result, isFalse);
+      expect(analytics.eventNames, isNot(contains('shopping_list_copied')));
     });
   });
 }

--- a/test/features/shopping_list/shopping_list_screen_test.dart
+++ b/test/features/shopping_list/shopping_list_screen_test.dart
@@ -12,6 +12,9 @@ import 'package:nibbles/src/common/domain/enums/shopping_list_source.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/common/services/shopping_list_service.dart';
 import 'package:nibbles/src/features/shopping_list/shopping_list_screen.dart';
+import 'package:nibbles/src/logging/analytics.dart';
+
+import '../../support/fake_analytics.dart';
 
 class MockShoppingListService extends Mock implements ShoppingListService {}
 
@@ -35,6 +38,7 @@ Widget _buildSut(MockShoppingListService svc) => ProviderScope(
   overrides: [
     currentBabyIdProvider.overrideWith((ref) async => _babyId),
     shoppingListServiceProvider.overrideWithValue(svc),
+    analyticsProvider.overrideWithValue(FakeAnalytics()),
   ],
   child: const MaterialApp(home: ShoppingListScreen()),
 );

--- a/test/support/fake_analytics.dart
+++ b/test/support/fake_analytics.dart
@@ -292,6 +292,29 @@ class FakeAnalytics implements Analytics {
       _record('account_deletion_completed');
 
   @override
+  Future<void> logShoppingItemAdded({required String source}) async =>
+      _record('shopping_item_added', {'source': source});
+
+  @override
+  Future<void> logShoppingItemChecked() async =>
+      _record('shopping_item_checked');
+
+  @override
+  Future<void> logShoppingItemUnchecked() async =>
+      _record('shopping_item_unchecked');
+
+  @override
+  Future<void> logShoppingItemDeleted({required String via}) async =>
+      _record('shopping_item_deleted', {'via': via});
+
+  @override
+  Future<void> logShoppingListCleared() async =>
+      _record('shopping_list_cleared');
+
+  @override
+  Future<void> logShoppingListCopied() async => _record('shopping_list_copied');
+
+  @override
   Future<void> logScreenView({required String screenName}) async =>
       _record('screen_view', {'screen_name': screenName});
 }


### PR DESCRIPTION
## NIB-89 — Shopping List analytics

Adds the 6 shopping-list analytics events. The controller previously fired none; `analytics.dart` had no shopping-list events.

### Events (snake_case, ≤40 chars, no PII)
| Method | Event | Params | Fires from (controller) |
|---|---|---|---|
| `logShoppingItemAdded` | `shopping_item_added` | `source` (manual\|recipe\|mealPlan) | `addManual()` on Success → `source: 'manual'` |
| `logShoppingItemChecked` | `shopping_item_checked` | — | `check()` on Success |
| `logShoppingItemUnchecked` | `shopping_item_unchecked` | — | `uncheck()` on Success |
| `logShoppingItemDeleted` | `shopping_item_deleted` | `via` (swipe\|button) | `delete()` on Success |
| `logShoppingListCleared` | `shopping_list_cleared` | — | `clearAll()` on Success |
| `logShoppingListCopied` | `shopping_list_copied` | — | `copyToClipboard()` after clipboard write succeeds |

### Design decisions
- **Success-only**: every event fires after the `Result` is `Success` (copy: after `Clipboard.setData`). Write failures stay P2 — no analytics-on-failure, no Crashlytics.
- **`via` for delete**: the screen has two distinct delete affordances (swipe-reveal pill vs per-row cancel chip) that were both wired to one callback. Plumbed `via` honestly from the call site — `_ItemsList.onDelete` now carries `via`, swipe passes `'swipe'`, the cancel chip passes `'button'`. Controller `delete(itemId, {via = 'button'})` defaults to `button` (the honest default for any direct caller).
- **`source` for add**: manual add path → `'manual'`. The `recipe`/`mealPlan` sources are added by the recipe/meal-plan flows (out of scope here) and are already covered by `recipe_added_to_shopping_list` / `meal_plan_add_to_shop_list`.
- **Best-effort**: analytics fired via a `_fireAndForget` helper (`unawaited(... .catchError)`) matching the auth controllers, so it never blocks or escalates the write path.
- **No PII**: only the enum-string params above — never item name or baby_id.

### Tests
- Extended `shopping_list_controller_test.dart`: each action asserts its event fires on Success and does **not** fire on failure; delete covers both `via=button` (default) and `via=swipe`.
- Added the 6 overrides to `test/support/fake_analytics.dart`.
- `shopping_list_screen_test.dart` now overrides `analyticsProvider` with `FakeAnalytics` (the controller now touches analytics on the copy/delete/check paths, which would otherwise hit the uninitialised Firebase singleton).

### Gates
- `flutter analyze --fatal-infos` → No issues found!
- `flutter test` → `+1047 ~1: All tests passed!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPzwgJsJ3BJYDF8PxK31dx