### PR TITLE
feat(meal-plan): redesign meal planner + AI meal-prep generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ android/key.properties
 .superset/
 supabase/.temp/
 supabase/.branches/
+supabase/functions/.env.local
+supabase/functions/**/.env*
 .mcp.json
 
 # Figma audit artifacts (screenshots, raw context) — keep only AUDIT.md

--- a/lib/src/app/qa_bypass.dart
+++ b/lib/src/app/qa_bypass.dart
@@ -12,6 +12,7 @@ import 'package:nibbles/src/common/domain/entities/allergen.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_log.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/entities/reaction_detail.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
@@ -239,6 +240,10 @@ class _QaMealPlanRepository implements MealPlanRepository {
       const Result.success(<MealPlanEntry>[]);
 
   @override
+  Future<Result<List<MealPlanEntry>>> getEntriesForPlan(String planId) async =>
+      const Result.success(<MealPlanEntry>[]);
+
+  @override
   Future<Result<MealPlanEntry>> assignRecipe(
     String babyId,
     String recipeId,
@@ -271,5 +276,20 @@ class _QaMealPlanRepository implements MealPlanRepository {
 
   @override
   Future<Result<void>> clearDay(String babyId, DateTime date) async =>
+      const Result.success(null);
+
+  @override
+  Future<Result<MealPlan?>> getActivePlan(String babyId) async =>
+      const Result.success(null);
+
+  @override
+  Future<Result<MealPlan>> createPlan(
+    String babyId,
+    DateTime start,
+    DateTime end,
+  ) async => const Result.failure(UnknownException('QA bypass: noop.'));
+
+  @override
+  Future<Result<void>> deletePlan(String planId) async =>
       const Result.success(null);
 }

--- a/lib/src/common/data/repositories/meal_plan_ai_repository.dart
+++ b/lib/src/common/data/repositories/meal_plan_ai_repository.dart
@@ -1,0 +1,97 @@
+import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'meal_plan_ai_repository.g.dart';
+
+/// Client for the `generate-meal-plan` Supabase Edge Function. The function
+/// owns the OpenAI call, allergen/age validation, and recipe-pool checks
+/// server-side; this repo only invokes it and parses the response into
+/// [RecipeAssignment]s ready for the existing meal-plan write path.
+// ignore: one_member_abstracts
+abstract interface class MealPlanAiRepository {
+  Future<Result<List<RecipeAssignment>>> generatePlan({
+    required String babyId,
+    required DateTime startDate,
+    required DateTime endDate,
+    required List<String> preferences,
+    required String notes,
+  });
+}
+
+class MealPlanAiRepositoryImpl implements MealPlanAiRepository {
+  MealPlanAiRepositoryImpl({SupabaseClient? supabaseClient})
+    : _supabase = supabaseClient ?? Supabase.instance.client;
+
+  final SupabaseClient _supabase;
+
+  @override
+  Future<Result<List<RecipeAssignment>>> generatePlan({
+    required String babyId,
+    required DateTime startDate,
+    required DateTime endDate,
+    required List<String> preferences,
+    required String notes,
+  }) async {
+    try {
+      final response = await _supabase.functions.invoke(
+        'generate-meal-plan',
+        body: <String, dynamic>{
+          'babyId': babyId,
+          'startDate': _formatDate(startDate),
+          'endDate': _formatDate(endDate),
+          'preferences': preferences,
+          'notes': notes,
+        },
+      );
+
+      final data = response.data;
+      if (data is! Map<String, dynamic>) return _invalid();
+
+      final rawAssignments = data['assignments'];
+      if (rawAssignments is! List) return _invalid();
+
+      final assignments = <RecipeAssignment>[];
+      for (final item in rawAssignments) {
+        if (item is! Map) return _invalid();
+        final recipeId = item['recipeId'];
+        final dayOffset = item['dayOffset'];
+        if (recipeId is! String || dayOffset is! int) return _invalid();
+        assignments.add(
+          RecipeAssignment(recipeId: recipeId, dayOffset: dayOffset),
+        );
+      }
+
+      return Result.success(assignments);
+    } on FunctionException catch (e) {
+      return Result.failure(ServerException(_functionMessage(e)));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  Result<List<RecipeAssignment>> _invalid() =>
+      const Result.failure(UnknownException());
+
+  String _functionMessage(FunctionException e) {
+    final details = e.details;
+    if (details is Map && details['error'] is String) {
+      return details['error'] as String;
+    }
+    return e.reasonPhrase ?? 'Failed to generate meal plan.';
+  }
+
+  static String _formatDate(DateTime date) =>
+      '${date.year.toString().padLeft(4, '0')}-'
+      '${date.month.toString().padLeft(2, '0')}-'
+      '${date.day.toString().padLeft(2, '0')}';
+}
+
+@Riverpod(keepAlive: true)
+MealPlanAiRepository mealPlanAiRepository(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  MealPlanAiRepositoryRef ref,
+) => MealPlanAiRepositoryImpl();

--- a/lib/src/common/data/repositories/meal_plan_ai_repository.g.dart
+++ b/lib/src/common/data/repositories/meal_plan_ai_repository.g.dart
@@ -1,27 +1,28 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'routes.dart';
+part of 'meal_plan_ai_repository.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'1f8e237bbfaabdc6ed570e128a36f948b7178308';
+String _$mealPlanAiRepositoryHash() =>
+    r'f1fe9f72e3b2c2d8e8179d6c60194c215a594687';
 
-/// See also [goRouter].
-@ProviderFor(goRouter)
-final goRouterProvider = Provider<GoRouter>.internal(
-  goRouter,
-  name: r'goRouterProvider',
+/// See also [mealPlanAiRepository].
+@ProviderFor(mealPlanAiRepository)
+final mealPlanAiRepositoryProvider = Provider<MealPlanAiRepository>.internal(
+  mealPlanAiRepository,
+  name: r'mealPlanAiRepositoryProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$goRouterHash,
+      : _$mealPlanAiRepositoryHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef GoRouterRef = ProviderRef<GoRouter>;
+typedef MealPlanAiRepositoryRef = ProviderRef<MealPlanAiRepository>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/common/data/repositories/meal_plan_repository.dart
+++ b/lib/src/common/data/repositories/meal_plan_repository.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -16,12 +17,17 @@ class MealPlanEntryInsert {
     required this.recipeId,
     required this.planDate,
     this.mealTime,
+    this.mealPlanId,
   });
 
   final String babyId;
   final String recipeId;
   final DateTime planDate;
   final TimeOfDay? mealTime;
+
+  /// Optional FK to the persisted `meal_plans` row this entry belongs to.
+  /// Null for legacy rolling-7 entries with no owning plan.
+  final String? mealPlanId;
 }
 
 abstract interface class MealPlanRepository {
@@ -44,6 +50,11 @@ abstract interface class MealPlanRepository {
   /// Fetch every meal_plan_entry for [babyId], ordered by plan_date.
   /// Backs the Home redesign's full dataset (mealPrepSetUp, plannedDates).
   Future<Result<List<MealPlanEntry>>> getAllEntries(String babyId);
+
+  /// Fetch every entry linked to [planId] regardless of `plan_date`, ordered by
+  /// date — so meals added on a "+ Add Date" day past the plan's end still
+  /// render after a refetch.
+  Future<Result<List<MealPlanEntry>>> getEntriesForPlan(String planId);
 
   /// MEAL-02: Insert a new meal entry for [planDate].
   /// Multiple entries per day are allowed.
@@ -78,6 +89,21 @@ abstract interface class MealPlanRepository {
 
   /// MEAL-05: Delete all entries for baby on [date].
   Future<Result<void>> clearDay(String babyId, DateTime date);
+
+  /// Returns the baby's current persisted plan (most recent by `created_at`),
+  /// or `null` if the baby has no plan.
+  Future<Result<MealPlan?>> getActivePlan(String babyId);
+
+  /// Creates a plan for `[start, end]`, enforcing a single active plan per
+  /// baby: any existing plans (and their cascaded entries) are deleted first.
+  Future<Result<MealPlan>> createPlan(
+    String babyId,
+    DateTime start,
+    DateTime end,
+  );
+
+  /// Deletes a plan by ID — cascades its `meal_plan_entries`.
+  Future<Result<void>> deletePlan(String planId);
 }
 
 class MealPlanRepositoryImpl implements MealPlanRepository {
@@ -144,6 +170,28 @@ class MealPlanRepositoryImpl implements MealPlanRepository {
   }
 
   @override
+  Future<Result<List<MealPlanEntry>>> getEntriesForPlan(String planId) async {
+    try {
+      final data = await _supabase
+          .from('meal_plan_entries')
+          .select()
+          .eq('meal_plan_id', planId)
+          .order('plan_date');
+
+      return Result.success(
+        (data as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .map(_entryFromRow)
+            .toList(),
+      );
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
   Future<Result<MealPlanEntry>> assignRecipe(
     String babyId,
     String recipeId,
@@ -185,6 +233,7 @@ class MealPlanRepositoryImpl implements MealPlanRepository {
               'recipe_id': e.recipeId,
               'plan_date': _formatDate(e.planDate),
               if (e.mealTime != null) 'meal_time': _formatTime(e.mealTime!),
+              if (e.mealPlanId != null) 'meal_plan_id': e.mealPlanId,
             },
           )
           .toList();
@@ -264,9 +313,77 @@ class MealPlanRepositoryImpl implements MealPlanRepository {
     }
   }
 
+  @override
+  Future<Result<MealPlan?>> getActivePlan(String babyId) async {
+    try {
+      final data = await _supabase
+          .from('meal_plans')
+          .select()
+          .eq('baby_id', babyId)
+          .order('created_at', ascending: false)
+          .limit(1)
+          .maybeSingle();
+
+      if (data == null) return const Result.success(null);
+      return Result.success(_planFromRow(data));
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<MealPlan>> createPlan(
+    String babyId,
+    DateTime start,
+    DateTime end,
+  ) async {
+    try {
+      // Enforce a single active plan per baby — cascade removes old entries.
+      await _supabase.from('meal_plans').delete().eq('baby_id', babyId);
+
+      final data = await _supabase
+          .from('meal_plans')
+          .insert(<String, dynamic>{
+            'baby_id': babyId,
+            'start_date': _formatDate(start),
+            'end_date': _formatDate(end),
+          })
+          .select()
+          .single();
+
+      return Result.success(_planFromRow(data));
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
+  @override
+  Future<Result<void>> deletePlan(String planId) async {
+    try {
+      await _supabase.from('meal_plans').delete().eq('id', planId);
+      return const Result.success(null);
+    } on PostgrestException catch (e) {
+      return Result.failure(ServerException(e.message));
+    } on Object {
+      return const Result.failure(UnknownException());
+    }
+  }
+
   // ---------------------------------------------------------------------------
-  // Row mapper
+  // Row mappers
   // ---------------------------------------------------------------------------
+
+  MealPlan _planFromRow(Map<String, dynamic> row) => MealPlan(
+    id: row['id'] as String,
+    babyId: row['baby_id'] as String,
+    startDate: DateTime.parse(row['start_date'] as String),
+    endDate: DateTime.parse(row['end_date'] as String),
+    createdAt: DateTime.parse(row['created_at'] as String),
+  );
 
   MealPlanEntry _entryFromRow(Map<String, dynamic> row) {
     final rawTime = row['meal_time'] as String?;

--- a/lib/src/common/domain/entities/meal_plan.dart
+++ b/lib/src/common/domain/entities/meal_plan.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'meal_plan.freezed.dart';
+
+@freezed
+class MealPlan with _$MealPlan {
+  const factory MealPlan({
+    required String id,
+    required String babyId,
+    required DateTime startDate,
+    required DateTime endDate,
+    required DateTime createdAt,
+  }) = _MealPlan;
+}

--- a/lib/src/common/domain/entities/meal_plan.freezed.dart
+++ b/lib/src/common/domain/entities/meal_plan.freezed.dart
@@ -1,0 +1,241 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'meal_plan.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$MealPlan {
+  String get id => throw _privateConstructorUsedError;
+  String get babyId => throw _privateConstructorUsedError;
+  DateTime get startDate => throw _privateConstructorUsedError;
+  DateTime get endDate => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+
+  /// Create a copy of MealPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $MealPlanCopyWith<MealPlan> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MealPlanCopyWith<$Res> {
+  factory $MealPlanCopyWith(MealPlan value, $Res Function(MealPlan) then) =
+      _$MealPlanCopyWithImpl<$Res, MealPlan>;
+  @useResult
+  $Res call({
+    String id,
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
+    DateTime createdAt,
+  });
+}
+
+/// @nodoc
+class _$MealPlanCopyWithImpl<$Res, $Val extends MealPlan>
+    implements $MealPlanCopyWith<$Res> {
+  _$MealPlanCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of MealPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? babyId = null,
+    Object? startDate = null,
+    Object? endDate = null,
+    Object? createdAt = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            babyId: null == babyId
+                ? _value.babyId
+                : babyId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            startDate: null == startDate
+                ? _value.startDate
+                : startDate // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            endDate: null == endDate
+                ? _value.endDate
+                : endDate // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            createdAt: null == createdAt
+                ? _value.createdAt
+                : createdAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$MealPlanImplCopyWith<$Res>
+    implements $MealPlanCopyWith<$Res> {
+  factory _$$MealPlanImplCopyWith(
+    _$MealPlanImpl value,
+    $Res Function(_$MealPlanImpl) then,
+  ) = __$$MealPlanImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
+    DateTime createdAt,
+  });
+}
+
+/// @nodoc
+class __$$MealPlanImplCopyWithImpl<$Res>
+    extends _$MealPlanCopyWithImpl<$Res, _$MealPlanImpl>
+    implements _$$MealPlanImplCopyWith<$Res> {
+  __$$MealPlanImplCopyWithImpl(
+    _$MealPlanImpl _value,
+    $Res Function(_$MealPlanImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of MealPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? babyId = null,
+    Object? startDate = null,
+    Object? endDate = null,
+    Object? createdAt = null,
+  }) {
+    return _then(
+      _$MealPlanImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        babyId: null == babyId
+            ? _value.babyId
+            : babyId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        startDate: null == startDate
+            ? _value.startDate
+            : startDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        endDate: null == endDate
+            ? _value.endDate
+            : endDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        createdAt: null == createdAt
+            ? _value.createdAt
+            : createdAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$MealPlanImpl implements _MealPlan {
+  const _$MealPlanImpl({
+    required this.id,
+    required this.babyId,
+    required this.startDate,
+    required this.endDate,
+    required this.createdAt,
+  });
+
+  @override
+  final String id;
+  @override
+  final String babyId;
+  @override
+  final DateTime startDate;
+  @override
+  final DateTime endDate;
+  @override
+  final DateTime createdAt;
+
+  @override
+  String toString() {
+    return 'MealPlan(id: $id, babyId: $babyId, startDate: $startDate, endDate: $endDate, createdAt: $createdAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MealPlanImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.babyId, babyId) || other.babyId == babyId) &&
+            (identical(other.startDate, startDate) ||
+                other.startDate == startDate) &&
+            (identical(other.endDate, endDate) || other.endDate == endDate) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, babyId, startDate, endDate, createdAt);
+
+  /// Create a copy of MealPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MealPlanImplCopyWith<_$MealPlanImpl> get copyWith =>
+      __$$MealPlanImplCopyWithImpl<_$MealPlanImpl>(this, _$identity);
+}
+
+abstract class _MealPlan implements MealPlan {
+  const factory _MealPlan({
+    required final String id,
+    required final String babyId,
+    required final DateTime startDate,
+    required final DateTime endDate,
+    required final DateTime createdAt,
+  }) = _$MealPlanImpl;
+
+  @override
+  String get id;
+  @override
+  String get babyId;
+  @override
+  DateTime get startDate;
+  @override
+  DateTime get endDate;
+  @override
+  DateTime get createdAt;
+
+  /// Create a copy of MealPlan
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$MealPlanImplCopyWith<_$MealPlanImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/common/domain/meal_stage.dart
+++ b/lib/src/common/domain/meal_stage.dart
@@ -1,0 +1,56 @@
+import 'package:nibbles/src/utils/age_in_months.dart';
+
+/// Solids-progression stage derived from the baby's age. Each stage carries a
+/// human label, a texture-rule description (from the feeding flowchart), and a
+/// target number of solid meals per day. Drives the meal-prep slot counts and
+/// the AI generation prompt.
+enum MealStage { stage0, stage1, stage2, stage3, stage4, stage5 }
+
+extension MealStageInfo on MealStage {
+  /// Human-readable texture rule for the stage.
+  String get texture => switch (this) {
+    MealStage.stage0 => 'Milk only',
+    MealStage.stage1 => 'Smooth / finely mashed',
+    MealStage.stage2 => 'Thick mash / soft small lumps',
+    MealStage.stage3 => 'Lumpy mash / minced / soft finger foods',
+    MealStage.stage4 => 'Chopped soft foods / mixed textures',
+    MealStage.stage5 => 'Soft family foods',
+  };
+
+  /// Zero-based stage index (stage0 → 0 … stage5 → 5).
+  int get stageNumber => index;
+
+  /// Display label, e.g. "Stage 2".
+  String get label => 'Stage $stageNumber';
+}
+
+/// Maps an age in whole months to its [MealStage].
+///
+/// `<5 → stage0`, `5 → stage1`, `6 → stage2`, `7–8 → stage3`,
+/// `9–11 → stage4`, `>=12 → stage5`.
+MealStage mealStageForAge(int ageMonths) {
+  if (ageMonths < 5) return MealStage.stage0;
+  if (ageMonths == 5) return MealStage.stage1;
+  if (ageMonths == 6) return MealStage.stage2;
+  if (ageMonths <= 8) return MealStage.stage3;
+  if (ageMonths <= 11) return MealStage.stage4;
+  return MealStage.stage5;
+}
+
+/// Target number of solid meals per day for an age in whole months, clamped to
+/// `[1, 3]`. Soft target — the planner allows more or fewer.
+int mealsPerDayForAge(int ageMonths) {
+  final perStage = switch (mealStageForAge(ageMonths)) {
+    MealStage.stage0 => 1,
+    MealStage.stage1 => 1,
+    MealStage.stage2 => 2,
+    MealStage.stage3 => 2,
+    MealStage.stage4 => 3,
+    MealStage.stage5 => 3,
+  };
+  return perStage.clamp(1, 3);
+}
+
+/// Convenience: target meals per day derived directly from a date of birth.
+int mealsPerDayForDob(DateTime dob, {DateTime? now}) =>
+    mealsPerDayForAge(ageInMonths(dob, now: now));

--- a/lib/src/common/services/meal_plan_ai_service.dart
+++ b/lib/src/common/services/meal_plan_ai_service.dart
@@ -1,0 +1,71 @@
+import 'package:nibbles/src/common/data/repositories/meal_plan_ai_repository.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan.dart';
+import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'meal_plan_ai_service.g.dart';
+
+/// Orchestrates AI meal-plan generation: asks the edge function for recipe
+/// assignments, then persists them through the existing plan write path
+/// ([MealPlanService.createPlan] + [MealPlanService.appendMealsToRange]).
+class MealPlanAiService {
+  const MealPlanAiService(this._aiRepo, this._mealPlanService);
+
+  final MealPlanAiRepository _aiRepo;
+  final MealPlanService _mealPlanService;
+
+  /// Generates assignments for `[startDate, endDate]` and persists them as a
+  /// new active plan (replacing any existing one). Returns the created plan.
+  Future<Result<MealPlan>> generateAndPersist({
+    required String babyId,
+    required DateTime startDate,
+    required DateTime endDate,
+    required List<String> preferences,
+    required String notes,
+  }) async {
+    final generated = await _aiRepo.generatePlan(
+      babyId: babyId,
+      startDate: startDate,
+      endDate: endDate,
+      preferences: preferences,
+      notes: notes,
+    );
+    if (generated.isFailure) {
+      return Result.failure(generated.errorOrNull!);
+    }
+
+    final planResult = await _mealPlanService.createPlan(
+      babyId,
+      startDate,
+      endDate,
+    );
+    if (planResult.isFailure) {
+      return Result.failure(planResult.errorOrNull!);
+    }
+    final plan = planResult.dataOrNull!;
+
+    final appendResult = await _mealPlanService.appendMealsToRange(
+      babyId: babyId,
+      startDate: startDate,
+      endDate: endDate,
+      assignments: generated.dataOrNull!,
+      mealPlanId: plan.id,
+    );
+    if (appendResult.isFailure) {
+      return Result.failure(appendResult.errorOrNull!);
+    }
+
+    return Result.success(plan);
+  }
+}
+
+@Riverpod(keepAlive: true)
+MealPlanAiService mealPlanAiService(
+  // Specific *Ref types are deprecated; will be Ref in riverpod_generator 3.0.
+  // ignore: deprecated_member_use_from_same_package
+  MealPlanAiServiceRef ref,
+) => MealPlanAiService(
+  ref.watch(mealPlanAiRepositoryProvider),
+  ref.watch(mealPlanServiceProvider),
+);

--- a/lib/src/common/services/meal_plan_ai_service.g.dart
+++ b/lib/src/common/services/meal_plan_ai_service.g.dart
@@ -1,27 +1,27 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'routes.dart';
+part of 'meal_plan_ai_service.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'1f8e237bbfaabdc6ed570e128a36f948b7178308';
+String _$mealPlanAiServiceHash() => r'1020c3bf44e6d523f20d3c4ff0c98b2b8ec2e26a';
 
-/// See also [goRouter].
-@ProviderFor(goRouter)
-final goRouterProvider = Provider<GoRouter>.internal(
-  goRouter,
-  name: r'goRouterProvider',
+/// See also [mealPlanAiService].
+@ProviderFor(mealPlanAiService)
+final mealPlanAiServiceProvider = Provider<MealPlanAiService>.internal(
+  mealPlanAiService,
+  name: r'mealPlanAiServiceProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$goRouterHash,
+      : _$mealPlanAiServiceHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef GoRouterRef = ProviderRef<GoRouter>;
+typedef MealPlanAiServiceRef = ProviderRef<MealPlanAiService>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/common/services/meal_plan_service.dart
+++ b/lib/src/common/services/meal_plan_service.dart
@@ -3,6 +3,7 @@ import 'package:nibbles/src/common/data/repositories/meal_plan_repository.dart';
 import 'package:nibbles/src/common/data/repositories/recipe_repository.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -51,6 +52,21 @@ class MealPlanService {
   Future<Result<List<MealPlanEntry>>> getAllEntries(String babyId) =>
       _repo.getAllEntries(babyId);
 
+  /// Returns all meal plan entries for the inclusive `[startDate, endDate]`
+  /// window. Used by the persisted-plan controller to load a plan of arbitrary
+  /// length (unlike [getRolling7], which is fixed at 7 days).
+  Future<Result<List<MealPlanEntry>>> getEntriesInRange(
+    String babyId,
+    DateTime startDate,
+    DateTime endDate,
+  ) =>
+      _repo.getEntriesInRange(babyId, _dateOnly(startDate), _dateOnly(endDate));
+
+  /// Returns every entry owned by [planId] regardless of date, so meals added
+  /// on a "+ Add Date" day past the plan's end still load.
+  Future<Result<List<MealPlanEntry>>> getEntriesForPlan(String planId) =>
+      _repo.getEntriesForPlan(planId);
+
   /// Inserts a new recipe assignment for [planDate].
   /// Multiple meals per day are allowed.
   Future<Result<MealPlanEntry>> assignRecipe(
@@ -70,6 +86,7 @@ class MealPlanService {
     required DateTime startDate,
     required DateTime endDate,
     required List<RecipeAssignment> assignments,
+    String? mealPlanId,
   }) {
     if (assignments.isEmpty) {
       return Future.value(const Result.success([]));
@@ -97,6 +114,7 @@ class MealPlanService {
           recipeId: a.recipeId,
           planDate: start.add(Duration(days: a.dayOffset)),
           mealTime: a.mealTime,
+          mealPlanId: mealPlanId,
         ),
       );
     }
@@ -213,6 +231,20 @@ class MealPlanService {
   /// Deletes all meal plan entries for [babyId] on [date].
   Future<Result<void>> clearDay(String babyId, DateTime date) =>
       _repo.clearDay(babyId, date);
+
+  /// Returns the baby's current persisted plan, or `null` if none.
+  Future<Result<MealPlan?>> getActivePlan(String babyId) =>
+      _repo.getActivePlan(babyId);
+
+  /// Creates a plan for `[start, end]`, replacing any existing plan.
+  Future<Result<MealPlan>> createPlan(
+    String babyId,
+    DateTime start,
+    DateTime end,
+  ) => _repo.createPlan(babyId, _dateOnly(start), _dateOnly(end));
+
+  /// Deletes a plan by ID — cascades its entries.
+  Future<Result<void>> deletePlan(String planId) => _repo.deletePlan(planId);
 
   static DateTime _weekEnd(DateTime weekStart) =>
       weekStart.add(const Duration(days: 6));

--- a/lib/src/features/meal_plan/ai/ai_loading_screen.dart
+++ b/lib/src/features/meal_plan/ai/ai_loading_screen.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/components.dart';
+import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
+import 'package:nibbles/src/common/services/meal_plan_ai_service.dart';
+
+/// Arguments for the full-screen AI generation loading route. Handed in via
+/// `GoRouterState.extra`.
+class AiLoadingArgs {
+  const AiLoadingArgs({
+    required this.babyId,
+    required this.babyName,
+    required this.startDate,
+    required this.endDate,
+    required this.preferences,
+    required this.notes,
+  });
+
+  final String babyId;
+  final String babyName;
+  final DateTime startDate;
+  final DateTime endDate;
+  final List<String> preferences;
+  final String notes;
+}
+
+/// Outcome popped by [AiLoadingScreen] once generation resolves.
+class AiLoadingResult {
+  const AiLoadingResult({required this.success, this.errorMessage});
+
+  final bool success;
+  final String? errorMessage;
+}
+
+/// Full-screen, non-dismissable loading route shown while the AI builds the
+/// meal plan. Runs [MealPlanAiService.generateAndPersist] on mount and pops
+/// with an [AiLoadingResult]. Wrapped in `PopScope(canPop: false)` so the
+/// user cannot back out mid-generation.
+class AiLoadingScreen extends ConsumerStatefulWidget {
+  const AiLoadingScreen({required this.args, super.key});
+
+  final AiLoadingArgs args;
+
+  @override
+  ConsumerState<AiLoadingScreen> createState() => _AiLoadingScreenState();
+}
+
+class _AiLoadingScreenState extends ConsumerState<AiLoadingScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _generate());
+  }
+
+  Future<void> _generate() async {
+    final args = widget.args;
+    final result = await ref
+        .read(mealPlanAiServiceProvider)
+        .generateAndPersist(
+          babyId: args.babyId,
+          startDate: args.startDate,
+          endDate: args.endDate,
+          preferences: args.preferences,
+          notes: args.notes,
+        );
+    if (!mounted) return;
+    context.pop(
+      AiLoadingResult(
+        success: result.isSuccess,
+        errorMessage: result.errorOrNull?.message,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      child: GradientScaffold(
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSizes.pagePaddingH),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const BrandFlowerLoader(),
+                const SizedBox(height: AppSizes.xl),
+                Text(
+                  "Building ${widget.args.babyName}'s plan…",
+                  textAlign: TextAlign.center,
+                  style: AppTypography.textTheme.titleLarge,
+                ),
+                const SizedBox(height: AppSizes.sm),
+                Text(
+                  'Picking recipes and mapping them across your days.',
+                  textAlign: TextAlign.center,
+                  style: AppTypography.textTheme.bodyMedium?.copyWith(
+                    color: AppColors.fgMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/meal_plan/ai/meal_notes_sheet.dart
+++ b/lib/src/features/meal_plan/ai/meal_notes_sheet.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+
+/// Second AI step (Figma 2846:17466): free-text notes for the meal plan.
+///
+/// "Anything else?" heading + a butter-tinted multiline textarea and a
+/// read-only "Preferences selected" recap of the chips picked in the previous
+/// step. "Continue" pops with the trimmed notes (may be empty); "Back" pops
+/// with `null` so the caller can return to the preferences step.
+Future<String?> showMealNotesSheet(
+  BuildContext context, {
+  required List<String> preferences,
+  required String babyName,
+  String initialNotes = '',
+}) {
+  return showModalBottomSheet<String>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppSizes.radiusLg),
+      ),
+    ),
+    builder: (_) => _MealNotesSheet(
+      preferences: preferences,
+      babyName: babyName,
+      initialNotes: initialNotes,
+    ),
+  );
+}
+
+class _MealNotesSheet extends StatefulWidget {
+  const _MealNotesSheet({
+    required this.preferences,
+    required this.babyName,
+    required this.initialNotes,
+  });
+
+  final List<String> preferences;
+  final String babyName;
+  final String initialNotes;
+
+  @override
+  State<_MealNotesSheet> createState() => _MealNotesSheetState();
+}
+
+class _MealNotesSheetState extends State<_MealNotesSheet> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialNotes);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(
+            AppSizes.pagePaddingH,
+            AppSizes.md,
+            AppSizes.pagePaddingH,
+            AppSizes.lg,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Center(child: _GrabHandle()),
+              const SizedBox(height: AppSizes.md),
+              Text('Anything else?', style: textTheme.titleLarge),
+              const SizedBox(height: AppSizes.xs),
+              Text(
+                'Add any extra notes for the meal plan',
+                style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
+              ),
+              const SizedBox(height: AppSizes.md),
+              _NotesField(controller: _controller, babyName: widget.babyName),
+              if (widget.preferences.isNotEmpty) ...[
+                const SizedBox(height: AppSizes.lg),
+                Text(
+                  'Preferences selected',
+                  style: textTheme.labelMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.fgStrong,
+                  ),
+                ),
+                const SizedBox(height: AppSizes.sm),
+                Wrap(
+                  spacing: AppSizes.sm,
+                  runSpacing: AppSizes.sm,
+                  children: [
+                    for (final pref in widget.preferences)
+                      AppChip(label: pref, tone: AppChipTone.green),
+                  ],
+                ),
+              ],
+              const SizedBox(height: AppSizes.lg),
+              Row(
+                children: [
+                  Expanded(
+                    child: AppPillButton(
+                      label: 'Back',
+                      variant: AppPillButtonVariant.secondary,
+                      onPressed: () => Navigator.of(context).pop(),
+                    ),
+                  ),
+                  const SizedBox(width: AppSizes.sm),
+                  Expanded(
+                    child: AppPillButton(
+                      label: 'Continue',
+                      onPressed: () => Navigator.of(
+                        context,
+                      ).pop(_controller.text.trim()),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NotesField extends StatelessWidget {
+  const _NotesField({required this.controller, required this.babyName});
+
+  final TextEditingController controller;
+  final String babyName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.md,
+        vertical: AppSizes.sm,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.butterSoft,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        border: Border.all(color: AppColors.butter),
+      ),
+      child: TextField(
+        controller: controller,
+        minLines: 4,
+        maxLines: 8,
+        textCapitalization: TextCapitalization.sentences,
+        cursorColor: AppColors.greenDeep,
+        style: theme.textTheme.bodyLarge?.copyWith(color: AppColors.fgStrong),
+        decoration: InputDecoration(
+          isCollapsed: true,
+          filled: false,
+          border: InputBorder.none,
+          enabledBorder: InputBorder.none,
+          focusedBorder: InputBorder.none,
+          hintText:
+              'e.g. $babyName loves sweet flavours, please avoid '
+              'anything too spicy',
+          hintStyle: theme.textTheme.bodyLarge?.copyWith(
+            color: AppColors.greenSoft,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GrabHandle extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 36,
+      height: 4,
+      decoration: BoxDecoration(
+        color: AppColors.divider,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+    );
+  }
+}

--- a/lib/src/features/meal_plan/ai/meal_preferences_sheet.dart
+++ b/lib/src/features/meal_plan/ai/meal_preferences_sheet.dart
@@ -1,0 +1,254 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/gen/fonts.gen.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/features/meal_plan/ai/meal_notes_sheet.dart';
+
+/// Preset meal-preference options (Figma 2846:17404), in display order. Sent
+/// verbatim to the AI generation prompt, so keep the strings stable.
+const List<String> kMealPreferencePresets = <String>[
+  'Quick to make',
+  'Finger foods',
+  'More veggies',
+  'Light & simple',
+  'Iron-rich puree',
+  'Iron-rich finger foods',
+  'Whipped bone marrow',
+  'Stool softening meals',
+  'High energy',
+];
+
+/// Runs the two-step AI preferences flow: [showMealPreferencesSheet] →
+/// [showMealNotesSheet]. Returns the chosen preferences + notes, or `null`
+/// if the user cancelled out of the preferences step.
+///
+/// "Back" on the notes step returns to the preferences step with selections
+/// preserved; "Back" on the preferences step cancels the whole flow. The
+/// caller owns launching the loading screen and calling generation — this
+/// helper only collects input.
+Future<({List<String> preferences, String notes})?> showAiPreferencesFlow(
+  BuildContext context, {
+  required String babyName,
+}) async {
+  var preferences = <String>[];
+  var notes = '';
+  while (true) {
+    if (!context.mounted) return null;
+    final chosen = await showMealPreferencesSheet(
+      context,
+      initialSelected: preferences,
+    );
+    if (chosen == null) return null;
+    preferences = chosen;
+
+    if (!context.mounted) return null;
+    final enteredNotes = await showMealNotesSheet(
+      context,
+      preferences: preferences,
+      babyName: babyName,
+      initialNotes: notes,
+    );
+    if (enteredNotes == null) {
+      // Back from notes → re-open preferences with the current selection.
+      if (!context.mounted) return null;
+      continue;
+    }
+    notes = enteredNotes;
+    return (preferences: preferences, notes: notes);
+  }
+}
+
+/// First AI step (Figma 2846:17404): multi-select preset preference chips.
+/// "Continue" pops with the selected presets (preset order); "Back" pops with
+/// `null` to cancel the flow.
+Future<List<String>?> showMealPreferencesSheet(
+  BuildContext context, {
+  List<String> initialSelected = const <String>[],
+}) {
+  return showModalBottomSheet<List<String>>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppSizes.radiusLg),
+      ),
+    ),
+    builder: (_) => _MealPreferencesSheet(initialSelected: initialSelected),
+  );
+}
+
+class _MealPreferencesSheet extends StatefulWidget {
+  const _MealPreferencesSheet({required this.initialSelected});
+
+  final List<String> initialSelected;
+
+  @override
+  State<_MealPreferencesSheet> createState() => _MealPreferencesSheetState();
+}
+
+class _MealPreferencesSheetState extends State<_MealPreferencesSheet> {
+  late final Set<String> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = {...widget.initialSelected};
+  }
+
+  void _toggle(String preset) {
+    setState(() {
+      if (!_selected.remove(preset)) _selected.add(preset);
+    });
+  }
+
+  List<String> get _orderedSelection =>
+      kMealPreferencePresets.where(_selected.contains).toList();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return SafeArea(
+      top: false,
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(
+          AppSizes.pagePaddingH,
+          AppSizes.md,
+          AppSizes.pagePaddingH,
+          AppSizes.lg,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(child: _GrabHandle()),
+            const SizedBox(height: AppSizes.md),
+            Text('Meal Preferences', style: textTheme.titleLarge),
+            const SizedBox(height: AppSizes.xs),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Select all that apply',
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: AppColors.fgMuted,
+                  ),
+                ),
+                Text(
+                  '${_selected.length} selected',
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: AppColors.greenDeep,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSizes.md),
+            Wrap(
+              spacing: AppSizes.sm,
+              runSpacing: AppSizes.sm,
+              children: [
+                for (final preset in kMealPreferencePresets)
+                  _PresetChip(
+                    label: preset,
+                    selected: _selected.contains(preset),
+                    onTap: () => _toggle(preset),
+                  ),
+              ],
+            ),
+            const SizedBox(height: AppSizes.xl),
+            Row(
+              children: [
+                Expanded(
+                  child: AppPillButton(
+                    label: 'Back',
+                    variant: AppPillButtonVariant.secondary,
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ),
+                const SizedBox(width: AppSizes.sm),
+                Expanded(
+                  child: AppPillButton(
+                    label: 'Continue',
+                    onPressed: () =>
+                        Navigator.of(context).pop(_orderedSelection),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Selectable preference pill. Unselected: butter-outlined, greenDeep label.
+/// Selected: forest fill, cream label.
+class _PresetChip extends StatelessWidget {
+  const _PresetChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      excludeSemantics: true,
+      child: Material(
+        color: selected ? AppColors.greenDeep : Colors.transparent,
+        shape: StadiumBorder(
+          side: BorderSide(
+            color: selected ? AppColors.greenDeep : AppColors.butterDark,
+            width: 1.5,
+          ),
+        ),
+        child: InkWell(
+          onTap: onTap,
+          customBorder: const StadiumBorder(),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSizes.md,
+              vertical: AppSizes.sm + 2,
+            ),
+            child: Text(
+              label,
+              style: TextStyle(
+                fontFamily: FontFamily.parkinsans,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                height: 1,
+                color: selected ? AppColors.cream : AppColors.greenDeep,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GrabHandle extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 36,
+      height: 4,
+      decoration: BoxDecoration(
+        color: AppColors.divider,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+    );
+  }
+}

--- a/lib/src/features/meal_plan/map/map_meals_controller.dart
+++ b/lib/src/features/meal_plan/map/map_meals_controller.dart
@@ -74,36 +74,55 @@ class MapMealsController extends _$MapMealsController {
     state = state.copyWith(selectedDay: _dateOnly(day));
   }
 
-  /// Adds (or overwrites) the assignment for [recipeId] to the currently
-  /// selected day on the state.
+  /// COPIES [recipeId] onto the currently selected day (appended to that
+  /// day's list). The picked palette is reusable, so the same recipe can be
+  /// added to many days and to one day multiple times — this never removes
+  /// anything from the palette.
   void assignToSelectedDay(String recipeId) {
-    final next = Map<String, DateTime>.from(state.assignments);
-    next[recipeId] = state.selectedDay;
+    final day = _dateOnly(state.selectedDay);
+    final next = <DateTime, List<String>>{
+      for (final entry in state.assignments.entries)
+        entry.key: List<String>.from(entry.value),
+    };
+    (next[day] ??= <String>[]).add(recipeId);
     state = state.copyWith(assignments: next, errorMessage: null);
     unawaited(
       ref
           .read(analyticsProvider)
           .logMealPrepMappingAssigned(
             recipeId: recipeId,
-            dayOffsetIso: _isoDate(state.selectedDay),
+            dayOffsetIso: _isoDate(day),
           ),
     );
   }
 
-  /// Removes [recipeId] from the assignments map.
-  void unassign(String recipeId) {
-    final next = Map<String, DateTime>.from(state.assignments)
-      ..remove(recipeId);
+  /// Removes a single mapped instance from the selected day by its position
+  /// [index] in that day's list (mapped cards can hold duplicates, so removal
+  /// is positional, not id-based).
+  void unassignFromSelectedDayAt(int index) {
+    final day = _dateOnly(state.selectedDay);
+    final current = state.assignments[day];
+    if (current == null || index < 0 || index >= current.length) return;
+    final updated = List<String>.from(current)..removeAt(index);
+    final next = <DateTime, List<String>>{
+      for (final entry in state.assignments.entries)
+        entry.key: List<String>.from(entry.value),
+    };
+    if (updated.isEmpty) {
+      next.remove(day);
+    } else {
+      next[day] = updated;
+    }
     state = state.copyWith(assignments: next, errorMessage: null);
   }
 
-  /// Bulk-commits the assignments via [MealPlanService.appendMealsToRange].
+  /// Creates/replaces the plan for the window, then bulk-appends every mapped
+  /// meal instance into it via [MealPlanService.appendMealsToRange].
   ///
+  /// Partial (or empty) mappings are allowed — Finish is enabled at any time.
   /// Returns true on success (caller pops with `true`). On failure leaves
   /// `errorMessage` set so the screen can show the P1 retry dialog.
   Future<bool> commit() async {
-    if (state.assignments.isEmpty) return false;
-
     state = state.copyWith(isCommitting: true, errorMessage: null);
 
     final babyId = await ref.read(currentBabyIdProvider.future);
@@ -115,38 +134,41 @@ class MapMealsController extends _$MapMealsController {
       return false;
     }
 
-    final start = state.startDate;
-    final assignments = state.assignments.entries.map((entry) {
-      final day = _dateOnly(entry.value);
-      final offset = day.difference(start).inDays;
-      return RecipeAssignment(recipeId: entry.key, dayOffset: offset);
-    }).toList();
-
-    final result = await ref
-        .read(mealPlanServiceProvider)
-        .appendMealsToRange(
-          babyId: babyId,
-          startDate: state.startDate,
-          endDate: state.endDate,
-          assignments: assignments,
+    final start = _dateOnly(state.startDate);
+    final assignments = <RecipeAssignment>[];
+    for (final entry in state.assignments.entries) {
+      final offset = _dateOnly(entry.key).difference(start).inDays;
+      for (final recipeId in entry.value) {
+        assignments.add(
+          RecipeAssignment(recipeId: recipeId, dayOffset: offset),
         );
+      }
+    }
+
+    final service = ref.read(mealPlanServiceProvider);
+
+    final planResult = await service.createPlan(
+      babyId,
+      state.startDate,
+      state.endDate,
+    );
+    if (planResult.isFailure) {
+      return _recordAndFail(
+        planResult.errorOrNull?.message,
+        assignments.length,
+      );
+    }
+
+    final result = await service.appendMealsToRange(
+      babyId: babyId,
+      startDate: state.startDate,
+      endDate: state.endDate,
+      mealPlanId: planResult.dataOrNull!.id,
+      assignments: assignments,
+    );
 
     if (result.isFailure) {
-      final dayCount = state.endDate.difference(state.startDate).inDays + 1;
-      await ref.read(mealPrepCrashRecorderProvider)(
-        'meal_prep_commit_failure: ${result.errorOrNull?.message}',
-        StackTrace.current,
-        reason: 'meal_prep_commit_failure',
-        information: <String>[
-          'recipe_count=${assignments.length}',
-          'day_count=$dayCount',
-        ],
-      );
-      state = state.copyWith(
-        isCommitting: false,
-        errorMessage: result.errorOrNull?.message ?? 'Failed to save plan.',
-      );
-      return false;
+      return _recordAndFail(result.errorOrNull?.message, assignments.length);
     }
 
     state = state.copyWith(isCommitting: false);
@@ -155,10 +177,29 @@ class MapMealsController extends _$MapMealsController {
           .read(analyticsProvider)
           .logMealPrepCommitted(
             recipeCount: assignments.length,
-            dayCount: state.endDate.difference(state.startDate).inDays + 1,
+            dayCount: state.dayCount,
           ),
     );
     return true;
+  }
+
+  /// Records the non-fatal crash payload, sets the P1 `errorMessage`, and
+  /// returns false so [commit] can bail out.
+  Future<bool> _recordAndFail(String? message, int recipeCount) async {
+    await ref.read(mealPrepCrashRecorderProvider)(
+      'meal_prep_commit_failure: $message',
+      StackTrace.current,
+      reason: 'meal_prep_commit_failure',
+      information: <String>[
+        'recipe_count=$recipeCount',
+        'day_count=${state.dayCount}',
+      ],
+    );
+    state = state.copyWith(
+      isCommitting: false,
+      errorMessage: message ?? 'Failed to save plan.',
+    );
+    return false;
   }
 
   /// `yyyy-MM-dd` for analytics. Locale-stable, no PII.

--- a/lib/src/features/meal_plan/map/map_meals_controller.g.dart
+++ b/lib/src/features/meal_plan/map/map_meals_controller.g.dart
@@ -29,7 +29,7 @@ final mealPrepCrashRecorderProvider =
 // ignore: unused_element
 typedef MealPrepCrashRecorderRef = ProviderRef<MealPrepCrashRecorderFn>;
 String _$mapMealsControllerHash() =>
-    r'3bd04cb23a21215baf69a349c8514a2adea03309';
+    r'dae52946f556a3de89a67b95f047b3d0918fc3c6';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/meal_plan/map/map_meals_screen.dart
+++ b/lib/src/features/meal_plan/map/map_meals_screen.dart
@@ -6,6 +6,8 @@ import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/components.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
+import 'package:nibbles/src/common/domain/meal_stage.dart';
+import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/common/services/meal_plan_service.dart'
     show MealPlanService;
 import 'package:nibbles/src/features/meal_plan/map/map_meals_controller.dart';
@@ -17,10 +19,12 @@ import 'package:nibbles/src/features/meal_plan/map/widgets/selected_day_slot_lis
 /// Map Meals Plan full-screen (NIB-95).
 ///
 /// Takes a list of picked recipes + a date range (handed in via
-/// [MapMealsArgs] through `GoRouterState.extra` from NIB-87's Browse Meal
-/// sheet) and lets the user assign each picked recipe to a day in the
-/// range. On commit, calls [MealPlanService.appendMealsToRange] (APPEND
-/// only — no replace per NIB-120). On success pops with `true`. On
+/// [MapMealsArgs] through `GoRouterState.extra`) and lets the user assign
+/// picked recipes to days in the range by DRAGGING them onto the day
+/// drop-zone or TAPPING them. The picked palette is reusable — a recipe can
+/// be mapped onto many days. On Finish, creates/replaces the plan via
+/// [MealPlanService.createPlan] then bulk-appends the mapped meals via
+/// [MealPlanService.appendMealsToRange]. On success pops with `true`; on
 /// failure shows a blocking P1 retry dialog.
 class MapMealsScreen extends ConsumerWidget {
   const MapMealsScreen({required this.args, super.key});
@@ -37,74 +41,49 @@ class MapMealsScreen extends ConsumerWidget {
     DateTime.sunday: 'Sunday',
   };
 
-  static const _weekdayShort = <int, String>{
-    DateTime.monday: 'Mon',
-    DateTime.tuesday: 'Tue',
-    DateTime.wednesday: 'Wed',
-    DateTime.thursday: 'Thu',
-    DateTime.friday: 'Fri',
-    DateTime.saturday: 'Sat',
-    DateTime.sunday: 'Sun',
-  };
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(mapMealsControllerProvider(args));
     final notifier = ref.read(mapMealsControllerProvider(args).notifier);
+    final mealsPerDay = _mealsPerDay(ref);
 
     return PopScope(
       canPop: state.assignments.isEmpty && !state.isCommitting,
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop) return;
-        final confirmed = await showDialog<bool>(
-          context: context,
-          builder: (ctx) => AlertDialog(
-            backgroundColor: AppColors.surface,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-            ),
-            title: const Text(
-              'Discard unsaved meal mappings?',
-              style: AppTypography.sectionTitle,
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(false),
-                child: Text(
-                  'Keep',
-                  style: AppTypography.button.copyWith(
-                    color: AppColors.fgMuted,
-                  ),
-                ),
-              ),
-              FilledButton(
-                style: FilledButton.styleFrom(
-                  backgroundColor: AppColors.destructive,
-                  foregroundColor: AppColors.onGreen,
-                ),
-                onPressed: () => Navigator.of(ctx).pop(true),
-                child: Text('Discard', style: AppTypography.button),
-              ),
-            ],
-          ),
-        );
+        final confirmed = await _confirmDiscard(context);
         if ((confirmed ?? false) && context.mounted) {
           Navigator.of(context).pop();
         }
       },
       child: GradientScaffold(
-        appBar: _MapMealsAppBar(state: state),
+        appBar: const _MapMealsAppBar(),
         body: SafeArea(
           top: false,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              const SizedBox(height: AppSizes.md),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSizes.pagePaddingH,
+                  0,
+                  AppSizes.pagePaddingH,
+                  AppSizes.md,
+                ),
+                child: Text(
+                  '${state.filledCount} of ${state.totalSlots(mealsPerDay)} '
+                  'slots filled',
+                  style: AppTypography.caption.copyWith(
+                    color: AppColors.fgMuted,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
               DayChipRow(
                 startDate: state.startDate,
                 endDate: state.endDate,
                 selectedDay: state.selectedDay,
-                filledDays: state.filledDays(),
+                fullDays: state.fullDays(mealsPerDay),
                 onSelect: notifier.selectDay,
               ),
               const SizedBox(height: AppSizes.md),
@@ -116,24 +95,18 @@ class MapMealsScreen extends ConsumerWidget {
                   children: [
                     _SelectedDayHeader(
                       state: state,
+                      mealsPerDay: mealsPerDay,
                       weekdayNames: _weekdayName,
                     ),
-                    if (state.recipesForSelectedDay().isNotEmpty) ...[
-                      const SizedBox(height: AppSizes.xs),
-                      Text(
-                        'Drag & drop or click meals below to add them',
-                        style: AppTypography.caption.copyWith(
-                          color: AppColors.fgMuted,
-                        ),
-                      ),
-                    ],
                     const SizedBox(height: AppSizes.sm),
-                    SelectedDaySlotList(
+                    _DayDropZone(
                       recipes: state.recipesForSelectedDay(),
-                      onRemove: notifier.unassign,
+                      onAccept: (recipe) =>
+                          notifier.assignToSelectedDay(recipe.id),
+                      onRemoveAt: notifier.unassignFromSelectedDayAt,
                     ),
                     const SizedBox(height: AppSizes.lg),
-                    _MealsPickedHeader(totalCount: state.totalCount),
+                    _MealsPickedHeader(count: state.pickedRecipes.length),
                     const SizedBox(height: AppSizes.sm),
                     for (var i = 0; i < state.pickedRecipes.length; i++) ...[
                       if (i != 0) const SizedBox(height: AppSizes.sm),
@@ -142,17 +115,16 @@ class MapMealsScreen extends ConsumerWidget {
                         onTap: () => notifier.assignToSelectedDay(
                           state.pickedRecipes[i].id,
                         ),
-                        assignedLabel: _assignedLabelFor(
-                          state.pickedRecipes[i],
-                          state,
-                        ),
                       ),
                     ],
                     const SizedBox(height: AppSizes.xl),
                   ],
                 ),
               ),
-              _CommitBar(state: state, onCommit: () => _onCommit(context, ref)),
+              _FinishBar(
+                isCommitting: state.isCommitting,
+                onFinish: () => _onFinish(context, ref),
+              ),
             ],
           ),
         ),
@@ -160,14 +132,46 @@ class MapMealsScreen extends ConsumerWidget {
     );
   }
 
-  String? _assignedLabelFor(Recipe recipe, MapMealsState state) {
-    final assignedDay = state.assignments[recipe.id];
-    if (assignedDay == null) return null;
-    final abbrev = _weekdayShort[assignedDay.weekday] ?? '';
-    return '$abbrev ${assignedDay.day}';
+  int _mealsPerDay(WidgetRef ref) {
+    final baby = ref.watch(currentBabyProvider).valueOrNull;
+    if (baby == null) return 1;
+    return mealsPerDayForDob(baby.dateOfBirth);
   }
 
-  Future<void> _onCommit(BuildContext context, WidgetRef ref) async {
+  Future<bool?> _confirmDiscard(BuildContext context) {
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        ),
+        title: const Text(
+          'Discard unsaved meal mappings?',
+          style: AppTypography.sectionTitle,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(
+              'Keep',
+              style: AppTypography.button.copyWith(color: AppColors.fgMuted),
+            ),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.destructive,
+              foregroundColor: AppColors.onGreen,
+            ),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text('Discard', style: AppTypography.button),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _onFinish(BuildContext context, WidgetRef ref) async {
     final notifier = ref.read(mapMealsControllerProvider(args).notifier);
     final success = await notifier.commit();
     if (!context.mounted) return;
@@ -214,7 +218,7 @@ class MapMealsScreen extends ConsumerWidget {
               ),
               onPressed: () {
                 Navigator.of(dialogContext).pop();
-                _onCommit(context, ref);
+                _onFinish(context, ref);
               },
               child: Text('Retry', style: AppTypography.button),
             ),
@@ -225,10 +229,39 @@ class MapMealsScreen extends ConsumerWidget {
   }
 }
 
-class _MapMealsAppBar extends StatelessWidget implements PreferredSizeWidget {
-  const _MapMealsAppBar({required this.state});
+/// `DragTarget<Recipe>` drop-zone wrapping the selected day's slot list.
+///
+/// Accepting a drop copies the recipe onto the selected day; while a drag
+/// hovers the dashed border turns green (Figma 971:8511).
+class _DayDropZone extends StatelessWidget {
+  const _DayDropZone({
+    required this.recipes,
+    required this.onAccept,
+    required this.onRemoveAt,
+  });
 
-  final MapMealsState state;
+  final List<Recipe> recipes;
+  final ValueChanged<Recipe> onAccept;
+  final ValueChanged<int> onRemoveAt;
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<Recipe>(
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (details) => onAccept(details.data),
+      builder: (context, candidate, rejected) {
+        return SelectedDaySlotList(
+          recipes: recipes,
+          onRemoveAt: onRemoveAt,
+          isHovering: candidate.isNotEmpty,
+        );
+      },
+    );
+  }
+}
+
+class _MapMealsAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const _MapMealsAppBar();
 
   @override
   Size get preferredSize => const Size.fromHeight(AppSizes.appBarHeight);
@@ -247,30 +280,6 @@ class _MapMealsAppBar extends StatelessWidget implements PreferredSizeWidget {
       ),
       title: Text('Map Meals Plan', style: AppTypography.textTheme.titleLarge),
       centerTitle: false,
-      actions: [
-        Padding(
-          padding: const EdgeInsets.only(right: AppSizes.pagePaddingH),
-          child: Center(
-            child: Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSizes.sp12,
-                vertical: AppSizes.xs,
-              ),
-              decoration: BoxDecoration(
-                color: AppColors.greenTint,
-                borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-              ),
-              child: Text(
-                '${state.filledCount} of ${state.totalCount} slots filled',
-                style: AppTypography.caption.copyWith(
-                  color: AppColors.greenDeep,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-            ),
-          ),
-        ),
-      ],
     );
   }
 }
@@ -279,9 +288,9 @@ class _MapMealsAppBar extends StatelessWidget implements PreferredSizeWidget {
 /// flush-left and the picked-count chip (`N selected`) sits flush-right
 /// on the same row.
 class _MealsPickedHeader extends StatelessWidget {
-  const _MealsPickedHeader({required this.totalCount});
+  const _MealsPickedHeader({required this.count});
 
-  final int totalCount;
+  final int count;
 
   @override
   Widget build(BuildContext context) {
@@ -291,7 +300,7 @@ class _MealsPickedHeader extends StatelessWidget {
           child: Text('Meals Picked', style: AppTypography.sectionTitle),
         ),
         Text(
-          '$totalCount selected',
+          '$count selected',
           style: AppTypography.caption.copyWith(
             color: AppColors.fgMuted,
             fontWeight: FontWeight.w600,
@@ -303,47 +312,39 @@ class _MealsPickedHeader extends StatelessWidget {
 }
 
 class _SelectedDayHeader extends StatelessWidget {
-  const _SelectedDayHeader({required this.state, required this.weekdayNames});
+  const _SelectedDayHeader({
+    required this.state,
+    required this.mealsPerDay,
+    required this.weekdayNames,
+  });
 
   final MapMealsState state;
+  final int mealsPerDay;
   final Map<int, String> weekdayNames;
 
   @override
   Widget build(BuildContext context) {
     final dayName = weekdayNames[state.selectedDay.weekday] ?? '';
-    final n = state.recipesForSelectedDay().length;
-    final m = state.totalCount;
+    final k = state.assignedCountForSelectedDay();
     return Text(
-      'Meals for $dayName ($n/$m)',
+      'Meals for $dayName ($k/$mealsPerDay)',
       style: AppTypography.sectionTitle,
     );
   }
 }
 
-/// Floating commit bar for the Map Meals Plan screen.
+/// Floating bottom "Finish" pill for the Map Meals Plan screen.
 ///
-/// Per the Figma spec (frames 971:8375 → 971:8511) the CTA progresses
-/// through three states based on how many picked recipes are assigned:
-///
-/// * 0 assignments      → bar is hidden (frames 03/04 show no CTA at all)
-/// * 1..N-1 assignments → `Add (<remaining>)`
-/// * N == totalCount    → `Complete Mapping`
-class _CommitBar extends StatelessWidget {
-  const _CommitBar({required this.state, required this.onCommit});
+/// Per the redesign the CTA is enabled at ANY time — partial (or empty)
+/// mapping is allowed. Only disabled while a commit is in flight.
+class _FinishBar extends StatelessWidget {
+  const _FinishBar({required this.isCommitting, required this.onFinish});
 
-  final MapMealsState state;
-  final VoidCallback onCommit;
+  final bool isCommitting;
+  final VoidCallback onFinish;
 
   @override
   Widget build(BuildContext context) {
-    final filled = state.filledCount;
-    final total = state.totalCount;
-    if (filled == 0) return const SizedBox.shrink();
-
-    final isComplete = filled >= total;
-    final label = isComplete ? 'Complete Mapping' : 'Add (${total - filled})';
-    final disabled = state.isCommitting;
-
     return SafeArea(
       top: false,
       child: Padding(
@@ -353,26 +354,18 @@ class _CommitBar extends StatelessWidget {
           AppSizes.pagePaddingH,
           AppSizes.sp12,
         ),
-        child: Semantics(
-          button: true,
-          enabled: !disabled,
-          label: state.isCommitting ? 'Saving meal plan' : label,
-          child: SizedBox(
-            width: double.infinity,
-            height: AppSizes.buttonHeight,
-            child: FilledButton(
-              style: FilledButton.styleFrom(
-                backgroundColor: AppColors.greenDeep,
-                foregroundColor: AppColors.onGreen,
-                disabledBackgroundColor: AppColors.borderMuted,
-                disabledForegroundColor: AppColors.fgFaint,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-                ),
-              ),
-              onPressed: disabled ? null : onCommit,
-              child: state.isCommitting
-                  ? const ExcludeSemantics(
+        child: isCommitting
+            ? Semantics(
+                button: true,
+                enabled: false,
+                label: 'Saving meal plan',
+                excludeSemantics: true,
+                child: const SizedBox(
+                  height: AppSizes.buttonHeight,
+                  child: Material(
+                    color: AppColors.borderMuted,
+                    shape: StadiumBorder(),
+                    child: Center(
                       child: SizedBox(
                         width: AppSizes.iconSm,
                         height: AppSizes.iconSm,
@@ -381,11 +374,15 @@ class _CommitBar extends StatelessWidget {
                           color: AppColors.onGreen,
                         ),
                       ),
-                    )
-                  : Text(label, style: AppTypography.button),
-            ),
-          ),
-        ),
+                    ),
+                  ),
+                ),
+              )
+            : AppPillButton(
+                label: 'Finish',
+                onPressed: onFinish,
+                identifier: 'map-meals-finish',
+              ),
       ),
     );
   }

--- a/lib/src/features/meal_plan/map/map_meals_state.dart
+++ b/lib/src/features/meal_plan/map/map_meals_state.dart
@@ -19,9 +19,11 @@ class MapMealsArgs with _$MapMealsArgs {
 
 /// NIB-95 Map Meals Plan screen state.
 ///
-/// `assignments` is `recipeId -> DateTime` (one slot per recipe). The user
-/// taps a picked recipe row to assign it to [selectedDay]; tapping again
-/// after picking a different chip re-assigns it.
+/// `assignments` is a MULTIMAP `day(date-only) -> ordered [recipeId]`. The
+/// picked-recipe palette is REUSABLE: dragging or tapping a picked recipe
+/// COPIES it onto [selectedDay] (appended to that day's list), so the same
+/// recipe can live on many days and a day can hold multiple copies. Removing
+/// a mapped card removes a single instance by its position in the day's list.
 @freezed
 class MapMealsState with _$MapMealsState {
   const factory MapMealsState({
@@ -29,36 +31,58 @@ class MapMealsState with _$MapMealsState {
     required DateTime startDate,
     required DateTime endDate,
     required DateTime selectedDay,
-    @Default(<String, DateTime>{}) Map<String, DateTime> assignments,
+    @Default(<DateTime, List<String>>{})
+    Map<DateTime, List<String>> assignments,
     @Default(false) bool isCommitting,
     String? errorMessage,
   }) = _MapMealsState;
 
   const MapMealsState._();
 
-  /// Number of slots filled (length of [assignments]) — for the AppBar chip.
-  int get filledCount => assignments.length;
+  /// Total number of assigned meal instances across every day — the "X" in
+  /// "X of M slots filled".
+  int get filledCount =>
+      assignments.values.fold(0, (sum, ids) => sum + ids.length);
 
-  /// Total picked recipes — for the AppBar chip's denominator.
-  int get totalCount => pickedRecipes.length;
+  /// Inclusive day count of the `[startDate, endDate]` window.
+  int get dayCount =>
+      _dateOnly(endDate).difference(_dateOnly(startDate)).inDays + 1;
 
-  /// Recipes assigned to [selectedDay].
+  /// Total slot target across the whole window — the "M" in
+  /// "X of M slots filled" — i.e. `dayCount * mealsPerDay`.
+  int totalSlots(int mealsPerDay) => dayCount * mealsPerDay;
+
+  /// Recipe ids assigned to [selectedDay], in insertion order (duplicates
+  /// preserved). Positional — index is the removal key.
+  List<String> recipeIdsForSelectedDay() => List<String>.from(
+    assignments[_dateOnly(selectedDay)] ?? const <String>[],
+  );
+
+  /// Recipes assigned to [selectedDay], expanded from
+  /// [recipeIdsForSelectedDay] preserving order and duplicates.
   List<Recipe> recipesForSelectedDay() {
-    final key = _dateKey(selectedDay);
-    final ids = assignments.entries
-        .where((e) => _dateKey(e.value) == key)
-        .map((e) => e.key)
-        .toSet();
-    return pickedRecipes.where((r) => ids.contains(r.id)).toList();
+    final byId = {for (final r in pickedRecipes) r.id: r};
+    return [
+      for (final id in recipeIdsForSelectedDay())
+        if (byId[id] != null) byId[id]!,
+    ];
   }
 
-  /// Set of days (date-only) that have at least one assignment — drives
-  /// the day-chip "Filled" variant (frame 971:8441).
-  Set<DateTime> filledDays() {
-    return assignments.values
-        .map((d) => DateTime(d.year, d.month, d.day))
-        .toSet();
+  /// Number of meals assigned to [selectedDay] — the "k" in "Meals for
+  /// {Weekday} (k/N)".
+  int assignedCountForSelectedDay() =>
+      assignments[_dateOnly(selectedDay)]?.length ?? 0;
+
+  /// Days whose assigned count meets or exceeds the per-day target — drives
+  /// the day-chip ✓ / "full" variant (frame 971:8441). A [mealsPerDay] of 0
+  /// never marks a day full.
+  Set<DateTime> fullDays(int mealsPerDay) {
+    if (mealsPerDay <= 0) return const <DateTime>{};
+    return {
+      for (final entry in assignments.entries)
+        if (entry.value.length >= mealsPerDay) entry.key,
+    };
   }
 
-  static String _dateKey(DateTime dt) => '${dt.year}-${dt.month}-${dt.day}';
+  static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
 }

--- a/lib/src/features/meal_plan/map/map_meals_state.freezed.dart
+++ b/lib/src/features/meal_plan/map/map_meals_state.freezed.dart
@@ -212,7 +212,8 @@ mixin _$MapMealsState {
   DateTime get startDate => throw _privateConstructorUsedError;
   DateTime get endDate => throw _privateConstructorUsedError;
   DateTime get selectedDay => throw _privateConstructorUsedError;
-  Map<String, DateTime> get assignments => throw _privateConstructorUsedError;
+  Map<DateTime, List<String>> get assignments =>
+      throw _privateConstructorUsedError;
   bool get isCommitting => throw _privateConstructorUsedError;
   String? get errorMessage => throw _privateConstructorUsedError;
 
@@ -235,7 +236,7 @@ abstract class $MapMealsStateCopyWith<$Res> {
     DateTime startDate,
     DateTime endDate,
     DateTime selectedDay,
-    Map<String, DateTime> assignments,
+    Map<DateTime, List<String>> assignments,
     bool isCommitting,
     String? errorMessage,
   });
@@ -285,7 +286,7 @@ class _$MapMealsStateCopyWithImpl<$Res, $Val extends MapMealsState>
             assignments: null == assignments
                 ? _value.assignments
                 : assignments // ignore: cast_nullable_to_non_nullable
-                      as Map<String, DateTime>,
+                      as Map<DateTime, List<String>>,
             isCommitting: null == isCommitting
                 ? _value.isCommitting
                 : isCommitting // ignore: cast_nullable_to_non_nullable
@@ -314,7 +315,7 @@ abstract class _$$MapMealsStateImplCopyWith<$Res>
     DateTime startDate,
     DateTime endDate,
     DateTime selectedDay,
-    Map<String, DateTime> assignments,
+    Map<DateTime, List<String>> assignments,
     bool isCommitting,
     String? errorMessage,
   });
@@ -363,7 +364,7 @@ class __$$MapMealsStateImplCopyWithImpl<$Res>
         assignments: null == assignments
             ? _value._assignments
             : assignments // ignore: cast_nullable_to_non_nullable
-                  as Map<String, DateTime>,
+                  as Map<DateTime, List<String>>,
         isCommitting: null == isCommitting
             ? _value.isCommitting
             : isCommitting // ignore: cast_nullable_to_non_nullable
@@ -385,7 +386,8 @@ class _$MapMealsStateImpl extends _MapMealsState {
     required this.startDate,
     required this.endDate,
     required this.selectedDay,
-    final Map<String, DateTime> assignments = const <String, DateTime>{},
+    final Map<DateTime, List<String>> assignments =
+        const <DateTime, List<String>>{},
     this.isCommitting = false,
     this.errorMessage,
   }) : _pickedRecipes = pickedRecipes,
@@ -406,10 +408,10 @@ class _$MapMealsStateImpl extends _MapMealsState {
   final DateTime endDate;
   @override
   final DateTime selectedDay;
-  final Map<String, DateTime> _assignments;
+  final Map<DateTime, List<String>> _assignments;
   @override
   @JsonKey()
-  Map<String, DateTime> get assignments {
+  Map<DateTime, List<String>> get assignments {
     if (_assignments is EqualUnmodifiableMapView) return _assignments;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableMapView(_assignments);
@@ -477,7 +479,7 @@ abstract class _MapMealsState extends MapMealsState {
     required final DateTime startDate,
     required final DateTime endDate,
     required final DateTime selectedDay,
-    final Map<String, DateTime> assignments,
+    final Map<DateTime, List<String>> assignments,
     final bool isCommitting,
     final String? errorMessage,
   }) = _$MapMealsStateImpl;
@@ -492,7 +494,7 @@ abstract class _MapMealsState extends MapMealsState {
   @override
   DateTime get selectedDay;
   @override
-  Map<String, DateTime> get assignments;
+  Map<DateTime, List<String>> get assignments;
   @override
   bool get isCommitting;
   @override

--- a/lib/src/features/meal_plan/map/widgets/day_chip_row.dart
+++ b/lib/src/features/meal_plan/map/widgets/day_chip_row.dart
@@ -8,16 +8,16 @@ import 'package:nibbles/src/app/themes/app_typography.dart';
 /// Renders one chip per day in `[startDate, endDate]`. Each chip renders
 /// in one of three states (Figma frame 971:8441 / CalendarPerday):
 ///
-/// * Selected (current chip)        — forestdarkn bg / cream text
-/// * Filled (has any assigned meal) — cream bg / forestdarkn text + check
-/// * Not-selected                   — white bg / forestdarkn text
+/// * Selected (current chip)        — forest fill / cream text
+/// * Full (slots for the day met)   — cream fill / forest text + ✓, lime outline
+/// * Not-selected                   — white fill / forest text
 class DayChipRow extends StatelessWidget {
   const DayChipRow({
     required this.startDate,
     required this.endDate,
     required this.selectedDay,
     required this.onSelect,
-    this.filledDays = const <DateTime>{},
+    this.fullDays = const <DateTime>{},
     super.key,
   });
 
@@ -26,9 +26,9 @@ class DayChipRow extends StatelessWidget {
   final DateTime selectedDay;
   final ValueChanged<DateTime> onSelect;
 
-  /// Set of days (date-only) that have at least one assigned meal — used
-  /// to render the "Filled" chip variant.
-  final Set<DateTime> filledDays;
+  /// Set of days (date-only) whose per-day slot target is met — used to
+  /// render the "full" chip variant (✓ + lime outline).
+  final Set<DateTime> fullDays;
 
   static const _weekdayAbbrev = <int, String>{
     DateTime.monday: 'Mon',
@@ -78,11 +78,11 @@ class DayChipRow extends StatelessWidget {
         itemBuilder: (context, index) {
           final day = days[index];
           final isSelected = _isSameDay(day, selectedDay);
-          final isFilled = filledDays.any((d) => _isSameDay(d, day));
+          final isFull = fullDays.any((d) => _isSameDay(d, day));
           return _DayChip(
             day: day,
             isSelected: isSelected,
-            isFilled: isFilled,
+            isFull: isFull,
             onTap: () => onSelect(day),
           );
         },
@@ -95,13 +95,13 @@ class _DayChip extends StatelessWidget {
   const _DayChip({
     required this.day,
     required this.isSelected,
-    required this.isFilled,
+    required this.isFull,
     required this.onTap,
   });
 
   final DateTime day;
   final bool isSelected;
-  final bool isFilled;
+  final bool isFull;
   final VoidCallback onTap;
 
   @override
@@ -116,10 +116,10 @@ class _DayChip extends StatelessWidget {
       bg = AppColors.greenDeep;
       fg = AppColors.onGreen;
       borderColor = AppColors.greenDeep;
-    } else if (isFilled) {
+    } else if (isFull) {
       bg = AppColors.butterSoft;
       fg = AppColors.greenDeep;
-      borderColor = AppColors.greenDeep;
+      borderColor = AppColors.butterDark;
     } else {
       bg = AppColors.surface;
       fg = AppColors.fgDefault;
@@ -149,7 +149,7 @@ class _DayChip extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.min,
             children: [
-              if (isFilled && !isSelected)
+              if (isFull && !isSelected)
                 Icon(Icons.check, color: fg, size: AppSizes.iconSm),
               Text(
                 abbrev,

--- a/lib/src/features/meal_plan/map/widgets/picked_recipe_row.dart
+++ b/lib/src/features/meal_plan/map/widgets/picked_recipe_row.dart
@@ -6,89 +6,115 @@ import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/chips/app_chip.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 
-/// A single picked-recipe row for the Map Meals Plan screen (NIB-95).
+/// A single reusable picked-recipe row for the Map Meals Plan screen (NIB-95).
 ///
-/// Renders thumbnail + title + allergen tag chips. Tap-to-assign drives
-/// the controller's `assignToSelectedDay`. If [assignedLabel] is non-null
-/// the row shows a trailing day badge (e.g. "Tue 3") so the user can see
-/// at a glance which day a picked recipe already lives on.
+/// Wrapped in a [Draggable] whose payload is the [Recipe] itself — dropping it
+/// on the day drop-zone COPIES it onto the selected day. Tapping does the same.
+/// The palette never shrinks: dragging/tapping does not remove the row, so a
+/// recipe can be mapped onto many days.
 class PickedRecipeRow extends StatelessWidget {
-  const PickedRecipeRow({
-    required this.recipe,
-    required this.onTap,
-    this.assignedLabel,
-    super.key,
-  });
+  const PickedRecipeRow({required this.recipe, required this.onTap, super.key});
 
   final Recipe recipe;
   final VoidCallback onTap;
-  final String? assignedLabel;
 
   @override
   Widget build(BuildContext context) {
-    final label = assignedLabel == null
-        ? recipe.title
-        : '${recipe.title}, assigned to $assignedLabel';
+    final card = _RowCard(recipe: recipe);
     return Semantics(
       button: true,
-      label: label,
+      label: '${recipe.title}. Drag or tap to add to the selected day',
       excludeSemantics: true,
       onTap: onTap,
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-        child: Container(
-          padding: const EdgeInsets.all(AppSizes.sp12),
-          decoration: BoxDecoration(
-            color: AppColors.surface,
-            borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-            border: Border.all(color: AppColors.borderSoft),
-          ),
-          child: Row(
-            children: [
-              _Thumbnail(url: recipe.thumbnailUrl),
-              const SizedBox(width: AppSizes.sp12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      recipe.title,
-                      style: AppTypography.bodyBold,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    if (recipe.allergenTags.isNotEmpty) ...[
-                      const SizedBox(height: AppSizes.xs),
-                      _TagsRow(tags: recipe.allergenTags),
-                    ],
-                  ],
-                ),
-              ),
-              if (assignedLabel != null) ...[
-                const SizedBox(width: AppSizes.sm),
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSizes.sm,
-                    vertical: AppSizes.xs,
-                  ),
-                  decoration: BoxDecoration(
-                    color: AppColors.greenTint,
-                    borderRadius: BorderRadius.circular(AppSizes.radiusFull),
-                  ),
-                  child: Text(
-                    assignedLabel!,
-                    style: AppTypography.caption.copyWith(
-                      color: AppColors.greenDeep,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
-              ],
-            ],
-          ),
+      child: Draggable<Recipe>(
+        data: recipe,
+        dragAnchorStrategy: pointerDragAnchorStrategy,
+        feedback: _DragFeedback(recipe: recipe),
+        childWhenDragging: Opacity(opacity: 0.4, child: card),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+          child: card,
         ),
+      ),
+    );
+  }
+}
+
+/// The lifted card shown under the finger while dragging.
+class _DragFeedback extends StatelessWidget {
+  const _DragFeedback({required this.recipe});
+
+  final Recipe recipe;
+
+  @override
+  Widget build(BuildContext context) {
+    return Transform.translate(
+      offset: const Offset(-120, -32),
+      child: Material(
+        color: Colors.transparent,
+        child: SizedBox(
+          width: 240,
+          child: _RowCard(recipe: recipe, elevated: true),
+        ),
+      ),
+    );
+  }
+}
+
+class _RowCard extends StatelessWidget {
+  const _RowCard({required this.recipe, this.elevated = false});
+
+  final Recipe recipe;
+  final bool elevated;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppSizes.sp12),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        border: Border.all(color: AppColors.borderSoft),
+        boxShadow: elevated
+            ? const [
+                BoxShadow(
+                  color: Color(0x33000000),
+                  blurRadius: 16,
+                  offset: Offset(0, 8),
+                ),
+              ]
+            : null,
+      ),
+      child: Row(
+        children: [
+          _Thumbnail(url: recipe.thumbnailUrl),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  recipe.title,
+                  style: AppTypography.bodyBold,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (recipe.allergenTags.isNotEmpty) ...[
+                  const SizedBox(height: AppSizes.xs),
+                  _TagsRow(tags: recipe.allergenTags),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: AppSizes.sm),
+          const Icon(
+            Icons.drag_indicator,
+            color: AppColors.fgFaint,
+            size: AppSizes.iconMd,
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart
+++ b/lib/src/features/meal_plan/map/widgets/selected_day_slot_list.dart
@@ -11,43 +11,59 @@ import 'package:nibbles/src/common/domain/entities/recipe.dart';
 /// populated container).
 const _kHelperText = 'Drag & drop or click meals below to add them';
 
-/// "Meals for {Day}" panel for the Map Meals Plan screen (NIB-95).
+/// The `DragTarget` drop-zone body for the Map Meals Plan screen (NIB-95).
 ///
-/// * Empty: dashed-border placeholder card containing
-///   "No Meals Mapped Yet" + a Drag-&-drop helper line (frame 971:8375).
-/// * Populated: cream-tinted dashed container holding one row per
-///   assigned recipe (thumbnail + title + allergen tags + delete_outline
-///   to unassign) — see frames 971:8476 / 971:8511.
+/// * Empty: dashed placeholder card containing "No Meals Mapped Yet" + a
+///   drag-&-drop helper line (frame 971:8375).
+/// * Populated: cream-tinted dashed container holding one card per assigned
+///   recipe instance (thumbnail + title + allergen tags + x to unassign) —
+///   frames 971:8476 / 971:8511. Removal is positional (duplicates allowed).
+/// * While a drag hovers ([isHovering]) the dashed border turns green
+///   (frame 971:8511).
 class SelectedDaySlotList extends StatelessWidget {
   const SelectedDaySlotList({
     required this.recipes,
-    required this.onRemove,
+    required this.onRemoveAt,
+    this.isHovering = false,
     super.key,
   });
 
+  /// Ordered recipes for the selected day (duplicates preserved). Index is the
+  /// removal key passed back through [onRemoveAt].
   final List<Recipe> recipes;
-  final ValueChanged<String> onRemove;
+  final ValueChanged<int> onRemoveAt;
+  final bool isHovering;
 
   @override
   Widget build(BuildContext context) {
+    final borderColor = isHovering ? AppColors.green : AppColors.borderMuted;
     if (recipes.isEmpty) {
-      return const _EmptyDayPlaceholder();
+      return _EmptyDayPlaceholder(borderColor: borderColor);
     }
-    return _PopulatedDayContainer(recipes: recipes, onRemove: onRemove);
+    return _PopulatedDayContainer(
+      recipes: recipes,
+      onRemoveAt: onRemoveAt,
+      borderColor: borderColor,
+    );
   }
 }
 
-/// Cream-tinted dashed container holding the assigned recipe rows.
+/// Cream-tinted dashed container holding the assigned recipe cards.
 class _PopulatedDayContainer extends StatelessWidget {
-  const _PopulatedDayContainer({required this.recipes, required this.onRemove});
+  const _PopulatedDayContainer({
+    required this.recipes,
+    required this.onRemoveAt,
+    required this.borderColor,
+  });
 
   final List<Recipe> recipes;
-  final ValueChanged<String> onRemove;
+  final ValueChanged<int> onRemoveAt;
+  final Color borderColor;
 
   @override
   Widget build(BuildContext context) {
     return CustomPaint(
-      painter: const _DashedBorderPainter(),
+      painter: _DashedBorderPainter(color: borderColor),
       child: Container(
         width: double.infinity,
         decoration: BoxDecoration(
@@ -61,7 +77,7 @@ class _PopulatedDayContainer extends StatelessWidget {
               if (i != 0) const SizedBox(height: AppSizes.sm),
               _AssignedRecipeCard(
                 recipe: recipes[i],
-                onRemove: () => onRemove(recipes[i].id),
+                onRemove: () => onRemoveAt(i),
               ),
             ],
           ],
@@ -74,8 +90,8 @@ class _PopulatedDayContainer extends StatelessWidget {
 /// Recipe card displayed inside a filled day slot.
 ///
 /// Mirrors the Figma frame 971:8476 layout — thumbnail, two-line title,
-/// allergen tag chips, and a trailing `delete_outline` icon that
-/// unassigns the recipe.
+/// allergen tag chips, and a trailing `close` icon that unassigns this
+/// instance.
 class _AssignedRecipeCard extends StatelessWidget {
   const _AssignedRecipeCard({required this.recipe, required this.onRemove});
 
@@ -115,9 +131,9 @@ class _AssignedRecipeCard extends StatelessWidget {
           const SizedBox(width: AppSizes.sm),
           IconButton(
             onPressed: onRemove,
-            tooltip: 'Remove from day',
+            tooltip: 'Remove ${recipe.title} from day',
             icon: const Icon(
-              Icons.delete_outline,
+              Icons.close,
               color: AppColors.fgMuted,
               size: AppSizes.iconMd,
             ),
@@ -187,12 +203,14 @@ class _TagsRow extends StatelessWidget {
 }
 
 class _EmptyDayPlaceholder extends StatelessWidget {
-  const _EmptyDayPlaceholder();
+  const _EmptyDayPlaceholder({required this.borderColor});
+
+  final Color borderColor;
 
   @override
   Widget build(BuildContext context) {
     return CustomPaint(
-      painter: const _DashedBorderPainter(),
+      painter: _DashedBorderPainter(color: borderColor),
       child: Container(
         width: double.infinity,
         padding: const EdgeInsets.symmetric(
@@ -219,12 +237,14 @@ class _EmptyDayPlaceholder extends StatelessWidget {
 }
 
 class _DashedBorderPainter extends CustomPainter {
-  const _DashedBorderPainter();
+  const _DashedBorderPainter({required this.color});
+
+  final Color color;
 
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
-      ..color = AppColors.borderMuted
+      ..color = color
       ..style = PaintingStyle.stroke
       ..strokeWidth = AppSizes.dividerThickness;
 
@@ -253,5 +273,6 @@ class _DashedBorderPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant _DashedBorderPainter oldDelegate) => false;
+  bool shouldRepaint(covariant _DashedBorderPainter oldDelegate) =>
+      oldDelegate.color != color;
 }

--- a/lib/src/features/meal_plan/meal_plan_controller.dart
+++ b/lib/src/features/meal_plan/meal_plan_controller.dart
@@ -3,7 +3,7 @@ import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
-import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
 import 'package:nibbles/src/common/services/allergen_service.dart';
@@ -34,56 +34,69 @@ class MealPlanController extends _$MealPlanController {
   Future<MealPlanState> build(String babyId) async {
     _babyId = babyId;
 
-    // NIB-159: anchor the 7-day window on today (date-only), NOT on the
-    // most-recent Monday. Monday-snapping (NIB-143) made a plan created for
-    // e.g. Thu 11–Wed 17 render the Mon 8–Sun 14 calendar week instead, so
-    // selected days fell outside the window and unselected days appeared.
-    final windowStart = _dateOnly(nowBuilder());
-    final windowEnd = windowStart.add(const Duration(days: 6));
-
     final mealPlanService = ref.read(mealPlanServiceProvider);
     final recipeService = ref.read(recipeServiceProvider);
     final babyService = ref.read(babyProfileServiceProvider);
     final allergenService = ref.read(allergenServiceProvider);
 
-    // Parallel fetch: baby + rolling-7 entries + flagged keys + program state.
+    // Parallel fetch: baby + active plan + flagged keys + program state.
     final results = await Future.wait<Object?>([
       babyService.getBaby(),
-      mealPlanService.getRolling7(babyId, today: windowStart),
+      mealPlanService.getActivePlan(babyId),
       recipeService.getFlaggedAllergenKeys(babyId),
       allergenService.getProgramState(babyId),
     ]);
 
     final baby = results[0] as Baby?;
 
-    final entriesResult = results[1]! as Result<List<MealPlanEntry>>;
-    if (entriesResult.isFailure) {
-      throw StateError(entriesResult.errorOrNull!.message);
+    final planResult = results[1]! as Result<MealPlan?>;
+    if (planResult.isFailure) {
+      throw StateError(planResult.errorOrNull!.message);
     }
-    final entries = entriesResult.dataOrNull!;
+    final plan = planResult.dataOrNull;
 
     final flaggedResult = results[2]! as Result<Set<String>>;
     final flaggedKeys = flaggedResult.dataOrNull ?? <String>{};
 
     final programResult = results[3]! as Result<AllergenProgramState>;
-    AllergenProgramState? programState;
-    AllergenBoardItem? currentBoardItem;
-    if (programResult.isSuccess) {
-      final ps = programResult.dataOrNull;
-      programState = ps;
-      if (ps != null && ps.status != AllergenProgramStatus.completed) {
-        final boardResult = await allergenService.getAllergenBoardSummary(
-          babyId,
-        );
-        if (boardResult.isSuccess) {
-          currentBoardItem = boardResult.dataOrNull!
-              .where(
-                (AllergenBoardItem item) =>
-                    item.allergen.key == ps.currentAllergenKey,
-              )
-              .firstOrNull;
-        }
-      }
+    final (programState, currentBoardItem) = await _resolveProgram(
+      babyId,
+      programResult,
+      allergenService,
+    );
+
+    // No active plan → empty state. windowStart/windowEnd are placeholders
+    // (today) and unused by the empty-state render path.
+    if (plan == null) {
+      final today = _dateOnly(nowBuilder());
+      return MealPlanState(
+        windowStart: today,
+        windowEnd: today,
+        entries: const [],
+        baby: baby,
+        flaggedAllergenKeys: flaggedKeys,
+        currentAllergenBoardItem: currentBoardItem,
+        programState: programState,
+      );
+    }
+
+    final windowStart = _dateOnly(plan.startDate);
+    final planEnd = _dateOnly(plan.endDate);
+
+    // Fetch by plan id (not date range) so meals added on a "+ Add Date" day
+    // beyond the plan's end still load.
+    final entriesResult = await mealPlanService.getEntriesForPlan(plan.id);
+    if (entriesResult.isFailure) {
+      throw StateError(entriesResult.errorOrNull!.message);
+    }
+    final entries = entriesResult.dataOrNull!;
+
+    // Window end is the plan's end, extended to cover any entry that lands
+    // past it (defensive: entries are normally inside the plan range).
+    var windowEnd = planEnd;
+    for (final entry in entries) {
+      final p = _dateOnly(entry.planDate);
+      if (p.isAfter(windowEnd)) windowEnd = p;
     }
 
     // Hydrate recipe lookup for every entry (best-effort, deduplicated).
@@ -98,12 +111,31 @@ class MealPlanController extends _$MealPlanController {
       windowStart: windowStart,
       windowEnd: windowEnd,
       entries: entries,
+      plan: plan,
       baby: baby,
       recipes: recipeMap,
       flaggedAllergenKeys: flaggedKeys,
       currentAllergenBoardItem: currentBoardItem,
       programState: programState,
     );
+  }
+
+  Future<(AllergenProgramState?, AllergenBoardItem?)> _resolveProgram(
+    String babyId,
+    Result<AllergenProgramState> programResult,
+    AllergenService allergenService,
+  ) async {
+    if (!programResult.isSuccess) return (null, null);
+    final ps = programResult.dataOrNull;
+    if (ps == null || ps.status == AllergenProgramStatus.completed) {
+      return (ps, null);
+    }
+    final boardResult = await allergenService.getAllergenBoardSummary(babyId);
+    if (!boardResult.isSuccess) return (ps, null);
+    final item = boardResult.dataOrNull!
+        .where((AllergenBoardItem i) => i.allergen.key == ps.currentAllergenKey)
+        .firstOrNull;
+    return (ps, item);
   }
 
   /// Flip the accordion expand state for [day]. Key is normalized to UTC
@@ -117,7 +149,7 @@ class MealPlanController extends _$MealPlanController {
     state = AsyncData(current.copyWith(expanded: next));
   }
 
-  /// NIB-59: APPEND-bulk add for [startDate]..[endDate]. Calls
+  /// APPEND-bulk add for [startDate]..[endDate]. Calls
   /// [MealPlanService.appendMealsToRange] then invalidates self to refetch.
   /// Returns false on failure — caller should surface a P2 toast.
   Future<bool> appendBulkPrep({
@@ -132,14 +164,15 @@ class MealPlanController extends _$MealPlanController {
           startDate: startDate,
           endDate: endDate,
           assignments: assignments,
+          mealPlanId: state.valueOrNull?.plan?.id,
         );
     if (result.isFailure) return false;
     ref.invalidateSelf();
     return true;
   }
 
-  /// NIB-59: explicit clear for an arbitrary date range. Returns false on
-  /// failure — caller should surface a P2 toast.
+  /// Explicit clear for an arbitrary date range. Returns false on failure —
+  /// caller should surface a P2 toast.
   Future<bool> clearRange(DateTime startDate, DateTime endDate) async {
     final result = await ref
         .read(mealPlanServiceProvider)
@@ -172,6 +205,17 @@ class MealPlanController extends _$MealPlanController {
     final result = await ref
         .read(mealPlanServiceProvider)
         .clearDay(_babyId, date);
+    if (result.isFailure) return false;
+    ref.invalidateSelf();
+    return true;
+  }
+
+  /// Deletes the active plan (cascades its entries), returning the planner to
+  /// the empty state. Returns false on failure — caller shows a P2 toast.
+  Future<bool> deleteActivePlan() async {
+    final plan = state.valueOrNull?.plan;
+    if (plan == null) return false;
+    final result = await ref.read(mealPlanServiceProvider).deletePlan(plan.id);
     if (result.isFailure) return false;
     ref.invalidateSelf();
     return true;

--- a/lib/src/features/meal_plan/meal_plan_controller.g.dart
+++ b/lib/src/features/meal_plan/meal_plan_controller.g.dart
@@ -7,7 +7,7 @@ part of 'meal_plan_controller.dart';
 // **************************************************************************
 
 String _$mealPlanControllerHash() =>
-    r'7c8d5cb090b009dc5b903f8e877fae27d54f4e55';
+    r'8c55aa4e0a15bcff79bb44ba296d70aa064abbdf';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/src/features/meal_plan/meal_plan_screen.dart
+++ b/lib/src/features/meal_plan/meal_plan_screen.dart
@@ -12,6 +12,8 @@ import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/common/services/meal_plan_service.dart';
+import 'package:nibbles/src/features/meal_plan/ai/ai_loading_screen.dart';
+import 'package:nibbles/src/features/meal_plan/ai/meal_preferences_sheet.dart';
 import 'package:nibbles/src/features/meal_plan/map/map_meals_state.dart';
 import 'package:nibbles/src/features/meal_plan/meal_plan_controller.dart';
 import 'package:nibbles/src/features/meal_plan/meal_plan_state.dart';
@@ -35,16 +37,13 @@ String _isoDate(DateTime dt) {
   return '${dt.year}-$m-$d';
 }
 
-/// Screen-level overflow menu actions (Figma 971:7999).
-enum _ScreenMenuAction { addToShopList, createMealPrep, clearCurrentWeek }
+/// Screen-level overflow menu actions (Figma 971:7826).
+enum _ScreenMenuAction { addToShopList, createMealPrep, clearCurrentPlan }
 
-/// Rewritten Meal Plan screen (NIB-69).
-///
-/// Renders a butter-gradient [MealPlanHeader] + a vertical list of
-/// [DayAccordionCard]s + an '+ Add Date' footer (or a [MealPlanEmptyState]
-/// when there are no entries). Consumes NIB-87's [showBrowseMealSheet],
-/// NIB-95's `AppRoute.mealPlanMap` + [MapMealsArgs], and NIB-103's
-/// [showClearMealPlanConfirm].
+/// Meal Plan screen. Renders a butter-gradient [MealPlanHeader] + a vertical
+/// list of [DayAccordionCard]s + a "+ Add Date" footer when a plan is active,
+/// or a [MealPlanEmptyState] when there is no active plan. Drives the manual
+/// (browse → map) and AI (preferences → loading → generate) meal-prep flows.
 class MealPlanScreen extends ConsumerWidget {
   const MealPlanScreen({super.key});
 
@@ -124,12 +123,12 @@ class _MealPlanBody extends ConsumerStatefulWidget {
 
 class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
   /// Local override that extends the visible window beyond the controller's
-  /// `windowEnd`. '+ Add Date' increments this by 1 day. Cleared when the
-  /// controller state changes window (e.g. invalidate on the day rollover).
+  /// `windowEnd`. "+ Add Date" increments this by 1 day. Cleared when the plan
+  /// changes (a fresh create/delete resets the body).
   DateTime? _extraEnd;
 
   /// Guard so `meal_plan_viewed` only fires once per mount, after the
-  /// controller resolves with success.
+  /// controller resolves with an active plan.
   bool _viewedFired = false;
 
   @override
@@ -155,21 +154,15 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
     if (baby == null) {
       return const Center(child: Text('No baby profile found.'));
     }
-    _fireViewedOnce(state);
-    if (state.entries.isEmpty) {
+    if (state.plan == null) {
       return MealPlanEmptyState(
         babyName: baby.name,
         ageMonths: ageInMonths(baby.dateOfBirth),
-        onCreateMealPlan: _onCreateMealPlanFromEmpty,
-        overflowButton: _NoFlashMenuTheme(
-          child: Builder(
-            builder: (btnContext) => MealPlanOverflowButton(
-              onTap: () => _openEmptyStateMenu(btnContext),
-            ),
-          ),
-        ),
+        onSetMealPrep: (range) => _startAiFlow(range, baby),
+        onFillInMyself: _startManualFlow,
       );
     }
+    _fireViewedOnce(state);
     return _PopulatedView(
       babyId: widget.babyId,
       state: state,
@@ -204,8 +197,6 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
     final notifier = ref.read(
       mealPlanControllerProvider(widget.babyId).notifier,
     );
-    // Read current expanded state BEFORE toggling so we can fire the correct
-    // expanded/collapsed event for the resulting state.
     final current = ref
         .read(mealPlanControllerProvider(widget.babyId))
         .valueOrNull;
@@ -239,7 +230,11 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
     unawaited(ref.read(analyticsProvider).logMealPlanAddDateTapped());
   }
 
-  Future<void> _onCreateMealPlanFromEmpty(DateTimeRange range) async {
+  // --- Meal-prep entry flows ------------------------------------------------
+
+  /// Manual path: browse recipes for the range, then map them onto days. The
+  /// Map screen self-persists the plan (createPlan + append) on Finish.
+  Future<void> _startManualFlow(DateTimeRange range) async {
     final days = range.end.difference(range.start).inDays + 1;
     unawaited(ref.read(analyticsProvider).logMealPrepRangeSelected(days: days));
     final picked = await showBrowseMealSheet(
@@ -251,6 +246,83 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
     if (picked == null || picked.isEmpty) return;
     if (!mounted) return;
     await _pushMapMeals(picked, range.start, range.end);
+  }
+
+  /// AI path: collect preferences + notes, run generation behind a full-screen
+  /// non-dismissable loading route, then land on the populated planner.
+  Future<void> _startAiFlow(DateTimeRange range, Baby baby) async {
+    final analytics = ref.read(analyticsProvider);
+    unawaited(analytics.logMealPrepAiStarted());
+
+    final input = await showAiPreferencesFlow(context, babyName: baby.name);
+    if (input == null || !mounted) return;
+    unawaited(
+      analytics.logMealPrepAiPreferencesSelected(
+        count: input.preferences.length,
+      ),
+    );
+
+    final result = await context.pushNamed<AiLoadingResult>(
+      AppRoute.mealPlanAiLoading.name,
+      extra: AiLoadingArgs(
+        babyId: widget.babyId,
+        babyName: baby.name,
+        startDate: range.start,
+        endDate: range.end,
+        preferences: input.preferences,
+        notes: input.notes,
+      ),
+    );
+    if (!mounted || result == null) return;
+
+    if (!result.success) {
+      unawaited(analytics.logMealPrepAiFailed());
+      await _showGenerateErrorDialog(result.errorMessage);
+      return;
+    }
+
+    ref.invalidate(mealPlanControllerProvider(widget.babyId));
+    final refreshed = await ref.read(
+      mealPlanControllerProvider(widget.babyId).future,
+    );
+    final days = range.end.difference(range.start).inDays + 1;
+    unawaited(analytics.logMealPlanCreated(days: days));
+    unawaited(
+      analytics.logMealPrepAiGenerated(
+        recipeCount: refreshed.entries.length,
+        dayCount: days,
+      ),
+    );
+  }
+
+  Future<void> _showGenerateErrorDialog(String? message) async {
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        ),
+        title: const Text(
+          "Couldn't build your plan",
+          style: AppTypography.sectionTitle,
+        ),
+        content: Text(
+          message ?? 'Please try again.',
+          style: AppTypography.textTheme.bodyMedium,
+        ),
+        actions: [
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.greenDeep,
+              foregroundColor: AppColors.onGreen,
+            ),
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text('OK', style: AppTypography.button),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _onDayAdd(DateTime day) async {
@@ -309,8 +381,8 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
       case _ScreenMenuAction.createMealPrep:
         unawaited(analytics.logMealPrepCreateStarted());
         await _onCreateMealPrep(state);
-      case _ScreenMenuAction.clearCurrentWeek:
-        await _onClearWindow(state);
+      case _ScreenMenuAction.clearCurrentPlan:
+        await _onDeletePlan();
     }
   }
 
@@ -318,54 +390,60 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
     DateTime day,
     DayCardMenuAction action,
   ) async {
-    final state = ref
-        .read(mealPlanControllerProvider(widget.babyId))
-        .valueOrNull;
-    if (state == null) return;
     switch (action) {
       case DayCardMenuAction.addToShopList:
-        // Per NIB-109 spec, `meal_plan_add_to_shop_list` only fires from the
-        // SCREEN-LEVEL overflow menu (see [_onScreenMenuSelected]). The
-        // day-card menu intentionally does not fire it.
         await _openAddToShoppingList(day);
-      case DayCardMenuAction.clearCurrentWeek:
-        await _onClearWindow(state);
+      case DayCardMenuAction.clearCurrentDate:
+        await _onClearDay(day);
     }
   }
 
   Future<void> _onCreateMealPrep(MealPlanState state) async {
-    // First let the user pick the date range via the Select Period Date
-    // bottom-sheet (Figma 971:8000). Pre-fill with the current window so the
-    // sheet opens on the same range the planner is showing.
-    final range = await showSelectPeriodDateSheet(
+    final baby = state.baby;
+    if (baby == null) return;
+    // Pick range + mode via the Select Period Date sheet (Figma 971:8053).
+    final result = await showSelectPeriodDateSheet(
       context,
       initialStart: state.windowStart,
       initialEnd: _effectiveWindowEnd(state),
     );
-    if (range == null) return;
-    if (!mounted) return;
+    if (result == null || !mounted) return;
 
-    final days = range.end.difference(range.start).inDays + 1;
-    unawaited(ref.read(analyticsProvider).logMealPrepRangeSelected(days: days));
-    final picked = await showBrowseMealSheet(
-      context,
-      babyId: widget.babyId,
-      startDate: range.start,
-      endDate: range.end,
-    );
-    if (picked == null || picked.isEmpty) return;
-    if (!mounted) return;
-    await _pushMapMeals(picked, range.start, range.end);
+    switch (result.mode) {
+      case MealPrepMode.ai:
+        await _startAiFlow(result.range, baby);
+      case MealPrepMode.manual:
+        await _startManualFlow(result.range);
+    }
   }
 
-  Future<void> _onClearWindow(MealPlanState state) async {
+  Future<void> _onDeletePlan() async {
     final confirmed = await showClearMealPlanConfirm(context);
-    if (confirmed != true) return;
-    if (!mounted) return;
-    final endDate = _effectiveWindowEnd(state);
+    if (confirmed != true || !mounted) return;
     final ok = await ref
         .read(mealPlanControllerProvider(widget.babyId).notifier)
-        .clearRange(state.windowStart, endDate);
+        .deleteActivePlan();
+    if (!ok) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text("Couldn't delete plan. Try again.")),
+        );
+      }
+      return;
+    }
+    setState(() => _extraEnd = null);
+    unawaited(ref.read(analyticsProvider).logMealPlanDeleted());
+  }
+
+  Future<void> _onClearDay(DateTime day) async {
+    final confirmed = await showClearMealPlanConfirm(
+      context,
+      title: 'Clear all meals for this day?',
+    );
+    if (confirmed != true || !mounted) return;
+    final ok = await ref
+        .read(mealPlanControllerProvider(widget.babyId).notifier)
+        .clearDay(day);
     if (!ok) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -374,11 +452,8 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
       }
       return;
     }
-    final dayCount = endDate.difference(state.windowStart).inDays + 1;
     unawaited(
-      ref
-          .read(analyticsProvider)
-          .logMealPlanClearWeekConfirmed(dayCount: dayCount),
+      ref.read(analyticsProvider).logMealPlanClearWeekConfirmed(dayCount: 1),
     );
   }
 
@@ -396,7 +471,6 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
     );
   }
 
-  /// NIB-136: range-scoped sheet from the screen-level overflow menu.
   Future<void> _openRangeAddToShoplist(DateTime start, DateTime end) async {
     await showRangeAddToShoplistSheet(
       context,
@@ -421,6 +495,8 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
     );
     if ((result ?? false) && mounted) {
       ref.invalidate(mealPlanControllerProvider(widget.babyId));
+      final days = endDate.difference(startDate).inDays + 1;
+      unawaited(ref.read(analyticsProvider).logMealPlanCreated(days: days));
     }
   }
 
@@ -429,57 +505,6 @@ class _MealPlanBodyState extends ConsumerState<_MealPlanBody> {
       AppRoute.recipeDetail.name,
       pathParameters: {'recipeId': recipeId},
     );
-  }
-
-  /// Opens the screen-level overflow menu while the empty state is showing.
-  /// Empty state has no entries, so 'Add to shop list' and 'Clear current
-  /// week' are not actionable — only the 'Create new meal prep' route is
-  /// surfaced, which funnels through the same Select Period Date sheet.
-  Future<void> _openEmptyStateMenu(BuildContext btnContext) async {
-    final state = ref
-        .read(mealPlanControllerProvider(widget.babyId))
-        .valueOrNull;
-    if (state == null) return;
-
-    final renderBox = btnContext.findRenderObject() as RenderBox?;
-    final overlay =
-        Overlay.of(btnContext).context.findRenderObject() as RenderBox?;
-    if (renderBox == null || overlay == null) return;
-
-    final topRight = renderBox.localToGlobal(
-      Offset(renderBox.size.width, 0),
-      ancestor: overlay,
-    );
-    final position = RelativeRect.fromLTRB(
-      topRight.dx - AppSizes.pagePaddingH * 2,
-      topRight.dy + AppSizes.xxl,
-      AppSizes.pagePaddingH,
-      0,
-    );
-
-    final action = await showMenu<_ScreenMenuAction>(
-      context: btnContext,
-      position: position,
-      color: AppColors.surface,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
-      ),
-      items: const [
-        PopupMenuItem<_ScreenMenuAction>(
-          value: _ScreenMenuAction.createMealPrep,
-          padding: EdgeInsets.zero,
-          child: _ScreenMenuRow(
-            icon: Icons.add,
-            label: 'Create new meal prep',
-            highlight: true,
-          ),
-        ),
-      ],
-    );
-    if (action == _ScreenMenuAction.createMealPrep) {
-      unawaited(ref.read(analyticsProvider).logMealPrepCreateStarted());
-      await _onCreateMealPrep(state);
-    }
   }
 }
 
@@ -514,9 +539,8 @@ class _PopulatedView extends StatelessWidget {
 
   static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
 
-  /// Match the controller's UTC date-only normalization (see
-  /// `MealPlanController._expandedKey`) so accordion expand state survives
-  /// across rebuilds.
+  /// Match the controller's UTC date-only normalization so accordion expand
+  /// state survives across rebuilds.
   static DateTime _expandedKey(DateTime day) =>
       DateTime.utc(day.year, day.month, day.day);
 
@@ -622,10 +646,10 @@ class _PopulatedView extends StatelessWidget {
           child: _ScreenMenuRow(icon: Icons.add, label: 'Create new meal prep'),
         ),
         PopupMenuItem<_ScreenMenuAction>(
-          value: _ScreenMenuAction.clearCurrentWeek,
+          value: _ScreenMenuAction.clearCurrentPlan,
           child: _ScreenMenuRow(
             icon: Icons.delete_outline,
-            label: 'Clear current week',
+            label: 'Clear current plan',
           ),
         ),
       ],
@@ -635,9 +659,8 @@ class _PopulatedView extends StatelessWidget {
 }
 
 /// Strips the grey/tinted [InkWell] splash + highlight from the overflow
-/// menu rows. `showMenu` captures the ambient [Theme] from the trigger
-/// context, so wrapping the overflow button here makes the popup rows
-/// stay white on press — only a resting `highlight` row paints lime.
+/// menu rows so the popup rows stay white on press — only a resting
+/// `highlight` row paints lime.
 class _NoFlashMenuTheme extends StatelessWidget {
   const _NoFlashMenuTheme({required this.child});
 
@@ -656,9 +679,9 @@ class _NoFlashMenuTheme extends StatelessWidget {
   }
 }
 
-/// Row used inside the screen-level overflow popup. When [highlight] is
-/// true the entire row paints in lime (butter) with forest-deep text +
-/// icon — matches the default-active row in Figma 971:7826.
+/// Row used inside the screen-level overflow popup. When [highlight] is true
+/// the entire row paints in lime (butter) with forest-deep text + icon —
+/// matches the default-active row in Figma 971:7826.
 class _ScreenMenuRow extends StatelessWidget {
   const _ScreenMenuRow({
     required this.icon,

--- a/lib/src/features/meal_plan/meal_plan_state.dart
+++ b/lib/src/features/meal_plan/meal_plan_state.dart
@@ -2,15 +2,17 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 
 part 'meal_plan_state.freezed.dart';
 
-/// Rolling-7 meal plan state (NIB-120):
-/// - [windowStart] is today (date-only).
-/// - [windowEnd] is today + 6 days.
-/// - [entries] is every meal_plan_entry in that inclusive window.
+/// Persisted-plan meal plan state.
+/// - [plan] is the baby's active [MealPlan] or `null` (→ empty state).
+/// - [windowStart] is `plan.startDate` (or today when [plan] is null).
+/// - [windowEnd] is `max(plan.endDate, latest entry planDate)`.
+/// - [entries] is every meal_plan_entry inside `[windowStart, windowEnd]`.
 /// - [expanded] tracks per-day accordion state, keyed by UTC date-only.
 @freezed
 class MealPlanState with _$MealPlanState {
@@ -18,6 +20,7 @@ class MealPlanState with _$MealPlanState {
     required DateTime windowStart,
     required DateTime windowEnd,
     required List<MealPlanEntry> entries,
+    MealPlan? plan,
     Baby? baby,
     @Default(<DateTime, bool>{}) Map<DateTime, bool> expanded,
     @Default(<String, Recipe>{}) Map<String, Recipe> recipes,

--- a/lib/src/features/meal_plan/meal_plan_state.freezed.dart
+++ b/lib/src/features/meal_plan/meal_plan_state.freezed.dart
@@ -20,6 +20,7 @@ mixin _$MealPlanState {
   DateTime get windowStart => throw _privateConstructorUsedError;
   DateTime get windowEnd => throw _privateConstructorUsedError;
   List<MealPlanEntry> get entries => throw _privateConstructorUsedError;
+  MealPlan? get plan => throw _privateConstructorUsedError;
   Baby? get baby => throw _privateConstructorUsedError;
   Map<DateTime, bool> get expanded => throw _privateConstructorUsedError;
   Map<String, Recipe> get recipes => throw _privateConstructorUsedError;
@@ -46,6 +47,7 @@ abstract class $MealPlanStateCopyWith<$Res> {
     DateTime windowStart,
     DateTime windowEnd,
     List<MealPlanEntry> entries,
+    MealPlan? plan,
     Baby? baby,
     Map<DateTime, bool> expanded,
     Map<String, Recipe> recipes,
@@ -54,6 +56,7 @@ abstract class $MealPlanStateCopyWith<$Res> {
     AllergenProgramState? programState,
   });
 
+  $MealPlanCopyWith<$Res>? get plan;
   $BabyCopyWith<$Res>? get baby;
   $AllergenBoardItemCopyWith<$Res>? get currentAllergenBoardItem;
   $AllergenProgramStateCopyWith<$Res>? get programState;
@@ -77,6 +80,7 @@ class _$MealPlanStateCopyWithImpl<$Res, $Val extends MealPlanState>
     Object? windowStart = null,
     Object? windowEnd = null,
     Object? entries = null,
+    Object? plan = freezed,
     Object? baby = freezed,
     Object? expanded = null,
     Object? recipes = null,
@@ -98,6 +102,10 @@ class _$MealPlanStateCopyWithImpl<$Res, $Val extends MealPlanState>
                 ? _value.entries
                 : entries // ignore: cast_nullable_to_non_nullable
                       as List<MealPlanEntry>,
+            plan: freezed == plan
+                ? _value.plan
+                : plan // ignore: cast_nullable_to_non_nullable
+                      as MealPlan?,
             baby: freezed == baby
                 ? _value.baby
                 : baby // ignore: cast_nullable_to_non_nullable
@@ -125,6 +133,20 @@ class _$MealPlanStateCopyWithImpl<$Res, $Val extends MealPlanState>
           )
           as $Val,
     );
+  }
+
+  /// Create a copy of MealPlanState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $MealPlanCopyWith<$Res>? get plan {
+    if (_value.plan == null) {
+      return null;
+    }
+
+    return $MealPlanCopyWith<$Res>(_value.plan!, (value) {
+      return _then(_value.copyWith(plan: value) as $Val);
+    });
   }
 
   /// Create a copy of MealPlanState
@@ -185,6 +207,7 @@ abstract class _$$MealPlanStateImplCopyWith<$Res>
     DateTime windowStart,
     DateTime windowEnd,
     List<MealPlanEntry> entries,
+    MealPlan? plan,
     Baby? baby,
     Map<DateTime, bool> expanded,
     Map<String, Recipe> recipes,
@@ -193,6 +216,8 @@ abstract class _$$MealPlanStateImplCopyWith<$Res>
     AllergenProgramState? programState,
   });
 
+  @override
+  $MealPlanCopyWith<$Res>? get plan;
   @override
   $BabyCopyWith<$Res>? get baby;
   @override
@@ -218,6 +243,7 @@ class __$$MealPlanStateImplCopyWithImpl<$Res>
     Object? windowStart = null,
     Object? windowEnd = null,
     Object? entries = null,
+    Object? plan = freezed,
     Object? baby = freezed,
     Object? expanded = null,
     Object? recipes = null,
@@ -239,6 +265,10 @@ class __$$MealPlanStateImplCopyWithImpl<$Res>
             ? _value._entries
             : entries // ignore: cast_nullable_to_non_nullable
                   as List<MealPlanEntry>,
+        plan: freezed == plan
+            ? _value.plan
+            : plan // ignore: cast_nullable_to_non_nullable
+                  as MealPlan?,
         baby: freezed == baby
             ? _value.baby
             : baby // ignore: cast_nullable_to_non_nullable
@@ -275,6 +305,7 @@ class _$MealPlanStateImpl implements _MealPlanState {
     required this.windowStart,
     required this.windowEnd,
     required final List<MealPlanEntry> entries,
+    this.plan,
     this.baby,
     final Map<DateTime, bool> expanded = const <DateTime, bool>{},
     final Map<String, Recipe> recipes = const <String, Recipe>{},
@@ -298,6 +329,8 @@ class _$MealPlanStateImpl implements _MealPlanState {
     return EqualUnmodifiableListView(_entries);
   }
 
+  @override
+  final MealPlan? plan;
   @override
   final Baby? baby;
   final Map<DateTime, bool> _expanded;
@@ -335,7 +368,7 @@ class _$MealPlanStateImpl implements _MealPlanState {
 
   @override
   String toString() {
-    return 'MealPlanState(windowStart: $windowStart, windowEnd: $windowEnd, entries: $entries, baby: $baby, expanded: $expanded, recipes: $recipes, flaggedAllergenKeys: $flaggedAllergenKeys, currentAllergenBoardItem: $currentAllergenBoardItem, programState: $programState)';
+    return 'MealPlanState(windowStart: $windowStart, windowEnd: $windowEnd, entries: $entries, plan: $plan, baby: $baby, expanded: $expanded, recipes: $recipes, flaggedAllergenKeys: $flaggedAllergenKeys, currentAllergenBoardItem: $currentAllergenBoardItem, programState: $programState)';
   }
 
   @override
@@ -348,6 +381,7 @@ class _$MealPlanStateImpl implements _MealPlanState {
             (identical(other.windowEnd, windowEnd) ||
                 other.windowEnd == windowEnd) &&
             const DeepCollectionEquality().equals(other._entries, _entries) &&
+            (identical(other.plan, plan) || other.plan == plan) &&
             (identical(other.baby, baby) || other.baby == baby) &&
             const DeepCollectionEquality().equals(other._expanded, _expanded) &&
             const DeepCollectionEquality().equals(other._recipes, _recipes) &&
@@ -370,6 +404,7 @@ class _$MealPlanStateImpl implements _MealPlanState {
     windowStart,
     windowEnd,
     const DeepCollectionEquality().hash(_entries),
+    plan,
     baby,
     const DeepCollectionEquality().hash(_expanded),
     const DeepCollectionEquality().hash(_recipes),
@@ -392,6 +427,7 @@ abstract class _MealPlanState implements MealPlanState {
     required final DateTime windowStart,
     required final DateTime windowEnd,
     required final List<MealPlanEntry> entries,
+    final MealPlan? plan,
     final Baby? baby,
     final Map<DateTime, bool> expanded,
     final Map<String, Recipe> recipes,
@@ -406,6 +442,8 @@ abstract class _MealPlanState implements MealPlanState {
   DateTime get windowEnd;
   @override
   List<MealPlanEntry> get entries;
+  @override
+  MealPlan? get plan;
   @override
   Baby? get baby;
   @override

--- a/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
+++ b/lib/src/features/meal_plan/sheets/browse_meal_sheet.dart
@@ -5,7 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nibbles/src/app/constants/allergen_emoji.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
-import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_status.dart';
@@ -13,6 +13,7 @@ import 'package:nibbles/src/common/services/allergen_service.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
 import 'package:nibbles/src/common/services/helpers/derive_allergen_status.dart';
 import 'package:nibbles/src/common/services/recipe_service.dart';
+import 'package:nibbles/src/features/meal_plan/sheets/review_selection_sheet.dart';
 import 'package:nibbles/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart';
 import 'package:nibbles/src/features/meal_plan/sheets/widgets/recommendation_carousel_section.dart';
 import 'package:nibbles/src/logging/analytics.dart';
@@ -205,14 +206,21 @@ class _BrowseMealSheetState extends ConsumerState<_BrowseMealSheet> {
     });
   }
 
-  void _confirm() {
+  /// "Next" → open the review sheet with the current picks. Confirming there
+  /// ("Map Meals") returns the final list up through this sheet; backing out
+  /// of review leaves the browse selection intact.
+  Future<void> _next() async {
     final all = _recipes ?? const <Recipe>[];
     final byId = {for (final r in all) r.id: r};
     final picked = _selectedRecipeIds
         .map((id) => byId[id])
         .whereType<Recipe>()
         .toList();
-    Navigator.of(context).pop(picked);
+    if (picked.isEmpty) return;
+    final confirmed = await showReviewSelectionSheet(context, recipes: picked);
+    if (confirmed != null && mounted) {
+      Navigator.of(context).pop(confirmed);
+    }
   }
 
   List<Recipe> get _searchResults {
@@ -336,10 +344,9 @@ class _BrowseMealSheetState extends ConsumerState<_BrowseMealSheet> {
                 const SizedBox(height: AppSizes.md),
                 Expanded(child: _body()),
                 if (!_loading && _error == null)
-                  _StickyAddBar(
-                    count: _selectedRecipeIds.length,
-                    inReviewMode: _filter != BrowseMealSelectionFilter.none,
-                    onPressed: _selectedRecipeIds.isEmpty ? null : _confirm,
+                  _FooterBar(
+                    onBack: _maybeClose,
+                    onNext: _selectedRecipeIds.isEmpty ? null : _next,
                   ),
               ],
             ),
@@ -618,23 +625,13 @@ class _ErrorPlaceholder extends StatelessWidget {
   }
 }
 
-class _StickyAddBar extends StatelessWidget {
-  const _StickyAddBar({
-    required this.count,
-    required this.inReviewMode,
-    required this.onPressed,
-  });
+/// Sticky Back / Next footer (Figma 971:8264). "Next" advances to the review
+/// sheet; it is disabled until at least one recipe is selected.
+class _FooterBar extends StatelessWidget {
+  const _FooterBar({required this.onBack, required this.onNext});
 
-  final int count;
-  final bool inReviewMode;
-  final VoidCallback? onPressed;
-
-  /// Floating CTA label per ticket NIB-87:
-  ///   * Browse phase  → "Add (N)"
-  ///   * Review phase  → "Mapp Meal Plan" (verbatim Figma copy; PO has the
-  ///     "Map" correction noted as an open question but the bracketed
-  ///     verbatim spelling is required until clarified).
-  String get _label => inReviewMode ? 'Mapp Meal Plan' : 'Add ($count)';
+  final VoidCallback onBack;
+  final VoidCallback? onNext;
 
   @override
   Widget build(BuildContext context) {
@@ -649,23 +646,20 @@ class _StickyAddBar extends StatelessWidget {
         AppSizes.pagePaddingH,
         AppSizes.md,
       ),
-      child: SizedBox(
-        width: double.infinity,
-        height: AppSizes.buttonHeight,
-        child: FilledButton(
-          onPressed: onPressed,
-          style: FilledButton.styleFrom(
-            backgroundColor: AppColors.primary,
-            foregroundColor: AppColors.onPrimary,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      child: Row(
+        children: [
+          Expanded(
+            child: AppPillButton(
+              label: 'Back',
+              variant: AppPillButtonVariant.secondary,
+              onPressed: onBack,
             ),
           ),
-          child: Text(
-            _label,
-            style: AppTypography.button.copyWith(color: AppColors.onPrimary),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: AppPillButton(label: 'Next', onPressed: onNext),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/src/features/meal_plan/sheets/review_selection_sheet.dart
+++ b/lib/src/features/meal_plan/sheets/review_selection_sheet.dart
@@ -1,0 +1,271 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+import 'package:nibbles/src/common/domain/entities/recipe.dart';
+
+/// Review-selection sheet (Figma 971:8354). Lists every recipe the user
+/// picked in the Browse Meal sheet so they can confirm before mapping.
+///
+/// Terminal actions:
+///   * "Back" → pops with `null` (caller returns to the browse sheet).
+///   * "Map Meals" → pops with the confirmed `List<Recipe>` (the caller
+///     navigates to the map route — this sheet never navigates itself).
+Future<List<Recipe>?> showReviewSelectionSheet(
+  BuildContext context, {
+  required List<Recipe> recipes,
+}) {
+  return showModalBottomSheet<List<Recipe>>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppSizes.radiusLg),
+      ),
+    ),
+    builder: (_) => _ReviewSelectionSheet(recipes: recipes),
+  );
+}
+
+class _ReviewSelectionSheet extends StatelessWidget {
+  const _ReviewSelectionSheet({required this.recipes});
+
+  final List<Recipe> recipes;
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final maxHeight = mediaQuery.size.height * 0.92;
+
+    return SafeArea(
+      top: false,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: maxHeight),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: AppSizes.sm),
+            _GrabHandle(),
+            const SizedBox(height: AppSizes.md),
+            _Header(count: recipes.length),
+            const SizedBox(height: AppSizes.sm),
+            Expanded(
+              child: ListView.separated(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.pagePaddingH,
+                  vertical: AppSizes.sm,
+                ),
+                itemCount: recipes.length,
+                separatorBuilder: (_, __) =>
+                    const SizedBox(height: AppSizes.sm),
+                itemBuilder: (context, index) => _ReviewRow(
+                  recipe: recipes[index],
+                ),
+              ),
+            ),
+            _FooterBar(
+              onBack: () => Navigator.of(context).pop(),
+              onMap: () => Navigator.of(context).pop(recipes),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GrabHandle extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 36,
+      height: 4,
+      decoration: BoxDecoration(
+        color: AppColors.divider,
+        borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Review Selection', style: textTheme.titleLarge),
+          const SizedBox(height: 2),
+          Text(
+            '$count selected',
+            style: textTheme.bodyMedium?.copyWith(color: AppColors.fgMuted),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReviewRow extends StatelessWidget {
+  const _ReviewRow({required this.recipe});
+
+  final Recipe recipe;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppSizes.sp12),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        border: Border.all(color: AppColors.borderSoft),
+      ),
+      child: Row(
+        children: [
+          _Thumbnail(url: recipe.thumbnailUrl),
+          const SizedBox(width: AppSizes.sp12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  recipe.title,
+                  style: AppTypography.bodyBold,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: AppSizes.xs),
+                _MetaRow(recipe: recipe),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Iron-Rich / nutrition chips + age range under the recipe title.
+class _MetaRow extends StatelessWidget {
+  const _MetaRow({required this.recipe});
+
+  final Recipe recipe;
+
+  @override
+  Widget build(BuildContext context) {
+    final tags = recipe.nutritionTags.take(2).toList();
+    final extra = recipe.nutritionTags.length - tags.length;
+    return Wrap(
+      spacing: AppSizes.xs,
+      runSpacing: AppSizes.xs,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        for (final tag in tags) AppChip(label: tag),
+        if (extra > 0) AppChip(label: '+$extra', tone: AppChipTone.mute),
+        Text(
+          recipe.ageRange,
+          style: Theme.of(
+            context,
+          ).textTheme.bodySmall?.copyWith(color: AppColors.fgMuted),
+        ),
+      ],
+    );
+  }
+}
+
+class _Thumbnail extends StatelessWidget {
+  const _Thumbnail({required this.url});
+
+  final String? url;
+
+  @override
+  Widget build(BuildContext context) {
+    const size = AppSizes.xxl;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSizes.radiusMd),
+      child: (url == null || url!.isEmpty)
+          ? Container(
+              width: size,
+              height: size,
+              color: AppColors.surfaceVariant,
+              child: const Icon(
+                Icons.restaurant_outlined,
+                color: AppColors.hint,
+                size: AppSizes.iconMd,
+              ),
+            )
+          : CachedNetworkImage(
+              imageUrl: url!,
+              width: size,
+              height: size,
+              fit: BoxFit.cover,
+              placeholder: (_, __) => Container(
+                width: size,
+                height: size,
+                color: AppColors.surfaceVariant,
+              ),
+              errorWidget: (_, __, ___) => Container(
+                width: size,
+                height: size,
+                color: AppColors.surfaceVariant,
+                child: const Icon(
+                  Icons.restaurant_outlined,
+                  color: AppColors.hint,
+                  size: AppSizes.iconMd,
+                ),
+              ),
+            ),
+    );
+  }
+}
+
+class _FooterBar extends StatelessWidget {
+  const _FooterBar({required this.onBack, required this.onMap});
+
+  final VoidCallback onBack;
+  final VoidCallback onMap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: AppColors.surface,
+        border: Border(top: BorderSide(color: AppColors.borderSoft)),
+      ),
+      padding: const EdgeInsets.fromLTRB(
+        AppSizes.pagePaddingH,
+        AppSizes.md,
+        AppSizes.pagePaddingH,
+        AppSizes.md,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: AppPillButton(
+              label: 'Back',
+              variant: AppPillButtonVariant.secondary,
+              onPressed: onBack,
+            ),
+          ),
+          const SizedBox(width: AppSizes.sm),
+          Expanded(
+            child: AppPillButton(label: 'Map Meals', onPressed: onMap),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/meal_plan/sheets/select_period_date_sheet.dart
+++ b/lib/src/features/meal_plan/sheets/select_period_date_sheet.dart
@@ -2,23 +2,58 @@ import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_date_range_form.dart';
 
-/// Bottom-sheet variant of the Meal Plan date range form (Figma 971:8000).
-///
-/// Title: 'Select Period Date'. Hosts the same [MealPlanDateRangeForm] used
-/// by the empty state, but with the 'Custom meal plan' CTA per the Figma
-/// frame. Launched from the meal-plan overflow → 'Create new meal prep'
-/// action. Pops with the chosen [DateTimeRange] on submit, or `null` on
+/// Which path the user chose out of the Select Period Date sheet.
+enum MealPrepMode {
+  /// Generate the plan with AI.
+  ai,
+
+  /// Fill the plan in manually (browse → review → map).
+  manual,
+}
+
+/// Result of the Select Period Date sheet: the chosen [mode] plus the
+/// selected [range]. Returned via [showSelectPeriodDateSheet].
+class SelectPeriodResult {
+  const SelectPeriodResult({required this.mode, required this.range});
+
+  final MealPrepMode mode;
+  final DateTimeRange range;
+}
+
+/// Bottom sheet "Select Period Date" (Figma 971:8053). Hosts the shared
+/// [MealPlanDateRangeForm] (two date fields + "N weeks · M days" chip) and a
+/// button pair: primary "Generate with AI" (sparkle) and ghost
+/// "Fill in myself". Launched from the meal-plan overflow →
+/// "Create new meal prep". Pops with a [SelectPeriodResult], or `null` on
 /// dismiss.
-class SelectPeriodDateSheet extends StatelessWidget {
+class SelectPeriodDateSheet extends StatefulWidget {
   const SelectPeriodDateSheet({this.initialStart, this.initialEnd, super.key});
 
   final DateTime? initialStart;
   final DateTime? initialEnd;
 
   @override
+  State<SelectPeriodDateSheet> createState() => _SelectPeriodDateSheetState();
+}
+
+class _SelectPeriodDateSheetState extends State<SelectPeriodDateSheet> {
+  DateTimeRange? _range;
+
+  void _submit(MealPrepMode mode) {
+    final range = _range;
+    if (range == null) return;
+    Navigator.of(
+      context,
+    ).pop(SelectPeriodResult(mode: mode, range: range));
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final hasRange = _range != null;
+
     return SafeArea(
       top: false,
       child: Padding(
@@ -55,10 +90,21 @@ class SelectPeriodDateSheet extends StatelessWidget {
               ),
               const SizedBox(height: AppSizes.md),
               MealPlanDateRangeForm(
-                ctaLabel: 'Custom meal plan',
-                initialStart: initialStart,
-                initialEnd: initialEnd,
-                onSubmit: (range) => Navigator.of(context).pop(range),
+                initialStart: widget.initialStart,
+                initialEnd: widget.initialEnd,
+                onRangeChanged: (range) => setState(() => _range = range),
+              ),
+              const SizedBox(height: AppSizes.lg),
+              AppPillButton(
+                label: 'Generate with AI',
+                leading: const Icon(Icons.auto_awesome),
+                onPressed: hasRange ? () => _submit(MealPrepMode.ai) : null,
+              ),
+              const SizedBox(height: AppSizes.sm),
+              AppPillButton(
+                label: 'Fill in myself',
+                variant: AppPillButtonVariant.ghost,
+                onPressed: hasRange ? () => _submit(MealPrepMode.manual) : null,
               ),
             ],
           ),
@@ -68,14 +114,14 @@ class SelectPeriodDateSheet extends StatelessWidget {
   }
 }
 
-/// Helper that shows [SelectPeriodDateSheet] as a modal bottom sheet.
-/// Returns the chosen [DateTimeRange], or `null` on dismiss.
-Future<DateTimeRange?> showSelectPeriodDateSheet(
+/// Shows [SelectPeriodDateSheet] as a modal bottom sheet. Returns the chosen
+/// [SelectPeriodResult] (mode + range), or `null` on dismiss.
+Future<SelectPeriodResult?> showSelectPeriodDateSheet(
   BuildContext context, {
   DateTime? initialStart,
   DateTime? initialEnd,
 }) {
-  return showModalBottomSheet<DateTimeRange>(
+  return showModalBottomSheet<SelectPeriodResult>(
     context: context,
     isScrollControlled: true,
     backgroundColor: AppColors.surface,

--- a/lib/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart
+++ b/lib/src/features/meal_plan/sheets/widgets/browse_meal_recipe_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:nibbles/src/app/constants/allergen_emoji.dart';
 import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 
 /// Vertical recipe card used inside the recommendation carousels of the
@@ -93,6 +94,10 @@ class BrowseMealRecipeCard extends StatelessWidget {
                         overflow: TextOverflow.ellipsis,
                       ),
                       const SizedBox(height: AppSizes.xs),
+                      if (recipe.nutritionTags.isNotEmpty) ...[
+                        _NutritionChips(tags: recipe.nutritionTags),
+                        const SizedBox(height: AppSizes.xs),
+                      ],
                       Text(
                         recipe.ageRange,
                         style: textTheme.bodySmall?.copyWith(
@@ -109,6 +114,29 @@ class BrowseMealRecipeCard extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// First nutrition tag (e.g. "Iron-Rich") as a coral chip, plus a "+N" mute
+/// chip when the recipe carries more. Single row — the 160px card can't fit
+/// a wrap without pushing the age line off.
+class _NutritionChips extends StatelessWidget {
+  const _NutritionChips({required this.tags});
+
+  final List<String> tags;
+
+  @override
+  Widget build(BuildContext context) {
+    final extra = tags.length - 1;
+    return Row(
+      children: [
+        Flexible(child: AppChip(label: tags.first)),
+        if (extra > 0) ...[
+          const SizedBox(width: AppSizes.xs),
+          AppChip(label: '+$extra', tone: AppChipTone.mute),
+        ],
+      ],
     );
   }
 }

--- a/lib/src/features/meal_plan/sheets/widgets/recommendation_carousel_section.dart
+++ b/lib/src/features/meal_plan/sheets/widgets/recommendation_carousel_section.dart
@@ -84,7 +84,7 @@ class BrowseMealSearchField extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: AppSizes.pagePaddingH),
       child: AppSearchField(
         controller: controller,
-        hintText: 'Search recipes',
+        hintText: 'Search recipe',
         onChanged: onChanged,
         onSubmitted: (_) => FocusScope.of(context).unfocus(),
       ),

--- a/lib/src/features/meal_plan/widgets/clear_confirm_dialog.dart
+++ b/lib/src/features/meal_plan/widgets/clear_confirm_dialog.dart
@@ -5,12 +5,16 @@ import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/brand/brand_flower.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 
-/// Shows the DS clear-week confirm bottom-sheet (Figma 971:8090).
+/// Shows the DS destructive-confirm bottom-sheet (Figma 971:8143).
 ///
-/// Renders a centered confirmation sheet pinned to the bottom of the screen
-/// with the planner visible behind a scrim. Returns `true` if the user tapped
-/// Delete, `false` if Cancel, and `null` if dismissed via the scrim.
-Future<bool?> showClearMealPlanConfirm(BuildContext context) {
+/// Centered brand flower + a confirmation prompt + a No / Yes pair (Yes is the
+/// destructive action). Reused for whole-plan delete and per-day clear — pass
+/// [title] to swap the copy. Returns `true` on Yes, `false` on No, `null` on
+/// scrim dismiss.
+Future<bool?> showClearMealPlanConfirm(
+  BuildContext context, {
+  String title = 'Are you sure you want to delete?',
+}) {
   return showModalBottomSheet<bool>(
     context: context,
     backgroundColor: AppColors.cream,
@@ -20,42 +24,39 @@ Future<bool?> showClearMealPlanConfirm(BuildContext context) {
         top: Radius.circular(AppSizes.radiusLg),
       ),
     ),
-    builder: (_) => const _ClearConfirmSheet(),
+    builder: (_) => _ClearConfirmSheet(title: title),
   );
 }
 
 class _ClearConfirmSheet extends StatelessWidget {
-  const _ClearConfirmSheet();
+  const _ClearConfirmSheet({required this.title});
+
+  final String title;
 
   @override
   Widget build(BuildContext context) {
     return SafeArea(
       top: false,
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(
-          AppSizes.lg,
-          AppSizes.lg,
-          AppSizes.lg,
-          AppSizes.lg,
-        ),
+        padding: const EdgeInsets.all(AppSizes.lg),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            const BrandFlower(size: AppSizes.avatarLg),
+            const SizedBox(height: AppSizes.lg),
             Text(
-              "Clear all meals for this week? This can't be undone.",
+              title,
               style:
                   Theme.of(context).textTheme.titleMedium ??
                   AppTypography.sectionTitle,
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: AppSizes.lg),
-            const BrandFlower(size: AppSizes.avatarLg),
-            const SizedBox(height: AppSizes.lg),
             Row(
               children: [
                 Expanded(
                   child: AppPillButton(
-                    label: 'Cancel',
+                    label: 'No',
                     variant: AppPillButtonVariant.secondary,
                     onPressed: () => Navigator.pop(context, false),
                   ),
@@ -63,7 +64,8 @@ class _ClearConfirmSheet extends StatelessWidget {
                 const SizedBox(width: AppSizes.sm),
                 Expanded(
                   child: AppPillButton(
-                    label: 'Clear',
+                    label: 'Yes',
+                    variant: AppPillButtonVariant.destructive,
                     onPressed: () => Navigator.pop(context, true),
                   ),
                 ),

--- a/lib/src/features/meal_plan/widgets/day_accordion_card.dart
+++ b/lib/src/features/meal_plan/widgets/day_accordion_card.dart
@@ -4,6 +4,7 @@ import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
+import 'package:nibbles/src/common/components/cards/app_card.dart';
 import 'package:nibbles/src/common/components/chips/app_chip.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
@@ -13,13 +14,16 @@ enum DayCardMenuAction {
   /// Add this day's recipes to the shopping list.
   addToShopList,
 
-  /// Clear meals for the entire current window.
-  clearCurrentWeek,
+  /// Clear all meals for this single day.
+  clearCurrentDate,
 }
 
-/// Collapsible day card (Figma 971:8570). Renders the date header,
-/// per-card overflow menu, a chevron, and on expand either a list of
-/// recipe rows + a butter "Add" pill OR an empty hint + the same pill.
+/// Collapsible day card (Figma 971:8619 / 971:8571).
+///
+/// A day WITH meals renders a solid card: date header + `⋯` menu + chevron,
+/// and on expand a list of recipe rows + a ghost "Add" pill. A day with NO
+/// meals renders a dashed card with a "No meal plan yet" hint + "Add" pill
+/// (always visible — no chevron).
 class DayAccordionCard extends StatelessWidget {
   const DayAccordionCard({
     required this.day,
@@ -78,11 +82,44 @@ class DayAccordionCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isEmpty = entries.isEmpty;
+    const margin = EdgeInsets.symmetric(
+      horizontal: AppSizes.pagePaddingH,
+      vertical: AppSizes.xs,
+    );
+
+    if (isEmpty) {
+      return Padding(
+        padding: margin,
+        child: AppCard(
+          variant: AppCardVariant.dashed,
+          padding: const EdgeInsets.all(AppSizes.cardPadding),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _Header(
+                dateLabel: _dateLabel(),
+                isExpanded: isExpanded,
+                onToggle: onToggle,
+                onMenuSelected: onMenuSelected,
+                showChevron: false,
+              ),
+              const SizedBox(height: AppSizes.sm),
+              _EmptyHint(),
+              const SizedBox(height: AppSizes.sm),
+              AppPillButton(
+                label: 'Add',
+                variant: AppPillButtonVariant.ghost,
+                onPressed: onAdd,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
     return Container(
-      margin: const EdgeInsets.symmetric(
-        horizontal: AppSizes.pagePaddingH,
-        vertical: AppSizes.xs,
-      ),
+      margin: margin,
       padding: const EdgeInsets.all(AppSizes.cardPadding),
       decoration: BoxDecoration(
         color: AppColors.surface,
@@ -100,17 +137,13 @@ class DayAccordionCard extends StatelessWidget {
           ),
           if (isExpanded) ...[
             const SizedBox(height: AppSizes.sm),
-            if (entries.isEmpty)
-              _EmptyHint()
-            else
-              _RecipeList(
-                entries: entries,
-                recipes: recipes,
-                flaggedAllergenKeys: flaggedAllergenKeys,
-                onRecipeTap: onRecipeTap,
-              ),
+            _RecipeList(
+              entries: entries,
+              recipes: recipes,
+              flaggedAllergenKeys: flaggedAllergenKeys,
+              onRecipeTap: onRecipeTap,
+            ),
             const SizedBox(height: AppSizes.sm),
-            // Full-width lime "Add" pill (Figma 971:8619, 971:7804).
             AppPillButton(
               label: 'Add',
               variant: AppPillButtonVariant.ghost,
@@ -129,18 +162,20 @@ class _Header extends StatelessWidget {
     required this.isExpanded,
     required this.onToggle,
     required this.onMenuSelected,
+    this.showChevron = true,
   });
 
   final String dateLabel;
   final bool isExpanded;
   final VoidCallback onToggle;
   final ValueChanged<DayCardMenuAction> onMenuSelected;
+  final bool showChevron;
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTap: onToggle,
+      onTap: showChevron ? onToggle : null,
       child: Row(
         children: [
           Expanded(
@@ -165,23 +200,24 @@ class _Header extends StatelessWidget {
                 ),
               ),
               PopupMenuItem<DayCardMenuAction>(
-                value: DayCardMenuAction.clearCurrentWeek,
+                value: DayCardMenuAction.clearCurrentDate,
                 child: _MenuRow(
                   icon: Icons.delete_outline,
-                  label: 'Clear current week',
+                  label: 'Clear current date',
                 ),
               ),
             ],
             child: const _DayCardChip(icon: Icons.more_horiz),
           ),
-          const SizedBox(width: AppSizes.xs),
-          // Green-filled rounded-square chevron button (Figma 971:8619).
-          _DayCardChip(
-            icon: isExpanded
-                ? Icons.keyboard_arrow_up
-                : Icons.keyboard_arrow_down,
-            onTap: onToggle,
-          ),
+          if (showChevron) ...[
+            const SizedBox(width: AppSizes.xs),
+            _DayCardChip(
+              icon: isExpanded
+                  ? Icons.keyboard_arrow_up
+                  : Icons.keyboard_arrow_down,
+              onTap: onToggle,
+            ),
+          ],
         ],
       ),
     );
@@ -244,8 +280,10 @@ class _EmptyHint extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: AppSizes.sm),
       child: Center(
         child: Text(
-          'No meal plan yet.',
-          style: AppTypography.textTheme.titleSmall,
+          'No meal plan yet',
+          style: AppTypography.textTheme.titleSmall?.copyWith(
+            color: AppColors.fgMuted,
+          ),
         ),
       ),
     );
@@ -297,16 +335,19 @@ class _RecipeRow extends StatelessWidget {
   final Set<String> flaggedAllergenKeys;
   final VoidCallback onTap;
 
-  static const _maxVisibleTags = 2;
+  static const _maxNutritionTags = 2;
 
   @override
   Widget build(BuildContext context) {
     final title = recipe?.title ?? '…';
-    final tags = recipe?.allergenTags ?? const <String>[];
-    final visible = tags.take(_maxVisibleTags).toList();
-    final overflow = tags.length - visible.length;
+    final ageRange = recipe?.ageRange;
+    final nutrition = (recipe?.nutritionTags ?? const <String>[])
+        .take(_maxNutritionTags)
+        .toList();
 
-    final flaggedNames = tags
+    // Preserve the flagged-allergen safety cue in the semantics label even
+    // though the visible chips now surface nutrition + age.
+    final flaggedNames = (recipe?.allergenTags ?? const <String>[])
         .where(flaggedAllergenKeys.contains)
         .map(AllergenEmoji.displayName)
         .toList();
@@ -346,18 +387,16 @@ class _RecipeRow extends StatelessWidget {
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
-                    if (tags.isNotEmpty) ...[
+                    if (ageRange != null || nutrition.isNotEmpty) ...[
                       const SizedBox(height: AppSizes.xs),
                       Wrap(
                         spacing: AppSizes.xs,
                         runSpacing: AppSizes.xs,
                         children: [
-                          for (final tag in visible)
-                            _AllergenTagChip(
-                              tag: tag,
-                              flagged: flaggedAllergenKeys.contains(tag),
-                            ),
-                          if (overflow > 0) _OverflowChip(count: overflow),
+                          for (final tag in nutrition)
+                            AppChip(label: tag),
+                          if (ageRange != null)
+                            AppChip(label: ageRange, tone: AppChipTone.mute),
                         ],
                       ),
                     ],
@@ -412,34 +451,5 @@ class _ThumbnailPlaceholder extends StatelessWidget {
         color: AppColors.fgFaint,
       ),
     );
-  }
-}
-
-class _AllergenTagChip extends StatelessWidget {
-  const _AllergenTagChip({required this.tag, required this.flagged});
-
-  final String tag;
-  final bool flagged;
-
-  @override
-  Widget build(BuildContext context) {
-    final emoji = AllergenEmoji.get(tag);
-    final name = AllergenEmoji.displayName(tag);
-    return AppChip(
-      label: name,
-      emoji: emoji,
-      tone: flagged ? AppChipTone.flag : AppChipTone.neutral,
-    );
-  }
-}
-
-class _OverflowChip extends StatelessWidget {
-  const _OverflowChip({required this.count});
-
-  final int count;
-
-  @override
-  Widget build(BuildContext context) {
-    return AppChip(label: '+$count');
   }
 }

--- a/lib/src/features/meal_plan/widgets/meal_plan_date_range_form.dart
+++ b/lib/src/features/meal_plan/widgets/meal_plan_date_range_form.dart
@@ -3,40 +3,55 @@ import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
-import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
+import 'package:nibbles/src/common/components/chips/app_chip.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/meal_prep_calendar.dart';
 
-/// Shared Start Date / End Date form used by both the Meal Plan empty-state
-/// (`MealPlanEmptyState`) and the Select Period Date bottom-sheet
-/// (`SelectPeriodDateSheet`, Figma 971:8000). Renders two date fields plus
-/// a primary CTA. Tapping a field opens an [InlineCalendar] directly below
-/// it — the OS picker is intentionally never used (per NIB-76 AC: the
-/// typo'd Figma weekday row is not replicated and the picker is themed to
-/// sage/butter, not iOS blue).
+/// Shared START DATE / END DATE range picker used by the Meal Plan empty
+/// state and the Select Period Date sheet (Figma 2839:15923). Renders two
+/// grey pill fields showing a `dd/MM/yyyy` placeholder until a date is
+/// chosen; tapping a field reveals a [MealPrepCalendar] inline directly
+/// below it (the OS picker is never used).
 ///
-/// Defaults to today + (today + 6 days) so the CTA is enabled on first
-/// paint. Dates render as `MMM d, yyyy` (e.g. `Apr 17, 2026`) to avoid
-/// day/month ambiguity (NIB-166).
+/// Once BOTH dates are set it surfaces the coral info chip
+/// "N weeks · M days of meals" (weeks = ceil(days / 7); days = inclusive
+/// end − start + 1) and reports the range through [onRangeChanged].
+///
+/// The in-form CTA is optional: pass [ctaLabel] (+ [onSubmit]) to render a
+/// primary pill under the fields (empty-state usage); omit it when the host
+/// owns its own buttons (the select-period sheet's AI / manual pair).
 class MealPlanDateRangeForm extends StatefulWidget {
   const MealPlanDateRangeForm({
-    required this.ctaLabel,
-    required this.onSubmit,
+    this.ctaLabel,
+    this.onSubmit,
+    this.onRangeChanged,
     this.initialStart,
     this.initialEnd,
+    this.showInfoChip = true,
     super.key,
   });
 
-  /// CTA label. Empty-state uses 'Create meal plan' (Figma 971:8199); the
-  /// bottom-sheet variant (971:8000) uses 'Custom meal plan'.
-  final String ctaLabel;
+  /// Optional in-form CTA label. When null no CTA pill is rendered.
+  final String? ctaLabel;
 
-  /// Fires when the user taps the CTA with a valid range.
-  final ValueChanged<DateTimeRange> onSubmit;
+  /// Fires when the user taps the in-form CTA with a valid range. Ignored
+  /// when [ctaLabel] is null.
+  final ValueChanged<DateTimeRange>? onSubmit;
 
-  /// Optional initial start date. Defaults to today (date-only).
+  /// Fires whenever the selected range changes. Emits the valid
+  /// [DateTimeRange] once both ends are set, or `null` while incomplete.
+  final ValueChanged<DateTimeRange?>? onRangeChanged;
+
+  /// Optional initial start date (date-only). No default — null shows the
+  /// placeholder.
   final DateTime? initialStart;
 
-  /// Optional initial end date. Defaults to today + 6 days (date-only).
+  /// Optional initial end date (date-only). No default — null shows the
+  /// placeholder.
   final DateTime? initialEnd;
+
+  /// Whether to show the coral "N weeks · M days of meals" summary chip once
+  /// both dates are set.
+  final bool showInfoChip;
 
   @override
   State<MealPlanDateRangeForm> createState() => _MealPlanDateRangeFormState();
@@ -45,8 +60,8 @@ class MealPlanDateRangeForm extends StatefulWidget {
 enum _OpenField { none, start, end }
 
 class _MealPlanDateRangeFormState extends State<MealPlanDateRangeForm> {
-  late DateTime _startDate;
-  late DateTime _endDate;
+  DateTime? _startDate;
+  DateTime? _endDate;
   late DateTime _focusedMonth;
   _OpenField _openField = _OpenField.none;
 
@@ -55,29 +70,37 @@ class _MealPlanDateRangeFormState extends State<MealPlanDateRangeForm> {
   @override
   void initState() {
     super.initState();
-    final today = _dateOnly(DateTime.now());
-    _startDate = widget.initialStart != null
-        ? _dateOnly(widget.initialStart!)
-        : today;
-    _endDate = widget.initialEnd != null
-        ? _dateOnly(widget.initialEnd!)
-        : today.add(const Duration(days: 6));
-    _focusedMonth = DateTime(_startDate.year, _startDate.month);
+    _startDate = widget.initialStart == null
+        ? null
+        : _dateOnly(widget.initialStart!);
+    _endDate = widget.initialEnd == null
+        ? null
+        : _dateOnly(widget.initialEnd!);
+    final anchor = _startDate ?? _dateOnly(DateTime.now());
+    _focusedMonth = DateTime(anchor.year, anchor.month);
+    if (_range != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) widget.onRangeChanged?.call(_range);
+      });
+    }
   }
 
-  bool get _canSubmit => !_endDate.isBefore(_startDate);
+  DateTimeRange? get _range {
+    final start = _startDate;
+    final end = _endDate;
+    if (start == null || end == null) return null;
+    if (end.isBefore(start)) return null;
+    return DateTimeRange(start: start, end: end);
+  }
 
-  String? get _rangeError => _endDate.isBefore(_startDate)
-      ? 'End date must be on or after start date.'
-      : null;
-
-  void _toggleField(_OpenField field, DateTime current) {
+  void _toggleField(_OpenField field, DateTime? current) {
     setState(() {
       if (_openField == field) {
         _openField = _OpenField.none;
       } else {
         _openField = field;
-        _focusedMonth = DateTime(current.year, current.month);
+        final anchor = current ?? _dateOnly(DateTime.now());
+        _focusedMonth = DateTime(anchor.year, anchor.month);
       }
     });
   }
@@ -86,13 +109,14 @@ class _MealPlanDateRangeFormState extends State<MealPlanDateRangeForm> {
     setState(() {
       if (_openField == _OpenField.start) {
         _startDate = day;
-        // Auto-bump end forward so the range stays valid.
-        if (_endDate.isBefore(day)) _endDate = day;
+        // Keep the range valid — never let end fall before start.
+        if (_endDate != null && _endDate!.isBefore(day)) _endDate = day;
       } else if (_openField == _OpenField.end) {
         _endDate = day;
       }
       _openField = _OpenField.none;
     });
+    widget.onRangeChanged?.call(_range);
   }
 
   void _onMonthChanged(DateTime month) {
@@ -100,27 +124,27 @@ class _MealPlanDateRangeFormState extends State<MealPlanDateRangeForm> {
   }
 
   void _onSubmit() {
-    if (!_canSubmit) return;
-    widget.onSubmit(DateTimeRange(start: _startDate, end: _endDate));
+    final range = _range;
+    if (range == null) return;
+    widget.onSubmit?.call(range);
   }
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final rangeError = _rangeError;
+    final range = _range;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _DateField(
-          label: 'Start Date',
+          label: 'START DATE',
           value: _startDate,
           isOpen: _openField == _OpenField.start,
           onTap: () => _toggleField(_OpenField.start, _startDate),
         ),
         _CalendarReveal(
           isOpen: _openField == _OpenField.start,
-          child: InlineCalendar(
+          child: MealPrepCalendar(
             selectedDate: _startDate,
             focusedMonth: _focusedMonth,
             onDaySelected: _onDaySelected,
@@ -129,14 +153,14 @@ class _MealPlanDateRangeFormState extends State<MealPlanDateRangeForm> {
         ),
         const SizedBox(height: AppSizes.md),
         _DateField(
-          label: 'End Date',
+          label: 'END DATE',
           value: _endDate,
           isOpen: _openField == _OpenField.end,
-          onTap: () => _toggleField(_OpenField.end, _endDate),
+          onTap: () => _toggleField(_OpenField.end, _endDate ?? _startDate),
         ),
         _CalendarReveal(
           isOpen: _openField == _OpenField.end,
-          child: InlineCalendar(
+          child: MealPrepCalendar(
             selectedDate: _endDate,
             focusedMonth: _focusedMonth,
             onDaySelected: _onDaySelected,
@@ -144,28 +168,39 @@ class _MealPlanDateRangeFormState extends State<MealPlanDateRangeForm> {
             minDate: _startDate,
           ),
         ),
-        if (rangeError != null) ...[
-          const SizedBox(height: AppSizes.xs),
-          Text(
-            rangeError,
-            style: theme.textTheme.bodySmall?.copyWith(color: AppColors.error),
+        if (widget.showInfoChip && range != null) ...[
+          const SizedBox(height: AppSizes.md),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: AppChip(
+              label: _summaryLabel(range),
+              icon: const Icon(Icons.event_note_rounded),
+            ),
           ),
         ],
-        const SizedBox(height: AppSizes.md),
-        AppPillButton(
-          label: widget.ctaLabel,
-          onPressed: _canSubmit ? _onSubmit : null,
-        ),
+        if (widget.ctaLabel != null) ...[
+          const SizedBox(height: AppSizes.md),
+          AppPillButton(
+            label: widget.ctaLabel!,
+            onPressed: range == null ? null : _onSubmit,
+          ),
+        ],
       ],
     );
   }
+
+  static String _summaryLabel(DateTimeRange range) {
+    final days = range.end.difference(range.start).inDays + 1;
+    final weeks = (days / 7).ceil();
+    final weekWord = weeks == 1 ? 'week' : 'weeks';
+    final dayWord = days == 1 ? 'day' : 'days';
+    return '$weeks $weekWord · $days $dayWord of meals';
+  }
 }
 
-/// Eases the inline calendar in/out instead of a hard blink when the
-/// owning field toggles. Combines a [SizeTransition] (height reveal) with
-/// a [FadeTransition] via [AnimatedSwitcher] (~200ms, easeOut). Adds the
-/// `sm` gap above the calendar only while open so collapsed spacing stays
-/// flush.
+/// Eases the inline calendar in/out instead of a hard blink when the owning
+/// field toggles. Combines a [SizeTransition] (height reveal) with a
+/// [FadeTransition] via [AnimatedSwitcher] (~200ms, easeOut).
 class _CalendarReveal extends StatelessWidget {
   const _CalendarReveal({required this.isOpen, required this.child});
 
@@ -196,10 +231,9 @@ class _CalendarReveal extends StatelessWidget {
   }
 }
 
-/// Single labelled date field. `value` is the currently chosen date —
-/// rendered as `MMM d, yyyy` (e.g. `Apr 17, 2026`) so the day and month
-/// are unambiguous. Border is forestdarkn (green-deep) at rest per Figma; the
-/// open state thickens it to 2px and switches the fill to white.
+/// Single labelled date field. Shows a `dd/MM/yyyy` placeholder until a date
+/// is chosen, then the picked date in the same format. Grey pill fill; the
+/// open state thickens the border to a 2px forest ring.
 class _DateField extends StatelessWidget {
   const _DateField({
     required this.label,
@@ -209,17 +243,15 @@ class _DateField extends StatelessWidget {
   });
 
   final String label;
-  final DateTime value;
+  final DateTime? value;
   final bool isOpen;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final displayText = _formatDate(value);
-    // Figma date Input = #eaeaea fill + forestdarkn (greenDeep) border at rest
-    // (971:8199); the open state only thickens it.
-    const borderColor = AppColors.greenDeep;
+    final hasValue = value != null;
+    final displayText = hasValue ? _formatDate(value!) : 'dd/MM/yyyy';
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -239,23 +271,34 @@ class _DateField extends StatelessWidget {
             duration: const Duration(milliseconds: 120),
             height: AppSizes.fieldHeight,
             padding: const EdgeInsets.symmetric(
-              horizontal: AppSizes.fieldPaddingH,
+              horizontal: AppSizes.fieldPaddingH + 2,
             ),
             decoration: BoxDecoration(
-              color: isOpen ? AppColors.surface : AppColors.bgInput,
-              borderRadius: BorderRadius.circular(AppSizes.radiusMd),
-              border: Border.all(color: borderColor, width: isOpen ? 2 : 1),
-            ),
-            // No trailing calendar icon — Figma 971:8199 date inputs show only
-            // the date text; the field still opens the inline calendar on tap.
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                displayText,
-                style: AppTypography.textTheme.bodyLarge?.copyWith(
-                  color: AppColors.fgStrong,
-                ),
+              color: AppColors.bgInput,
+              borderRadius: BorderRadius.circular(AppSizes.radiusFull),
+              border: Border.all(
+                color: isOpen ? AppColors.greenDeep : Colors.transparent,
+                width: isOpen ? 2 : 1,
               ),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    displayText,
+                    style: AppTypography.textTheme.bodyLarge?.copyWith(
+                      color: hasValue
+                          ? AppColors.fgStrong
+                          : AppColors.greenSoft,
+                    ),
+                  ),
+                ),
+                const Icon(
+                  Icons.calendar_today_outlined,
+                  size: AppSizes.iconSm,
+                  color: AppColors.greenSoft,
+                ),
+              ],
             ),
           ),
         ),
@@ -263,22 +306,9 @@ class _DateField extends StatelessWidget {
     );
   }
 
-  static const _monthAbbr = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
-  ];
-
   static String _formatDate(DateTime d) {
-    return '${_monthAbbr[d.month - 1]} ${d.day}, ${d.year}';
+    final dd = d.day.toString().padLeft(2, '0');
+    final mm = d.month.toString().padLeft(2, '0');
+    return '$dd/$mm/${d.year}';
   }
 }

--- a/lib/src/features/meal_plan/widgets/meal_plan_empty_state.dart
+++ b/lib/src/features/meal_plan/widgets/meal_plan_empty_state.dart
@@ -3,47 +3,55 @@ import 'package:nibbles/src/app/themes/app_colors.dart';
 import 'package:nibbles/src/app/themes/app_sizes.dart';
 import 'package:nibbles/src/app/themes/app_typography.dart';
 import 'package:nibbles/src/common/components/brand/brand_flower.dart';
+import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_date_range_form.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_header.dart';
 
-/// Meal Plan empty-state route (Figma 971:8199 / 971:8547).
+/// Meal Plan empty-state route (Figma 2839:16295 / 2839:15923).
 ///
 /// Layout (top → bottom):
-/// 1. Butter-gradient [MealPlanHeader] (title + age subtitle + overflow).
-/// 2. White rounded form card hosting [MealPlanDateRangeForm] with the
-///    'Create meal plan' CTA.
-/// 3. Brand [BrandFlower] flower illustration.
-/// 4. Caption "Let's create a meal plan for {babyName}!" — the baby name
-///    interpolates the runtime value.
-///
-/// Tapping a date field opens an inline calendar directly below it — never
-/// the OS picker. Hitting the CTA emits a [DateTimeRange] via
-/// [onCreateMealPlan].
-class MealPlanEmptyState extends StatelessWidget {
+/// 1. Butter-gradient [MealPlanHeader] (title + age subtitle). The overflow
+///    `⋯` is HIDDEN in the empty state — creation happens via the card CTAs.
+/// 2. White rounded form card hosting [MealPlanDateRangeForm] (two date fields
+///    + the coral "N weeks · M days" info chip once both dates are set) plus
+///    the CTA pair: primary "Set a Meal Prep" (sparkle → AI flow) and ghost
+///    "Fill in myself" (→ manual flow). Both stay disabled until a valid range
+///    is chosen.
+/// 3. Brand [BrandFlower] + caption "Let's create meal plan for {babyName}!".
+class MealPlanEmptyState extends StatefulWidget {
   const MealPlanEmptyState({
     required this.babyName,
     required this.ageMonths,
-    required this.onCreateMealPlan,
-    this.overflowButton,
+    required this.onSetMealPrep,
+    required this.onFillInMyself,
     super.key,
   });
 
   final String babyName;
   final int ageMonths;
-  final ValueChanged<DateTimeRange> onCreateMealPlan;
 
-  /// Optional overflow button slot — empty state still renders the header,
-  /// so pass a [MealPlanOverflowButton] to enable the screen-level menu.
-  final Widget? overflowButton;
+  /// AI path — fires with the chosen range when "Set a Meal Prep" is tapped.
+  final ValueChanged<DateTimeRange> onSetMealPrep;
+
+  /// Manual path — fires with the chosen range when "Fill in myself" is tapped.
+  final ValueChanged<DateTimeRange> onFillInMyself;
+
+  @override
+  State<MealPlanEmptyState> createState() => _MealPlanEmptyStateState();
+}
+
+class _MealPlanEmptyStateState extends State<MealPlanEmptyState> {
+  DateTimeRange? _range;
 
   @override
   Widget build(BuildContext context) {
+    final range = _range;
     return Column(
       children: [
         MealPlanHeader(
-          babyName: babyName,
-          ageMonths: ageMonths,
-          overflowButton: overflowButton ?? const SizedBox.shrink(),
+          babyName: widget.babyName,
+          ageMonths: widget.ageMonths,
+          overflowButton: const SizedBox.shrink(),
         ),
         Expanded(
           child: SingleChildScrollView(
@@ -57,9 +65,29 @@ class MealPlanEmptyState extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 _FormCard(
-                  child: MealPlanDateRangeForm(
-                    ctaLabel: 'Create meal plan',
-                    onSubmit: onCreateMealPlan,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      MealPlanDateRangeForm(
+                        onRangeChanged: (r) => setState(() => _range = r),
+                      ),
+                      const SizedBox(height: AppSizes.md),
+                      AppPillButton(
+                        label: 'Set a Meal Prep',
+                        leading: const Icon(Icons.auto_awesome),
+                        onPressed: range == null
+                            ? null
+                            : () => widget.onSetMealPrep(range),
+                      ),
+                      const SizedBox(height: AppSizes.sm),
+                      AppPillButton(
+                        label: 'Fill in myself',
+                        variant: AppPillButtonVariant.ghost,
+                        onPressed: range == null
+                            ? null
+                            : () => widget.onFillInMyself(range),
+                      ),
+                    ],
                   ),
                 ),
                 const SizedBox(height: AppSizes.xxl),
@@ -67,7 +95,7 @@ class MealPlanEmptyState extends StatelessWidget {
                 const SizedBox(height: AppSizes.md),
                 Center(
                   child: Text(
-                    "Let's create a meal plan for $babyName!",
+                    "Let's create meal plan for ${widget.babyName}!",
                     textAlign: TextAlign.center,
                     style: AppTypography.emptyStateTitle,
                   ),
@@ -82,8 +110,7 @@ class MealPlanEmptyState extends StatelessWidget {
   }
 }
 
-/// White rounded card with soft shadow that wraps the date-range form
-/// — matches the Figma 971:8199 card around the Start/End/CTA stack.
+/// White rounded card with soft shadow that wraps the date-range form + CTAs.
 class _FormCard extends StatelessWidget {
   const _FormCard({required this.child});
 

--- a/lib/src/features/meal_plan/widgets/meal_prep_calendar.dart
+++ b/lib/src/features/meal_plan/widgets/meal_prep_calendar.dart
@@ -1,0 +1,293 @@
+import 'package:flutter/material.dart';
+import 'package:nibbles/src/app/themes/app_colors.dart';
+import 'package:nibbles/src/app/themes/app_sizes.dart';
+import 'package:nibbles/src/app/themes/app_typography.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+/// Styled month calendar wrapping the `table_calendar` package (Figma
+/// 2839:16295 "Image 4"). Fully controlled — the consumer owns
+/// [selectedDate] + [focusedMonth] and wires the callbacks; the widget holds
+/// no state of its own so it drops cleanly into the date-range form and the
+/// select-period sheet in place of any native picker.
+///
+/// Layout: month title on the left, a grouped `< >` chevron pair top-right,
+/// a SUN..SAT weekday header, then the day grid. Today is highlighted with a
+/// butter fill + green ring; the selected day is a filled forest circle.
+/// Days outside [minDate]/[maxDate] are dimmed and untappable (the package's
+/// `firstDay`/`lastDay` bounds drive this, so paging can't overshoot them).
+class MealPrepCalendar extends StatelessWidget {
+  const MealPrepCalendar({
+    required this.selectedDate,
+    required this.focusedMonth,
+    required this.onDaySelected,
+    required this.onMonthChanged,
+    this.minDate,
+    this.maxDate,
+    super.key,
+  });
+
+  /// Currently selected day. `null` renders no selection highlight.
+  final DateTime? selectedDate;
+
+  /// Month currently shown (only year + month matter).
+  final DateTime focusedMonth;
+
+  /// Fires when the user taps a tappable (in-range) day cell.
+  final ValueChanged<DateTime> onDaySelected;
+
+  /// Fires when the user pages the calendar — emits the new focused month
+  /// (normalised to day 1).
+  final ValueChanged<DateTime> onMonthChanged;
+
+  /// Optional lower bound (inclusive). Earlier days are dimmed + untappable.
+  final DateTime? minDate;
+
+  /// Optional upper bound (inclusive). Later days are dimmed + untappable.
+  final DateTime? maxDate;
+
+  static const List<String> _monthNames = <String>[
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+
+  static DateTime _dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
+
+  DateTime get _firstDay => minDate != null
+      ? _dateOnly(minDate!)
+      : DateTime(focusedMonth.year - 2, focusedMonth.month);
+
+  DateTime get _lastDay => maxDate != null
+      ? _dateOnly(maxDate!)
+      : DateTime(focusedMonth.year + 2, focusedMonth.month + 1, 0);
+
+  /// [TableCalendar] asserts `firstDay <= focusedDay <= lastDay`; a day-1
+  /// [focusedMonth] can fall before a mid-month [minDate], so clamp it.
+  DateTime get _focusedDay {
+    final first = _firstDay;
+    final last = _lastDay;
+    if (focusedMonth.isBefore(first)) return first;
+    if (focusedMonth.isAfter(last)) return last;
+    return focusedMonth;
+  }
+
+  void _stepMonth(int delta) {
+    onMonthChanged(DateTime(focusedMonth.year, focusedMonth.month + delta));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radiusLg),
+        border: Border.all(color: AppColors.borderSoft),
+        boxShadow: AppSizes.shadowCard,
+      ),
+      padding: const EdgeInsets.all(AppSizes.md),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _Header(
+            label:
+                '${_monthNames[focusedMonth.month - 1]} ${focusedMonth.year}',
+            onPrev: () => _stepMonth(-1),
+            onNext: () => _stepMonth(1),
+          ),
+          const SizedBox(height: AppSizes.sp12),
+          TableCalendar<void>(
+            firstDay: _firstDay,
+            lastDay: _lastDay,
+            focusedDay: _focusedDay,
+            headerVisible: false,
+            daysOfWeekHeight: AppSizes.lg,
+            rowHeight: AppSizes.xxl,
+            selectedDayPredicate: (day) =>
+                selectedDate != null && isSameDay(day, selectedDate),
+            onDaySelected: (selected, _) => onDaySelected(_dateOnly(selected)),
+            onPageChanged: (focused) =>
+                onMonthChanged(DateTime(focused.year, focused.month)),
+            availableGestures: AvailableGestures.horizontalSwipe,
+            calendarBuilders: CalendarBuilders<void>(
+              dowBuilder: (context, day) => _Dow(weekday: day.weekday),
+              defaultBuilder: (context, day, _) => _DayCell(day: day),
+              outsideBuilder: (context, day, _) =>
+                  _DayCell(day: day, muted: true),
+              disabledBuilder: (context, day, _) =>
+                  _DayCell(day: day, muted: true),
+              todayBuilder: (context, day, _) =>
+                  _DayCell(day: day, isToday: true),
+              selectedBuilder: (context, day, _) =>
+                  _DayCell(day: day, isSelected: true),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.label,
+    required this.onPrev,
+    required this.onNext,
+  });
+
+  final String label;
+  final VoidCallback onPrev;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            label,
+            style: AppTypography.textTheme.titleSmall?.copyWith(
+              color: AppColors.fgStrong,
+            ),
+          ),
+        ),
+        _Chevron(
+          icon: Icons.chevron_left_rounded,
+          onPressed: onPrev,
+          semanticLabel: 'Previous month',
+        ),
+        const SizedBox(width: AppSizes.sm),
+        _Chevron(
+          icon: Icons.chevron_right_rounded,
+          onPressed: onNext,
+          semanticLabel: 'Next month',
+        ),
+      ],
+    );
+  }
+}
+
+class _Chevron extends StatelessWidget {
+  const _Chevron({
+    required this.icon,
+    required this.onPressed,
+    required this.semanticLabel,
+  });
+
+  final IconData icon;
+  final VoidCallback onPressed;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.greenTint,
+      shape: const CircleBorder(),
+      child: InkWell(
+        onTap: onPressed,
+        customBorder: const CircleBorder(),
+        child: SizedBox(
+          width: AppSizes.roundButtonSm,
+          height: AppSizes.roundButtonSm,
+          child: Icon(
+            icon,
+            size: AppSizes.iconMd,
+            color: AppColors.greenDeep,
+            semanticLabel: semanticLabel,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Dow extends StatelessWidget {
+  const _Dow({required this.weekday});
+
+  final int weekday;
+
+  static const List<String> _labels = <String>[
+    'MON',
+    'TUE',
+    'WED',
+    'THU',
+    'FRI',
+    'SAT',
+    'SUN',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        _labels[weekday - 1],
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          fontWeight: FontWeight.w700,
+          color: AppColors.fgFaint,
+          letterSpacing: 0.4,
+        ),
+      ),
+    );
+  }
+}
+
+class _DayCell extends StatelessWidget {
+  const _DayCell({
+    required this.day,
+    this.isToday = false,
+    this.isSelected = false,
+    this.muted = false,
+  });
+
+  final DateTime day;
+  final bool isToday;
+  final bool isSelected;
+  final bool muted;
+
+  @override
+  Widget build(BuildContext context) {
+    Color bg;
+    Color fg;
+    BoxBorder? border;
+
+    if (isSelected) {
+      bg = AppColors.greenDeep;
+      fg = AppColors.butterSoft;
+    } else if (isToday) {
+      bg = AppColors.butterSoft;
+      fg = AppColors.greenDeep;
+      border = Border.all(color: AppColors.green);
+    } else {
+      bg = Colors.transparent;
+      fg = muted ? AppColors.fgFaint : AppColors.fgStrong;
+    }
+
+    return Center(
+      child: Container(
+        width: AppSizes.sp40,
+        height: AppSizes.sp40,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: bg,
+          shape: BoxShape.circle,
+          border: border,
+        ),
+        child: Text(
+          '${day.day}',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+            color: fg,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/logging/analytics.dart
+++ b/lib/src/logging/analytics.dart
@@ -437,6 +437,43 @@ class Analytics {
     );
   }
 
+  Future<void> logMealPlanCreated({required int days}) async {
+    await _logEvent('meal_plan_created', parameters: {'days': days});
+  }
+
+  Future<void> logMealPlanDeleted() async {
+    await _logEvent('meal_plan_deleted');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Meal Prep — AI generation. Non-PII: counts only, no names/notes/IDs.
+  // ---------------------------------------------------------------------------
+
+  Future<void> logMealPrepAiStarted() async {
+    await _logEvent('meal_prep_ai_started');
+  }
+
+  Future<void> logMealPrepAiPreferencesSelected({required int count}) async {
+    await _logEvent(
+      'meal_prep_ai_preferences_selected',
+      parameters: {'count': count},
+    );
+  }
+
+  Future<void> logMealPrepAiGenerated({
+    required int recipeCount,
+    required int dayCount,
+  }) async {
+    await _logEvent(
+      'meal_prep_ai_generated',
+      parameters: {'recipe_count': recipeCount, 'day_count': dayCount},
+    );
+  }
+
+  Future<void> logMealPrepAiFailed() async {
+    await _logEvent('meal_prep_ai_failed');
+  }
+
   // ---------------------------------------------------------------------------
   // Home (NIB-106) — non-PII only: allergen_key + intent taps.
   // ---------------------------------------------------------------------------

--- a/lib/src/routing/route_enums.dart
+++ b/lib/src/routing/route_enums.dart
@@ -36,6 +36,10 @@ enum AppRoute {
   home(path: '/home', name: 'home'),
   mealPlan(path: '/home/meal', name: 'meal-plan'),
   mealPlanMap(path: '/home/meal/map', name: 'meal-plan-map'),
+  mealPlanAiLoading(
+    path: '/home/meal/ai-loading',
+    name: 'meal-plan-ai-loading',
+  ),
   shoppingList(path: '/home/shopping-list', name: 'shopping-list'),
   recipeLibrary(path: '/home/recipe', name: 'recipe-library'),
   startingGuide(path: '/home/recipe/guide', name: 'starting-guide'),

--- a/lib/src/routing/routes.dart
+++ b/lib/src/routing/routes.dart
@@ -14,6 +14,7 @@ import 'package:nibbles/src/features/auth/register/register_screen.dart';
 import 'package:nibbles/src/features/auth/reset_password/reset_password_screen.dart';
 import 'package:nibbles/src/features/home/home_screen.dart';
 import 'package:nibbles/src/features/home/home_shell_screen.dart';
+import 'package:nibbles/src/features/meal_plan/ai/ai_loading_screen.dart';
 import 'package:nibbles/src/features/meal_plan/map/map_meals_screen.dart';
 import 'package:nibbles/src/features/meal_plan/map/map_meals_state.dart';
 import 'package:nibbles/src/features/meal_plan/meal_plan_screen.dart';
@@ -397,6 +398,15 @@ GoRouter goRouter(Ref ref) {
                     builder: (context, state) {
                       final args = state.extra! as MapMealsArgs;
                       return MapMealsScreen(args: args);
+                    },
+                  ),
+                  GoRoute(
+                    path: 'ai-loading',
+                    name: AppRoute.mealPlanAiLoading.name,
+                    parentNavigatorKey: rootNavigatorKey,
+                    builder: (context, state) {
+                      final args = state.extra! as AiLoadingArgs;
+                      return AiLoadingScreen(args: args);
                     },
                   ),
                 ],

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -1,0 +1,129 @@
+# Supabase Edge Functions
+
+Deno + Supabase Functions runtime. Each function lives in its own folder;
+`_shared/` holds cross-function helpers.
+
+```
+functions/
+  _shared/cors.ts                 # shared CORS headers
+  generate-meal-plan/
+    index.ts                      # AI meal-plan generator
+    deno.json                     # import map (supabase-js pin)
+```
+
+---
+
+## generate-meal-plan
+
+First edge function in the repo. Generates an AI meal plan by selecting from the
+existing `recipes` pool, honouring the baby's age/stage and allergen history.
+
+### What it does
+
+1. Verifies the caller's JWT (401 if missing/invalid).
+2. Reads, via a **JWT-bound client** (RLS-enforced, so only the caller's own
+   data is visible): the `babies` row (name, DOB) and all `allergen_logs` for
+   the baby. `recipes` are public-read, so no service role is used.
+3. Computes `ageMonths` (whole months), the meal **stage** and **meals/day**
+   target (clamped 1..3), and per-allergen status mirroring the app
+   (`deriveStatusForLogs`: any reaction → flagged, ≥3 clean → safe, ≥1 → in
+   progress, none → not started).
+4. Builds an OpenAI Chat Completions request (JSON mode) with the baby context,
+   per-allergen status, and the recipe pool, asking the model to fill each day
+   up to the meals/day target.
+5. **Validates the model output server-side**: keeps only assignments whose
+   `recipeId` exists in the pool, drops any recipe containing a **flagged**
+   allergen, and drops `dayOffset` outside `[0, dayCount-1]`.
+6. Returns `{ assignments: [...] }`. Under-filling is acceptable (soft target);
+   an empty valid result returns `502`.
+
+The OpenAI key is read from `Deno.env.get("OPENAI_API_KEY")` and is never
+hardcoded, logged, or returned in a response.
+
+### Request / response contract
+
+`POST /functions/v1/generate-meal-plan`
+
+Headers: `Authorization: Bearer <user JWT>`, `Content-Type: application/json`.
+
+Request body:
+
+```json
+{
+  "babyId": "uuid",
+  "startDate": "2026-07-07",
+  "endDate": "2026-07-13",
+  "preferences": ["Iron-rich puree", "Quick to make"],
+  "notes": "No repeats on the same day, please."
+}
+```
+
+- `babyId` — required, must be a baby the caller owns (RLS).
+- `startDate` / `endDate` — required, `yyyy-MM-dd`; `endDate >= startDate`.
+  Inclusive; `dayCount = end - start + 1` (capped at 60).
+- `preferences` — optional `string[]` (preset labels; ignored if empty).
+- `notes` — optional free-text string.
+
+Success `200`:
+
+```json
+{
+  "assignments": [
+    { "recipeId": "e0000000-0000-0000-0000-000000000001", "dayOffset": 0 },
+    { "recipeId": "e0000000-0000-0000-0000-000000000004", "dayOffset": 1 }
+  ]
+}
+```
+
+`dayOffset` is `0..dayCount-1` relative to `startDate`. Every `recipeId` is
+guaranteed to exist in `recipes` and to be allergen-safe (no flagged allergen).
+
+Error responses `{ "error": "<message>" }`:
+
+| Status | When                                            |
+| ------ | ----------------------------------------------- |
+| 400    | missing/invalid body, dates, or range           |
+| 401    | missing / invalid JWT                           |
+| 404    | baby not found (or not owned by caller)         |
+| 405    | non-POST method                                 |
+| 500    | server misconfig or a DB read error             |
+| 502    | OpenAI failure or no valid assignments produced |
+
+### Environment / secrets
+
+`SUPABASE_URL` and `SUPABASE_ANON_KEY` are injected by the runtime. Only the
+OpenAI values must be set as secrets:
+
+| Name             | Required | Default       |
+| ---------------- | -------- | ------------- |
+| `OPENAI_API_KEY` | yes      | —             |
+| `OPENAI_MODEL`   | no       | `gpt-4o-mini` |
+
+---
+
+## Human-run commands (auth-gated — run these yourself)
+
+Set the secret(s) on the linked project (dev or prod):
+
+```bash
+supabase secrets set OPENAI_API_KEY=sk-...            # required
+supabase secrets set OPENAI_MODEL=gpt-4o-mini          # optional override
+```
+
+Serve locally (uses a local `.env` for the OpenAI key — do NOT commit it):
+
+```bash
+supabase functions serve generate-meal-plan --env-file ./supabase/functions/.env.local
+```
+
+`supabase functions serve` verifies JWTs by default; invoke with a real user
+access token in the `Authorization` header.
+
+Deploy:
+
+```bash
+supabase functions deploy generate-meal-plan
+```
+
+Deploy targets whichever project is currently linked (`make link-dev` /
+`make link-prod`). Set the secret on each project you deploy to.

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,6 @@
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};

--- a/supabase/functions/generate-meal-plan/deno.json
+++ b/supabase/functions/generate-meal-plan/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.45.4"
+  }
+}

--- a/supabase/functions/generate-meal-plan/deno.lock
+++ b/supabase/functions/generate-meal-plan/deno.lock
@@ -1,0 +1,6 @@
+{
+  "version": "5",
+  "remote": {
+    "https://esm.sh/@supabase/supabase-js@2.45.4": "1108d69216995335d057dbd15907caaf514a4d1ef082f097050573b9d589a57c"
+  }
+}

--- a/supabase/functions/generate-meal-plan/index.ts
+++ b/supabase/functions/generate-meal-plan/index.ts
@@ -1,0 +1,370 @@
+import { createClient } from "@supabase/supabase-js";
+import { corsHeaders } from "../_shared/cors.ts";
+
+const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+const DEFAULT_MODEL = "gpt-4o-mini";
+
+const kAllergenKeys = [
+  "peanut",
+  "egg",
+  "dairy",
+  "tree_nuts",
+  "sesame",
+  "soy",
+  "wheat",
+  "fish",
+  "shellfish",
+] as const;
+
+type AllergenStatus = "notStarted" | "inProgress" | "safe" | "flagged";
+
+interface AllergenLogRow {
+  allergen_key: string;
+  had_reaction: boolean;
+  log_date: string;
+}
+
+interface RecipeRow {
+  id: string;
+  title: string;
+  age_range: string | null;
+  allergen_tags: string[] | null;
+  nutrition_tags: string[] | null;
+  category: string | null;
+}
+
+interface RequestBody {
+  babyId?: unknown;
+  startDate?: unknown;
+  endDate?: unknown;
+  preferences?: unknown;
+  notes?: unknown;
+}
+
+interface Assignment {
+  recipeId: string;
+  dayOffset: number;
+}
+
+const STAGE_TEXTURE: Record<number, { label: string; texture: string }> = {
+  0: { label: "Stage 0", texture: "Milk only — not on solids yet" },
+  1: { label: "Stage 1", texture: "Smooth, thin single-ingredient purées" },
+  2: { label: "Stage 2", texture: "Thicker purées and soft mashes" },
+  3: { label: "Stage 3", texture: "Lumpy mashes and soft finger foods" },
+  4: { label: "Stage 4", texture: "Soft chopped foods and finger foods" },
+  5: { label: "Stage 5", texture: "Soft family foods" },
+};
+
+// Whole-month age, mirroring lib/src/utils/age_in_months.dart.
+function ageInMonths(dob: Date, now: Date): number {
+  if (now <= dob) return 0;
+  let months = (now.getUTCFullYear() - dob.getUTCFullYear()) * 12 +
+    (now.getUTCMonth() - dob.getUTCMonth());
+  if (now.getUTCDate() < dob.getUTCDate()) months -= 1;
+  return months < 0 ? 0 : months;
+}
+
+// Mirrors the plan's meal_stage rule: <5→s0, 5→s1, 6→s2, 7-8→s3, 9-11→s4, >=12→s5.
+function mealStageForAge(ageMonths: number): number {
+  if (ageMonths < 5) return 0;
+  if (ageMonths === 5) return 1;
+  if (ageMonths === 6) return 2;
+  if (ageMonths <= 8) return 3;
+  if (ageMonths <= 11) return 4;
+  return 5;
+}
+
+// s0=1,s1=1,s2=2,s3=2,s4=3,s5=3 — clamped [1,3].
+function mealsPerDayForAge(ageMonths: number): number {
+  const perStage = [1, 1, 2, 2, 3, 3];
+  const meals = perStage[mealStageForAge(ageMonths)];
+  return Math.min(3, Math.max(1, meals));
+}
+
+// Mirrors deriveStatusForLogs (lib/src/common/services/helpers/derive_allergen_status.dart).
+function deriveStatusForLogs(logs: AllergenLogRow[]): AllergenStatus {
+  if (logs.length === 0) return "notStarted";
+  if (logs.some((l) => l.had_reaction)) return "flagged";
+  if (logs.length >= 3) return "safe";
+  return "inProgress";
+}
+
+function isoDateOnly(value: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const date = new Date(`${value}T00:00:00Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return json({ error: "Method not allowed" }, 405);
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  const openAiKey = Deno.env.get("OPENAI_API_KEY");
+  const model = Deno.env.get("OPENAI_MODEL") ?? DEFAULT_MODEL;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return json({ error: "Server misconfigured." }, 500);
+  }
+  if (!openAiKey) {
+    return json({ error: "AI service unavailable." }, 500);
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return json({ error: "Missing authorization." }, 401);
+  }
+
+  // JWT-bound client: RLS enforces that reads are limited to the caller's own
+  // babies / allergen logs. recipes are public-read, so no service role needed.
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false },
+  });
+
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  if (userError || !userData?.user) {
+    return json({ error: "Invalid or expired session." }, 401);
+  }
+
+  let body: RequestBody;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "Invalid JSON body." }, 400);
+  }
+
+  const babyId = typeof body.babyId === "string" ? body.babyId.trim() : "";
+  const startRaw = typeof body.startDate === "string" ? body.startDate : "";
+  const endRaw = typeof body.endDate === "string" ? body.endDate : "";
+  const preferences = Array.isArray(body.preferences)
+    ? body.preferences.filter((p): p is string => typeof p === "string")
+    : [];
+  const notes = typeof body.notes === "string" ? body.notes.trim() : "";
+
+  if (!babyId) return json({ error: "babyId is required." }, 400);
+
+  const startDate = isoDateOnly(startRaw);
+  const endDate = isoDateOnly(endRaw);
+  if (!startDate || !endDate) {
+    return json({ error: "startDate and endDate must be yyyy-MM-dd." }, 400);
+  }
+  if (endDate < startDate) {
+    return json({ error: "endDate must be on or after startDate." }, 400);
+  }
+
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const dayCount =
+    Math.round((endDate.getTime() - startDate.getTime()) / msPerDay) + 1;
+  if (dayCount < 1 || dayCount > 60) {
+    return json({ error: "Date range out of bounds." }, 400);
+  }
+
+  // ── Server-side reads ──────────────────────────────────────────────────────
+  const { data: baby, error: babyError } = await supabase
+    .from("babies")
+    .select("name, date_of_birth")
+    .eq("id", babyId)
+    .maybeSingle();
+
+  if (babyError) {
+    return json({ error: "Could not load baby profile." }, 500);
+  }
+  if (!baby) {
+    return json({ error: "Baby not found." }, 404);
+  }
+
+  const dob = isoDateOnly(String(baby.date_of_birth).slice(0, 10));
+  const ageMonths = dob ? ageInMonths(dob, new Date()) : 0;
+  const stage = mealStageForAge(ageMonths);
+  const mealsPerDay = mealsPerDayForAge(ageMonths);
+  const stageInfo = STAGE_TEXTURE[stage];
+
+  const { data: logRows, error: logsError } = await supabase
+    .from("allergen_logs")
+    .select("allergen_key, had_reaction, log_date")
+    .eq("baby_id", babyId);
+
+  if (logsError) {
+    return json({ error: "Could not load allergen history." }, 500);
+  }
+
+  const logsByKey = new Map<string, AllergenLogRow[]>();
+  for (const row of (logRows ?? []) as AllergenLogRow[]) {
+    const list = logsByKey.get(row.allergen_key) ?? [];
+    list.push(row);
+    logsByKey.set(row.allergen_key, list);
+  }
+
+  const statusByKey: Record<string, AllergenStatus> = {};
+  for (const key of kAllergenKeys) {
+    statusByKey[key] = deriveStatusForLogs(logsByKey.get(key) ?? []);
+  }
+  const flaggedKeys = new Set<string>(
+    kAllergenKeys.filter((k) => statusByKey[k] === "flagged"),
+  );
+
+  const { data: recipeRows, error: recipesError } = await supabase
+    .from("recipes")
+    .select("id, title, age_range, allergen_tags, nutrition_tags, category");
+
+  if (recipesError) {
+    return json({ error: "Could not load recipes." }, 500);
+  }
+
+  const pool = ((recipeRows ?? []) as RecipeRow[]).map((r) => ({
+    id: r.id,
+    title: r.title,
+    ageRange: r.age_range ?? "",
+    allergenTags: r.allergen_tags ?? [],
+    nutritionTags: r.nutrition_tags ?? [],
+    category: r.category ?? "Other",
+  }));
+
+  const poolById = new Map(pool.map((r) => [r.id, r]));
+
+  if (pool.length === 0) {
+    return json({ error: "No recipes available to plan from." }, 502);
+  }
+
+  // ── Prompt ─────────────────────────────────────────────────────────────────
+  const statusLines = kAllergenKeys
+    .map((k) => `- ${k}: ${statusByKey[k]}`)
+    .join("\n");
+
+  const poolLines = pool
+    .map((r) => {
+      const contains = r.allergenTags.length
+        ? r.allergenTags.join(", ")
+        : "none";
+      const nutrition = r.nutritionTags.length
+        ? r.nutritionTags.join(", ")
+        : "none";
+      return `- id="${r.id}" | "${r.title}" | age ${
+        r.ageRange || "n/a"
+      } | category ${r.category} | contains allergens: [${contains}] | nutrition: [${nutrition}]`;
+    })
+    .join("\n");
+
+  const systemPrompt =
+    "You are a paediatric-nutrition-aware meal planning assistant for a baby " +
+    "solids app. You ONLY select from the provided recipe pool and you return " +
+    "STRICT JSON. Never invent recipe ids. Prioritise safety: never assign a " +
+    "recipe that contains an allergen the baby has reacted to (flagged).";
+
+  const userPrompt = [
+    `Baby: ${baby.name}, age ${ageMonths} months.`,
+    `Meal stage: ${stageInfo.label} — texture rule: ${stageInfo.texture}.`,
+    `Target meals per day: ${mealsPerDay} (soft target, fill up to this many per day when good options exist).`,
+    `Plan spans ${dayCount} day(s), dayOffset 0..${dayCount - 1} inclusive.`,
+    "",
+    "Per-allergen status (safe = tolerated, flagged = reacted/AVOID, inProgress = currently being introduced, notStarted = not yet introduced):",
+    statusLines,
+    "",
+    "Rules:",
+    `- NEVER pick a recipe whose "contains allergens" intersects any FLAGGED allergen.`,
+    `- Prefer recipes whose minimum age is <= ${ageMonths} months (age-appropriate).`,
+    "- Honor the caregiver's preferences and notes below when choosing recipes.",
+    "- Variety across days is preferable; repeats are acceptable if the pool is small.",
+    "",
+    `Caregiver preferences: ${
+      preferences.length ? preferences.join(", ") : "none"
+    }.`,
+    `Caregiver notes: ${notes || "none"}.`,
+    "",
+    "Recipe pool:",
+    poolLines,
+    "",
+    'Return ONLY JSON of the form: {"assignments":[{"recipeId":"<id from pool>","dayOffset":<int>}]}.',
+    `Fill each day (dayOffset 0..${
+      dayCount - 1
+    }) with up to ${mealsPerDay} assignment(s).`,
+  ].join("\n");
+
+  // ── OpenAI call ──────────────────────────────────────────────────────────────
+  let aiResponse: Response;
+  try {
+    aiResponse = await fetch(OPENAI_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${openAiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        temperature: 0.4,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+      }),
+    });
+  } catch (_err) {
+    return json({ error: "AI request failed." }, 502);
+  }
+
+  if (!aiResponse.ok) {
+    // Do not surface the provider body — it can echo request context.
+    console.error(`OpenAI error status ${aiResponse.status}`);
+    return json({ error: "AI generation failed." }, 502);
+  }
+
+  let content: string;
+  try {
+    const payload = await aiResponse.json();
+    content = payload?.choices?.[0]?.message?.content ?? "";
+  } catch {
+    return json({ error: "AI returned an unreadable response." }, 502);
+  }
+
+  let parsed: { assignments?: unknown };
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return json({ error: "AI returned malformed JSON." }, 502);
+  }
+
+  const rawAssignments = Array.isArray(parsed?.assignments)
+    ? parsed.assignments
+    : [];
+
+  // ── Server-side validation ───────────────────────────────────────────────────
+  const assignments: Assignment[] = [];
+  for (const item of rawAssignments) {
+    if (typeof item !== "object" || item === null) continue;
+    const recipeId = (item as Record<string, unknown>).recipeId;
+    const dayOffset = (item as Record<string, unknown>).dayOffset;
+    if (typeof recipeId !== "string") continue;
+    if (typeof dayOffset !== "number" || !Number.isInteger(dayOffset)) continue;
+    if (dayOffset < 0 || dayOffset > dayCount - 1) continue;
+
+    const recipe = poolById.get(recipeId);
+    if (!recipe) continue;
+    if (recipe.allergenTags.some((tag) => flaggedKeys.has(tag))) continue;
+
+    assignments.push({ recipeId, dayOffset });
+  }
+
+  if (assignments.length === 0) {
+    return json(
+      { error: "AI did not produce any valid meal assignments." },
+      502,
+    );
+  }
+
+  return json({ assignments }, 200);
+});

--- a/supabase/migrations/20260707000001_create_meal_plans.sql
+++ b/supabase/migrations/20260707000001_create_meal_plans.sql
@@ -1,0 +1,36 @@
+-- Persisted meal-prep plan period. One active plan per baby is enforced
+-- app-side (create-new replaces). Existing meal_plan_entries without a
+-- meal_plan_id stay valid for the legacy rolling-7 path.
+CREATE TABLE IF NOT EXISTS public.meal_plans (
+  id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  baby_id    uuid        NOT NULL REFERENCES public.babies(id) ON DELETE CASCADE,
+  start_date date        NOT NULL,
+  end_date   date        NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS meal_plans_baby_id_idx
+  ON public.meal_plans (baby_id);
+
+ALTER TABLE public.meal_plan_entries
+  ADD COLUMN IF NOT EXISTS meal_plan_id uuid
+    REFERENCES public.meal_plans(id) ON DELETE CASCADE;
+
+ALTER TABLE public.meal_plans ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage meal plans for their own babies"
+  ON public.meal_plans FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.babies
+      WHERE babies.id = meal_plans.baby_id
+        AND babies.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.babies
+      WHERE babies.id = meal_plans.baby_id
+        AND babies.user_id = auth.uid()
+    )
+  );

--- a/test/common/domain/meal_stage_test.dart
+++ b/test/common/domain/meal_stage_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nibbles/src/common/domain/meal_stage.dart';
+
+void main() {
+  group('mealStageForAge', () {
+    test('boundaries map to expected stage', () {
+      expect(mealStageForAge(3), MealStage.stage0);
+      expect(mealStageForAge(4), MealStage.stage0);
+      expect(mealStageForAge(5), MealStage.stage1);
+      expect(mealStageForAge(6), MealStage.stage2);
+      expect(mealStageForAge(7), MealStage.stage3);
+      expect(mealStageForAge(8), MealStage.stage3);
+      expect(mealStageForAge(9), MealStage.stage4);
+      expect(mealStageForAge(11), MealStage.stage4);
+      expect(mealStageForAge(12), MealStage.stage5);
+      expect(mealStageForAge(18), MealStage.stage5);
+    });
+  });
+
+  group('mealsPerDayForAge', () {
+    test('boundaries map to expected meals per day (clamped [1,3])', () {
+      expect(mealsPerDayForAge(3), 1);
+      expect(mealsPerDayForAge(4), 1);
+      expect(mealsPerDayForAge(5), 1);
+      expect(mealsPerDayForAge(6), 2);
+      expect(mealsPerDayForAge(7), 2);
+      expect(mealsPerDayForAge(8), 2);
+      expect(mealsPerDayForAge(9), 3);
+      expect(mealsPerDayForAge(11), 3);
+      expect(mealsPerDayForAge(12), 3);
+      expect(mealsPerDayForAge(18), 3);
+    });
+
+    test('result always within [1,3]', () {
+      for (var age = 0; age <= 36; age++) {
+        final meals = mealsPerDayForAge(age);
+        expect(meals, greaterThanOrEqualTo(1));
+        expect(meals, lessThanOrEqualTo(3));
+      }
+    });
+  });
+
+  group('MealStageInfo', () {
+    test('texture strings match the flowchart', () {
+      expect(MealStage.stage0.texture, 'Milk only');
+      expect(MealStage.stage1.texture, 'Smooth / finely mashed');
+      expect(MealStage.stage2.texture, 'Thick mash / soft small lumps');
+      expect(
+        MealStage.stage3.texture,
+        'Lumpy mash / minced / soft finger foods',
+      );
+      expect(MealStage.stage4.texture, 'Chopped soft foods / mixed textures');
+      expect(MealStage.stage5.texture, 'Soft family foods');
+    });
+
+    test('stageNumber and label', () {
+      expect(MealStage.stage0.stageNumber, 0);
+      expect(MealStage.stage5.stageNumber, 5);
+      expect(MealStage.stage2.label, 'Stage 2');
+    });
+  });
+
+  group('mealsPerDayForDob', () {
+    test('derives meals per day from a date of birth', () {
+      final now = DateTime(2026, 7, 7);
+      // 6 months old → stage2 → 2 meals.
+      expect(mealsPerDayForDob(DateTime(2026, 1, 7), now: now), 2);
+      // 12 months old → stage5 → 3 meals.
+      expect(mealsPerDayForDob(DateTime(2025, 7, 7), now: now), 3);
+      // 3 months old → stage0 → 1 meal.
+      expect(mealsPerDayForDob(DateTime(2026, 4, 7), now: now), 1);
+    });
+  });
+}

--- a/test/features/meal_plan/map/map_meals_controller_test.dart
+++ b/test/features/meal_plan/map/map_meals_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
@@ -47,6 +48,14 @@ const _recipeB = Recipe(
   ingredients: [],
   steps: [],
   howToServe: 'Serve.',
+);
+
+final _fakePlan = MealPlan(
+  id: 'plan-001',
+  babyId: _babyId,
+  startDate: DateTime(2026, 5, 30),
+  endDate: DateTime(2026, 6, 5),
+  createdAt: DateTime(2026, 5, 30),
 );
 
 void main() {
@@ -141,7 +150,8 @@ void main() {
   });
 
   group('MapMealsController.assignToSelectedDay', () {
-    test('maps recipeId → selectedDay (overwrites on re-assign)', () {
+    test('COPIES recipe onto selectedDay — palette is reusable, so the same '
+        'recipe can land on multiple days', () {
       final container = buildContainer();
       final args = makeArgs();
       final notifier = container.read(mapMealsControllerProvider(args).notifier)
@@ -149,7 +159,7 @@ void main() {
         ..assignToSelectedDay('r-A');
 
       var state = container.read(mapMealsControllerProvider(args));
-      expect(state.assignments['r-A'], DateTime(2026, 5, 31));
+      expect(state.assignments[DateTime(2026, 5, 31)], ['r-A']);
 
       notifier
         ..selectDay(DateTime(2026, 6, 3))
@@ -157,35 +167,73 @@ void main() {
 
       state = container.read(mapMealsControllerProvider(args));
       expect(
-        state.assignments['r-A'],
-        DateTime(2026, 6, 3),
-        reason: 'Re-assignment should overwrite the original day.',
+        state.assignments[DateTime(2026, 5, 31)],
+        ['r-A'],
+        reason: 'The original day keeps its copy — assign never moves it.',
+      );
+      expect(
+        state.assignments[DateTime(2026, 6, 3)],
+        ['r-A'],
+        reason: 'A second copy lands on the newly selected day.',
+      );
+      expect(state.filledCount, 2);
+    });
+
+    test('appends multiple copies of the same recipe to one day', () {
+      final container = buildContainer();
+      final args = makeArgs();
+      container.read(mapMealsControllerProvider(args).notifier)
+        ..selectDay(DateTime(2026, 5, 31))
+        ..assignToSelectedDay('r-A')
+        ..assignToSelectedDay('r-A');
+
+      final state = container.read(mapMealsControllerProvider(args));
+      expect(state.assignments[DateTime(2026, 5, 31)], ['r-A', 'r-A']);
+    });
+  });
+
+  group('MapMealsController.unassignFromSelectedDayAt', () {
+    test('removes a single instance by index; empties the day when last '
+        'instance goes', () {
+      final container = buildContainer();
+      final args = makeArgs();
+      final notifier = container.read(mapMealsControllerProvider(args).notifier)
+        ..selectDay(DateTime(2026, 5, 31))
+        ..assignToSelectedDay('r-A')
+        ..assignToSelectedDay('r-B')
+        ..unassignFromSelectedDayAt(0);
+
+      var state = container.read(mapMealsControllerProvider(args));
+      expect(state.assignments[DateTime(2026, 5, 31)], ['r-B']);
+
+      notifier.unassignFromSelectedDayAt(0);
+      state = container.read(mapMealsControllerProvider(args));
+      expect(
+        state.assignments,
+        isEmpty,
+        reason: 'Removing the last instance drops the day key entirely.',
       );
     });
   });
 
-  group('MapMealsController.unassign', () {
-    test('removes the recipeId from assignments', () {
-      final container = buildContainer();
-      final args = makeArgs();
-      container.read(mapMealsControllerProvider(args).notifier)
-        ..assignToSelectedDay('r-A')
-        ..unassign('r-A');
-
-      final state = container.read(mapMealsControllerProvider(args));
-      expect(state.assignments, isEmpty);
-    });
-  });
+  void stubCreatePlanSuccess() {
+    when(
+      () => mockMealPlanService.createPlan(any(), any(), any()),
+    ).thenAnswer((_) async => Result.success(_fakePlan));
+  }
 
   group('MapMealsController.commit', () {
-    test('success: maps assignments → RecipeAssignment(dayOffset) and '
-        'returns true', () async {
+    test('success: creates the plan, then appends assignments →'
+        ' RecipeAssignment(dayOffset) carrying mealPlanId, and returns true',
+        () async {
       final args = makeArgs();
+      stubCreatePlanSuccess();
       when(
         () => mockMealPlanService.appendMealsToRange(
           babyId: any(named: 'babyId'),
           startDate: any(named: 'startDate'),
           endDate: any(named: 'endDate'),
+          mealPlanId: any(named: 'mealPlanId'),
           assignments: any(named: 'assignments'),
         ),
       ).thenAnswer((_) async => const Result.success([]));
@@ -201,12 +249,20 @@ void main() {
       final ok = await notifier.commit();
 
       expect(ok, isTrue);
+      verify(
+        () => mockMealPlanService.createPlan(
+          _babyId,
+          DateTime(2026, 5, 30),
+          DateTime(2026, 6, 5),
+        ),
+      ).called(1);
       final captured =
           verify(
                 () => mockMealPlanService.appendMealsToRange(
                   babyId: _babyId,
                   startDate: DateTime(2026, 5, 30),
                   endDate: DateTime(2026, 6, 5),
+                  mealPlanId: 'plan-001',
                   assignments: captureAny(named: 'assignments'),
                 ),
               ).captured.single
@@ -221,11 +277,13 @@ void main() {
     test('failure: sets errorMessage, returns false, records non-fatal via '
         'injected MealPrepCrashRecorderFn', () async {
       final args = makeArgs();
+      stubCreatePlanSuccess();
       when(
         () => mockMealPlanService.appendMealsToRange(
           babyId: any(named: 'babyId'),
           startDate: any(named: 'startDate'),
           endDate: any(named: 'endDate'),
+          mealPlanId: any(named: 'mealPlanId'),
           assignments: any(named: 'assignments'),
         ),
       ).thenAnswer((_) async => const Result.failure(ServerException('boom')));
@@ -249,28 +307,73 @@ void main() {
       );
     });
 
-    test(
-      'empty assignments short-circuits to false (no service call)',
-      () async {
-        final container = buildContainer();
-        final args = makeArgs();
-        final notifier = container.read(
-          mapMealsControllerProvider(args).notifier,
-        );
+    test('createPlan failure short-circuits before append, records non-fatal',
+        () async {
+      final args = makeArgs();
+      when(
+        () => mockMealPlanService.createPlan(any(), any(), any()),
+      ).thenAnswer((_) async => const Result.failure(ServerException('nope')));
 
-        final ok = await notifier.commit();
+      final container = buildContainer();
+      final notifier = container.read(mapMealsControllerProvider(args).notifier)
+        ..assignToSelectedDay('r-A');
 
-        expect(ok, isFalse);
-        verifyNever(
-          () => mockMealPlanService.appendMealsToRange(
-            babyId: any(named: 'babyId'),
-            startDate: any(named: 'startDate'),
-            endDate: any(named: 'endDate'),
-            assignments: any(named: 'assignments'),
-          ),
-        );
-      },
-    );
+      final ok = await notifier.commit();
+
+      expect(ok, isFalse);
+      expect(
+        container.read(mapMealsControllerProvider(args)).errorMessage,
+        'nope',
+      );
+      verifyNever(
+        () => mockMealPlanService.appendMealsToRange(
+          babyId: any(named: 'babyId'),
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          mealPlanId: any(named: 'mealPlanId'),
+          assignments: any(named: 'assignments'),
+        ),
+      );
+      expect(recorderCalls, hasLength(1));
+    });
+
+    test('empty assignments still creates the plan and returns true '
+        '(partial/empty mapping allowed)', () async {
+      final args = makeArgs();
+      stubCreatePlanSuccess();
+      when(
+        () => mockMealPlanService.appendMealsToRange(
+          babyId: any(named: 'babyId'),
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          mealPlanId: any(named: 'mealPlanId'),
+          assignments: any(named: 'assignments'),
+        ),
+      ).thenAnswer((_) async => const Result.success([]));
+
+      final container = buildContainer();
+      final notifier = container.read(
+        mapMealsControllerProvider(args).notifier,
+      );
+
+      final ok = await notifier.commit();
+
+      expect(ok, isTrue);
+      verify(() => mockMealPlanService.createPlan(any(), any(), any()))
+          .called(1);
+      final captured =
+          verify(
+                () => mockMealPlanService.appendMealsToRange(
+                  babyId: any(named: 'babyId'),
+                  startDate: any(named: 'startDate'),
+                  endDate: any(named: 'endDate'),
+                  mealPlanId: 'plan-001',
+                  assignments: captureAny(named: 'assignments'),
+                ),
+              ).captured.single
+              as List<RecipeAssignment>;
+      expect(captured, isEmpty);
+    });
   });
 }
 

--- a/test/features/meal_plan/map/map_meals_screen_test.dart
+++ b/test/features/meal_plan/map/map_meals_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/app_exception.dart';
 import 'package:nibbles/src/common/data/sources/remote/config/result.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 import 'package:nibbles/src/common/domain/enums/gender.dart';
 import 'package:nibbles/src/common/services/baby_profile_service.dart';
@@ -25,13 +26,24 @@ class _MockMealPlanService extends Mock implements MealPlanService {}
 
 const _babyId = 'baby-001';
 
+// DOB comfortably ≥12 months in the past → Stage 5 → 3 meals/day. Over a
+// 7-day window that is 7 × 3 = 21 target slots. Kept in the past so the
+// derived stage stays deterministic as the real clock advances.
 final _fakeBaby = Baby(
   id: _babyId,
   userId: 'user-001',
   name: 'Lily',
-  dateOfBirth: DateTime(2025, 6),
+  dateOfBirth: DateTime(2024),
   gender: Gender.female,
   onboardingCompleted: true,
+);
+
+final _fakePlan = MealPlan(
+  id: 'plan-001',
+  babyId: _babyId,
+  startDate: DateTime(2026, 5, 30),
+  endDate: DateTime(2026, 6, 5),
+  createdAt: DateTime(2026, 5, 30),
 );
 
 const _recipeA = Recipe(
@@ -132,20 +144,19 @@ void main() {
 
   group('MapMealsScreen', () {
     testWidgets(
-      'renders day chips, picked recipe list and the "X of Y slots filled" '
-      'progress badge',
+      'renders day chips, picked recipe list and the "X of M slots filled" '
+      'subtitle (M = days × mealsPerDay = 7 × 3 = 21)',
       (tester) async {
         await pumpMap(tester);
 
         expect(find.byType(DayChipRow), findsOneWidget);
         expect(find.byType(PickedRecipeRow), findsNWidgets(2));
-        expect(find.text('0 of 2 slots filled'), findsOneWidget);
+        expect(find.text('0 of 21 slots filled'), findsOneWidget);
       },
     );
 
-    testWidgets('tapping a picked recipe assigns it to the selected day', (
-      tester,
-    ) async {
+    testWidgets('tapping a picked recipe assigns (copies) it to the selected '
+        'day and bumps the filled count', (tester) async {
       await pumpMap(tester);
 
       // Tap the first picked recipe to assign it to the (currently) selected
@@ -153,30 +164,21 @@ void main() {
       await tester.tap(find.text(_recipeA.title));
       await tester.pumpAndSettle();
 
-      expect(find.text('1 of 2 slots filled'), findsOneWidget);
+      expect(find.text('1 of 21 slots filled'), findsOneWidget);
+      // Palette never shrinks — both picked rows remain after assigning.
+      expect(find.byType(PickedRecipeRow), findsNWidgets(2));
     });
 
     testWidgets(
-      'floating CTA is absent with 0 assignments, says "Add (N)" while '
-      'partial, and "Complete Mapping" once every picked recipe is assigned',
+      'floating Finish pill is present and enabled with 0 assignments '
+      '(partial/empty mapping allowed)',
       (tester) async {
         await pumpMap(tester);
 
-        // 0 assignments → no CTA rendered at all.
-        expect(find.byType(FilledButton), findsNothing);
-
-        // 1 of 2 assigned → "Add (1)".
-        await tester.tap(find.text(_recipeA.title));
-        await tester.pumpAndSettle();
-        expect(find.widgetWithText(FilledButton, 'Add (1)'), findsOneWidget);
-
-        // 2 of 2 assigned → "Complete Mapping".
-        await tester.tap(find.text(_recipeB.title));
-        await tester.pumpAndSettle();
-        expect(
-          find.widgetWithText(FilledButton, 'Complete Mapping'),
-          findsOneWidget,
-        );
+        // Finish is always available — no per-progress label swap.
+        expect(find.text('Finish'), findsOneWidget);
+        expect(find.text('Add (1)'), findsNothing);
+        expect(find.text('Complete Mapping'), findsNothing);
       },
     );
 
@@ -193,12 +195,18 @@ void main() {
       },
     );
 
-    testWidgets('commit success pops the route with true', (tester) async {
+    testWidgets('Finish creates the plan then appends and pops with true', (
+      tester,
+    ) async {
+      when(
+        () => mockMealPlanService.createPlan(any(), any(), any()),
+      ).thenAnswer((_) async => Result.success(_fakePlan));
       when(
         () => mockMealPlanService.appendMealsToRange(
           babyId: any(named: 'babyId'),
           startDate: any(named: 'startDate'),
           endDate: any(named: 'endDate'),
+          mealPlanId: any(named: 'mealPlanId'),
           assignments: any(named: 'assignments'),
         ),
       ).thenAnswer((_) async => const Result.success([]));
@@ -251,25 +259,38 @@ void main() {
       await tester.tap(find.text('Push'));
       await tester.pumpAndSettle();
 
-      // Assign both recipes (so the CTA says "Complete Mapping") + commit.
+      // Assign both recipes, then Finish.
       await tester.tap(find.text(_recipeA.title));
       await tester.pumpAndSettle();
       await tester.tap(find.text(_recipeB.title));
       await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(FilledButton, 'Complete Mapping'));
+      await tester.tap(find.text('Finish'));
       await tester.pumpAndSettle();
 
       expect(popResult, isTrue);
+      verify(
+        () => mockMealPlanService.appendMealsToRange(
+          babyId: _babyId,
+          startDate: DateTime(2026, 5, 30),
+          endDate: DateTime(2026, 6, 5),
+          mealPlanId: 'plan-001',
+          assignments: any(named: 'assignments'),
+        ),
+      ).called(1);
     });
 
     testWidgets('commit failure shows a blocking AlertDialog with Retry that '
         're-calls commit', (tester) async {
       var callCount = 0;
       when(
+        () => mockMealPlanService.createPlan(any(), any(), any()),
+      ).thenAnswer((_) async => Result.success(_fakePlan));
+      when(
         () => mockMealPlanService.appendMealsToRange(
           babyId: any(named: 'babyId'),
           startDate: any(named: 'startDate'),
           endDate: any(named: 'endDate'),
+          mealPlanId: any(named: 'mealPlanId'),
           assignments: any(named: 'assignments'),
         ),
       ).thenAnswer((_) async {
@@ -283,7 +304,7 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.text(_recipeB.title));
       await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(FilledButton, 'Complete Mapping'));
+      await tester.tap(find.text('Finish'));
       await tester.pumpAndSettle();
 
       // Blocking AlertDialog with Retry button.
@@ -303,10 +324,14 @@ void main() {
       tester,
     ) async {
       when(
+        () => mockMealPlanService.createPlan(any(), any(), any()),
+      ).thenAnswer((_) async => Result.success(_fakePlan));
+      when(
         () => mockMealPlanService.appendMealsToRange(
           babyId: any(named: 'babyId'),
           startDate: any(named: 'startDate'),
           endDate: any(named: 'endDate'),
+          mealPlanId: any(named: 'mealPlanId'),
           assignments: any(named: 'assignments'),
         ),
       ).thenAnswer((_) async => const Result.failure(NetworkException()));
@@ -317,7 +342,7 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.text(_recipeB.title));
       await tester.pumpAndSettle();
-      await tester.tap(find.widgetWithText(FilledButton, 'Complete Mapping'));
+      await tester.tap(find.text('Finish'));
       await tester.pumpAndSettle();
 
       // The dialog now shows the controller's real failure message (the P1

--- a/test/features/meal_plan/map/widgets/picked_recipe_row_test.dart
+++ b/test/features/meal_plan/map/widgets/picked_recipe_row_test.dart
@@ -1,6 +1,6 @@
-// a11y coverage for PickedRecipeRow — the bare InkWell tap-to-assign target
-// now exposes a labelled button; the assigned-day badge is surfaced in the
-// accessible name (excludeSemantics would otherwise drop it).
+// a11y + interaction coverage for PickedRecipeRow — the reusable palette row
+// exposes a labelled tap-to-assign button AND is wrapped in a Draggable<Recipe>
+// so it can be dropped onto the day drop-zone.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -28,28 +28,27 @@ void main() {
       _wrap(PickedRecipeRow(recipe: _recipe, onTap: () => tapped = true)),
     );
 
-    expect(find.bySemanticsLabel('Pea Puree'), findsOneWidget);
+    final label = find.bySemanticsLabel(
+      'Pea Puree. Drag or tap to add to the selected day',
+    );
+    expect(label, findsOneWidget);
 
-    await tester.tap(find.bySemanticsLabel('Pea Puree'));
+    await tester.tap(label);
     expect(tapped, isTrue);
 
     handle.dispose();
   });
 
-  testWidgets('assignedLabel is surfaced in the button label', (tester) async {
-    final handle = tester.ensureSemantics();
-
+  testWidgets('is wrapped in a Draggable<Recipe> carrying the recipe', (
+    tester,
+  ) async {
     await tester.pumpWidget(
-      _wrap(
-        PickedRecipeRow(recipe: _recipe, onTap: () {}, assignedLabel: 'Tue 3'),
-      ),
+      _wrap(PickedRecipeRow(recipe: _recipe, onTap: () {})),
     );
 
-    expect(
-      find.bySemanticsLabel('Pea Puree, assigned to Tue 3'),
-      findsOneWidget,
+    final draggable = tester.widget<Draggable<Recipe>>(
+      find.byType(Draggable<Recipe>),
     );
-
-    handle.dispose();
+    expect(draggable.data, _recipe);
   });
 }

--- a/test/features/meal_plan/map/widgets/selected_day_slot_list_test.dart
+++ b/test/features/meal_plan/map/widgets/selected_day_slot_list_test.dart
@@ -1,6 +1,7 @@
 // a11y coverage for SelectedDaySlotList — the icon-only unassign button now
-// carries a "Remove from day" tooltip (which also serves as its screen-reader
-// label) and fires onRemove with the recipe id.
+// carries a per-recipe "Remove {title} from day" tooltip (which also serves as
+// its screen-reader label) and fires onRemoveAt with the card's positional
+// index (duplicates are removed by position, not id).
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,25 +19,24 @@ const _recipe = Recipe(
 );
 
 void main() {
-  testWidgets('remove button has a tooltip label + fires onRemove with id', (
-    tester,
-  ) async {
-    String? removed;
+  testWidgets('remove button has a per-recipe tooltip + fires onRemoveAt with '
+      'the index', (tester) async {
+    int? removedIndex;
 
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: SelectedDaySlotList(
             recipes: const [_recipe],
-            onRemove: (id) => removed = id,
+            onRemoveAt: (index) => removedIndex = index,
           ),
         ),
       ),
     );
 
-    expect(find.byTooltip('Remove from day'), findsOneWidget);
+    expect(find.byTooltip('Remove Pea Puree from day'), findsOneWidget);
 
-    await tester.tap(find.byTooltip('Remove from day'));
-    expect(removed, 'r1');
+    await tester.tap(find.byTooltip('Remove Pea Puree from day'));
+    expect(removedIndex, 0);
   });
 }

--- a/test/features/meal_plan/meal_plan_controller_test.dart
+++ b/test/features/meal_plan/meal_plan_controller_test.dart
@@ -7,6 +7,7 @@ import 'package:nibbles/src/common/domain/entities/allergen.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
@@ -38,6 +39,14 @@ final _fakeBaby = Baby(
   dateOfBirth: DateTime(2025, 6),
   gender: Gender.female,
   onboardingCompleted: true,
+);
+
+final _defaultPlan = MealPlan(
+  id: 'plan-1',
+  babyId: _babyId,
+  startDate: DateTime(2026, 5, 30),
+  endDate: DateTime(2026, 6, 5),
+  createdAt: DateTime(2026, 5, 29),
 );
 
 const _peanutAllergen = Allergen(
@@ -124,10 +133,15 @@ void main() {
   void stubHappy({
     List<MealPlanEntry> entries = const [],
     AllergenProgramState? programState,
+    MealPlan? plan,
+    bool hasPlan = true,
   }) {
     when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);
+    when(() => mockMealPlanService.getActivePlan(any())).thenAnswer(
+      (_) async => Result.success(hasPlan ? (plan ?? _defaultPlan) : null),
+    );
     when(
-      () => mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
+      () => mockMealPlanService.getEntriesForPlan(any()),
     ).thenAnswer((_) async => Result.success(entries));
     when(
       () => mockRecipeService.getFlaggedAllergenKeys(any()),
@@ -150,8 +164,8 @@ void main() {
   }
 
   group('MealPlanController.build', () {
-    test('NIB-159: windowStart is today (date-only), windowEnd is today + 6, '
-        'populates entries + baby, expanded starts empty', () async {
+    test('active plan → window is the plan range, populates entries + '
+        'baby + plan, expanded starts empty', () async {
       final entry = _makeEntry();
       stubHappy(entries: [entry]);
 
@@ -160,13 +174,9 @@ void main() {
         mealPlanControllerProvider(_babyId).future,
       );
 
-      final today = DateTime.now();
-      final expectedStart = DateTime(today.year, today.month, today.day);
-      final expectedEnd = expectedStart.add(const Duration(days: 6));
-
-      expect(state.windowStart, expectedStart);
-      expect(state.windowEnd, expectedEnd);
-      expect(state.windowEnd.difference(state.windowStart).inDays, 6);
+      expect(state.plan?.id, 'plan-1');
+      expect(state.windowStart, DateTime(2026, 5, 30));
+      expect(state.windowEnd, DateTime(2026, 6, 5));
       expect(state.entries, hasLength(1));
       expect(state.entries.single.id, 'mp-1');
       expect(state.baby?.id, _babyId);
@@ -174,75 +184,56 @@ void main() {
       expect(state.recipes['recipe-001']?.title, 'Peanut Butter Toast');
     });
 
-    test('NIB-159: getRolling7 is invoked with today as windowStart, '
-        'not the Monday-snapped week start', () async {
+    test('no active plan → plan null, entries empty', () async {
+      stubHappy(hasPlan: false);
+
+      final container = buildContainer();
+      final state = await container.read(
+        mealPlanControllerProvider(_babyId).future,
+      );
+
+      expect(state.plan, isNull);
+      expect(state.entries, isEmpty);
+      // getEntriesForPlan is not called when there is no plan.
+      verifyNever(
+        () => mockMealPlanService.getEntriesForPlan(any()),
+      );
+    });
+
+    test('getEntriesForPlan is invoked with the active plan id', () async {
       stubHappy();
       final container = buildContainer();
       await container.read(mealPlanControllerProvider(_babyId).future);
 
-      final today = DateTime.now();
-      final expectedStart = DateTime(today.year, today.month, today.day);
-
       verify(
-        () => mockMealPlanService.getRolling7(_babyId, today: expectedStart),
+        () => mockMealPlanService.getEntriesForPlan('plan-1'),
       ).called(1);
     });
 
-    test(
-      'NIB-159 regression: a plan starting Thu 11 Jun renders exactly '
-      '11..17, not the Mon 8–Sun 14 calendar week',
-      () async {
-        // Fix "now" to Thu 11 Jun 2026 — the exact repro from the ticket.
-        MealPlanController.nowBuilder = () => DateTime(2026, 6, 11, 9, 30);
-        expect(DateTime(2026, 6, 11).weekday, DateTime.thursday);
+    test('window end extends to cover an entry past the plan end', () async {
+      stubHappy(
+        plan: MealPlan(
+          id: 'plan-2',
+          babyId: _babyId,
+          startDate: DateTime(2026, 6, 11),
+          endDate: DateTime(2026, 6, 13),
+          createdAt: DateTime(2026, 6, 10),
+        ),
+        entries: [_makeEntry(planDate: DateTime(2026, 6, 17))],
+      );
 
-        // Entry on the last selected day (17th) — invisible under Monday-snap.
-        stubHappy(entries: [_makeEntry(planDate: DateTime(2026, 6, 17))]);
+      final container = buildContainer();
+      final state = await container.read(
+        mealPlanControllerProvider(_babyId).future,
+      );
 
-        final container = buildContainer();
-        final state = await container.read(
-          mealPlanControllerProvider(_babyId).future,
-        );
+      expect(state.windowStart, DateTime(2026, 6, 11));
+      expect(state.windowEnd, DateTime(2026, 6, 17));
+    });
 
-        expect(state.windowStart, DateTime(2026, 6, 11));
-        expect(state.windowEnd, DateTime(2026, 6, 17));
-
-        // The rendered day list (screen derives it from windowStart..windowEnd)
-        // must be exactly 11..17 inclusive.
-        final start = DateTime(
-          state.windowStart.year,
-          state.windowStart.month,
-          state.windowStart.day,
-        );
-        final count = state.windowEnd.difference(start).inDays + 1;
-        final days = [
-          for (var i = 0; i < count; i++) start.add(Duration(days: i)),
-        ];
-        expect(days, [
-          DateTime(2026, 6, 11),
-          DateTime(2026, 6, 12),
-          DateTime(2026, 6, 13),
-          DateTime(2026, 6, 14),
-          DateTime(2026, 6, 15),
-          DateTime(2026, 6, 16),
-          DateTime(2026, 6, 17),
-        ]);
-        // Monday-snap bug days must NOT appear; selected tail days must.
-        expect(days.contains(DateTime(2026, 6, 8)), isFalse);
-        expect(days.contains(DateTime(2026, 6, 9)), isFalse);
-        expect(days.contains(DateTime(2026, 6, 10)), isFalse);
-        expect(days.contains(DateTime(2026, 6, 15)), isTrue);
-        expect(days.contains(DateTime(2026, 6, 16)), isTrue);
-        expect(days.contains(DateTime(2026, 6, 17)), isTrue);
-      },
-    );
-
-    test('build() with getRolling7 failure surfaces AsyncError', () async {
+    test('build() with getActivePlan failure surfaces AsyncError', () async {
       when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);
-      when(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).thenAnswer(
+      when(() => mockMealPlanService.getActivePlan(any())).thenAnswer(
         (_) async => const Result.failure(ServerException('db down')),
       );
       when(
@@ -258,13 +249,27 @@ void main() {
         throwsA(isA<StateError>()),
       );
     });
+
+    test('getEntriesForPlan failure surfaces AsyncError', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.getEntriesForPlan(any()),
+      ).thenAnswer(
+        (_) async => const Result.failure(ServerException('db down')),
+      );
+
+      final container = buildContainer();
+      await expectLater(
+        container.read(mealPlanControllerProvider(_babyId).future),
+        throwsA(isA<StateError>()),
+      );
+    });
   });
 
   group('MealPlanController.toggleExpanded', () {
     test('flips a day key WITHOUT re-fetching from the service', () async {
       stubHappy();
       final container = buildContainer();
-      // Initial build
       await container.read(mealPlanControllerProvider(_babyId).future);
 
       final notifier = container.read(
@@ -284,11 +289,7 @@ void main() {
       state = container.read(mealPlanControllerProvider(_babyId)).valueOrNull!;
       expect(state.expanded[key], isFalse);
 
-      // Toggle does not refetch.
-      verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(1);
+      verify(() => mockMealPlanService.getActivePlan(any())).called(1);
     });
   });
 
@@ -301,6 +302,7 @@ void main() {
           startDate: any(named: 'startDate'),
           endDate: any(named: 'endDate'),
           assignments: any(named: 'assignments'),
+          mealPlanId: any(named: 'mealPlanId'),
         ),
       ).thenAnswer((_) async => const Result.success([]));
 
@@ -319,14 +321,20 @@ void main() {
         ],
       );
 
-      // Re-await the future so the invalidate-driven rebuild settles.
       await container.read(mealPlanControllerProvider(_babyId).future);
 
       expect(ok, isTrue);
+      // Passes the active plan id through to the append.
       verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(2);
+        () => mockMealPlanService.appendMealsToRange(
+          babyId: _babyId,
+          startDate: any(named: 'startDate'),
+          endDate: any(named: 'endDate'),
+          assignments: any(named: 'assignments'),
+          mealPlanId: 'plan-1',
+        ),
+      ).called(1);
+      verify(() => mockMealPlanService.getActivePlan(any())).called(2);
     });
 
     test('returns false on failure and does NOT invalidate self', () async {
@@ -337,6 +345,7 @@ void main() {
           startDate: any(named: 'startDate'),
           endDate: any(named: 'endDate'),
           assignments: any(named: 'assignments'),
+          mealPlanId: any(named: 'mealPlanId'),
         ),
       ).thenAnswer(
         (_) async => const Result.failure(ServerException('db down')),
@@ -357,11 +366,7 @@ void main() {
       );
 
       expect(ok, isFalse);
-      // Only the initial build call — no invalidation.
-      verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(1);
+      verify(() => mockMealPlanService.getActivePlan(any())).called(1);
     });
   });
 
@@ -385,10 +390,7 @@ void main() {
       await container.read(mealPlanControllerProvider(_babyId).future);
 
       expect(ok, isTrue);
-      verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(2);
+      verify(() => mockMealPlanService.getActivePlan(any())).called(2);
     });
 
     test('returns false on failure and does NOT invalidate self', () async {
@@ -411,99 +413,7 @@ void main() {
       );
 
       expect(ok, isFalse);
-      verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(1);
-    });
-  });
-
-  group('MealPlanController.assignRecipe', () {
-    test('returns true on success and invalidates self', () async {
-      stubHappy();
-      when(
-        () => mockMealPlanService.assignRecipe(any(), any(), any()),
-      ).thenAnswer((_) async => Result.success(_makeEntry()));
-
-      final container = buildContainer();
-      await container.read(mealPlanControllerProvider(_babyId).future);
-
-      final ok = await container
-          .read(mealPlanControllerProvider(_babyId).notifier)
-          .assignRecipe(DateTime(2026, 5, 30), 'recipe-001');
-      await container.read(mealPlanControllerProvider(_babyId).future);
-
-      expect(ok, isTrue);
-      verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(2);
-    });
-
-    test('returns false on failure, does NOT invalidate self', () async {
-      stubHappy();
-      when(
-        () => mockMealPlanService.assignRecipe(any(), any(), any()),
-      ).thenAnswer(
-        (_) async => const Result.failure(ServerException('assign failed')),
-      );
-
-      final container = buildContainer();
-      await container.read(mealPlanControllerProvider(_babyId).future);
-
-      final ok = await container
-          .read(mealPlanControllerProvider(_babyId).notifier)
-          .assignRecipe(DateTime(2026, 5, 30), 'recipe-001');
-
-      expect(ok, isFalse);
-      verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(1);
-    });
-  });
-
-  group('MealPlanController.removeEntry', () {
-    test('returns true on success and invalidates self', () async {
-      stubHappy();
-      when(
-        () => mockMealPlanService.removeEntry(any()),
-      ).thenAnswer((_) async => const Result<void>.success(null));
-
-      final container = buildContainer();
-      await container.read(mealPlanControllerProvider(_babyId).future);
-
-      final ok = await container
-          .read(mealPlanControllerProvider(_babyId).notifier)
-          .removeEntry('mp-1');
-      await container.read(mealPlanControllerProvider(_babyId).future);
-
-      expect(ok, isTrue);
-      verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(2);
-    });
-
-    test('returns false on failure, does NOT invalidate self', () async {
-      stubHappy();
-      when(() => mockMealPlanService.removeEntry(any())).thenAnswer(
-        (_) async =>
-            const Result<void>.failure(ServerException('delete failed')),
-      );
-
-      final container = buildContainer();
-      await container.read(mealPlanControllerProvider(_babyId).future);
-
-      final ok = await container
-          .read(mealPlanControllerProvider(_babyId).notifier)
-          .removeEntry('mp-1');
-
-      expect(ok, isFalse);
-      verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(1);
+      verify(() => mockMealPlanService.getActivePlan(any())).called(1);
     });
   });
 
@@ -523,10 +433,7 @@ void main() {
       await container.read(mealPlanControllerProvider(_babyId).future);
 
       expect(ok, isTrue);
-      verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(2);
+      verify(() => mockMealPlanService.getActivePlan(any())).called(2);
     });
 
     test('returns false on failure, does NOT invalidate self', () async {
@@ -544,10 +451,80 @@ void main() {
           .clearDay(DateTime(2026, 5, 30));
 
       expect(ok, isFalse);
-      verify(
-        () =>
-            mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
-      ).called(1);
+      verify(() => mockMealPlanService.getActivePlan(any())).called(1);
+    });
+  });
+
+  group('MealPlanController.deleteActivePlan', () {
+    test('returns true on success and invalidates self', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.deletePlan(any()),
+      ).thenAnswer((_) async => const Result<void>.success(null));
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final ok = await container
+          .read(mealPlanControllerProvider(_babyId).notifier)
+          .deleteActivePlan();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      expect(ok, isTrue);
+      verify(() => mockMealPlanService.deletePlan('plan-1')).called(1);
+      verify(() => mockMealPlanService.getActivePlan(any())).called(2);
+    });
+
+    test('returns false when there is no active plan', () async {
+      stubHappy(hasPlan: false);
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final ok = await container
+          .read(mealPlanControllerProvider(_babyId).notifier)
+          .deleteActivePlan();
+
+      expect(ok, isFalse);
+      verifyNever(() => mockMealPlanService.deletePlan(any()));
+    });
+  });
+
+  group('MealPlanController.removeEntry', () {
+    test('returns true on success and invalidates self', () async {
+      stubHappy();
+      when(
+        () => mockMealPlanService.removeEntry(any()),
+      ).thenAnswer((_) async => const Result<void>.success(null));
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final ok = await container
+          .read(mealPlanControllerProvider(_babyId).notifier)
+          .removeEntry('mp-1');
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      expect(ok, isTrue);
+      verify(() => mockMealPlanService.getActivePlan(any())).called(2);
+    });
+
+    test('returns false on failure, does NOT invalidate self', () async {
+      stubHappy();
+      when(() => mockMealPlanService.removeEntry(any())).thenAnswer(
+        (_) async =>
+            const Result<void>.failure(ServerException('delete failed')),
+      );
+
+      final container = buildContainer();
+      await container.read(mealPlanControllerProvider(_babyId).future);
+
+      final ok = await container
+          .read(mealPlanControllerProvider(_babyId).notifier)
+          .removeEntry('mp-1');
+
+      expect(ok, isFalse);
+      verify(() => mockMealPlanService.getActivePlan(any())).called(1);
     });
   });
 }

--- a/test/features/meal_plan/meal_plan_screen_test.dart
+++ b/test/features/meal_plan/meal_plan_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:nibbles/src/common/domain/entities/allergen.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_board_item.dart';
 import 'package:nibbles/src/common/domain/entities/allergen_program_state.dart';
 import 'package:nibbles/src/common/domain/entities/baby.dart';
+import 'package:nibbles/src/common/domain/entities/meal_plan.dart';
 import 'package:nibbles/src/common/domain/entities/meal_plan_entry.dart';
 import 'package:nibbles/src/common/domain/entities/recipe.dart';
 import 'package:nibbles/src/common/domain/enums/allergen_program_status.dart';
@@ -62,6 +63,19 @@ const _fakeRecipe = Recipe(
   ingredients: [],
   steps: [],
   howToServe: 'Serve.',
+);
+
+DateTime _today() {
+  final n = DateTime.now();
+  return DateTime(n.year, n.month, n.day);
+}
+
+MealPlan _planFrom(DateTime start, {int days = 7}) => MealPlan(
+  id: 'plan-1',
+  babyId: _babyId,
+  startDate: start,
+  endDate: start.add(Duration(days: days - 1)),
+  createdAt: start,
 );
 
 AllergenProgramState _makeProgramState({
@@ -123,12 +137,16 @@ void main() {
   });
 
   void stubBoot({
+    MealPlan? plan,
     List<MealPlanEntry> entries = const [],
     AllergenProgramState? programState,
   }) {
     when(() => mockBabyService.getBaby()).thenAnswer((_) async => _fakeBaby);
     when(
-      () => mockMealPlanService.getRolling7(any(), today: any(named: 'today')),
+      () => mockMealPlanService.getActivePlan(any()),
+    ).thenAnswer((_) async => Result.success(plan));
+    when(
+      () => mockMealPlanService.getEntriesForPlan(any()),
     ).thenAnswer((_) async => Result.success(entries));
     when(
       () => mockRecipeService.getFlaggedAllergenKeys(any()),
@@ -173,34 +191,33 @@ void main() {
 
   group('MealPlanScreen empty branch', () {
     testWidgets(
-      'renders MealPlanEmptyState + header (no day-count line) and no '
-      'DayAccordionCards when entries is empty',
+      'no active plan → MealPlanEmptyState + header (no day-count line) + no '
+      'DayAccordionCards + no overflow button',
       (tester) async {
         stubBoot();
         await pumpScreen(tester);
 
         expect(find.byType(MealPlanEmptyState), findsOneWidget);
         expect(find.byType(DayAccordionCard), findsNothing);
-        // Per Figma 971:8199 the empty state still shows the header (title +
-        // age subtitle + overflow button) — only the populated view renders
-        // the "Meal plan for X days" line.
         expect(find.byType(MealPlanHeader), findsOneWidget);
         expect(find.textContaining('Meal plan for'), findsNothing);
+        // Overflow is hidden on the empty state.
+        expect(find.byType(MealPlanOverflowButton), findsNothing);
+        // Both meal-prep CTAs are present (disabled until a range is chosen).
+        expect(find.text('Set a Meal Prep'), findsOneWidget);
+        expect(find.text('Fill in myself'), findsOneWidget);
       },
     );
   });
 
   group('MealPlanScreen populated branch', () {
-    testWidgets('renders MealPlanHeader + 7 DayAccordionCards + AddDatePill', (
-      tester,
-    ) async {
-      final start = DateTime.now();
-      final today = DateTime(start.year, start.month, start.day);
-      stubBoot(entries: [_entry(today)]);
+    testWidgets('active plan → MealPlanHeader + 7 DayAccordionCards + '
+        'AddDatePill', (tester) async {
+      final today = _today();
+      stubBoot(plan: _planFrom(today), entries: [_entry(today)]);
       await pumpScreen(tester);
 
       expect(find.byType(MealPlanHeader), findsOneWidget);
-      // Rolling-7 window.
       expect(find.byType(DayAccordionCard), findsNWidgets(7));
       expect(find.byType(AddDatePill), findsOneWidget);
       expect(find.byType(MealPlanEmptyState), findsNothing);
@@ -211,9 +228,8 @@ void main() {
     testWidgets('shows exactly 3 items in the screen-level menu', (
       tester,
     ) async {
-      final start = DateTime.now();
-      final today = DateTime(start.year, start.month, start.day);
-      stubBoot(entries: [_entry(today)]);
+      final today = _today();
+      stubBoot(plan: _planFrom(today), entries: [_entry(today)]);
       await pumpScreen(tester);
 
       await tester.tap(find.byType(MealPlanOverflowButton));
@@ -221,44 +237,34 @@ void main() {
 
       expect(find.text('Add to shop list'), findsOneWidget);
       expect(find.text('Create new meal prep'), findsOneWidget);
-      expect(find.text('Clear current week'), findsOneWidget);
-      // PopupMenuItem<_ScreenMenuAction> is private — match by superclass.
+      expect(find.text('Clear current plan'), findsOneWidget);
       expect(
         find.byWidgetPredicate((w) => w is PopupMenuItem),
         findsNWidgets(3),
       );
     });
 
-    testWidgets('empty-state overflow → Create new meal prep opens '
-        'SelectPeriodDateSheet', (tester) async {
-      // Force the empty branch so we land on MealPlanEmptyState with the
-      // single-item overflow menu.
-      stubBoot();
+    testWidgets('Create new meal prep opens SelectPeriodDateSheet', (
+      tester,
+    ) async {
+      final today = _today();
+      stubBoot(plan: _planFrom(today), entries: [_entry(today)]);
       await pumpScreen(tester);
 
-      // Tap the header overflow button on the empty state.
       await tester.tap(find.byType(MealPlanOverflowButton));
       await tester.pumpAndSettle();
-
-      // The empty-state menu carries only 'Create new meal prep'.
-      expect(find.text('Create new meal prep'), findsOneWidget);
-      expect(find.byWidgetPredicate((w) => w is PopupMenuItem), findsOneWidget);
-
-      // Picking it opens the Select Period Date sheet.
       await tester.tap(find.text('Create new meal prep'));
       await tester.pumpAndSettle();
+
       expect(find.byType(SelectPeriodDateSheet), findsOneWidget);
       expect(find.text('Select Period Date'), findsOneWidget);
     });
 
     testWidgets('per-card overflow menu shows exactly 2 items', (tester) async {
-      final start = DateTime.now();
-      final today = DateTime(start.year, start.month, start.day);
-      stubBoot(entries: [_entry(today)]);
+      final today = _today();
+      stubBoot(plan: _planFrom(today), entries: [_entry(today)]);
       await pumpScreen(tester);
 
-      // Tap the kebab INSIDE the first DayAccordionCard (avoid the
-      // header-level MealPlanOverflowButton which renders the same icon).
       final cardKebab = find
           .descendant(
             of: find.byType(DayAccordionCard).first,
@@ -269,7 +275,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Add to shop list'), findsOneWidget);
-      expect(find.text('Clear current week'), findsOneWidget);
+      expect(find.text('Clear current date'), findsOneWidget);
       expect(
         find.byWidgetPredicate((w) => w is PopupMenuItem),
         findsNWidgets(2),
@@ -279,15 +285,11 @@ void main() {
 
   group('MealPlanScreen single-day Add flow', () {
     testWidgets(
-      'tapping a day-card + Add pill → BrowseMealSheet returns [recipe] → '
-      'appendMealsToRange called with startDate == endDate for that day',
+      'day-card Add pill → BrowseMealSheet returns [recipe] → '
+      'appendMealsToRange called with startDate == endDate + plan id',
       (tester) async {
-        final start = DateTime.now();
-        final today = DateTime(start.year, start.month, start.day);
-        stubBoot(entries: [_entry(today)]);
-        // BrowseMealSheet needs these to load + render. Use a distinct
-        // sheet recipe so the master-list row tap doesn't collide with the
-        // expanded day-card row that renders `_fakeRecipe.title`.
+        final today = _today();
+        stubBoot(plan: _planFrom(today), entries: [_entry(today)]);
         const sheetRecipe = Recipe(
           id: 'recipe-sheet',
           title: 'Avocado Mash',
@@ -319,12 +321,12 @@ void main() {
             startDate: any(named: 'startDate'),
             endDate: any(named: 'endDate'),
             assignments: any(named: 'assignments'),
+            mealPlanId: any(named: 'mealPlanId'),
           ),
         ).thenAnswer((_) async => const Result.success(<MealPlanEntry>[]));
 
         await pumpScreen(tester);
 
-        // Expand the first day card so its 'Add' pill is visible.
         final firstCard = find.byType(DayAccordionCard).first;
         final chevron = find
             .descendant(
@@ -335,26 +337,25 @@ void main() {
         await tester.tap(chevron);
         await tester.pumpAndSettle();
 
-        // Tap the 'Add' pill inside the expanded card.
         final addPill = find
             .descendant(of: firstCard, matching: find.text('Add'))
             .first;
         await tester.tap(addPill);
-        // Drive the sheet entrance + _load() — pumpAndSettle would hang on
-        // the CircularProgressIndicator the sheet shows while loading.
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 350));
         await tester.pump();
         await tester.pump();
 
-        // Pick the recipe in the sheet's master list.
+        // Select the recipe in the master list.
         await tester.tap(find.text(sheetRecipe.title).first);
         await tester.pump();
 
-        // Confirm the picked count + tap the sticky CTA to pop with the list.
-        expect(find.text('Add (1)'), findsOneWidget);
-        await tester.tap(find.text('Add (1)'));
-        // Drive the sheet dismissal + appendBulkPrep future.
+        // Browse → review: "Next" then confirm with "Map Meals".
+        await tester.tap(find.text('Next'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+        await tester.pump();
+        await tester.tap(find.text('Map Meals'));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 400));
         await tester.pump();
@@ -365,14 +366,13 @@ void main() {
             startDate: captureAny(named: 'startDate'),
             endDate: captureAny(named: 'endDate'),
             assignments: captureAny(named: 'assignments'),
+            mealPlanId: 'plan-1',
           ),
         ).captured;
         expect(captured, hasLength(3));
         final startDate = captured[0] as DateTime;
         final endDate = captured[1] as DateTime;
         expect(startDate, endDate, reason: 'single-day range');
-        // NIB-159: window is today-anchored, so the first day card is today
-        // itself — not the most-recent Monday.
         expect(startDate, today);
         final assignments = captured[2] as List<dynamic>;
         expect(assignments, hasLength(1));
@@ -380,62 +380,53 @@ void main() {
     );
   });
 
-  group('MealPlanScreen clear-week flow', () {
+  group('MealPlanScreen delete-plan flow', () {
     testWidgets(
-      'tapping Delete in the real confirm dialog calls clearRange on the '
-      'service',
+      'Clear current plan → Yes in confirm sheet → deletePlan on the service',
       (tester) async {
-        final start = DateTime.now();
-        final today = DateTime(start.year, start.month, start.day);
-        stubBoot(entries: [_entry(today)]);
+        final today = _today();
+        stubBoot(plan: _planFrom(today), entries: [_entry(today)]);
         when(
-          () => mockMealPlanService.clearRange(any(), any(), any()),
+          () => mockMealPlanService.deletePlan(any()),
         ).thenAnswer((_) async => const Result.success(null));
 
         await pumpScreen(tester);
 
-        // Open the screen-level menu, pick Clear current week.
         await tester.tap(find.byType(MealPlanOverflowButton));
         await tester.pumpAndSettle();
-        await tester.tap(find.text('Clear current week'));
+        await tester.tap(find.text('Clear current plan'));
         await tester.pumpAndSettle();
 
-        // Real confirm dialog rendered with scope-specific copy (NIB-185).
         expect(
-          find.text("Clear all meals for this week? This can't be undone."),
+          find.text('Are you sure you want to delete?'),
           findsOneWidget,
         );
 
-        await tester.tap(find.text('Clear'));
-        // clearRange triggers ref.invalidateSelf → re-fetches getRolling7.
+        await tester.tap(find.text('Yes'));
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 100));
 
-        verify(
-          () => mockMealPlanService.clearRange(_babyId, any(), any()),
-        ).called(1);
+        verify(() => mockMealPlanService.deletePlan('plan-1')).called(1);
       },
     );
 
-    testWidgets(
-      'tapping Cancel in the confirm dialog leaves clearRange unmocked-called',
-      (tester) async {
-        final start = DateTime.now();
-        final today = DateTime(start.year, start.month, start.day);
-        stubBoot(entries: [_entry(today)]);
+    testWidgets('No in the confirm sheet leaves deletePlan uncalled', (
+      tester,
+    ) async {
+      final today = _today();
+      stubBoot(plan: _planFrom(today), entries: [_entry(today)]);
 
-        await pumpScreen(tester);
+      await pumpScreen(tester);
 
-        await tester.tap(find.byType(MealPlanOverflowButton));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Clear current week'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.byType(MealPlanOverflowButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Clear current plan'));
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Cancel'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('No'));
+      await tester.pumpAndSettle();
 
-        verifyNever(() => mockMealPlanService.clearRange(any(), any(), any()));
-      },
-    );
+      verifyNever(() => mockMealPlanService.deletePlan(any()));
+    });
   });
 }

--- a/test/features/meal_plan/sheets/browse_meal_sheet_test.dart
+++ b/test/features/meal_plan/sheets/browse_meal_sheet_test.dart
@@ -231,7 +231,7 @@ void main() {
       expect(find.textContaining('No results for "zzz"'), findsOneWidget);
     });
 
-    testWidgets('"Add (N)" returns picked recipes on Navigator.pop', (
+    testWidgets('Next → review "Map Meals" returns picks on Navigator.pop', (
       tester,
     ) async {
       await openSheet(
@@ -243,11 +243,11 @@ void main() {
       await tester.tap(find.text(_safeA.title).first);
       await tester.pump();
 
-      // CTA reflects the count.
-      expect(find.text('Add (1)'), findsOneWidget);
-
-      await tester.tap(find.text('Add (1)'));
-      // Drive the sheet dismissal animation.
+      // Advance to the review sheet, then confirm with "Map Meals".
+      await tester.tap(find.text('Next'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.tap(find.text('Map Meals'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 400));
 
@@ -334,7 +334,7 @@ void main() {
     );
 
     testWidgets(
-      'tapping selected counter chip toggles review mode + CTA label',
+      'tapping selected counter chip toggles review mode (hides search)',
       (tester) async {
         await openSheet(
           tester,
@@ -346,20 +346,18 @@ void main() {
         await tester.tap(find.text(_safeA.title).first);
         await tester.pump();
 
-        // CTA default label.
-        expect(find.text('Add (1)'), findsOneWidget);
-        expect(find.text('Mapp Meal Plan'), findsNothing);
+        // Browse mode shows the search field.
+        expect(find.text('Search recipe'), findsOneWidget);
 
-        // Enter review mode via the selected pill.
+        // Enter review mode via the selected pill — search + carousels hide.
         await tester.tap(find.text('1 selected'));
         await tester.pump();
 
-        expect(find.text('Mapp Meal Plan'), findsOneWidget);
-        expect(find.text('Add (1)'), findsNothing);
+        expect(find.text('Search recipe'), findsNothing);
       },
     );
 
-    testWidgets('search field uses verbatim "Search recipes" hint', (
+    testWidgets('search field uses verbatim "Search recipe" hint', (
       tester,
     ) async {
       await openSheet(
@@ -368,7 +366,7 @@ void main() {
         flaggedKeys: const {},
       );
 
-      expect(find.text('Search recipes'), findsOneWidget);
+      expect(find.text('Search recipe'), findsOneWidget);
     });
 
     testWidgets('close (X) icon dismisses the sheet with a null result', (

--- a/test/features/meal_plan/sheets/select_period_date_sheet_test.dart
+++ b/test/features/meal_plan/sheets/select_period_date_sheet_test.dart
@@ -2,15 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
 import 'package:nibbles/src/features/meal_plan/sheets/select_period_date_sheet.dart';
-import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
+import 'package:nibbles/src/features/meal_plan/widgets/meal_prep_calendar.dart';
 
-Future<DateTimeRange?> _open(WidgetTester tester) async {
-  tester.view.physicalSize = const Size(1080, 2800);
+Future<SelectPeriodResult?> _open(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(1080, 3200);
   tester.view.devicePixelRatio = 1;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
 
-  DateTimeRange? captured;
+  SelectPeriodResult? captured;
   await tester.pumpWidget(
     MaterialApp(
       home: Builder(
@@ -32,58 +32,58 @@ Future<DateTimeRange?> _open(WidgetTester tester) async {
   return captured;
 }
 
+/// Picks start (15) → end (20) of the focused month so the CTAs enable.
+Future<void> _pickRange(WidgetTester tester) async {
+  await tester.tap(find.text('dd/MM/yyyy').first);
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('15').first);
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('dd/MM/yyyy'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('20').first);
+  await tester.pumpAndSettle();
+}
+
 void main() {
   group('SelectPeriodDateSheet', () {
-    testWidgets('renders Figma verbatim title + Custom meal plan CTA', (
+    testWidgets('renders title + date fields + AI/manual CTA pair', (
       tester,
     ) async {
       await _open(tester);
 
       expect(find.text('Select Period Date'), findsOneWidget);
-      expect(find.text('Start Date'), findsOneWidget);
-      expect(find.text('End Date'), findsOneWidget);
+      expect(find.text('START DATE'), findsOneWidget);
+      expect(find.text('END DATE'), findsOneWidget);
       expect(
-        find.widgetWithText(AppPillButton, 'Custom meal plan'),
+        find.widgetWithText(AppPillButton, 'Generate with AI'),
+        findsOneWidget,
+      );
+      expect(
+        find.widgetWithText(AppPillButton, 'Fill in myself'),
         findsOneWidget,
       );
     });
 
-    testWidgets('tapping Start Date opens the inline calendar', (tester) async {
-      await _open(tester);
-
-      expect(find.byType(InlineCalendar), findsNothing);
-      final today = DateTime.now();
-      const monthAbbr = [
-        'Jan',
-        'Feb',
-        'Mar',
-        'Apr',
-        'May',
-        'Jun',
-        'Jul',
-        'Aug',
-        'Sep',
-        'Oct',
-        'Nov',
-        'Dec',
-      ];
-      final startText =
-          '${monthAbbr[today.month - 1]} ${today.day}, '
-          '${today.year}';
-      await tester.tap(find.text(startText).first);
-      await tester.pumpAndSettle();
-      expect(find.byType(InlineCalendar), findsOneWidget);
-    });
-
-    testWidgets('tapping CTA pops the sheet with a DateTimeRange', (
+    testWidgets('tapping a date field reveals a MealPrepCalendar', (
       tester,
     ) async {
-      tester.view.physicalSize = const Size(1080, 2800);
+      await _open(tester);
+
+      expect(find.byType(MealPrepCalendar), findsNothing);
+      await tester.tap(find.text('dd/MM/yyyy').first);
+      await tester.pumpAndSettle();
+      expect(find.byType(MealPrepCalendar), findsWidgets);
+    });
+
+    testWidgets('Generate with AI pops SelectPeriodResult(mode: ai)', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1080, 3200);
       tester.view.devicePixelRatio = 1;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
-      DateTimeRange? captured;
+      SelectPeriodResult? captured;
       await tester.pumpWidget(
         MaterialApp(
           home: Builder(
@@ -103,15 +103,13 @@ void main() {
       await tester.tap(find.text('Open Sheet'));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(AppPillButton, 'Custom meal plan'));
+      await _pickRange(tester);
+      await tester.tap(find.widgetWithText(AppPillButton, 'Generate with AI'));
       await tester.pumpAndSettle();
 
       expect(captured, isNotNull);
-      expect(
-        captured!.end.difference(captured!.start).inDays,
-        6,
-        reason: 'Default end = start + 6 days.',
-      );
+      expect(captured!.mode, MealPrepMode.ai);
+      expect(!captured!.range.end.isBefore(captured!.range.start), isTrue);
     });
   });
 }

--- a/test/features/meal_plan/widgets/day_accordion_card_test.dart
+++ b/test/features/meal_plan/widgets/day_accordion_card_test.dart
@@ -20,12 +20,15 @@ MealPlanEntry _entry({
 Recipe _recipe({
   String id = 'r-1',
   String title = 'Peanut Butter Toast',
-  List<String> tags = const ['peanut'],
+  String ageRange = '6m+',
+  List<String> allergenTags = const ['peanut'],
+  List<String> nutritionTags = const ['Iron-Rich'],
 }) => Recipe(
   id: id,
   title: title,
-  ageRange: '6m+',
-  allergenTags: tags,
+  ageRange: ageRange,
+  allergenTags: allergenTags,
+  nutritionTags: nutritionTags,
   ingredients: const [],
   steps: const [],
   howToServe: 'Serve.',
@@ -62,7 +65,9 @@ Future<void> _pumpCard(
 
 void main() {
   group('DayAccordionCard', () {
-    testWidgets('collapsed: header visible, body hidden', (tester) async {
+    testWidgets('non-empty collapsed: header visible, body hidden', (
+      tester,
+    ) async {
       await _pumpCard(
         tester,
         entries: [_entry()],
@@ -70,95 +75,83 @@ void main() {
         isExpanded: false,
       );
 
-      // Header includes the date label e.g. "Saturday, 30 May".
       expect(find.textContaining('30 May'), findsOneWidget);
-      // Body content (recipe title + Add pill) is hidden.
       expect(find.text('Peanut Butter Toast'), findsNothing);
       expect(find.text('Add'), findsNothing);
-      expect(find.text('No meal plan yet.'), findsNothing);
     });
 
-    testWidgets('expanded + entries: recipe row renders with title + tag chips '
+    testWidgets('non-empty expanded: recipe row title + nutrition + age chips '
         '+ Add pill', (tester) async {
       await _pumpCard(
         tester,
         entries: [_entry()],
-        recipes: {
-          'r-1': _recipe(tags: const ['peanut', 'egg']),
-        },
+        recipes: {'r-1': _recipe()},
         isExpanded: true,
       );
 
       expect(find.text('Peanut Butter Toast'), findsOneWidget);
       expect(find.text('Add'), findsOneWidget);
-      // Tag chips render with replaced underscore labels.
-      expect(find.text('Peanut'), findsOneWidget);
-      expect(find.text('Egg'), findsOneWidget);
-      // No empty-state hint.
-      expect(find.text('No meal plan yet.'), findsNothing);
+      // Nutrition + age chips render (allergen chips are no longer shown).
+      expect(find.text('Iron-Rich'), findsOneWidget);
+      expect(find.text('6m+'), findsOneWidget);
     });
 
-    testWidgets(
-      'expanded + entries: 3+ tags renders +N overflow chip after first 2',
-      (tester) async {
-        await _pumpCard(
-          tester,
-          entries: [_entry()],
-          recipes: {
-            'r-1': _recipe(tags: const ['peanut', 'egg', 'dairy', 'soy']),
-          },
-          isExpanded: true,
-        );
+    testWidgets('expanded: only the first 2 nutrition tags render', (
+      tester,
+    ) async {
+      await _pumpCard(
+        tester,
+        entries: [_entry()],
+        recipes: {
+          'r-1': _recipe(
+            nutritionTags: const ['Iron-Rich', 'High Energy', 'Extra'],
+          ),
+        },
+        isExpanded: true,
+      );
 
-        // First 2 tags visible.
-        expect(find.text('Peanut'), findsOneWidget);
-        expect(find.text('Egg'), findsOneWidget);
-        // 4 - 2 = +2 overflow chip.
-        expect(find.text('+2'), findsOneWidget);
-        // Hidden tags should not render their labels.
-        expect(find.text('Dairy'), findsNothing);
-        expect(find.text('Soy'), findsNothing);
-      },
-    );
+      expect(find.text('Iron-Rich'), findsOneWidget);
+      expect(find.text('High Energy'), findsOneWidget);
+      expect(find.text('Extra'), findsNothing);
+    });
 
-    testWidgets('expanded + empty: shows empty hint and Add pill', (
+    testWidgets('empty day: dashed "No meal plan yet" + Add always visible', (
       tester,
     ) async {
       await _pumpCard(
         tester,
         entries: const [],
         recipes: const {},
-        isExpanded: true,
+        isExpanded: false,
       );
 
-      expect(find.text('No meal plan yet.'), findsOneWidget);
+      expect(find.text('No meal plan yet'), findsOneWidget);
       expect(find.text('Add'), findsOneWidget);
     });
 
-    testWidgets('header tap fires onToggle', (tester) async {
+    testWidgets('non-empty header tap fires onToggle', (tester) async {
       var toggled = 0;
       await _pumpCard(
         tester,
-        entries: const [],
-        recipes: const {},
+        entries: [_entry()],
+        recipes: {'r-1': _recipe()},
         isExpanded: false,
         onToggle: () => toggled++,
       );
 
-      // Tap on the header text — the GestureDetector wraps the row.
       await tester.tap(find.textContaining('30 May'));
       await tester.pumpAndSettle();
 
       expect(toggled, 1);
     });
 
-    testWidgets('"Add" pill tap fires onAdd', (tester) async {
+    testWidgets('empty-day "Add" pill tap fires onAdd', (tester) async {
       var added = 0;
       await _pumpCard(
         tester,
         entries: const [],
         recipes: const {},
-        isExpanded: true,
+        isExpanded: false,
         onAdd: () => added++,
       );
 

--- a/test/features/meal_plan/widgets/meal_plan_empty_state_test.dart
+++ b/test/features/meal_plan/widgets/meal_plan_empty_state_test.dart
@@ -1,38 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nibbles/src/common/components/buttons/app_pill_button.dart';
-import 'package:nibbles/src/features/meal_plan/widgets/inline_calendar.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_empty_state.dart';
 import 'package:nibbles/src/features/meal_plan/widgets/meal_plan_header.dart';
-
-const _monthAbbr = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-];
-
-String _formatDisplayDate(DateTime d) {
-  return '${_monthAbbr[d.month - 1]} ${d.day}, ${d.year}';
-}
+import 'package:nibbles/src/features/meal_plan/widgets/meal_prep_calendar.dart';
 
 Future<void> _pump(
   WidgetTester tester, {
   required String babyName,
   int ageMonths = 4,
-  ValueChanged<DateTimeRange>? onCreate,
+  ValueChanged<DateTimeRange>? onSetMealPrep,
+  ValueChanged<DateTimeRange>? onFillInMyself,
 }) async {
-  // Give the screen extra height so the CTA + calendars fit in the viewport
-  // without scrolling — keeps taps deterministic.
-  tester.view.physicalSize = const Size(1080, 2800);
+  tester.view.physicalSize = const Size(1080, 3200);
   tester.view.devicePixelRatio = 1;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
@@ -42,116 +22,105 @@ Future<void> _pump(
         body: MealPlanEmptyState(
           babyName: babyName,
           ageMonths: ageMonths,
-          onCreateMealPlan: onCreate ?? (_) {},
+          onSetMealPrep: onSetMealPrep ?? (_) {},
+          onFillInMyself: onFillInMyself ?? (_) {},
         ),
       ),
     ),
   );
 }
 
+/// Picks a start + end day via the two inline [MealPrepCalendar]s so the CTAs
+/// become enabled. Uses days 15 → 20 of the focused (current) month.
+Future<void> _pickRange(WidgetTester tester) async {
+  // Open the START field (both fields show the placeholder initially).
+  await tester.tap(find.text('dd/MM/yyyy').first);
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('15').first);
+  await tester.pumpAndSettle();
+
+  // Only the END field still shows the placeholder now.
+  await tester.tap(find.text('dd/MM/yyyy'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('20').first);
+  await tester.pumpAndSettle();
+}
+
 void main() {
   group('MealPlanEmptyState', () {
-    testWidgets('renders Figma verbatim copy with babyName', (tester) async {
-      await _pump(tester, babyName: 'Oliver');
-
-      // Header from MealPlanHeader.
-      expect(find.byType(MealPlanHeader), findsOneWidget);
-      expect(find.text('Meal Planner for Oliver'), findsOneWidget);
-      expect(find.text('4 Month'), findsOneWidget);
-
-      // Form labels + verbatim caption under the flower.
-      expect(find.text('Start Date'), findsOneWidget);
-      expect(find.text('End Date'), findsOneWidget);
-      expect(find.text("Let's create a meal plan for Oliver!"), findsOneWidget);
-    });
-
-    testWidgets(
-      'CTA is enabled by default — defaults are today + (today + 6 days)',
-      (tester) async {
-        await _pump(tester, babyName: 'Oliver');
-
-        final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
-        expect(cta, findsOneWidget);
-
-        // Enabled on first paint because defaults are populated.
-        expect(tester.widget<AppPillButton>(cta).onPressed, isNotNull);
-      },
-    );
-
-    testWidgets('tapping a date field opens the inline calendar', (
+    testWidgets('renders header + caption + both CTAs (disabled initially)', (
       tester,
     ) async {
       await _pump(tester, babyName: 'Oliver');
 
-      expect(find.byType(InlineCalendar), findsNothing);
+      expect(find.byType(MealPlanHeader), findsOneWidget);
+      expect(find.text('Meal Planner for Oliver'), findsOneWidget);
+      expect(find.text('4 Month'), findsOneWidget);
+      expect(find.text("Let's create meal plan for Oliver!"), findsOneWidget);
 
-      // The field is tappable via its `MMM d, yyyy` value text inside the
-      // GestureDetector. Use today's value to find the Start Date row.
-      final today = DateTime.now();
-      final startText = _formatDisplayDate(
-        DateTime(today.year, today.month, today.day),
-      );
-      await tester.tap(find.text(startText).first);
-      await tester.pumpAndSettle();
-      expect(find.byType(InlineCalendar), findsOneWidget);
+      // Overflow is hidden on the empty state.
+      expect(find.byType(MealPlanOverflowButton), findsNothing);
 
-      // Toggle the same field — should close.
-      await tester.tap(find.text(startText).first);
-      await tester.pumpAndSettle();
-      expect(find.byType(InlineCalendar), findsNothing);
+      final setCta = find.widgetWithText(AppPillButton, 'Set a Meal Prep');
+      final fillCta = find.widgetWithText(AppPillButton, 'Fill in myself');
+      expect(setCta, findsOneWidget);
+      expect(fillCta, findsOneWidget);
+      // Disabled until a valid range is chosen.
+      expect(tester.widget<AppPillButton>(setCta).onPressed, isNull);
+      expect(tester.widget<AppPillButton>(fillCta).onPressed, isNull);
     });
 
-    testWidgets(
-      'picking a Start Date keeps CTA enabled (form auto-bumps end)',
-      (tester) async {
-        DateTimeRange? captured;
-        await _pump(tester, babyName: 'Oliver', onCreate: (r) => captured = r);
+    testWidgets('tapping a date field reveals a MealPrepCalendar', (
+      tester,
+    ) async {
+      await _pump(tester, babyName: 'Oliver');
 
-        final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
-        final today = DateTime.now();
-        final startText = _formatDisplayDate(
-          DateTime(today.year, today.month, today.day),
-        );
+      expect(find.byType(MealPrepCalendar), findsNothing);
+      await tester.tap(find.text('dd/MM/yyyy').first);
+      await tester.pumpAndSettle();
+      expect(find.byType(MealPrepCalendar), findsWidgets);
+    });
 
-        // Open the Start Date inline calendar and pick day 28 of the
-        // focused month (day 28 exists in every month).
-        await tester.tap(find.text(startText).first);
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('28').first);
-        await tester.pumpAndSettle();
+    testWidgets('choosing a range enables the CTAs and "Set a Meal Prep" '
+        'fires onSetMealPrep with the range', (tester) async {
+      DateTimeRange? captured;
+      await _pump(
+        tester,
+        babyName: 'Oliver',
+        onSetMealPrep: (r) => captured = r,
+      );
 
-        // CTA must remain enabled — the form auto-bumps end if needed so
-        // end >= start.
-        expect(
-          tester.widget<AppPillButton>(cta).onPressed,
-          isNotNull,
-          reason: 'Form must auto-bump end so range stays valid.',
-        );
+      await _pickRange(tester);
 
-        await tester.tap(cta);
-        await tester.pumpAndSettle();
-        expect(captured, isNotNull);
-        expect(!captured!.end.isBefore(captured!.start), isTrue);
-      },
-    );
+      final setCta = find.widgetWithText(AppPillButton, 'Set a Meal Prep');
+      expect(tester.widget<AppPillButton>(setCta).onPressed, isNotNull);
 
-    testWidgets(
-      'tapping CTA emits the picked DateTimeRange via onCreateMealPlan',
-      (tester) async {
-        DateTimeRange? captured;
-        await _pump(tester, babyName: 'Oliver', onCreate: (r) => captured = r);
+      await tester.tap(setCta);
+      await tester.pumpAndSettle();
 
-        final cta = find.widgetWithText(AppPillButton, 'Create meal plan');
-        await tester.tap(cta);
-        await tester.pumpAndSettle();
+      expect(captured, isNotNull);
+      expect(!captured!.end.isBefore(captured!.start), isTrue);
+    });
 
-        expect(captured, isNotNull);
-        expect(
-          captured!.end.difference(captured!.start).inDays,
-          6,
-          reason: 'Default end = start + 6 days.',
-        );
-      },
-    );
+    testWidgets('"Fill in myself" fires onFillInMyself with the range', (
+      tester,
+    ) async {
+      DateTimeRange? captured;
+      await _pump(
+        tester,
+        babyName: 'Oliver',
+        onFillInMyself: (r) => captured = r,
+      );
+
+      await _pickRange(tester);
+
+      final fillCta = find.widgetWithText(AppPillButton, 'Fill in myself');
+      expect(tester.widget<AppPillButton>(fillCta).onPressed, isNotNull);
+
+      await tester.tap(fillCta);
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+    });
   });
 }

--- a/test/support/fake_analytics.dart
+++ b/test/support/fake_analytics.dart
@@ -267,6 +267,33 @@ class FakeAnalytics implements Analytics {
       _record('meal_plan_add_to_shop_list', {'day_count': dayCount});
 
   @override
+  Future<void> logMealPlanCreated({required int days}) async =>
+      _record('meal_plan_created', {'days': days});
+
+  @override
+  Future<void> logMealPlanDeleted() async => _record('meal_plan_deleted');
+
+  @override
+  Future<void> logMealPrepAiStarted() async =>
+      _record('meal_prep_ai_started');
+
+  @override
+  Future<void> logMealPrepAiPreferencesSelected({required int count}) async =>
+      _record('meal_prep_ai_preferences_selected', {'count': count});
+
+  @override
+  Future<void> logMealPrepAiGenerated({
+    required int recipeCount,
+    required int dayCount,
+  }) async => _record('meal_prep_ai_generated', {
+    'recipe_count': recipeCount,
+    'day_count': dayCount,
+  });
+
+  @override
+  Future<void> logMealPrepAiFailed() async => _record('meal_prep_ai_failed');
+
+  @override
   Future<void> logHomeOngoingAllergenTapped({
     required String allergenKey,
   }) async =>


### PR DESCRIPTION
Redesigns the Meals tab to the new Figma flows and adds an AI-generated meal-prep path, on a new **persisted-plan** data model. Rebuilds in place — existing controller/service/analytics reused.

## What's in it
- **Data model** — new `meal_plans` table (persisted period + single active plan per baby). `MealPlan` entity; repo/service `getActivePlan` / `createPlan` (replaces existing) / `deletePlan`. Entries carry `meal_plan_id`; the planner fetches entries **by plan id** (not date range) so meals added via "+ Add Date" past the plan's end survive a refetch.
- **Meal-stage rule** — `meal_stage.dart`: age → stage → meals-per-day (clamped 1–3; milk-only babies get 1). Drives the per-day slot target and "X of N slots filled".
- **AI generation** — first Supabase edge function `generate-meal-plan`: JWT-auth, fetches baby + allergen + recipe pool server-side, prompts OpenAI (JSON mode), and **validates every returned recipe id against the pool + drops allergen-flagged/out-of-range** before returning. Dart client/service persists via `createPlan` + `appendMealsToRange`. Key is a **Supabase secret**, never bundled.
- **UI** — empty state (date range + "Set a Meal Prep"/AI + "Fill in myself"/manual), `table_calendar` picker, browse → review → **map screen with real drag-and-drop** (reusable picked palette, tap also works), populated planner with day/header ⋯ menus, add-to-shoplist + brand-flower delete confirm, and AI preferences → notes → non-dismissable loading. New `mealPlanAiLoading` route + AI/plan analytics events.

## Verification
`make gen` clean · `flutter analyze lib test` → no issues · meal_plan + shopping_list + service/repo/stage suites green.

## Non-obvious choices
- Slot target is a **soft** guide (manual mode isn't capped); Stage 0 shows a gentle note but planning stays allowed.
- Drag from "Meals Picked" **copies** (palette never shrinks; a recipe can go on many days).
- The `recipe_id` FK means AI **selects existing recipes**, it doesn't invent dishes.

## Required follow-ups (auth-gated / on-device — not in this PR)
1. **Deploy the AI backend** (needs `supabase login` — the stored management token was rejected on this machine): `supabase secrets set OPENAI_API_KEY=… OPENAI_MODEL=gpt-4o-mini` then `supabase functions deploy generate-meal-plan` (dev + prod).
2. **Apply the migration** to dev/prod. `supabase db push` is currently **blocked** by a remote migration (`20260706000001`) that isn't in this branch — likely from a parallel session; reconcile before pushing.
3. **Remove `OPENAI_API_KEY` from `.env.dev`/`.env.prod`** — those files bundle into the app (extractable). The key belongs only as the Supabase secret above.
4. **On-device Figma visual pass** — sub-agents built visuals from spec (Figma MCP wasn't reachable to them), so a pixel pass against Figma is still needed. Known delta: add-to-shoplist labels read "Unselect All"/"Add (N)" vs Figma "Deselect"/"Select (N)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)