### PR TITLE
fix(meal-plan): render plan's actual date range, not Monday-snapped week [NIB-159]

### DIFF
--- a/lib/src/features/meal_plan/meal_plan_controller.dart
+++ b/lib/src/features/meal_plan/meal_plan_controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
@@ -20,13 +21,9 @@ class MealPlanController extends _$MealPlanController {
 
   static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
 
-  /// NIB-143: most-recent Monday on or before [dt] (local-date floor).
-  /// `DateTime.weekday` is 1 (Mon) through 7 (Sun), so subtracting
-  /// `weekday - 1` lands on Monday.
-  static DateTime _mondayOnOrBefore(DateTime dt) {
-    final dateOnly = _dateOnly(dt);
-    return dateOnly.subtract(Duration(days: dateOnly.weekday - 1));
-  }
+  /// Injectable clock so the window derivation is deterministic under test.
+  @visibleForTesting
+  static DateTime Function() nowBuilder = DateTime.now;
 
   /// Normalize an expand-map key to a UTC date-only [DateTime] so keys match
   /// regardless of the input's local TZ or sub-day precision.
@@ -37,9 +34,11 @@ class MealPlanController extends _$MealPlanController {
   Future<MealPlanState> build(String babyId) async {
     _babyId = babyId;
 
-    // NIB-143: anchor the 7-day window on the most-recent Monday
-    // on/before today so the planner always renders a Mon-Sun week.
-    final windowStart = _mondayOnOrBefore(DateTime.now());
+    // NIB-159: anchor the 7-day window on today (date-only), NOT on the
+    // most-recent Monday. Monday-snapping (NIB-143) made a plan created for
+    // e.g. Thu 11–Wed 17 render the Mon 8–Sun 14 calendar week instead, so
+    // selected days fell outside the window and unselected days appeared.
+    final windowStart = _dateOnly(nowBuilder());
     final windowEnd = windowStart.add(const Duration(days: 6));
 
     final mealPlanService = ref.read(mealPlanServiceProvider);

--- a/test/features/meal_plan/meal_plan_controller_test.dart
+++ b/test/features/meal_plan/meal_plan_controller_test.dart
@@ -103,6 +103,10 @@ void main() {
     fakeAnalytics = FakeAnalytics();
   });
 
+  tearDown(() {
+    MealPlanController.nowBuilder = DateTime.now;
+  });
+
   ProviderContainer buildContainer() {
     final container = ProviderContainer(
       overrides: [
@@ -146,9 +150,8 @@ void main() {
   }
 
   group('MealPlanController.build', () {
-    test('NIB-143: windowStart is most-recent Monday on/before today, '
-        'windowEnd is windowStart + 6 (Sunday), populates entries + baby, '
-        'expanded starts empty', () async {
+    test('NIB-159: windowStart is today (date-only), windowEnd is today + 6, '
+        'populates entries + baby, expanded starts empty', () async {
       final entry = _makeEntry();
       stubHappy(entries: [entry]);
 
@@ -158,16 +161,11 @@ void main() {
       );
 
       final today = DateTime.now();
-      final todayDateOnly = DateTime(today.year, today.month, today.day);
-      final expectedStart = todayDateOnly.subtract(
-        Duration(days: todayDateOnly.weekday - 1),
-      );
+      final expectedStart = DateTime(today.year, today.month, today.day);
       final expectedEnd = expectedStart.add(const Duration(days: 6));
 
       expect(state.windowStart, expectedStart);
-      expect(state.windowStart.weekday, DateTime.monday);
       expect(state.windowEnd, expectedEnd);
-      expect(state.windowEnd.weekday, DateTime.sunday);
       expect(state.windowEnd.difference(state.windowStart).inDays, 6);
       expect(state.entries, hasLength(1));
       expect(state.entries.single.id, 'mp-1');
@@ -176,22 +174,68 @@ void main() {
       expect(state.recipes['recipe-001']?.title, 'Peanut Butter Toast');
     });
 
-    test('NIB-143: getRolling7 is invoked with the Monday windowStart, '
-        'not today', () async {
+    test('NIB-159: getRolling7 is invoked with today as windowStart, '
+        'not the Monday-snapped week start', () async {
       stubHappy();
       final container = buildContainer();
       await container.read(mealPlanControllerProvider(_babyId).future);
 
       final today = DateTime.now();
-      final todayDateOnly = DateTime(today.year, today.month, today.day);
-      final expectedStart = todayDateOnly.subtract(
-        Duration(days: todayDateOnly.weekday - 1),
-      );
+      final expectedStart = DateTime(today.year, today.month, today.day);
 
       verify(
         () => mockMealPlanService.getRolling7(_babyId, today: expectedStart),
       ).called(1);
     });
+
+    test(
+      'NIB-159 regression: a plan starting Thu 11 Jun renders exactly '
+      '11..17, not the Mon 8–Sun 14 calendar week',
+      () async {
+        // Fix "now" to Thu 11 Jun 2026 — the exact repro from the ticket.
+        MealPlanController.nowBuilder = () => DateTime(2026, 6, 11, 9, 30);
+        expect(DateTime(2026, 6, 11).weekday, DateTime.thursday);
+
+        // Entry on the last selected day (17th) — invisible under Monday-snap.
+        stubHappy(entries: [_makeEntry(planDate: DateTime(2026, 6, 17))]);
+
+        final container = buildContainer();
+        final state = await container.read(
+          mealPlanControllerProvider(_babyId).future,
+        );
+
+        expect(state.windowStart, DateTime(2026, 6, 11));
+        expect(state.windowEnd, DateTime(2026, 6, 17));
+
+        // The rendered day list (screen derives it from windowStart..windowEnd)
+        // must be exactly 11..17 inclusive.
+        final start = DateTime(
+          state.windowStart.year,
+          state.windowStart.month,
+          state.windowStart.day,
+        );
+        final count = state.windowEnd.difference(start).inDays + 1;
+        final days = [
+          for (var i = 0; i < count; i++) start.add(Duration(days: i)),
+        ];
+        expect(days, [
+          DateTime(2026, 6, 11),
+          DateTime(2026, 6, 12),
+          DateTime(2026, 6, 13),
+          DateTime(2026, 6, 14),
+          DateTime(2026, 6, 15),
+          DateTime(2026, 6, 16),
+          DateTime(2026, 6, 17),
+        ]);
+        // Monday-snap bug days must NOT appear; selected tail days must.
+        expect(days.contains(DateTime(2026, 6, 8)), isFalse);
+        expect(days.contains(DateTime(2026, 6, 9)), isFalse);
+        expect(days.contains(DateTime(2026, 6, 10)), isFalse);
+        expect(days.contains(DateTime(2026, 6, 15)), isTrue);
+        expect(days.contains(DateTime(2026, 6, 16)), isTrue);
+        expect(days.contains(DateTime(2026, 6, 17)), isTrue);
+      },
+    );
 
     test('build() with getRolling7 failure surfaces AsyncError', () async {
       when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);

--- a/test/features/meal_plan/meal_plan_screen_test.dart
+++ b/test/features/meal_plan/meal_plan_screen_test.dart
@@ -371,10 +371,9 @@ void main() {
         final startDate = captured[0] as DateTime;
         final endDate = captured[1] as DateTime;
         expect(startDate, endDate, reason: 'single-day range');
-        // NIB-143: first day card is Monday of the current week, which is the
-        // most-recent Monday on/before today.
-        final monday = today.subtract(Duration(days: today.weekday - 1));
-        expect(startDate, monday);
+        // NIB-159: window is today-anchored, so the first day card is today
+        // itself — not the most-recent Monday.
+        expect(startDate, today);
         final assignments = captured[2] as List<dynamic>;
         expect(assignments, hasLength(1));
       },


### PR DESCRIPTION
## NIB-159 — Created plan renders the wrong week

### Bug (reproduced in current code)
A plan created for **Thu 11 Jun – Wed 17 Jun** rendered the **Mon 8 – Sun 14** calendar week in the list/day view: days 8/9/10 (never selected) appeared and 15/16/17 (selected) were missing. The assigned meal still lived under its real date, so persistence was fine — only the *window derivation* was wrong.

### Root cause
`MealPlanController.build` (`lib/src/features/meal_plan/meal_plan_controller.dart:42`) derived the 7-day window by snapping to the most-recent Monday:

```dart
// before (NIB-143)
final windowStart = _mondayOnOrBefore(DateTime.now()); // Mon 8 when today = Thu 11
final windowEnd = windowStart.add(const Duration(days: 6)); // Sun 14
```

The screen's day list (`_PopulatedView._days()`) spans `windowStart..windowEnd`, so the whole planner shifted to the Mon–Sun calendar week regardless of the plan's real range. Introduced by `0d90593 refactor(meal-plan): anchor 7-day window on most-recent Monday [NIB-143]`.

### Fix
Revert to the today-anchored rolling-7 window — the original NIB-120 design that `meal_plan_state.dart` still documents:

```dart
// after (NIB-159)
final windowStart = _dateOnly(nowBuilder()); // today (Thu 11)
final windowEnd = windowStart.add(const Duration(days: 6)); // Thu 17
```

`nowBuilder` is an injectable `@visibleForTesting` clock seam so the derivation is deterministic under test. No visual/layout changes — date-logic correctness only. `getRolling7`, `+ Add Date`, clear-range and every other caller keep their existing contract.

### Proving test
`meal_plan_controller_test.dart` — new `NIB-159 regression` test fixes `now` to Thu 11 Jun 2026 and asserts the window is exactly 11..17:
- **Before fix:** `Expected: 2026-06-11, Actual: 2026-06-08` (fails — the exact bug).
- **After fix:** passes.

The two former NIB-143 Monday-snap assertions (controller + screen tests) were updated to assert today-anchoring.

### Gate
- `flutter analyze --fatal-infos`: **No issues found!**
- `flutter test` (full suite): **+1048 ~1: All tests passed!**

> human-touch — do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)