### PR TITLE
feat(infra): max-rounded design system — collapse radius scale to pill

### DIFF
--- a/lib/src/app/themes/app_sizes.dart
+++ b/lib/src/app/themes/app_sizes.dart
@@ -15,16 +15,16 @@ abstract final class AppSizes {
   static const double xxl = 48;
   static const double xxxl = 64;
 
-  // Border radius
-  static const double radiusXs = 4;
-  static const double radiusSm = 8;
-  static const double radiusMd = 10;
-  static const double radiusLg = 16;
-  static const double radiusXl = 20;
-  static const double radius2xl = 24;
-  // Floating Add-Ingredient card — Figma 971:9883 (rounded-[30px]).
-  static const double radius3xl = 30;
+  // Border radius — max-rounded design system: every corner token maps to the
+  // full pill radius; revert to the graded 4/8/10/16/20/24/30 scale to undo.
   static const double radiusFull = 999;
+  static const double radiusXs = radiusFull;
+  static const double radiusSm = radiusFull;
+  static const double radiusMd = radiusFull;
+  static const double radiusLg = radiusFull;
+  static const double radiusXl = radiusFull;
+  static const double radius2xl = radiusFull;
+  static const double radius3xl = radiusFull;
 
   // Icon sizes
   static const double iconSm = 16;

--- a/lib/src/common/components/cards/shop_row.dart
+++ b/lib/src/common/components/cards/shop_row.dart
@@ -35,7 +35,7 @@ class ShopRow extends StatelessWidget {
 
   // Kit-spec sizes (.shop-row__cb / .shop-row__del).
   static const double _affordance = 22;
-  static const double _cbRadius = 6;
+  static const double _cbRadius = AppSizes.radiusFull;
   static const double _checkGlyphSize = 13;
   static const double _delGlyphSize = 14;
 

--- a/lib/src/features/home/widgets/todays_meals_card.dart
+++ b/lib/src/features/home/widgets/todays_meals_card.dart
@@ -91,7 +91,6 @@ class TodaysMealsCard extends StatelessWidget {
                   variant: AppCardVariant.dashed,
                   borderColor: AppColors.lime,
                   borderWidth: 2,
-                  cornerRadius: AppSizes.radiusMd,
                   padding: const EdgeInsets.all(AppSizes.sp12),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/src/features/starting_guide/introduction/introduction_view.dart
+++ b/lib/src/features/starting_guide/introduction/introduction_view.dart
@@ -10,8 +10,7 @@ import 'package:nibbles/src/common/domain/entities/baby.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/routing/route_enums.dart';
 
-/// Figma cards on Introduction use a 12px corner radius (no exact token).
-const double _cardRadius = 12;
+const double _cardRadius = AppSizes.radiusFull;
 
 /// Skill-card decorative quatrefoil — natural render size of the cropped
 /// `blob_hero.svg` window, nudged off the top-right corner so only the inner

--- a/lib/src/features/starting_guide/readiness_signs/readiness_signs_view.dart
+++ b/lib/src/features/starting_guide/readiness_signs/readiness_signs_view.dart
@@ -10,8 +10,7 @@ import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/features/onboarding/readiness/readiness_signs.dart';
 import 'package:nibbles/src/features/starting_guide/widgets/guide_section_heading.dart';
 
-/// Figma cards on the guide use a 12px corner radius (no exact token).
-const double _cardRadius = 12;
+const double _cardRadius = AppSizes.radiusFull;
 
 /// Figma readiness hero "Group 78" baby icon is 154×154; it punches through the
 /// top edge of the signs card.


### PR DESCRIPTION
## What
Shifts the design language to fully-rounded ("circled") components across every screen. Points every `AppSizes.radius*` corner token at `radiusFull` (999), so cards, list tiles, the static segmented control, inputs, and checkboxes all go maximally rounded. Repoints the three literals that bypassed the token system (`ShopRow` checkbox `_cbRadius`, `starting_guide` `_cardRadius` ×2) to `radiusFull` for consistency.

## Why
Design-system change: the whole UI should read as soft/circular. Because ~97% of corner rounding already funnels through the `AppSizes` tokens, collapsing the scale in one file propagates through the theme (`CardTheme`, `InputDecorationTheme`, `ChipTheme`, `SnackBarTheme`) and ~150 references across components and features. Buttons/pills/chips/switch/search were already max-rounded and are untouched.

Reverting is a one-file change: restore the graded `4/8/10/16/20/24/30` values in `app_sizes.dart`.

## Watch items for review (visual)
- **Bottom sheets** share these tokens, so their top corners now clamp to a full semicircle dome. If undesirable, escape hatch is a dedicated capped `radiusSheet` token repointed only at sheet-tops (not done here — awaiting visual confirmation).
- **`AppSlidingSegmentedControl`** wraps native `CupertinoSlidingSegmentedControl`; its radius is a Cupertino default and does not max via tokens (unchanged).
- **`bottomNavRadius = 28`** left as-is (nav bar, not in scope).

## Verification
- `flutter analyze` on all touched files: no issues.
- No code-gen needed (constant-value changes only).
- On-device visual check deferred — simulator is paused per project rules.